### PR TITLE
[MCJ-1348] FIX: Flyway starter 적용으로 dev/prod 마이그레이션 자동실행 보장

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
     // Flyway
-    implementation("org.flywaydb:flyway-core")
+    implementation("org.springframework.boot:spring-boot-starter-flyway")
     implementation("org.flywaydb:flyway-mysql")
 }
 

--- a/src/test/kotlin/com/moongchijang/MoongchijangApplicationTests.kt
+++ b/src/test/kotlin/com/moongchijang/MoongchijangApplicationTests.kt
@@ -1,8 +1,10 @@
 package com.moongchijang
 
 import org.junit.jupiter.api.Test
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.boot.test.context.SpringBootTest
 
+@ActiveProfiles("test")
 @SpringBootTest
 class MoongchijangApplicationTests {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+spring:
+  flyway:
+    enabled: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,20 @@
 spring:
   flyway:
     enabled: false
+
+oauth:
+  kakao:
+    client-id: test-client-id
+    client-secret: test-client-secret
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+    redirect-uri: http://localhost:3000/oauth
+
+jwt:
+  secret: test-jwt-secret-test-jwt-secret-test-jwt-secret
+  access-token:
+    expiration-minutes: 60
+
+auth:
+  refresh:
+    expiration-days: 14


### PR DESCRIPTION
## 📌 작업한 내용
- Flyway 자동설정이 안정적으로 동작하도록 의존성을 `flyway-core`에서 `spring-boot-starter-flyway`로 전환했습니다.
- MySQL 마이그레이션을 위해 `flyway-mysql` 의존성은 유지했습니다.
- `application-dev.yml`, `application-prod.yml`의 Flyway 마이그레이션 경로를 `classpath:db/migration`으로 명시해 설정을 고정했습니다.

## 🔍 참고 사항
- JPA 설정이 `ddl-auto=validate`이므로, Flyway가 선행 실행되지 않으면 `users` 테이블 검증 단계에서 애플리케이션이 기동 실패합니다.
- 배포 후 컨테이너 로그에서 Flyway 실행 로그(`Successfully applied ...` 또는 `Schema is up to date`)를 반드시 확인해야 합니다.
- 최종 검증 쿼리:
  - `SHOW TABLES;`
  - `SELECT * FROM flyway_schema_history;`
 
## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #54 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인