### PR TITLE
[MCJ-98] CHORE: 계층형 JAR 기반 Docker 이미지 구조 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,3 +60,9 @@ allOpen {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks.bootJar {
+    layered {
+        enabled.set(true)
+    }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,39 @@
-# 애플리케이션 실행 전용 이미지
+# ===========================
+# 1단계: 빌드된 JAR에서 레이어 추출
+# ===========================
+FROM eclipse-temurin:21-jre AS builder
+
+WORKDIR /builder
+
+# GitHub Actions에서 준비한 실행 JAR 복사
+COPY build/libs/app.jar app.jar
+
+# Spring Boot layertools를 이용해 레이어를 추출
+RUN java -Djarmode=layertools -jar app.jar extract
+
+# ==================
+# 2단계: 실행 전용 이미지
+# ==================
 FROM eclipse-temurin:21-jre
 
-# 애플리케이션 작업 디렉터리 설정
 WORKDIR /app
 
 # 비특권 사용자와 그룹 생성
 RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 
-# GitHub Actions에서 준비한 실행 JAR 복사
-COPY build/libs/app.jar app.jar
+# 추출된 레이어를 순서대로 복사
+COPY --from=builder /builder/dependencies/ ./
+COPY --from=builder /builder/spring-boot-loader/ ./
+COPY --from=builder /builder/snapshot-dependencies/ ./
+COPY --from=builder /builder/application/ ./
 
-# 애플리케이션 실행 권한을 appuser에게 부여
-RUN chown appuser:appgroup /app/app.jar
+# 파일 권한 부여
+RUN chown -R appuser:appgroup /app
 
-# 비특권 사용자로 애플리케이션 실행
+# 비특권 사용자로 실행
 USER appuser
 
-# 애플리케이션 포트 노출
 EXPOSE 8080
 
-# Spring Boot 애플리케이션 실행
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# Spring Boot loader를 직접 실행
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,14 +21,11 @@ WORKDIR /app
 # 비특권 사용자와 그룹 생성
 RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 
-# 추출된 레이어를 순서대로 복사
-COPY --from=builder /builder/dependencies/ ./
-COPY --from=builder /builder/spring-boot-loader/ ./
-COPY --from=builder /builder/snapshot-dependencies/ ./
-COPY --from=builder /builder/application/ ./
-
-# 파일 권한 부여
-RUN chown -R appuser:appgroup /app
+# 추출된 레이어를 복사하면서 실행 사용자 권한을 함께 설정
+COPY --chown=appuser:appgroup --from=builder /builder/dependencies/ ./
+COPY --chown=appuser:appgroup --from=builder /builder/spring-boot-loader/ ./
+COPY --chown=appuser:appgroup --from=builder /builder/snapshot-dependencies/ ./
+COPY --chown=appuser:appgroup --from=builder /builder/application/ ./
 
 # 비특권 사용자로 실행
 USER appuser


### PR DESCRIPTION
## 📌 작업한 내용
- `bootJar`가 계층형 JAR(layered jar)로 생성되도록 설정을 추가했습니다.
- Dockerfile을 계층형 JAR 기반 구조로 변경해 layertools를 이용해 레이어를 추출하도록 수정했습니다.
- Docker 이미지 빌드 시 `dependencies`, `spring-boot-loader`, `snapshot-dependencies`, `application` 레이어를 분리해 복사하도록 반영했습니다.
- 기존 non-root 사용자 실행 구조는 유지한 채 layered jar 방식으로 실행 이미지 구성을 변경했습니다.

## 🔍 참고 사항
- 기존에는 실행용 `app.jar`를 단일 파일로 이미지에 복사하는 구조였기 때문에, 애플리케이션 코드가 조금만 변경되어도 해당 레이어 전체가 다시 생성되는 한계가 있었습니다.
- 이번 변경으로 Spring Boot layertools를 활용해 변경되지 않은 의존성 레이어를 Docker 캐시로 재사용할 수 있는 구조로 개선했습니다.
- `deploy-dev.yml`, `deploy-prod.yml`의 기존 `bootJar` 및 `app.jar` 준비 흐름은 그대로 사용하므로 workflow 추가 수정은 필요하지 않습니다.
- 로컬에서 `./gradlew bootJar`, `docker build`, `docker run`, `/health` 호출까지 확인해 정상 동작을 검증했습니다.

<img width="1408" height="353" alt="스크린샷 2026-04-19 오전 2 16 04" src="https://github.com/user-attachments/assets/ed181104-8841-4739-b833-5ff5b46ef13b" />
<img width="1422" height="418" alt="스크린샷 2026-04-19 오전 2 16 12" src="https://github.com/user-attachments/assets/a54e24c2-fef4-4f18-8c30-19a6af3c0c79" />

Spring Boot layertools를 활용한 계층형 JAR 구조를 적용했습니다.
다만 이번 측정 기준으로는 `Build and push image` 시간이 56초로 확인되어, 직전 캐시 반영 배포(52초) 대비 유의미한 성능 개선은 확인하지 못했습니다.
이번 변경은 구조 적용 및 동작 검증에 의미가 있으며, 반복 배포 시 캐시 재사용 효과는 추후 추가 관찰이 필요합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #28 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인