### PR TITLE
[MCJ-1297] DOCS: OpenAPI required/nullable 명세 보완

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1209,7 +1209,7 @@ components:
         data: { nullable: true, example: null }
         error:
           type: object
-          required: [code, message]
+          required: [code, message, detail]
           properties:
             code: { type: string, example: GROUPBUY_NOT_FOUND }
             message: { type: string, example: 존재하지 않는 공구입니다 }
@@ -1247,7 +1247,7 @@ components:
     # ── GroupBuy ───────────────────────────────────────────────
     GroupBuyFeedItem:
       type: object
-      required: [id, storeName, region, productName, thumbnailUrl, price, achievementRate, currentQuantity, targetQuantity, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, dDay, isWishlisted, isClosed, canParticipate]
+      required: [id, storeName, region, productName, thumbnailUrl, price, achievementRate, currentQuantity, targetQuantity, maxQuantity, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, dDay, isWishlisted, isClosed, canParticipate]
       properties:
         id: { type: integer, format: int64 }
         storeName: { type: string }
@@ -1294,7 +1294,7 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [id, storeName, region, productName, productDescription, notice, imageUrls, price, achievementRate, currentQuantity, targetQuantity, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, pickupLatitude, pickupLongitude, dDay, isWishlisted, isClosed, isParticipated, canParticipate, minQuantityPerPerson, maxQuantityPerPerson]
+          required: [id, storeName, region, productName, productDescription, notice, imageUrls, price, achievementRate, currentQuantity, targetQuantity, maxQuantity, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, pickupLatitude, pickupLongitude, dDay, isWishlisted, isClosed, isParticipated, canParticipate]
           properties:
             id: { type: integer, format: int64 }
             storeName: { type: string }
@@ -1322,8 +1322,6 @@ components:
             isClosed: { type: boolean }
             isParticipated: { type: boolean }
             canParticipate: { type: boolean }
-            minQuantityPerPerson: { type: integer, description: "인당 최소 구매 수량. 예) 1" }
-            maxQuantityPerPerson: { type: integer, nullable: true, description: "인당 최대 구매 수량. null이면 제한 없음. 예) 2" }
         error: { nullable: true, example: null }
 
     ApiResponseGroupBuyProgress:
@@ -1546,7 +1544,7 @@ components:
 
     PaymentFail:
       type: object
-      required: [paymentId, participationId, errorCode]
+      required: [paymentId, participationId, errorCode, message]
       description: 포트원 v2 결제 실패/취소 콜백 처리
       properties:
         paymentId:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1195,6 +1195,7 @@ components:
     # ── 공통 응답 래퍼 ──────────────────────────────────────────
     ApiResponseEmpty:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data: { nullable: true, example: null }
@@ -1202,11 +1203,13 @@ components:
 
     ApiResponseError:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: false }
         data: { nullable: true, example: null }
         error:
           type: object
+          required: [code, message]
           properties:
             code: { type: string, example: GROUPBUY_NOT_FOUND }
             message: { type: string, example: 존재하지 않는 공구입니다 }
@@ -1215,10 +1218,12 @@ components:
     # ── Auth ───────────────────────────────────────────────────
     ApiResponseAuthToken:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [accessToken, refreshToken, isNewUser]
           properties:
             accessToken: { type: string }
             refreshToken: { type: string }
@@ -1227,10 +1232,12 @@ components:
 
     ApiResponseUserInfo:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [id, nickname, profileImageUrl]
           properties:
             id: { type: integer, format: int64 }
             nickname: { type: string }
@@ -1240,6 +1247,7 @@ components:
     # ── GroupBuy ───────────────────────────────────────────────
     GroupBuyFeedItem:
       type: object
+      required: [id, storeName, region, productName, thumbnailUrl, price, achievementRate, currentQuantity, targetQuantity, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, dDay, isWishlisted, isClosed, canParticipate]
       properties:
         id: { type: integer, format: int64 }
         storeName: { type: string }
@@ -1262,10 +1270,12 @@ components:
 
     ApiResponseGroupBuyFeedPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [content, totalElements, totalPages, number, size]
           properties:
             content:
               type: array
