### PR TITLE
[MCJ-1281] DOCS: 기능명세서 기반 담당 범위 OpenAPI 명세 수정

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -231,9 +231,113 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponseShareMeta'
 
+  /api/v1/search:
+    post:
+      tags: [GroupBuy]
+      summary: 검색 실행 및 AI 키워드 분석 (1.1.4-1)
+      description: |
+        검색어를 입력하면 동네/베이커리 키워드를 AI로 분석하고 최근 검색어로 저장한다.
+        분석 결과에 따라 4가지 케이스로 분기한다.
+        - case 1: 베이커리 인식, 동네 미인식
+        - case 2: 동네 인식, 베이커리 미인식
+        - case 3: 동네+베이커리 모두 인식
+        - case 4: 모두 인식 불가
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [keyword]
+              properties:
+                keyword:
+                  type: string
+                  minLength: 1
+      responses:
+        '200':
+          description: AI 분석 결과
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseSearchAnalysis'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /api/v1/search/recent:
+    get:
+      tags: [GroupBuy]
+      summary: 최근 검색어 목록 조회
+      description: |
+        검색창 탭 시 표시할 사용자의 최근 검색어를 최신순으로 반환한다. (1.1.4-10)
+        검색 이력이 없으면 빈 배열 반환.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 최근 검색어 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseRecentSearchList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    delete:
+      tags: [GroupBuy]
+      summary: 최근 검색어 전체 삭제
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessNoData'
+
+  /api/v1/search/recent/{keyword}:
+    delete:
+      tags: [GroupBuy]
+      summary: 최근 검색어 단건 삭제
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: keyword
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessNoData'
+
   # ─────────────────────────────────────────────────────────────
   # GroupBuyRequest (소비자)
   # ─────────────────────────────────────────────────────────────
+  /api/v1/stores/search:
+    get:
+      tags: [GroupBuyRequest]
+      summary: 매장 검색 자동완성 (2.1.1-1)
+      description: |
+        매장명 또는 주소 입력 시 외부 지도/장소 API 기반 매장 후보 목록을 반환한다.
+        각 항목은 매장명과 주소를 함께 포함한다. 예: 모모양과 / 서울 성북구 화랑로11길 23
+      parameters:
+        - name: keyword
+          in: query
+          required: true
+          description: 매장명 또는 주소 검색어
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        '200':
+          description: 매장 후보 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseStoreSearchList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
   /api/v1/group-buy-requests:
     post:
       tags: [GroupBuyRequest]
@@ -352,6 +456,23 @@ paths:
   # ─────────────────────────────────────────────────────────────
   # Participation & Payment
   # ─────────────────────────────────────────────────────────────
+  /api/v1/admin/summary:
+    get:
+      tags: [Admin]
+      summary: 운영자 대시보드 요약 정보
+      description: 헤더에 항상 노출되는 대기중 요청 / 진행 중 공구 / 달성률 / 대기 환불 요약을 반환한다.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 대시보드 요약
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminDashboardSummary'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/group-buys/{groupBuyId}/participations:
     post:
       tags: [Participation]
@@ -1189,6 +1310,8 @@ components:
             isClosed: { type: boolean }
             isParticipated: { type: boolean }
             canParticipate: { type: boolean }
+            minQuantityPerPerson: { type: integer, description: "인당 최소 구매 수량. 예) 1" }
+            maxQuantityPerPerson: { type: integer, nullable: true, description: "인당 최대 구매 수량. null이면 제한 없음. 예) 2" }
         error: { nullable: true, example: null }
 
     ApiResponseGroupBuyProgress:
@@ -1250,6 +1373,19 @@ components:
         storeName:
           type: string
           maxLength: 100
+        storeAddress:
+          type: string
+          maxLength: 200
+          nullable: true
+          description: 외부 지도 API로 선택한 매장 도로명 주소
+        storeLatitude:
+          type: number
+          format: double
+          nullable: true
+        storeLongitude:
+          type: number
+          format: double
+          nullable: true
         productName:
           type: string
           maxLength: 100
@@ -1286,8 +1422,11 @@ components:
         additionalNote: { type: string, nullable: true }
         status:
           type: string
