### PR TITLE
[MCJ-95] CHORE: Docker 기반 배포 파이프라인 속도 개선

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,6 +16,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # JAR 빌드를 위해 JDK 21 환경을 설정하고 Gradle 캐시를 사용합니다.
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      # Gradle Wrapper 실행 권한을 부여합니다.
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      # Docker 이미지 생성 전에 실행 가능한 JAR를 먼저 빌드합니다.
+      - name: Build jar
+        run: ./gradlew bootJar --no-daemon
+
       # GitHub Actions에서 dev 이미지를 빌드하고 ECR에 push
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -28,14 +44,15 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      # ARM64 기반 EC2 환경에 배포할 이미지를 빌드하기 위해 QEMU 설정
+      # ARM64 기반 EC2 환경에 배포할 이미지를 빌드하기 위해 QEMU를 설정합니다.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
-      # Buildx를 사용해 특정 아키텍처의 Docker 이미지를 빌드하고 푸시
+      # 특정 아키텍처 이미지를 빌드하기 위해 Buildx를 설정합니다.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # 빌드된 JAR를 포함한 Docker 이미지를 생성하고 ECR에 푸시합니다.
       - name: Build and push dev image
         uses: docker/build-push-action@v6
         with:
@@ -43,6 +60,8 @@ jobs:
           file: ./docker/Dockerfile
           push: true
           platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ vars.ECR_REPOSITORY_URL }}:develop
 
   deploy:
@@ -66,7 +85,4 @@ jobs:
             cd docker
 
             export ECR_REPOSITORY_URL="${{ vars.ECR_REPOSITORY_URL }}"
-            ECR_REGISTRY="${ECR_REPOSITORY_URL%%/*}"
-            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
-            docker compose --profile dev pull app-dev
-            docker compose --profile dev up -d nginx app-dev
+            ECR_REGISTRY="${ECR_RE

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,7 +32,12 @@ jobs:
       - name: Build jar
         run: ./gradlew bootJar --no-daemon
 
-      # GitHub Actions에서 dev 이미지를 빌드하고 ECR에 push
+      # Docker 이미지에서 사용할 실행 JAR 파일명을 고정합니다.
+      - name: Prepare jar for Docker image
+        run: |
+          JAR_FILE=$(find build/libs -maxdepth 1 -type f -name "*.jar" ! -name "*-plain.jar" | head -n 1)
+          cp "$JAR_FILE" build/libs/app.jar
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,6 +39,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # JAR 빌드를 위해 JDK 21 환경을 설정하고 Gradle 캐시를 사용합니다.
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      # Gradle Wrapper 실행 권한을 부여합니다.
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      # Docker 이미지 생성 전에 실행 가능한 JAR를 먼저 빌드합니다.
+      - name: Build jar
+        run: ./gradlew bootJar --no-daemon
+
       # 검증된 main 이미지를 빌드하고 ECR에 push
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -51,14 +67,15 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      # ARM64 기반 EC2 환경에 배포할 이미지를 빌드하기 위해 QEMU 설정
+      # ARM64 기반 EC2 환경에 배포할 이미지를 빌드하기 위해 QEMU를 설정합니다.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
-      # Buildx를 사용해 특정 아키텍처의 Docker 이미지를 빌드하고 푸시
+      # 특정 아키텍처 이미지를 빌드하기 위해 Buildx를 설정합니다.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # 빌드된 JAR를 포함한 Docker 이미지를 생성하고 ECR에 푸시합니다.
       - name: Build and push prod image
         uses: docker/build-push-action@v6
         with:
@@ -66,6 +83,8 @@ jobs:
           file: ./docker/Dockerfile
           push: true
           platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ vars.ECR_REPOSITORY_URL }}:main
 
   deploy:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Build jar
         run: ./gradlew bootJar --no-daemon
 
+      # Docker 이미지에서 사용할 실행 JAR 파일명을 고정합니다.
+      - name: Prepare jar for Docker image
+        run: |
+          JAR_FILE=$(find build/libs -maxdepth 1 -type f -name "*.jar" ! -name "*-plain.jar" | head -n 1)
+          cp "$JAR_FILE" build/libs/app.jar
+
       # 검증된 main 이미지를 빌드하고 ECR에 push
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,8 @@ FROM eclipse-temurin:21-jre
 # 애플리케이션 작업 디렉터리 설정
 WORKDIR /app
 