@@ -1279,10 +1289,12 @@ components:
 
     ApiResponseGroupBuyDetail:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [id, storeName, region, productName, productDescription, notice, imageUrls, price, achievementRate, currentQuantity, targetQuantity, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, pickupLatitude, pickupLongitude, dDay, isWishlisted, isClosed, isParticipated, canParticipate, minQuantityPerPerson, maxQuantityPerPerson]
           properties:
             id: { type: integer, format: int64 }
             storeName: { type: string }
@@ -1316,10 +1328,12 @@ components:
 
     ApiResponseGroupBuyProgress:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [groupBuyId, achievementRate, currentQuantity, targetQuantity, isClosed]
           properties:
             groupBuyId: { type: integer, format: int64 }
             achievementRate: { type: integer }
@@ -1330,6 +1344,7 @@ components:
 
     GroupBuyProgressItem:
       type: object
+      required: [groupBuyId, achievementRate, currentQuantity, targetQuantity, isClosed]
       properties:
         groupBuyId: { type: integer, format: int64 }
         achievementRate: { type: integer }
@@ -1339,6 +1354,7 @@ components:
 
     ApiResponseGroupBuyProgressList:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
@@ -1349,10 +1365,12 @@ components:
 
     ApiResponseShareMeta:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [shareUrl, title, description, imageUrl, storeName, deadline, pickupDate, pickupTimeStart, pickupTimeEnd]
           properties:
             shareUrl: { type: string }
             title: { type: string }
@@ -1403,16 +1421,19 @@ components:
 
     ApiResponseRequestId:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [requestId]
           properties:
             requestId: { type: integer, format: int64 }
         error: { nullable: true, example: null }
 
     GroupBuyRequestDetail:
       type: object
+      required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, rejectionReason, createdAt]
       properties:
         requestId: { type: integer, format: int64 }
         storeName: { type: string }
@@ -1431,6 +1452,7 @@ components:
 
     ApiResponseGroupBuyRequestList:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
@@ -1441,6 +1463,7 @@ components:
 
     ApiResponseGroupBuyRequestDetail:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
@@ -1450,10 +1473,12 @@ components:
     # ── Wishlist ───────────────────────────────────────────────
     ApiResponseWishlistPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [content, totalElements, totalPages, number, size, urgentCount]
           properties:
             content:
               type: array
@@ -1490,10 +1515,12 @@ components:
 
     ApiResponseParticipationCreated:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [participationId, orderName, totalAmount, productAmount, feeAmount]
           properties:
             participationId: { type: integer, format: int64 }
             orderName: { type: string, description: "포트원 SDK에 전달할 주문명. 예) 두쫀쿠 오리지널 1개" }
@@ -1519,6 +1546,7 @@ components:
 
     PaymentFail:
       type: object
+      required: [paymentId, participationId, errorCode]
       description: 포트원 v2 결제 실패/취소 콜백 처리
       properties:
         paymentId:
@@ -1531,12 +1559,14 @@ components:
 
     ApiResponseRefundList:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: array
           items:
             type: object
+            required: [participationId, productName, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, paymentAmount, quantity, refundStatus, cancelReason]
             properties:
               participationId: { type: integer, format: int64 }
               productName: { type: string }
@@ -1559,17 +1589,19 @@ components:
     # ── Pickup & QR ────────────────────────────────────────────
     ApiResponsePickupInfo:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [participationId, storeName, storePhone, storeAddress, latitude, longitude, transitInfo, pickupDate, pickupTimeStart, pickupTimeEnd, productName, quantity, remainingMinutes]
           properties:
             participationId: { type: integer, format: int64 }
             storeName: { type: string }
             storePhone: { type: string }
             storeAddress: { type: string }
-            latitude: { type: number, format: double }
-            longitude: { type: number, format: double }
+            latitude: { type: number, format: double, nullable: true }
+            longitude: { type: number, format: double, nullable: true }
             transitInfo: { type: string, nullable: true, description: "대중교통 안내 텍스트. 예) 2호선 성수역 3번 출구에서 도보 5분" }
             pickupDate: { type: string, format: date }
             pickupTimeStart: { type: string, format: time }
