### PR TITLE
[MCJ-1420] FEAT: 공구 개설 요청 기능 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,12 +18,16 @@ class GroupBuyOpenRequestService(
         if (openRequestRepository.existsByUserIdAndRegionAndProductName(userId, request.region, request.productName)) {
             throw CustomException(ErrorCode.DUPLICATE_OPEN_REQUEST)
         }
-        openRequestRepository.save(
-            GroupBuyOpenRequest(
-                userId = userId,
-                region = request.region,
-                productName = request.productName
+        try {
+            openRequestRepository.saveAndFlush(
+                GroupBuyOpenRequest(
+                    userId = userId,
+                    region = request.region,
+                    productName = request.productName
+                )
             )
-        )
+        } catch (e: DataIntegrityViolationException) {
+            throw CustomException(ErrorCode.DUPLICATE_OPEN_REQUEST)
+        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -1,0 +1,28 @@
+package com.moongchijang.domain.groupbuy.application
+
+import com.moongchijang.domain.groupbuy.application.dto.CreateGroupBuyOpenRequestRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class GroupBuyOpenRequestService(
+    private val openRequestRepository: GroupBuyOpenRequestRepository
+) {
+    fun create(userId: Long, request: CreateGroupBuyOpenRequestRequest) {
+        if (openRequestRepository.existsByUserIdAndRegionAndProductName(userId, request.region, request.productName)) {
+            throw CustomException(ErrorCode.DUPLICATE_OPEN_REQUEST)
+        }
+        openRequestRepository.save(
+            GroupBuyOpenRequest(
+                userId = userId,
+                region = request.region,
+                productName = request.productName
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/CreateGroupBuyOpenRequestRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/CreateGroupBuyOpenRequestRequest.kt
@@ -1,8 +1,14 @@
 package com.moongchijang.domain.groupbuy.application.dto
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 
 data class CreateGroupBuyOpenRequestRequest(
-    @field:NotBlank val region: String,
-    @field:NotBlank val productName: String
+    @field:NotBlank(message = "지역은 필수입니다")
+    @field:Size(max = 50, message = "지역은 50자 이하이어야 합니다")
+    val region: String,
+
+    @field:NotBlank(message = "상품명은 필수입니다")
+    @field:Size(max = 100, message = "상품명은 100자 이하이어야 합니다")
+    val productName: String
 )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/CreateGroupBuyOpenRequestRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/CreateGroupBuyOpenRequestRequest.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class CreateGroupBuyOpenRequestRequest(
+    @field:NotBlank val region: String,
+    @field:NotBlank val productName: String
+)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOpenRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOpenRequest.kt
@@ -1,0 +1,28 @@
+package com.moongchijang.domain.groupbuy.domain.entity
+
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "group_buy_open_requests",
+    indexes = [Index(name = "idx_open_req_user_region_product", columnList = "user_id,region,product_name")]
+)
+class GroupBuyOpenRequest(
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    @Column(nullable = false, length = 50)
+    val region: String,
+
+    @Column(name = "product_name", nullable = false, length = 100)
+    val productName: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_status", nullable = false, length = 20)
+    var notificationStatus: NotificationStatus = NotificationStatus.PENDING,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity()

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOpenRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOpenRequest.kt
@@ -6,7 +6,12 @@ import jakarta.persistence.*
 @Entity
 @Table(
     name = "group_buy_open_requests",
-    indexes = [Index(name = "idx_open_req_user_region_product", columnList = "user_id,region,product_name")]
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_open_req_user_region_product",
+            columnNames = ["user_id", "region", "product_name"]
+        )
+    ]
 )
 class GroupBuyOpenRequest(
     @Column(name = "user_id", nullable = false)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/NotificationStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/NotificationStatus.kt
@@ -1,0 +1,5 @@
+package com.moongchijang.domain.groupbuy.domain.entity
+
+enum class NotificationStatus {
+    PENDING, SENT, FAILED
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyOpenRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyOpenRequestRepository.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.groupbuy.domain.repository
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GroupBuyOpenRequestRepository : JpaRepository<GroupBuyOpenRequest, Long> {
+    fun existsByUserIdAndRegionAndProductName(userId: Long, region: String, productName: String): Boolean
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
@@ -1,0 +1,33 @@
+package com.moongchijang.domain.groupbuy.presentation
+
+import com.moongchijang.domain.groupbuy.application.GroupBuyOpenRequestService
+import com.moongchijang.domain.groupbuy.application.dto.CreateGroupBuyOpenRequestRequest
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/group-buy-open-requests")
+@Tag(name = "GroupBuyOpenRequest", description = "공구 개설 알림 신청")
+class GroupBuyOpenRequestController(
+    private val openRequestService: GroupBuyOpenRequestService
+) {
+    @PostMapping
+    @Operation(summary = "공구 개설 알림 신청")
+    fun create(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @Valid @RequestBody request: CreateGroupBuyOpenRequestRequest
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        openRequestService.create(principal.id, request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -32,6 +32,9 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_REQUEST_FORBIDDEN(403_010, "본인의 공구 요청만 조회할 수 있습니다.", 403),
     GROUPBUY_REQUEST_INVALID_DATE(400_010, "희망 픽업 날짜는 오늘 이후여야 합니다.", 400),
 
+    // GroupBuyOpenRequest
+    DUPLICATE_OPEN_REQUEST(409_010, "이미 알림 신청한 공구입니다.", 409),
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(500_000, "서버 내부 오류입니다.", 500),
     

--- a/src/main/resources/db/migration/V6__create_group_buy_open_requests_table.sql
+++ b/src/main/resources/db/migration/V6__create_group_buy_open_requests_table.sql
@@ -7,5 +7,5 @@ CREATE TABLE group_buy_open_requests
     notification_status VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
     created_at          DATETIME     NOT NULL,
     updated_at          DATETIME     NOT NULL,
-    INDEX idx_open_req_user_region_product (user_id, region, product_name)
+    CONSTRAINT uk_open_req_user_region_product UNIQUE (user_id, region, product_name)
 );

--- a/src/main/resources/db/migration/V6__create_group_buy_open_requests_table.sql
+++ b/src/main/resources/db/migration/V6__create_group_buy_open_requests_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE group_buy_open_requests
+(
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id             BIGINT       NOT NULL,
+    region              VARCHAR(50)  NOT NULL,
+    product_name        VARCHAR(100) NOT NULL,
+    notification_status VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at          DATETIME     NOT NULL,
+    updated_at          DATETIME     NOT NULL,
+    INDEX idx_open_req_user_region_product (user_id, region, product_name)
+);

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -1,0 +1,55 @@
+package com.moongchijang.domain.groupbuy.service
+
+import com.moongchijang.domain.groupbuy.application.GroupBuyOpenRequestService
+import com.moongchijang.domain.groupbuy.application.dto.CreateGroupBuyOpenRequestRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class GroupBuyOpenRequestServiceTest {
+
+    @Mock
+    private lateinit var openRequestRepository: GroupBuyOpenRequestRepository
+
+    @InjectMocks
+    private lateinit var service: GroupBuyOpenRequestService
+
+    @Test
+    fun `정상 알림 신청 시 저장 성공`() {
+        val userId = 1L
+        val request = CreateGroupBuyOpenRequestRequest(region = "성수", productName = "소금빵")
+
+        `when`(openRequestRepository.existsByUserIdAndRegionAndProductName(userId, "성수", "소금빵"))
+            .thenReturn(false)
+        `when`(openRequestRepository.save(any())).thenReturn(
+            GroupBuyOpenRequest(userId = userId, region = "성수", productName = "소금빵").apply { id = 1L }
+        )
+
+        service.create(userId, request)
+
+        verify(openRequestRepository).save(any())
+    }
+
+    @Test
+    fun `중복 알림 신청 시 DUPLICATE_OPEN_REQUEST 예외`() {
+        val userId = 1L
+        val request = CreateGroupBuyOpenRequestRequest(region = "성수", productName = "소금빵")
+
+        `when`(openRequestRepository.existsByUserIdAndRegionAndProductName(userId, "성수", "소금빵"))
+            .thenReturn(true)
+
+        val ex = assertThrows<CustomException> { service.create(userId, request) }
+        assertEquals(ErrorCode.DUPLICATE_OPEN_REQUEST, ex.errorCode)
+        verify(openRequestRepository, never()).save(any())
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.dao.DataIntegrityViolationException
 
 @ExtendWith(MockitoExtension::class)
 class GroupBuyOpenRequestServiceTest {
@@ -31,13 +32,13 @@ class GroupBuyOpenRequestServiceTest {
 
         `when`(openRequestRepository.existsByUserIdAndRegionAndProductName(userId, "성수", "소금빵"))
             .thenReturn(false)
-        `when`(openRequestRepository.save(any())).thenReturn(
+        `when`(openRequestRepository.saveAndFlush(any())).thenReturn(
             GroupBuyOpenRequest(userId = userId, region = "성수", productName = "소금빵").apply { id = 1L }
         )
 
         service.create(userId, request)
 
-        verify(openRequestRepository).save(any())
+        verify(openRequestRepository).saveAndFlush(any())
     }
 
     @Test
@@ -50,6 +51,20 @@ class GroupBuyOpenRequestServiceTest {
 
         val ex = assertThrows<CustomException> { service.create(userId, request) }
         assertEquals(ErrorCode.DUPLICATE_OPEN_REQUEST, ex.errorCode)
-        verify(openRequestRepository, never()).save(any())
+        verify(openRequestRepository, never()).saveAndFlush(any())
+    }
+
+    @Test
+    fun `동시 신청으로 UNIQUE 제약 위반 시 DUPLICATE_OPEN_REQUEST 예외`() {
+        val userId = 1L
+        val request = CreateGroupBuyOpenRequestRequest(region = "성수", productName = "소금빵")
+
+        `when`(openRequestRepository.existsByUserIdAndRegionAndProductName(userId, "성수", "소금빵"))
+            .thenReturn(false)
+        `when`(openRequestRepository.saveAndFlush(any<GroupBuyOpenRequest>()))
+            .thenThrow(DataIntegrityViolationException("uk_open_req_user_region_product"))
+
+        val ex = assertThrows<CustomException> { service.create(userId, request) }
+        assertEquals(ErrorCode.DUPLICATE_OPEN_REQUEST, ex.errorCode)
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용

사용자가 원하는 지역/상품 조합으로 "공구가 열리면 알려달라"를 신청해두는 **공구 개설 요청** 기능을 추가합니다. 알림 발송 통합 및 검색 인덱싱은 본 PR 범위에서 제외하고 후속 PR에서 다룰 예정입니다.

### 포함 사항
- `GroupBuyOpenRequest` 엔티티 + `NotificationStatus` enum (PENDING/SENT/FAILED)
- `GroupBuyOpenRequestRepository` (사용자/지역/상품 중복 체크용 `existsBy` 한 개)
- `CreateGroupBuyOpenRequestRequest` DTO (`@NotBlank` validation)
- `GroupBuyOpenRequestService.create()` — 중복 신청 차단 + 저장
- `POST /api/v1/group-buy-open-requests` (`GroupBuyOpenRequestController`)
- `ErrorCode.DUPLICATE_OPEN_REQUEST` (409_010)
- Flyway `V6__create_group_buy_open_requests_table.sql` (현행 develop이 V1~V5 사용 중)
- 서비스 단위 테스트 2건 (정상 저장 / 중복 예외)

## 🔍 참고 사항

### 기존 계획에서 범위가 좁아진 이유

MCJ-1355(도메인형 아키텍처 재편) 머지 이후 develop의 `GroupBuy` catalog 모델이 기존 검색 MVP 작업 기준과 크게 달라졌습니다. 본 PR은 충돌 없는 **공구 개설 요청 신청 기능**만 먼저 머지하고, 아래 항목은 별도 PR로 미룹니다.

| 항목 | 사유 |
|------|------|
| `GroupBuy` catalog 엔티티/Service/Repository 재정의 | develop의 풍부한 catalog 모델과 충돌 — 검색 MVP 리베이스 시점에 재설계 |
| `GroupBuyOpenNotificationService` 통합 | develop에서 "공구가 새로 열리는" 진입점을 다시 찾아 붙여야 함 |
| 검색 인덱싱 이벤트 (`GroupBuyIndexingEventPublisher`) | 카탈로그 재설계와 묶어서 진행 |
| `이미 열린 공구` 검증 (`GROUP_BUY_ALREADY_OPEN`) | 현행 GroupBuy(Store FK 기반)에서 region 매칭 로직 신규 설계 필요 |

### 후속 작업

- 검색 MVP는 현행 `GroupBuy`/`Store`/`GroupBuyRequest` 도메인 기준으로 재설계 후 별도 PR
- 알림 발송 통합은 공구 오픈 이벤트 진입점 확정 후 별도 PR

## 🔗 관련 이슈

closes #67

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료 (`./gradlew test`)
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인 (검색 MVP 재설계 이슈에서 다룸)