### PR TITLE
[SCRUM-71] FEAT: 공통 응답 형식 및 에러 코드 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -19,15 +19,6 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: branchName
-    attributes:
-      label: '브랜치 설명'
-      description: '영문 소문자로 간단한 설명 (예: login, fix-button)'
-      placeholder: 'login'
-    validations:
-      required: true
-
   - type: textarea
     attributes:
       label: 📄 설명

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          BRANCH_NAME="${{ steps.issue-parser.outputs.issueparser_branchPrefix }}/${{ steps.create.outputs.issue }}-${{ steps.issue-parser.outputs.issueparser_branchName }}"
+          BRANCH_NAME="${{ steps.issue-parser.outputs.issueparser_branchPrefix }}/#${{ github.event.issue.number }}-${{ steps.create.outputs.issue }}"
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("tools.jackson.module:jackson-module-kotlin")
     compileOnly("org.projectlombok:lombok")

--- a/src/main/kotlin/com/moongchijang/global/exception/CustomException.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/CustomException.kt
@@ -1,0 +1,6 @@
+package com.moongchijang.global.exception
+
+class CustomException(
+    val errorCode: ErrorCode,
+    val errorMessage: String? = null
+) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -2,7 +2,7 @@ package com.moongchijang.global.exception
 
 enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     // 100 Test
-    TEST_ERROR(100_000, "테스트 에러입니다.", 100),
+    TEST_ERROR(100_000, "테스트 에러입니다.", 200),
 
     // 400 Bad Request
     BAD_REQUEST(400_000, "잘못된 요청입니다.", 400),
@@ -42,6 +42,4 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(500_000, "서버 내부 오류입니다.", 500);
-
-    fun resolvedHttpStatus(): Int = if (httpStatus == 100) 200 else httpStatus
 }

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -1,0 +1,47 @@
+package com.moongchijang.global.exception
+
+enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
+    // 100 Test
+    TEST_ERROR(100_000, "테스트 에러입니다.", 100),
+
+    // 400 Bad Request
+    BAD_REQUEST(400_000, "잘못된 요청입니다.", 400),
+    INVALID_FILE_FORMAT(400_001, "업로드된 파일 형식이 올바르지 않습니다.", 400),
+    INVALID_INPUT(400_002, "입력값이 올바르지 않습니다.", 400),
+    NULL_VALUE(400_003, "Null 값이 들어왔습니다.", 400),
+
+    // 401 Unauthorized
+    TOKEN_EXPIRED(401_000, "토큰이 만료되었습니다.", 401),
+    TOKEN_INVALID(401_001, "유효하지 않은 토큰입니다.", 401),
+    TOKEN_NOT_FOUND(401_002, "토큰이 존재하지 않습니다.", 401),
+    TOKEN_UNSUPPORTED(401_003, "지원하지 않는 토큰 형식입니다.", 401),
+    INVALID_CREDENTIALS(401_004, "인증 정보가 올바르지 않습니다.", 401),
+    INVALID_REFRESH_TOKEN(401_005, "재발급 토큰이 유효하지 않습니다.", 401),
+    INVALID_ACCESS_TOKEN(401_006, "접근 토큰이 유효하지 않습니다.", 401),
+    INVALID_TOKEN(401_007, "토큰이 생성되지 않았습니다.", 401),
+    INVALID_LOGIN(401_008, "로그인이 필요합니다.", 401),
+    REFRESH_TOKEN_MISMATCH(401_009, "저장된 리프레시 토큰과 일치하지 않습니다.", 401),
+    EXPIRED_REFRESH_TOKEN(401_010, "리프레시 토큰이 만료되었습니다.", 401),
+    REFRESH_TOKEN_NOT_FOUND(401_011, "저장된 리프레시 토큰이 존재하지 않습니다.", 401),
+
+    // 403 Forbidden
+    FORBIDDEN(403_000, "접속 권한이 없습니다.", 403),
+    ACCESS_DENY(403_001, "접근이 거부되었습니다.", 403),
+    UNAUTHORIZED_POST_ACCESS(403_002, "해당 게시글에 접근할 권한이 없습니다.", 403),
+
+    // 404 Not Found
+    NOT_FOUND_END_POINT(404_000, "요청한 대상이 존재하지 않습니다.", 404),
+    USER_NOT_FOUND(404_001, "사용자를 찾을 수 없습니다.", 404),
+    USER_NOT_FOUND_IN_COOKIE(404_002, "쿠키에서 사용자 정보를 찾을 수 없습니다.", 404),
+    POST_NOT_FOUND(404_003, "요청한 게시글을 찾을 수 없습니다.", 404),
+    POST_TYPE_NOT_FOUND(404_004, "게시글 타입을 찾을 수 없습니다.", 404),
+    COMMENT_NOT_FOUND(404_005, "요청한 댓글을 찾을 수 없습니다.", 404),
+
+    // 409 Conflict
+    DUPLICATE_EMAIL(409_001, "이미 사용 중인 이메일입니다.", 409),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(500_000, "서버 내부 오류입니다.", 500);
+
+    fun resolvedHttpStatus(): Int = if (httpStatus == 100) 200 else httpStatus
+}

