### PR TITLE
[MCJ-1208] CHORE: 배포 후 미사용 Docker 이미지 정리 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -94,3 +94,6 @@ jobs:
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
             docker compose --profile dev pull app-dev
             docker compose --profile dev up -d nginx app-dev
+
+            # 태그 없는 미사용 이미지를 정리해 디스크 사용량 누적을 완화합니다.
+            docker image prune -f

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -118,3 +118,6 @@ jobs:
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
             docker compose --profile prod pull app-prod
             docker compose --profile prod up -d nginx app-prod
+
+            # 태그 없는 미사용 이미지를 정리해 디스크 사용량 누적을 완화합니다.
+            docker image prune -f


### PR DESCRIPTION
## 📌 작업한 내용
- `deploy-dev.yml`, `deploy-prod.yml`의 EC2 배포 스크립트 마지막에 `docker image prune -f`를 추가했습니다.
- 배포 후 태그 없는 미사용 Docker 이미지를 자동으로 정리하도록 배포 흐름을 보완했습니다.
- 반복 배포 시 dangling image 누적으로 인한 디스크 사용량 증가를 완화할 수 있도록 정리 전략을 반영했습니다.

## 🔍 참고 사항
- 실제 배포 중 `failed to register layer: write /opt/java/openjdk/lib/modules: no space left on device` 오류가 발생했고, 당시 EC2 루트 디스크 사용률은 97%까지 증가한 상태였습니다.
- `docker system prune -af` 수행 후 디스크 사용률은 62%까지 감소했고, 이후 배포 1회 수행 후 67% 수준으로 증가하는 것을 확인했습니다.
- 이후 배포 스크립트에 `docker image prune -f`를 반영한 뒤 자동 정리 결과를 확인한 결과, dangling image만 정리되었고 현재 실행 중인 `dev`, `prod`, `nginx` 이미지에는 영향이 없음을 확인했습니다.
- 자동 정리 후 디스크 사용률은 65%, 남은 용량은 2.9GB 수준으로 확인되었으며, 현재 운영에 필요한 이미지 3개만 유지되는 상태를 확인했습니다.
- 이번 변경은 `docker system prune -af`처럼 광범위한 정리 대신, 비교적 안전한 `docker image prune -f`를 배포 후 자동 수행하도록 적용한 것입니다.

| 구분 | 디스크 사용률 | 남은 용량 |
|---|---:|---:|
| 정리 전 | 97% | 324MB |
| `docker system prune -af` 후 | 62% | 3.1GB |
| 배포 1회 후 | 67% | 2.7GB |
| `docker image prune -f` 자동 적용 후 | 65% | 2.9GB |

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closed #31 

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인