### PR TITLE
[MCJ-1283] FIX: dev 환경 Swagger UI 경로 절대 경로로 명시

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,3 +25,8 @@ app:
   s3:
     bucket: ${S3_BUCKET}
     prefix: ${S3_PREFIX}
+
+springdoc:
+  swagger-ui:
+    url: /dev/openapi.yaml
+    config-url: /dev/v3/api-docs/swagger-config

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1716,8 +1716,8 @@ components:
                   productName: { type: string }
                   storeName: { type: string }
                   pickupDate: { type: string, format: date, nullable: true }
-              pickupTimeStart: { type: string, format: time, nullable: true }
-              pickupTimeEnd: { type: string, format: time, nullable: true }
+                  pickupTimeStart: { type: string, format: time, nullable: true }
+                  pickupTimeEnd: { type: string, format: time, nullable: true }
                   paymentAmount: { type: integer }
                   quantity: { type: integer }
                   achievementRate: { type: integer }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
 Nginx 리버스 프록시 환경에서 dev Swagger UI가 정상적으로 렌더링되지 않는 문제를 수정합니다.  

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
### 원인                                                                                                                                                          
                  
Nginx가 /dev/ prefix를 제거하고 Spring 앱으로 프록시하는 구조에서, springdoc.swagger-ui.url=/openapi.yaml이 절대 경로로 설정되어 Swagger UI JS가 리소스를 요청할 때 Nginx가 prod 앱으로 잘못 라우팅하는 문제가 발생했습니다.
                                                                                                                                                                
브라우저 → /dev/swagger-ui/index.html → Nginx → app-dev ✅
Swagger UI JS → /openapi.yaml → Nginx → app-prod ❌                                                                                                            
                                                                                                                                                                
### 변경 사항                                                                                                                                                     
                                                                                                                                                                
- application-dev.yml에 dev 환경 기준 springdoc URL 경로 명시

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
closed #41 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인