--- a/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
@@ -1,0 +1,56 @@
+package com.moongchijang.global.handler
+
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.response.ApiResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.AuthenticationException
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException::class)
+    fun handleCustomException(e: CustomException): ResponseEntity<ApiResponse<Nothing>> {
+        val errorCode = e.errorCode
+        return ResponseEntity
+            .status(errorCode.resolvedHttpStatus())
+            .body(ApiResponse.fail(errorCode, e.errorMessage))
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
+        val errorMessage = e.bindingResult.allErrors
+            .filterIsInstance<FieldError>()
+            .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, errorMessage))
+    }
+
+    @ExceptionHandler(AccessDeniedException::class)
+    fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ApiResponse<Nothing>> {
+        return ResponseEntity
+            .status(HttpStatus.FORBIDDEN)
+            .body(ApiResponse.fail(ErrorCode.FORBIDDEN))
+    }
+
+    @ExceptionHandler(AuthenticationException::class)
+    fun handleAuthenticationException(e: AuthenticationException): ResponseEntity<ApiResponse<Nothing>> {
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ApiResponse.fail(ErrorCode.INVALID_LOGIN))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.moongchijang.global.handler
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
@@ -15,11 +16,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @ExceptionHandler(CustomException::class)
     fun handleCustomException(e: CustomException): ResponseEntity<ApiResponse<Nothing>> {
         val errorCode = e.errorCode
         return ResponseEntity
-            .status(errorCode.resolvedHttpStatus())
+            .status(errorCode.httpStatus)
             .body(ApiResponse.fail(errorCode, e.errorMessage))
     }
 
@@ -49,6 +52,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception::class)
     fun handleException(e: Exception): ResponseEntity<ApiResponse<Nothing>> {
+        log.error("Unhandled exception occurred", e)
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR))

--- a/src/main/kotlin/com/moongchijang/global/response/ApiResponse.kt
+++ b/src/main/kotlin/com/moongchijang/global/response/ApiResponse.kt
@@ -1,0 +1,28 @@
+package com.moongchijang.global.response
+
+import com.moongchijang.global.exception.ErrorCode
+
+data class ApiResponse<T>(
+    val success: Boolean,
+    val data: T?,
+    val error: ErrorResponse?
+) {
+    companion object {
+        fun <T> success(data: T): ApiResponse<T> =
+            ApiResponse(success = true, data = data, error = null)
+
+        fun success(): ApiResponse<Nothing> =
+            ApiResponse(success = true, data = null, error = null)
+
+        fun fail(errorCode: ErrorCode, errorMessage: String? = null): ApiResponse<Nothing> =
+            ApiResponse(
+                success = false,
+                data = null,
+                error = ErrorResponse(
+                    code = errorCode.code,
+                    message = errorCode.message,
+                    errorMessage = errorMessage
+                )
+            )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/moongchijang/global/response/ErrorResponse.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.global.response
+
+data class ErrorResponse(
+    val code: Int,
+    val message: String,
+    val errorMessage: String?
+)


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
공통 응답 구조 및 에러 처리 방식을 표준화했습니다.
                                                                                                                                                                                
  - `ApiResponse<T>` : 모든 API 응답을 성공/실패로 통일된 형식으로 래핑                                                                                                           
  - `ErrorResponse` : 에러 응답 구조 (code, message, errorMessage)                                                                                                                
  - `ErrorCode` : 도메인 에러 코드 Enum (27개, HTTP 상태별 분류)                                                                                                                  
  - `CustomException` : 비즈니스 로직에서 사용하는 커스텀 예외                                                                                                                    
  - `GlobalExceptionHandler` : 모든 예외를 ApiResponse 형식으로 변환하여 반환

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
  - 노션에 있는 공통 에러를 구현했습니다! 에러 추가가 필요하다면 분류해놓은 HTTP 상태에 맞춰 추가해주시면 됩니다!
  - HTTP 상태 코드와 도메인 에러 코드는 분리되어 있으며, 응답 body의 error.code는 항상 도메인 코드로 반환됩니다.                                                                
  - errorMessage 필드는 Validation 실패 또는 필드별 오류 안내가 필요한 경우에만 사용됩니다.


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
x

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
closed #12 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인