@@ -1581,10 +1613,12 @@ components:
 
     ApiResponseQrCode:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [qrCode, nickname, productName, quantity, isUsed, storeName, pickupDate, pickupTimeStart, pickupTimeEnd]
           properties:
             qrCode: { type: string, format: uuid }
             nickname: { type: string }
@@ -1599,10 +1633,12 @@ components:
 
     ApiResponsePickupVerify:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [participationId, userName, productName, quantity, pickupDate, pickupTimeStart, pickupTimeEnd, pickupStatus]
           properties:
             participationId: { type: integer, format: int64 }
             userName: { type: string }
@@ -1619,6 +1655,7 @@ components:
     # ── Notification ───────────────────────────────────────────
     NotificationItem:
       type: object
+      required: [id, category, type, title, body, targetType, targetId, isRead, readAt, createdAt]
       properties:
         id:
           type: integer
@@ -1667,6 +1704,7 @@ components:
 
     NotificationPage:
       type: object
+      required: [content, totalElements, totalPages, number, size]
       properties:
         content:
           type: array
@@ -1683,6 +1721,7 @@ components:
 
     ApiResponseNotificationPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
@@ -1691,10 +1730,12 @@ components:
 
     ApiResponseUnreadCount:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [count]
           properties:
             count: { type: integer }
         error: { nullable: true, example: null }
@@ -1702,15 +1743,18 @@ components:
     # ── MyPage ─────────────────────────────────────────────────
     ApiResponseParticipationPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [content, totalElements, totalPages]
           properties:
             content:
               type: array
               items:
                 type: object
+                required: [participationId, productName, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, paymentAmount, quantity, achievementRate, achievementStatus, dDay, groupBuyId, canCancel, canViewPickup, canViewQr]
                 properties:
                   participationId: { type: integer, format: int64 }
                   productName: { type: string }
@@ -1735,10 +1779,12 @@ components:
 
     ApiResponseTabCounts:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [activeCount, completedCount, refundedCount, requestCount]
           properties:
             activeCount: { type: integer, description: 참여중 }
             completedCount: { type: integer, description: 완료 }
@@ -1749,10 +1795,12 @@ components:
     # ── Owner ──────────────────────────────────────────────────
     ApiResponseOwnerSummary:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [pickupWaitingCount, pickupCompletedCount, activeGroupBuyCount, nextPickupTime]
           properties:
             pickupWaitingCount: { type: integer }
             pickupCompletedCount: { type: integer }
@@ -1762,12 +1810,14 @@ components:
 
     ApiResponsePickupScheduleList:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: array
           items:
             type: object
+            required: [timeSlot, totalReservationCount, waitingCount, completedCount]
             properties:
               timeSlot: { type: string, example: "13:00~14:00" }
               totalReservationCount: { type: integer }
@@ -1777,12 +1827,14 @@ components:
 
     ApiResponseOwnerGroupBuyList:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: array
           items:
             type: object
+            required: [groupBuyId, productName, achievementRate, currentQuantity, targetQuantity, deadline, status]
             properties:
               groupBuyId: { type: integer, format: int64 }
               productName: { type: string }
@@ -1797,15 +1849,18 @@ components:
     
     ApiResponseReservationPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [content, waitingCount, completedCount, totalElements, totalPages]
           properties:
             content:
               type: array
               items:
                 type: object
+                required: [participationId, userName, productName, quantity, pickupDate, pickupTimeStart, pickupTimeEnd, status]
                 properties:
                   participationId: { type: integer, format: int64 }
                   userName: { type: string }
@@ -1826,10 +1881,12 @@ components:
     # ── Admin ──────────────────────────────────────────────────
     ApiResponseAdminDashboardSummary:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [pendingRequestCount, activeGroupBuyCount, achievementRate, pendingRefundCount]
           properties:
             pendingRequestCount:
               type: integer