-          enum: [SUBMITTED, REVIEWING, CONTACTING, OPENED, REJECTED]
-        rejectionReason: { type: string, nullable: true }
+          enum: [SUBMITTED, IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
+          description: |
+            SUBMITTED=요청 접수 / IN_REVIEW=검토 중 / IN_CONTACT=매장 컨택 중 /
+            OPENED=공구 개설 완료 / REJECTED=개설 불가
+        rejectionReason: { type: string, nullable: true, description: status=REJECTED 시 노출 }
         createdAt: { type: string, format: date-time }
 
     ApiResponseGroupBuyRequestList:
@@ -1357,26 +1496,38 @@ components:
           type: object
           properties:
             participationId: { type: integer, format: int64 }
-            paymentKey: { type: string }
-            totalAmount: { type: integer, description: 상품금액 + 수수료(30%) }
+            orderName: { type: string, description: "포트원 SDK에 전달할 주문명. 예) 두쫀쿠 오리지널 1개" }
+            totalAmount: { type: integer, description: 상품금액 + 수수료(30%) — 포트원 SDK totalAmount에 사용 }
             productAmount: { type: integer }
             feeAmount: { type: integer }
         error: { nullable: true, example: null }
 
     PaymentConfirm:
       type: object
-      required: [paymentKey, participationId, amount]
+      required: [paymentId, participationId, amount]
+      description: |
+        포트원 v2 + 토스페이먼츠 결제 성공 후 서버 검증 요청.
+        클라이언트가 PortOne.requestPayment() 완료 시 반환된 paymentId를 전달한다.
+        서버는 포트원 API(GET /payments/{paymentId})로 위변조 검증 후 확정 처리한다.
       properties:
-        paymentKey: { type: string }
+        paymentId:
+          type: string
+          format: uuid
+          description: 포트원 결제 ID (클라이언트가 UUID로 생성하여 SDK 호출 시 사용한 값)
         participationId: { type: integer, format: int64 }
-        amount: { type: integer }
+        amount: { type: integer, description: 결제 요청 금액 — 서버 저장값과 불일치 시 위변조로 처리 }
 
     PaymentFail:
       type: object
+      description: 포트원 v2 결제 실패/취소 콜백 처리
       properties:
-        paymentKey: { type: string }
+        paymentId:
+          type: string
+          format: uuid
+          description: 포트원 결제 ID
         participationId: { type: integer, format: int64 }
-        errorCode: { type: string }
+        errorCode: { type: string, description: 포트원/토스페이먼츠 오류 코드 }
+        message: { type: string, nullable: true, description: 오류 메시지 }
 
     ApiResponseRefundList:
       type: object
@@ -1390,12 +1541,17 @@ components:
               participationId: { type: integer, format: int64 }
               productName: { type: string }
               storeName: { type: string }
+              pickupDateTime: { type: string, format: date-time, nullable: true }
               paymentAmount: { type: integer }
               quantity: { type: integer }
               refundStatus:
                 type: string
                 enum: [PENDING, COMPLETED]
-              cancelReason: { type: string }
+                description: PENDING=환불대기 / COMPLETED=환불완료
+              cancelReason:
+                type: string
+                enum: [NOT_ACHIEVED, EARLY_EXIT, PAYMENT_ERROR, OTHER]
+                description: 취소 사유
         error: { nullable: true, example: null }
 
     # ── Pickup & QR ────────────────────────────────────────────
@@ -1412,6 +1568,7 @@ components:
             storeAddress: { type: string }
             latitude: { type: number, format: double }
             longitude: { type: number, format: double }
+            transitInfo: { type: string, nullable: true, description: "대중교통 안내 텍스트. 예) 2호선 성수역 3번 출구에서 도보 5분" }
             pickupDate: { type: string, format: date }
             pickupTimeStart: { type: string, format: time }
             pickupTimeEnd: { type: string, format: time }
@@ -1433,7 +1590,9 @@ components:
             quantity: { type: integer }
             isUsed: { type: boolean }
             storeName: { type: string }
-            pickupDateTime: { type: string, format: date-time }
+            pickupDate: { type: string, format: date }
+            pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
+            pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
         error: { nullable: true, example: null }
 
     ApiResponsePickupVerify:
@@ -1447,7 +1606,9 @@ components:
             userName: { type: string }
             productName: { type: string }
             quantity: { type: integer }
-            pickupDateTime: { type: string, format: date-time }
+            pickupDate: { type: string, format: date }
+            pickupTimeStart: { type: string, format: time }
+            pickupTimeEnd: { type: string, format: time }
             pickupStatus:
               type: string
               enum: [WAITING, COMPLETED]
@@ -1646,7 +1807,9 @@ components:
                   userName: { type: string }
                   productName: { type: string }
                   quantity: { type: integer }
-                  pickupDateTime: { type: string, format: date-time }
+                  pickupDate: { type: string, format: date }
+                  pickupTimeStart: { type: string, format: time }
+                  pickupTimeEnd: { type: string, format: time }
                   status:
                     type: string
                     enum: [WAITING, COMPLETED]
@@ -1657,6 +1820,28 @@ components:
         error: { nullable: true, example: null }
 
     # ── Admin ──────────────────────────────────────────────────
+    ApiResponseAdminDashboardSummary:
+      type: object
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          properties:
+            pendingRequestCount:
+              type: integer
+              description: 대기중 요청 건수 (처리 필요)
+            activeGroupBuyCount:
+              type: integer
+              description: 진행 중 공구 개수
+            achievementRate:
+              type: number
+              format: double
+              description: 최근 30일 공구 달성률 (%). 달성완료 / 마감된 전체 공구 기준
+            pendingRefundCount:
+              type: integer
+              description: 대기 환불 건수 (처리 필요)
+        error: { nullable: true, example: null }
+
     ApiResponseAdminRequestPage:
       type: object
       properties:
@@ -1757,16 +1942,18 @@ components:
       properties:
         requestId: { type: integer, format: int64, nullable: true }
         storeId: { type: integer, format: int64 }
-        productName: { type: string }
+        productName: { type: string, maxLength: 100 }
         productDescription: { type: string }
         price: { type: integer, minimum: 1 }
-        targetQuantity: { type: integer, minimum: 1 }
-        maxQuantity: { type: integer, minimum: 1 }
+        targetQuantity: { type: integer, minimum: 1, description: 목표 수량 }
+        maxQuantity: { type: integer, minimum: 1, description: 최대 수량 (선착순 마감 기준) }
+        notice: { type: string, nullable: true, description: 유의사항 }
         deadline: { type: string, format: date-time }
         pickupDate: { type: string, format: date }
         pickupTimeStart: { type: string, format: time }
         pickupTimeEnd: { type: string, format: time }
         pickupLocation: { type: string }
+        pickupAddress: { type: string, nullable: true, description: "픽업 장소 주소 (매장 주소와 다를 경우 입력)" }
 
     AdminGroupBuyUpdate:
       type: object
@@ -1817,6 +2004,30 @@ components:
           properties:
             groupBuyId: { type: integer, format: int64 }
         error: { nullable: true, example: null }
+
+    AdminGroupBuyDetail:
+      type: object
+      properties:
+        groupBuyId: { type: integer, format: int64 }
+        storeName: { type: string }
+        productName: { type: string }
+        price: { type: integer }
+        targetQuantity: { type: integer }
+        maxQuantity: { type: integer }
+        currentQuantity: { type: integer }
+        achievementRate: { type: integer }
+        description: { type: string, nullable: true }
+        notice: { type: string, nullable: true }
+        deadline: { type: string, format: date-time }
+        pickupDate: { type: string, format: date }
+        pickupTimeStart: { type: string, format: time }
+        pickupTimeEnd: { type: string, format: time }
+        status:
+          type: string
+          enum: [IN_PROGRESS, ACHIEVED, FAILED]
+        isOrderConfirmed: { type: boolean }
+        isOrderSheetSent: { type: boolean }
+        requestId: { type: integer, format: int64, nullable: true }
 
     ApiResponseAdminGroupBuyDetail:
       type: object
@@ -1913,4 +2124,80 @@ components:
           type: object
           properties:
             settlementId: { type: integer, format: int64 }
+        error: { nullable: true, example: null }
+
+    ApiResponseSearchAnalysis:
+      type: object
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          properties:
+            keyword: { type: string, description: 원본 검색어 }
+            detectedNeighborhood: { type: string, nullable: true, description: AI가 감지한 동네 키워드 }
+            detectedBakery: { type: string, nullable: true, description: AI가 감지한 베이커리/상품 키워드 }
+            searchCase:
+              type: integer
+              enum: [1, 2, 3, 4]
+              description: |
+                1=베이커리 인식·동네 미인식 / 2=동네 인식·베이커리 미인식 /
+                3=동네+베이커리 모두 인식 / 4=모두 인식 불가
+            groupBuys:
+              type: array
+              description: case 3 또는 검색 결과가 있을 때 반환되는 공구 목록
+              items:
+                $ref: '#/components/schemas/GroupBuyFeedItem'
+        error: { nullable: true, example: null }
+
+    ApiResponseRecentSearchList:
+      type: object
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          properties:
+            keywords:
+              type: array
+              description: 최근 검색어 목록 (최신순). 이력 없으면 빈 배열.
+              items:
+                type: object
+                properties:
+                  keyword: { type: string }
+                  searchedAt: { type: string, format: date-time }
+        error: { nullable: true, example: null }
+
+    ApiResponseStoreSearchList:
+      type: object
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          properties:
+            stores:
+              type: array
+              description: 외부 지도 API 기반 매장 후보 목록
+              items:
+                type: object
+                properties:
+                  placeId:
+                    type: string
+                    description: 외부 지도 API 장소 고유 ID (운영자 공구 개설 시 storeId 대신 활용)
+                  storeName:
+                    type: string
+                    description: 매장명. 예) 모모양과
+                  roadAddress:
+                    type: string
+                    description: 도로명 주소. 예) 서울 성북구 화랑로11길 23
+                  lotAddress:
+                    type: string
+                    description: 지번 주소
+                    nullable: true
+                  latitude:
+                    type: number
+                    format: double
+                    description: 위도
+                  longitude:
+                    type: number
+                    format: double
+                    description: 경도
         error: { nullable: true, example: null }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
