### PR TITLE
HOTFIX: dev 배포 스크립트 문법 오류 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -90,4 +90,7 @@ jobs:
             cd docker
 
             export ECR_REPOSITORY_URL="${{ vars.ECR_REPOSITORY_URL }}"
-            ECR_REGISTRY="${ECR_RE
+            ECR_REGISTRY="${ECR_REPOSITORY_URL%%/*}"
+            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+            docker compose --profile dev pull app-dev
+            docker compose --profile dev up -d nginx app-dev


### PR DESCRIPTION
## 📌 작업한 내용
- `deploy-dev.yml`의 EC2 배포 스크립트에서 잘려 있던 변수 치환 구문을 수정했습니다.
- dev 배포 단계에서 발생하던 쉘 문법 오류를 해결했습니다.

## 🔍 참고 사항
- 기존에는 `ECR_REGISTRY` 변수 선언이 중간에서 잘려 `unexpected EOF while looking for matching \`}'` 오류가 발생하고 있었습니다.
- 해당 오류로 인해 GitHub Actions의 dev 배포 단계가 실패하고 있었습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #26 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인