-# GitHub Actions에서 미리 빌드한 실행 JAR 복사
-COPY build/libs/*-SNAPSHOT.jar app.jar
+# GitHub Actions에서 준비한 실행 JAR 복사
+COPY build/libs/app.jar app.jar
 
 # 애플리케이션 포트 노출
 EXPOSE 8080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,17 @@ FROM eclipse-temurin:21-jre
 # 애플리케이션 작업 디렉터리 설정
 WORKDIR /app
 
+# 비특권 사용자와 그룹 생성
+RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+
 # GitHub Actions에서 준비한 실행 JAR 복사
 COPY build/libs/app.jar app.jar
+
+# 애플리케이션 실행 권한을 appuser에게 부여
+RUN chown appuser:appgroup /app/app.jar
+
+# 비특권 사용자로 애플리케이션 실행
+USER appuser
 
 # 애플리케이션 포트 노출
 EXPOSE 8080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,43 +1,14 @@
-# =================
-# 애플리케이션 빌드 단계
-# =================
-FROM gradle:8.14.3-jdk21 AS builder
-
-# 빌드 작업 디렉터리 설정
-WORKDIR /app
-
-# Gradle 실행 파일 복사
-COPY gradlew .
-
-# Gradle 설정 디렉터리 복사
-COPY gradle gradle
-
-# Gradle 빌드 설정 파일 복사
-COPY build.gradle.kts .
-COPY settings.gradle.kts .
-
-# 애플리케이션 소스 복사
-COPY src src
-
-# Gradle 실행 권한 부여
-RUN chmod +x ./gradlew
-
-# Spring Boot 실행 JAR 생성
-RUN ./gradlew bootJar --no-daemon
-
-# =================
-# 애플리케이션 실행 단계
-# =================
+# 애플리케이션 실행 전용 이미지
 FROM eclipse-temurin:21-jre
 
-# 실행 작업 디렉터리 설정
+# 애플리케이션 작업 디렉터리 설정
 WORKDIR /app
 
-# 실행 가능한 JAR 복사
-COPY --from=builder /app/build/libs/*-SNAPSHOT.jar app.jar
+# GitHub Actions에서 미리 빌드한 실행 JAR 복사
+COPY build/libs/*-SNAPSHOT.jar app.jar
 
 # 애플리케이션 포트 노출
 EXPOSE 8080
 
-# 애플리케이션 실행 명령
+# Spring Boot 애플리케이션 실행
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 📌 작업한 내용
- Dockerfile을 실행 전용 이미지 구조로 변경했습니다.
- GitHub Actions 배포 워크플로우에서 Docker 이미지 생성 전에 `bootJar`를 먼저 수행하도록 수정했습니다.
- `deploy-dev.yml`, `deploy-prod.yml`에 Gradle 캐시 설정을 추가했습니다.
- Docker build cache를 적용해 반복 빌드 시 캐시를 활용할 수 있도록 수정했습니다.
- ARM64 기반 EC2 환경에 맞춰 기존 이미지 빌드 구조를 유지하면서 배포 속도 개선이 가능하도록 배포 흐름을 정리했습니다.
- `.dockerignore`를 추가해 Docker 빌드 시 불필요한 파일이 포함되지 않도록 정리했습니다.
- Docker 이미지에서 사용할 실행용 JAR 경로를 고정해 와일드카드 매칭 및 버전 하드코딩 의존성을 줄였습니다.
- 컨테이너가 non-root 사용자로 실행되도록 Dockerfile을 수정했습니다.

## 🔍 참고 사항
- 기존에는 Docker 빌드 내부에서 `./gradlew bootJar --no-daemon`를 수행하고 있어 Gradle Wrapper 다운로드 및 애플리케이션 빌드가 반복되고 있었습니다.
- 이로 인해 `Build and push image` 단계에서 dev/prod 배포 시간이 과도하게 길어지는 문제가 있었습니다.
- 이번 변경으로 애플리케이션 빌드와 Docker 이미지 빌드 책임을 분리하여 배포 속도 개선을 기대할 수 있습니다.
- Docker 이미지에서 사용하는 JAR 파일은 workflow에서 별도로 준비하도록 변경해 `COPY build/libs/*-SNAPSHOT.jar` 방식의 불안정성을 제거했습니다.
- 보안 관점에서 컨테이너 실행 사용자를 제한하도록 반영했습니다.
- Spring Boot layertools를 활용한 계층형 JAR 구조 적용은 후속 최적화 작업으로 분리하여 별도 이슈에서 검토할 예정입니다.
- ARM64 이미지 빌드는 유지되므로, 배포 시간 개선 효과는 후속 배포에서 추가 확인이 필요합니다.

배포 구조 개선 이후 dev 배포의 `Build and push image` 단계는 첫 실행 기준 약 14분 13초에서 1분 52초로 단축되었습니다.
애플리케이션 빌드와 Docker 이미지 빌드 책임을 분리한 효과로, 첫 실행 기준 약 87% 수준의 시간 감소를 확인했습니다.

이후 문법 오류 수정 과정에서 재실행한 배포에서는 `Build and push image`가 52초까지 단축되었으며, 이는 GitHub Actions 캐시가 추가로 반영된 결과일 가능성이 있습니다.

<img width="1414" height="237" alt="스크린샷 2026-04-19 오전 2 12 44" src="https://github.com/user-attachments/assets/ede14d22-9c02-4911-a911-0e22ec0ec31e" />
<img width="1409" height="242" alt="스크린샷 2026-04-19 오전 2 12 59" src="https://github.com/user-attachments/assets/5758695e-889d-4d61-a558-eb4f7f241074" />
<img width="1416" height="239" alt="스크린샷 2026-04-19 오전 2 14 21" src="https://github.com/user-attachments/assets/ce76de40-f6d4-4efe-8dec-2f24b48a5308" />

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #24 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인