기능명세서 및 Figma 와이어프레임 기준으로 담당 범위(김은서) API 명세를 검토하고 openapi.yaml을 수정합니다.
                                                                                                                                                                
  **신규 추가**                                                                                                                                                 
  - `POST /api/v1/search` — AI 키워드 분석 (searchCase 1~4 분기)                                                                                                
  - `GET|DELETE /api/v1/search/recent` — 최근 검색어 목록 / 전체 삭제                                                                                           
  - `DELETE /api/v1/search/recent/{keyword}` — 최근 검색어 단건 삭제                                                                                            
  - `GET /api/v1/stores/search` — 매장 검색 자동완성 (placeId 포함)                                                                                             
  - `GET /api/v1/admin/summary` — 운영자 대시보드 요약 정보                                                                                                     
                                                                                                                                                                
  **스키마 수정**                                                                                                                                               
  - `GroupBuyRequestCreate` — storeAddress / storeLatitude / storeLongitude 추가                                                                                
  - `GroupBuyRequestDetail.status` enum 수정: `REVIEWING` → `IN_REVIEW`, `CONTACTING` → `IN_CONTACT`                                                            
  - `ApiResponseParticipationCreated` — paymentKey 제거 → orderName 추가 (포트원 v2)                                                                            
  - `PaymentConfirm` / `PaymentFail` — paymentKey → paymentId(UUID) 변경                                                                                        
  - `ApiResponseQrCode` / `ApiResponsePickupVerify` — pickupDateTime → pickupDate / pickupTimeStart / pickupTimeEnd 분리                                        
  - `ApiResponsePickupInfo` — transitInfo(nullable) 추가                                                                                                        
  - `ApiResponseRefundList` — pickupDateTime(nullable), cancelReason enum 명시 (NOT_ACHIEVED / EARLY_EXIT / PAYMENT_ERROR / OTHER)                              
  - `AdminGroupBuyCreate` — maxQuantity / notice / pickupAddress 추가, required 보완                                                                            
  - `AdminGroupBuyDetail` — AdminGroupBuyCreate에서 별도 분리, status에 FAILED 추가                                                                             
  - `ApiResponseGroupBuyDetail` — minQuantityPerPerson / maxQuantityPerPerson 추가

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
- 결제 PG는 포트원 v2 + 토스페이먼츠로 확정. paymentId는 클라이언트가 UUID로 생성하여 SDK 호출 시 사용                                                        
- 픽업 시간은 단일 datetime이 아닌 date + 시작/종료 time 범위로 변경                                                                                          
- 검색 칩(성수, 망원 등)은 하드코딩 값이며 직접 입력 시 keyword를 그대로 사용 

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
x

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
closed #36 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인