### PR TITLE
[MCJ-1282] FIX: openapi.yaml 스키마 중복 정의 제거

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1984,6 +1984,7 @@ components:
         currentQuantity: { type: integer }
         remainingQuantity: { type: integer }
         achievementRate: { type: integer }
+        notice: { type: string, nullable: true }
         status:
           type: string
           enum: [IN_PROGRESS, ACHIEVED, FAILED]
@@ -2004,30 +2005,6 @@ components:
           properties:
             groupBuyId: { type: integer, format: int64 }
         error: { nullable: true, example: null }
-
-    AdminGroupBuyDetail:
-      type: object
-      properties:
-        groupBuyId: { type: integer, format: int64 }
-        storeName: { type: string }
-        productName: { type: string }
-        price: { type: integer }
-        targetQuantity: { type: integer }
-        maxQuantity: { type: integer }
-        currentQuantity: { type: integer }
-        achievementRate: { type: integer }
-        description: { type: string, nullable: true }
-        notice: { type: string, nullable: true }
-        deadline: { type: string, format: date-time }
-        pickupDate: { type: string, format: date }
-        pickupTimeStart: { type: string, format: time }
-        pickupTimeEnd: { type: string, format: time }
-        status:
-          type: string
-          enum: [IN_PROGRESS, ACHIEVED, FAILED]
-        isOrderConfirmed: { type: boolean }
-        isOrderSheetSent: { type: boolean }
-        requestId: { type: integer, format: int64, nullable: true }
 
     ApiResponseAdminGroupBuyDetail:
       type: object

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1253,8 +1253,8 @@ components:
         maxQuantity: { type: integer, nullable: true }
         deadline: { type: string, format: date-time }
         pickupDate: { type: string, format: date }
-        pickupStartAt: { type: string, format: date-time }
-        pickupEndAt: { type: string, format: date-time }
+        pickupTimeStart: { type: string, format: time }
+        pickupTimeEnd: { type: string, format: time }
         dDay: { type: integer }
         isWishlisted: { type: boolean }
         isClosed: { type: boolean }
@@ -1300,8 +1300,8 @@ components:
             maxQuantity: { type: integer, nullable: true }
             deadline: { type: string, format: date-time }
             pickupDate: { type: string, format: date }
-            pickupStartAt: { type: string, format: date-time }
-            pickupEndAt: { type: string, format: date-time }
+            pickupTimeStart: { type: string, format: time }
+            pickupTimeEnd: { type: string, format: time }
             pickupLocation: { type: string }
             pickupLatitude: { type: number, format: double, nullable: true }
             pickupLongitude: { type: number, format: double, nullable: true }
@@ -1361,8 +1361,8 @@ components:
             storeName: { type: string }
             deadline: { type: string, format: date-time }
             pickupDate: { type: string, format: date }
-            pickupStartAt: { type: string, format: date-time, nullable: true }
-            pickupEndAt: { type: string, format: date-time, nullable: true }
+            pickupTimeStart: { type: string, format: time, nullable: true }
+            pickupTimeEnd: { type: string, format: time, nullable: true }
         error: { nullable: true, example: null }
 
     # ── GroupBuyRequest ────────────────────────────────────────
@@ -1541,7 +1541,9 @@ components:
               participationId: { type: integer, format: int64 }
               productName: { type: string }
               storeName: { type: string }
-              pickupDateTime: { type: string, format: date-time, nullable: true }
+              pickupDate: { type: string, format: date, nullable: true }
+              pickupTimeStart: { type: string, format: time, nullable: true }
+              pickupTimeEnd: { type: string, format: time, nullable: true }
               paymentAmount: { type: integer }
               quantity: { type: integer }
               refundStatus:
@@ -1713,7 +1715,9 @@ components:
                   participationId: { type: integer, format: int64 }
                   productName: { type: string }
                   storeName: { type: string }
-                  pickupDateTime: { type: string, format: date-time, nullable: true }
+                  pickupDate: { type: string, format: date, nullable: true }
+              pickupTimeStart: { type: string, format: time, nullable: true }
+              pickupTimeEnd: { type: string, format: time, nullable: true }
                   paymentAmount: { type: integer }
                   quantity: { type: integer }
                   achievementRate: { type: integer }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
배포 Swagger UI에서 발생한 파서 오류를 수정합니다.                                                                                                            
                                                    
- 오류: Parser error on line 2008 — duplicated mapping key                                                                                                    
- 원인: stash 병합 과정에서 AdminGroupBuyDetail 스키마가 openapi.yaml에 두 번 정의됨                                                                          
- 수정: upstream 버전 기준으로 통합하고 stash 버전의 notice 필드를 추가 후 중복 블록 제거 

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
closed #39 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인