### PR TITLE
[MCJ-84] FEAT: 헬스체크 API 및 Swagger, Security 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation(platform("software.amazon.awssdk:bom:2.31.18"))
     implementation("software.amazon.awssdk:s3")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
 }
 
 kotlin {

--- a/src/main/kotlin/com/moongchijang/global/health/HealthController.kt
+++ b/src/main/kotlin/com/moongchijang/global/health/HealthController.kt
@@ -1,0 +1,24 @@
+package com.moongchijang.global.health
+
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Health", description = "서버 상태 확인을 위한 헬스체크 API")
+@RestController
+@RequestMapping("/health")
+class HealthController {
+
+    @Operation(summary = "헬스 체크", description = "정상적으로 서버가 실행 중인지 확인합니다.")
+    @GetMapping
+    fun check(): ResponseEntity<ApiResponse<Map<String, String>>> {
+        return ResponseEntity.ok(
+            ApiResponse.success(mapOf("status" to "UP"))
+        )
+    }
+
+}

--- a/src/main/kotlin/com/moongchijang/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/security/config/SecurityConfig.kt
@@ -18,6 +18,10 @@ class SecurityConfig {
         http
             .csrf { it.disable() }
             .cors {  }
+        http
+            .csrf { it.disable() }
+            .cors { }
+            .sessionManagement { it.sessionCreationPolicy(org.springframework.security.config.http.SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
                 it.requestMatchers(
                     "/health",

--- a/src/main/kotlin/com/moongchijang/global/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/security/config/SecurityConfig.kt
@@ -1,0 +1,50 @@
+package com.moongchijang.global.security.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .cors {  }
+            .authorizeHttpRequests {
+                it.requestMatchers(
+                    "/health",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**"
+                ).permitAll()
+
+                // 개발 진행 시에는 모든 경로 허용 후 실제 배포 시 변경 필요
+                it.anyRequest().permitAll()
+            }
+            .formLogin { it.disable() }
+            .httpBasic { it.disable() }
+
+        return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+
+        configuration.allowedOrigins = listOf("http://localhost:3000", "http://localhost:5173")
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        configuration.allowedHeaders = listOf("Authorization", "Content-Type", "Accept")
+        configuration.allowCredentials = true
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /health` 헬스체크 API를 추가했습니다.
- Swagger 적용을 위해 `springdoc-openapi` 의존성을 추가했습니다.
- Spring Security 설정을 추가하고 `/health`, `/swagger-ui/**`, `/v3/api-docs/**` 경로를 허용했습니다.
- 로컬 개발 환경을 위해 CORS 설정을 추가했습니다.
- CORS 허용 Origin에 `http://localhost:3000`, `http://localhost:5173`를 추가했습니다.
- REST API 환경에 맞게 세션 정책을 `STATELESS`로 설정했습니다.

## 🔍 참고 사항
- 현재는 개발 편의를 위해 `anyRequest().permitAll()`로 전체 경로를 허용하고 있습니다.
- 추후 인증/인가 로직 적용 시 헬스체크 및 Swagger 경로를 제외한 나머지 경로는 권한 정책에 맞게 재설정이 필요합니다.
- 헬스체크 응답은 공통 응답 포맷(`ApiResponse`)으로 반환하도록 구현했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #14 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인