### PR TITLE
[MCJ-1298] DOCS: NotificationItem 스키마에 actionType, dateGroup 필드 추가

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1696,6 +1696,14 @@ components:
           type: string
           format: date-time
           nullable: true
+        actionType:
+          type: string
+          nullable: true
+          description: "인라인 액션 버튼 유형. null이면 버튼 없음 (예: QR_CODE, PICKUP_GUIDE, GROUP_BUY_DETAIL)"
+        dateGroup:
+          type: string
+          enum: [TODAY, YESTERDAY, BEFORE]
+          description: "알림 날짜 그룹 (오늘/어제/이전)"
         createdAt:
           type: string
           format: date-time

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1653,7 +1653,7 @@ components:
     # ── Notification ───────────────────────────────────────────
     NotificationItem:
       type: object
-      required: [id, category, type, title, body, targetType, targetId, isRead, readAt, createdAt]
+      required: [id, category, type, title, body, targetType, targetId, isRead, readAt, actionType, dateGroup, createdAt]
       properties:
         id:
           type: integer
@@ -1699,7 +1699,8 @@ components:
         actionType:
           type: string
           nullable: true
-          description: "인라인 액션 버튼 유형. null이면 버튼 없음 (예: QR_CODE, PICKUP_GUIDE, GROUP_BUY_DETAIL)"
+          enum: [QR_CODE, PICKUP_GUIDE, GROUP_BUY_DETAIL, MY_PAGE_ACTIVE, MY_PAGE_REFUND, REQUEST_STATUS]
+          description: "인라인 액션 버튼 유형. null이면 버튼 미노출"
         dateGroup:
           type: string
           enum: [TODAY, YESTERDAY, BEFORE]


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
  - `NotificationItem` 스키마에 `actionType` 필드 추가 (nullable string)                                                                                        
  - `NotificationItem` 스키마에 `dateGroup` 필드 추가 (enum: TODAY / YESTERDAY / BEFORE)                                                                        
  - Figma 알림 화면 분석 결과 반영

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->
## 상세
  | 필드 | 타입 | 설명 |                                                                                                                                        
  |------|------|------|                                                                                                                                        
  | `actionType` | string (nullable) | 알림 카드 인라인 버튼 유형. null이면 버튼 미노출 |
  | `dateGroup` | enum | 오늘(TODAY) / 어제(YESTERDAY) / 이전(BEFORE) 그룹 구분값. 서버에서 createdAt 기준으로 계산하여 반환 | 

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->
closed #45 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인