@@ -1848,15 +1905,18 @@ components:
 
     ApiResponseAdminRequestPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [content, totalElements, totalPages]
           properties:
             content:
               type: array
               items:
                 type: object
+                required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, requesterName, createdAt]
                 properties:
                   requestId: { type: integer, format: int64 }
                   storeName: { type: string }
@@ -1874,10 +1934,12 @@ components:
 
     ApiResponseAdminRequestDetail:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, additionalNote, status, contactPhone, contactInstagram, rejectionReason, requesterName, createdAt]
           properties:
             requestId: { type: integer, format: int64 }
             storeName: { type: string }
@@ -1918,12 +1980,14 @@ components:
 
     ApiResponseAdminGroupBuyList:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: array
           items:
             type: object
+            required: [groupBuyId, storeName, productName, status, deadline, achievementRate, currentQuantity, targetQuantity, remainingQuantity, isOrderConfirmed, isOrderSheetSent]
             properties:
               groupBuyId: { type: integer, format: int64 }
               storeName: { type: string }
@@ -1975,6 +2039,7 @@ components:
         
     AdminGroupBuyDetail:
       type: object
+      required: [groupBuyId, requestId, storeId, storeName, productName, productDescription, price, targetQuantity, maxQuantity, currentQuantity, remainingQuantity, achievementRate, notice, status, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, isOrderConfirmed, isOrderSheetSent]
       properties:
         groupBuyId: { type: integer, format: int64 }
         requestId: { type: integer, format: int64, nullable: true }
@@ -2002,16 +2067,19 @@ components:
 
     ApiResponseGroupBuyId:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [groupBuyId]
           properties:
             groupBuyId: { type: integer, format: int64 }
         error: { nullable: true, example: null }
 
     ApiResponseAdminGroupBuyDetail:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
@@ -2020,15 +2088,18 @@ components:
 
     ApiResponseAdminRefundPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [content, totalElements, totalPages]
           properties:
             content:
               type: array
               items:
                 type: object
+                required: [participationId, userName, productName, storeName, paymentAmount, refundStatus, refundReason, createdAt]
                 properties:
                   participationId: { type: integer, format: int64 }
                   userName: { type: string }
@@ -2058,15 +2129,18 @@ components:
 
     ApiResponseSettlementPage:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [content, totalElements, totalPages]
           properties:
             content:
               type: array
               items:
                 type: object
+                required: [settlementId, storeName, productName, totalAmount, escrowStatus, scheduledPaymentDate, settlementMethod, memo, createdAt]
                 properties:
                   settlementId: { type: integer, format: int64 }
                   storeName: { type: string }
@@ -2099,10 +2173,12 @@ components:
 
     ApiResponseSettlementId:
       type: object
+      required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
+          required: [settlementId]
           properties:
             settlementId: { type: integer, format: int64 }
         error: { nullable: true, example: null }


### PR DESCRIPTION
## 📌 작업한 내용
- `src/main/resources/static/openapi.yaml`의 request/response 스키마에 `required`를 보완해 필수 필드가 타입 생성 시 optional로 누락되지 않도록 정리했습니다.
- 실제로 `null` 가능성이 있는 필드만 `nullable: true`로 유지하고, 응답 계약을 기준으로 필수/선택 값을 재정렬했습니다.
- 소비자/알림/마이페이지/사장님/운영자 영역의 주요 응답 스키마를 기능명세와 ERD 기준에 맞춰 일관성 있게 정리했습니다.

## 🔍 참고 사항
- 대상 파일: `src/main/resources/static/openapi.yaml`
- 프론트에서 OpenAPI 기반 타입 생성 및 정합성 체크를 사용하는 전제를 반영한 문서 보완입니다.
- `required + nullable: true` 조합은 “키는 항상 존재하지만 값은 null 가능”한 필드(예: `readAt`, `targetId`, `pickupLatitude`, `pickupLongitude`, `nextPickupTime`)에 의도적으로 유지했습니다.
- 구현 코드 변경 없이 Swagger/OpenAPI 문서 스키마 정합성만 수정했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #43 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인