### PR TITLE
[MCJ-1401] CHORE: local DB를 H2에서 MySQL로 전환

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,11 @@
+DB_URL=jdbc:mysql://localhost:3306/moongchijang_local?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+DB_USERNAME=moongchijang
+DB_PASSWORD=moongchijang
+
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+MYSQL_DATABASE=moongchijang_local
+MYSQL_ROOT_PASSWORD=root
+MYSQL_USER=moongchijang
+MYSQL_PASSWORD=moongchijang

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ out/
 .env.*
 !.env.dev.example
 !.env.prod.example
+!.env.local.example
 docker/.env
 !docker/.env.example
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     image: mysql:8.4
     container_name: moongchijang-mysql-local
     environment:
-      MYSQL_DATABASE: moongchijang_local
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-moongchijang_local}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+      MYSQL_USER: ${MYSQL_USER:-moongchijang}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-moongchijang}
       TZ: Asia/Seoul
     ports:
       - "3306:3306"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,33 @@
 services:
+  mysql-local:
+    # local 프로필에서 사용하는 MySQL
+    profiles: ["local"]
+    image: mysql:8.4
+    container_name: moongchijang-mysql-local
+    environment:
+      MYSQL_DATABASE: moongchijang_local
+      MYSQL_ROOT_PASSWORD: root
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql-local-data:/var/lib/mysql
+    restart: unless-stopped
+
+  redis-local:
+    # local 프로필에서 사용하는 Redis
+    profiles: ["local"]
+    image: redis:7-alpine
+    container_name: moongchijang-redis-local
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-local-data:/data
+    restart: unless-stopped
+
   app-dev:
     # develop 태그 이미지를 사용하는 dev 애플리케이션
     profiles: ["dev"]
@@ -26,3 +55,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     restart: unless-stopped
+
+volumes:
+  mysql-local-data:
+  redis-local-data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     url: ${DB_URL:jdbc:mysql://localhost:3306/moongchijang_local?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
-    username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:root}
+    username: ${DB_USERNAME:moongchijang}
+    password: ${DB_PASSWORD:moongchijang}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
@@ -12,8 +12,8 @@ spring:
 
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
   flyway:
     enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,15 +1,14 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: ${DB_URL:jdbc:mysql://localhost:3306/moongchijang_local?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:root}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     hibernate:
-      ddl-auto: create-drop
-  h2:
-    console:
-      enabled: true
+      ddl-auto: validate
+    open-in-view: false
 
   data:
     redis:
@@ -17,7 +16,9 @@ spring:
       port: 6379
 
   flyway:
-    enabled: false
+    enabled: true
+    locations:
+      - classpath:db/migration
 
 app:
   s3:


### PR DESCRIPTION
## 📌 작업한 내용
- `application-local.yml`의 datasource를 H2에서 MySQL로 전환했습니다.
- local 프로필에서 Flyway 마이그레이션이 동작하도록 설정(`flyway.enabled: true`)했습니다.
- 로컬 개발용 `mysql/redis` 컨테이너를 `docker/docker-compose.yml`에 `local` profile로 추가했습니다.
- DataGrip 기준 local/dev/prod DB 연결 절차를 노션에 문서화했습니다.

## 🔍 참고 사항
- 로컬 실행 시 먼저 아래 명령으로 인프라를 올린 뒤 앱을 실행합니다.
  `docker compose -f docker/docker-compose.yml --profile local up -d mysql-local redis-local`
- 앱은 `local` 프로필로 실행하며, 최초 실행 시 Flyway 마이그레이션이 반영됩니다.
- dev/prod RDS는 DataGrip에서 `SSH 터널(EC2 경유)` 방식으로 연결합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #62 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인