### PR TITLE
[MCJ-1346] CHORE: dev/prod 배포 프로필 및 env 검증 설정 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -91,6 +91,9 @@ jobs:
 
             export ECR_REPOSITORY_URL="${{ vars.ECR_REPOSITORY_URL }}"
             ECR_REGISTRY="${ECR_REPOSITORY_URL%%/*}"
+            test -f ../.env.dev
+            grep -q '^DB_URL=' ../.env.dev
+            grep -q '^SPRING_PROFILES_ACTIVE=' ../.env.dev
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
             docker compose --profile dev pull app-dev
             docker compose --profile dev up -d nginx app-dev

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -115,6 +115,9 @@ jobs:
 
             export ECR_REPOSITORY_URL="${{ vars.ECR_REPOSITORY_URL }}"
             ECR_REGISTRY="${ECR_REPOSITORY_URL%%/*}"
+            test -f ../.env.prod
+            grep -q '^DB_URL=' ../.env.prod
+            grep -q '^SPRING_PROFILES_ACTIVE=' ../.env.prod
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
             docker compose --profile prod pull app-prod
             docker compose --profile prod up -d nginx app-prod

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     container_name: moongchijang-dev
     env_file:
       - ../.env.dev
-    environment:
-      SPRING_PROFILES_ACTIVE: dev
     restart: unless-stopped
 
   app-prod:
@@ -17,8 +15,6 @@ services:
     container_name: moongchijang-prod
     env_file:
       - ../.env.prod
-    environment:
-      SPRING_PROFILES_ACTIVE: prod
     restart: unless-stopped
 
   nginx:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: moongchijang-dev
     env_file:
       - ../.env.dev
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
     restart: unless-stopped
 
   app-prod:
@@ -15,6 +17,8 @@ services:
     container_name: moongchijang-prod
     env_file:
       - ../.env.prod
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
     restart: unless-stopped
 
   nginx:


### PR DESCRIPTION
## 📌 작업한 내용
- docker-compose의 app-dev, app-prod 서비스에 SPRING_PROFILES_ACTIVE를 각각 dev, prod로 명시했습니다.
- GitHub Actions 배포 워크플로우(dev/prod)에 .env 파일 존재 여부 검증을 추가했습니다.
- 배포 전에 DB_URL, SPRING_PROFILES_ACTIVE 필수 키 존재 여부를 검증하도록 추가했습니다.
- 배포 환경에서 프로필/환경변수 누락으로 Flyway가 의도한 DB에 적용되지 않는 리스크를 줄이도록 정리했습니다.

## 🔍 참고 사항
- 이번 변경은 애플리케이션 비즈니스 로직 수정 없이 배포 설정만 다룹니다.
- EC2 경로 기준으로 ../.env.dev, ../.env.prod를 참조하므로 서버 파일 위치가 현재 배포 구조와 일치해야 합니다.
- 적용 후 dev/prod 배포 로그에서 Flyway 적용 로그와 대상 DB(moongchijang_dev/moongchijang_prod)를 확인해야 합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #50 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인