### PR TITLE
[MCJ-1410] FEAT: 이메일 로그인/회원가입 및 인증 플로우 구현

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -21,3 +21,7 @@ COOLSMS_SENDER=010-0000-0000
 JWT_SECRET=jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret
 
 AUTH_REFRESH_EXPIRATION_DAYS=14
+
+SES_ENABLED=
+SES_REGION=
+SES_FROM_EMAIL=

--- a/.env.local.example
+++ b/.env.local.example
@@ -9,3 +9,7 @@ MYSQL_DATABASE=moongchijang_local
 MYSQL_ROOT_PASSWORD=root
 MYSQL_USER=moongchijang
 MYSQL_PASSWORD=moongchijang
+
+SES_ENABLED=
+SES_REGION=
+SES_FROM_EMAIL=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -21,3 +21,7 @@ COOLSMS_SENDER=010-0000-0000
 JWT_SECRET=jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret
 
 AUTH_REFRESH_EXPIRATION_DAYS=14
+
+SES_ENABLED=
+SES_REGION=
+SES_FROM_EMAIL=

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation(platform("software.amazon.awssdk:bom:2.31.18"))
     implementation("software.amazon.awssdk:s3")
+    implementation("software.amazon.awssdk:sesv2")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
 
     // JWT

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -102,14 +102,9 @@ resource "aws_iam_instance_profile" "ec2_profile" {
   role = aws_iam_role.ec2_role.name
 }
 
-// Amazon Linux 2023 ARM AMI 조회
-data "aws_ssm_parameter" "al2023_arm_ami" {
-  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
-}
-
 // EC2 인스턴스 생성
 resource "aws_instance" "app_server" {
-  ami                    = data.aws_ssm_parameter.al2023_arm_ami.value
+  ami                    = var.ec2_ami_id
   instance_type          = var.ec2_instance_type
   key_name               = var.key_name
   vpc_security_group_ids = [aws_security_group.app_sg.id]

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -21,3 +21,29 @@ output "redis_endpoint" {
 output "ecr_repository_url" {
   value = aws_ecr_repository.app.repository_url
 }
+
+output "ses_identity_arn" {
+  description = "SES domain identity ARN (null when SES is disabled)"
+  value       = try(aws_ses_domain_identity.domain[0].arn, null)
+}
+
+output "ses_verification_txt_name" {
+  description = "DNS TXT record name for SES identity verification"
+  value       = var.ses_domain != "" ? "_amazonses.${var.ses_domain}" : null
+}
+
+output "ses_verification_txt_value" {
+  description = "DNS TXT record value for SES identity verification"
+  value       = try(aws_ses_domain_identity.domain[0].verification_token, null)
+}
+
+output "ses_dkim_cname_records" {
+  description = "DNS CNAME records for SES DKIM verification"
+  value = var.ses_domain != "" ? [
+    for token in aws_ses_domain_dkim.domain[0].dkim_tokens : {
+      name  = "${token}._domainkey.${var.ses_domain}"
+      type  = "CNAME"
+      value = "${token}.dkim.amazonses.com"
+    }
+  ] : []
+}

--- a/infra/terraform/ses.tf
+++ b/infra/terraform/ses.tf
@@ -1,0 +1,15 @@
+locals {
+  ses_enabled = var.ses_domain != ""
+}
+
+resource "aws_ses_domain_identity" "domain" {
+  count = local.ses_enabled ? 1 : 0
+
+  domain = var.ses_domain
+}
+
+resource "aws_ses_domain_dkim" "domain" {
+  count = local.ses_enabled ? 1 : 0
+
+  domain = var.ses_domain
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -18,6 +18,11 @@ variable "ec2_instance_type" {
   type        = string
 }
 
+variable "ec2_ami_id" {
+  description = "EC2 AMI ID (pin this value to avoid unintended instance replacement)"
+  type        = string
+}
+
 variable "key_name" {
   description = "EC2 key pair name"
   type        = string
@@ -52,4 +57,10 @@ variable "db_password" {
 variable "redis_node_type" {
   description = "ElastiCache Redis node type"
   type        = string
+}
+
+variable "ses_domain" {
+  description = "SES sender domain (e.g. example.com). When empty, SES resources are skipped."
+  type        = string
+  default     = ""
 }

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
@@ -103,9 +103,8 @@ class AuthService(
         log.info("[AuthService] 로그아웃 처리 완료: userId={}", userId)
     }
 
-    fun validateSignupToken(email: String, signupToken: String) {
-        val normalizedEmail = email.trim().lowercase()
-        if (!emailSignupTokenStore.isValid(normalizedEmail, signupToken)) {
+    private fun validateSignupTokenForNormalizedEmail(email: String, signupToken: String) {
+        if (!emailSignupTokenStore.isValid(email, signupToken)) {
             throw CustomException(ErrorCode.INVALID_SIGNUP_TOKEN)
         }
     }
@@ -115,7 +114,7 @@ class AuthService(
         val normalizedEmail = request.email.trim().lowercase()
         log.info("[AuthService] 이메일 회원가입 처리 시작: email={}", normalizedEmail)
 
-        validateSignupToken(normalizedEmail, request.signupToken)
+        validateSignupTokenForNormalizedEmail(normalizedEmail, request.signupToken)
         validatePasswordPolicy(normalizedEmail, request.password)
 
         val passwordHash = requireNotNull(passwordEncoder.encode(request.password)) {

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
@@ -5,9 +5,11 @@ import com.moongchijang.domain.auth.application.dto.AccessTokenResponse
 import com.moongchijang.domain.auth.application.dto.AuthLoginResult
 import com.moongchijang.domain.auth.application.dto.AuthLoginResponse
 import com.moongchijang.domain.auth.application.dto.AuthUserResponse
+import com.moongchijang.domain.auth.application.dto.EmailSignupRequest
 import com.moongchijang.domain.auth.application.dto.KakaoAuthUser
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
 import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
+import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -15,6 +17,7 @@ import com.moongchijang.security.jwt.JwtTokenProvider
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
@@ -24,6 +27,7 @@ class AuthService(
     private val emailSignupTokenStore: EmailSignupTokenStore,
     private val tokenService: TokenService,
     private val jwtTokenProvider: JwtTokenProvider,
+    private val passwordEncoder: PasswordEncoder,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -102,5 +106,54 @@ class AuthService(
         if (!emailSignupTokenStore.isValid(normalizedEmail, signupToken)) {
             throw CustomException(ErrorCode.INVALID_SIGNUP_TOKEN)
         }
+    }
+
+    @Transactional
+    fun signupWithEmail(request: EmailSignupRequest): AuthLoginResult {
+        val normalizedEmail = request.email.trim().lowercase()
+        log.info("[AuthService] 이메일 회원가입 처리 시작: email={}", normalizedEmail)
+
+        validateSignupToken(normalizedEmail, request.signupToken)
+        validatePasswordPolicy(normalizedEmail, request.password)
+
+        val passwordHash = requireNotNull(passwordEncoder.encode(request.password)) {
+            "Password hash must not be null"
+        }
+        val user: User = userService.createEmailUser(normalizedEmail, passwordHash)
+
+        emailSignupTokenStore.delete(normalizedEmail)
+
+        val accessToken = jwtTokenProvider.generateAccessToken(user.id!!)
+        val refreshToken = tokenService.issueRefreshToken(user.id!!)
+        val expiresIn = jwtTokenProvider.getAccessTokenExpiresInSeconds()
+
+        val response = AuthLoginResponse(
+            accessToken = accessToken,
+            tokenType = "Bearer",
+            expiresIn = expiresIn,
+            isNewUser = true,
+            user = AuthUserResponse.from(user),
+        )
+
+        log.info("[AuthService] 이메일 회원가입 처리 완료: userId={}", user.id)
+        return AuthLoginResult(
+            response = response,
+            refreshToken = refreshToken,
+        )
+    }
+
+    private fun validatePasswordPolicy(email: String, password: String) {
+        if (!PASSWORD_REGEX.matches(password)) {
+            throw CustomException(ErrorCode.INVALID_PASSWORD_FORMAT)
+        }
+
+        val emailLocalPart = email.substringBefore("@")
+        if (emailLocalPart.equals(password, ignoreCase = true)) {
+            throw CustomException(ErrorCode.INVALID_PASSWORD_SAME_AS_EMAIL_ID)
+        }
+    }
+
+    companion object {
+        private val PASSWORD_REGEX = Regex("^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}$")
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
@@ -7,6 +7,7 @@ import com.moongchijang.domain.auth.application.dto.AuthLoginResponse
 import com.moongchijang.domain.auth.application.dto.AuthUserResponse
 import com.moongchijang.domain.auth.application.dto.KakaoAuthUser
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
+import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
 import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service
 class AuthService(
     private val kakaoAuthService: KakaoAuthService,
     private val userService: UserService,
+    private val emailSignupTokenStore: EmailSignupTokenStore,
     private val tokenService: TokenService,
     private val jwtTokenProvider: JwtTokenProvider,
 ) {
@@ -93,5 +95,12 @@ class AuthService(
         log.info("[AuthService] 로그아웃 처리 시작: userId={}", userId)
         tokenService.deleteByUserId(userId)
         log.info("[AuthService] 로그아웃 처리 완료: userId={}", userId)
+    }
+
+    fun validateSignupToken(email: String, signupToken: String) {
+        val normalizedEmail = email.trim().lowercase()
+        if (!emailSignupTokenStore.isValid(normalizedEmail, signupToken)) {
+            throw CustomException(ErrorCode.INVALID_SIGNUP_TOKEN)
+        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.auth.application.dto.AccessTokenResponse
 import com.moongchijang.domain.auth.application.dto.AuthLoginResult
 import com.moongchijang.domain.auth.application.dto.AuthLoginResponse
 import com.moongchijang.domain.auth.application.dto.AuthUserResponse
+import com.moongchijang.domain.auth.application.dto.EmailLoginRequest
 import com.moongchijang.domain.auth.application.dto.EmailSignupRequest
 import com.moongchijang.domain.auth.application.dto.KakaoAuthUser
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
@@ -13,6 +14,7 @@ import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.MaskingUtils.maskEmail
 import com.moongchijang.security.jwt.JwtTokenProvider
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.transaction.Transactional
@@ -151,6 +153,39 @@ class AuthService(
         if (emailLocalPart.equals(password, ignoreCase = true)) {
             throw CustomException(ErrorCode.INVALID_PASSWORD_SAME_AS_EMAIL_ID)
         }
+    }
+
+    @Transactional
+    fun loginWithEmail(request: EmailLoginRequest): AuthLoginResult {
+        val normalizedEmail = request.email.trim().lowercase()
+        log.info("[AuthService] 이메일 로그인 처리 시작: email={}", maskEmail(normalizedEmail))
+
+        val user = userService.findActiveEmailUser(normalizedEmail)
+            ?: throw CustomException(ErrorCode.INVALID_CREDENTIALS)
+
+        val passwordHash = user.passwordHash ?: throw CustomException(ErrorCode.INVALID_CREDENTIALS)
+        if (!passwordEncoder.matches(request.password, passwordHash)) {
+            throw CustomException(ErrorCode.INVALID_CREDENTIALS)
+        }
+
+        val accessToken = jwtTokenProvider.generateAccessToken(user.id!!)
+        val refreshToken = tokenService.issueRefreshToken(user.id!!)
+        val expiresIn = jwtTokenProvider.getAccessTokenExpiresInSeconds()
+
+        val response = AuthLoginResponse(
+            accessToken = accessToken,
+            tokenType = "Bearer",
+            expiresIn = expiresIn,
+            isNewUser = false,
+            user = AuthUserResponse.from(user),
+        )
+
+        log.info("[AuthService] 이메일 로그인 처리 완료: userId={}", user.id)
+
+        return AuthLoginResult(
+            response = response,
+            refreshToken = refreshToken,
+        )
     }
 
     companion object {

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/EmailVerificationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/EmailVerificationService.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeSentRes
 import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeVerifyRequest
 import com.moongchijang.domain.auth.application.dto.EmailVerificationVerifiedResponse
 import com.moongchijang.domain.auth.application.port.EmailSender
+import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
 import com.moongchijang.domain.auth.application.port.EmailVerificationStore
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -18,6 +19,7 @@ import kotlin.math.pow
 @Service
 class EmailVerificationService(
     private val emailVerificationStore: EmailVerificationStore,
+    private val emailSignupTokenStore: EmailSignupTokenStore,
     private val emailSender: EmailSender,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -64,11 +66,13 @@ class EmailVerificationService(
         }
 
         emailVerificationStore.deleteCode(email)
+        val signupToken = UUID.randomUUID().toString()
+        emailSignupTokenStore.save(email, signupToken, SIGNUP_TOKEN_TTL_SECONDS)
         log.info("[EmailVerificationService] 이메일 인증코드 검증 완료: email={}", maskEmail(email))
 
         return EmailVerificationVerifiedResponse(
             verified = true,
-            signupToken = UUID.randomUUID().toString(),
+            signupToken = signupToken,
         )
     }
 
@@ -84,6 +88,7 @@ class EmailVerificationService(
         private const val CODE_EXPIRES_SECONDS = 180L
         private const val RESEND_COOLDOWN_SECONDS = 60L
         private const val DAILY_LIMIT = 5L
+        private const val SIGNUP_TOKEN_TTL_SECONDS = 1800L
         private const val OTP_LENGTH = 6
         private val secureRandom = SecureRandom()
     }

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/EmailVerificationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/EmailVerificationService.kt
@@ -8,6 +8,7 @@ import com.moongchijang.domain.auth.application.port.EmailSender
 import com.moongchijang.domain.auth.application.port.EmailVerificationStore
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.MaskingUtils.maskEmail
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.security.SecureRandom
@@ -77,18 +78,6 @@ class EmailVerificationService(
         val bound = 10.0.pow(OTP_LENGTH.toDouble()).toInt()
         val number = secureRandom.nextInt(bound)
         return number.toString().padStart(OTP_LENGTH, '0')
-    }
-
-    private fun maskEmail(email: String): String {
-        val parts = email.split("@")
-        if (parts.size != 2) return "***"
-        val local = parts[0]
-        val domain = parts[1]
-        val maskedLocal = when {
-            local.length <= 2 -> "${local.first()}*"
-            else -> local.take(2) + "*".repeat(local.length - 2)
-        }
-        return "$maskedLocal@$domain"
     }
 
     companion object {

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/EmailVerificationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/EmailVerificationService.kt
@@ -1,0 +1,101 @@
+package com.moongchijang.domain.auth.application
+
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeSendRequest
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeSentResponse
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeVerifyRequest
+import com.moongchijang.domain.auth.application.dto.EmailVerificationVerifiedResponse
+import com.moongchijang.domain.auth.application.port.EmailSender
+import com.moongchijang.domain.auth.application.port.EmailVerificationStore
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.security.SecureRandom
+import java.util.UUID
+import kotlin.math.pow
+
+@Service
+class EmailVerificationService(
+    private val emailVerificationStore: EmailVerificationStore,
+    private val emailSender: EmailSender,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun sendEmailVerificationCode(request: EmailVerificationCodeSendRequest): EmailVerificationCodeSentResponse {
+        val email = normalizeEmail(request.email)
+        log.info("[EmailVerificationService] 이메일 인증코드 발송 시작: email={}", maskEmail(email))
+
+        val dailyCount = emailVerificationStore.getDailySendCount(email)
+        if (dailyCount >= DAILY_LIMIT) {
+            throw CustomException(ErrorCode.EMAIL_VERIFICATION_DAILY_LIMIT_EXCEEDED)
+        }
+
+        val resendAvailableInSeconds = emailVerificationStore.getResendAvailableInSeconds(email)
+        if (resendAvailableInSeconds > 0) {
+            throw CustomException(ErrorCode.EMAIL_VERIFICATION_RESEND_COOLDOWN)
+        }
+
+        val code = generateCode()
+        emailVerificationStore.saveCode(email, code, CODE_EXPIRES_SECONDS)
+        emailVerificationStore.setResendCooldown(email, RESEND_COOLDOWN_SECONDS)
+        val usedCount = emailVerificationStore.incrementDailySendCount(email)
+
+        emailSender.sendVerificationCode(email, code, CODE_EXPIRES_SECONDS)
+        log.info("[EmailVerificationService] 이메일 인증코드 발송 완료: email={}", maskEmail(email))
+
+        return EmailVerificationCodeSentResponse(
+            expiresInSeconds = CODE_EXPIRES_SECONDS.toInt(),
+            resendAvailableInSeconds = RESEND_COOLDOWN_SECONDS.toInt(),
+            remainingDailyAttempts = (DAILY_LIMIT - usedCount).coerceAtLeast(0).toInt(),
+        )
+    }
+
+    fun verifyEmailVerificationCode(request: EmailVerificationCodeVerifyRequest): EmailVerificationVerifiedResponse {
+        val email = normalizeEmail(request.email)
+        log.info("[EmailVerificationService] 이메일 인증코드 검증 시작: email={}", maskEmail(email))
+
+        val savedCode = emailVerificationStore.getCode(email)
+            ?: throw CustomException(ErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED)
+
+        if (savedCode != request.code) {
+            log.info("[EmailVerificationService] 이메일 인증코드 불일치: email={}", maskEmail(email))
+            throw CustomException(ErrorCode.EMAIL_VERIFICATION_CODE_MISMATCH)
+        }
+
+        emailVerificationStore.deleteCode(email)
+        log.info("[EmailVerificationService] 이메일 인증코드 검증 완료: email={}", maskEmail(email))
+
+        return EmailVerificationVerifiedResponse(
+            verified = true,
+            signupToken = UUID.randomUUID().toString(),
+        )
+    }
+
+    private fun normalizeEmail(email: String): String = email.trim().lowercase()
+
+    private fun generateCode(): String {
+        val bound = 10.0.pow(OTP_LENGTH.toDouble()).toInt()
+        val number = secureRandom.nextInt(bound)
+        return number.toString().padStart(OTP_LENGTH, '0')
+    }
+
+    private fun maskEmail(email: String): String {
+        val parts = email.split("@")
+        if (parts.size != 2) return "***"
+        val local = parts[0]
+        val domain = parts[1]
+        val maskedLocal = when {
+            local.length <= 2 -> "${local.first()}*"
+            else -> local.take(2) + "*".repeat(local.length - 2)
+        }
+        return "$maskedLocal@$domain"
+    }
+
+    companion object {
+        private const val CODE_EXPIRES_SECONDS = 180L
+        private const val RESEND_COOLDOWN_SECONDS = 60L
+        private const val DAILY_LIMIT = 5L
+        private const val OTP_LENGTH = 6
+        private val secureRandom = SecureRandom()
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailLoginRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailLoginRequest.kt
@@ -1,0 +1,18 @@
+package com.moongchijang.domain.auth.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "이메일 로그인 요청")
+data class EmailLoginRequest(
+
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아니에요.")
+    @field:Schema(description = "이메일", example = "user@example.com")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호는 필수입니다.")
+    @field:Schema(description = "비밀번호", example = "abc12345")
+    val password: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailSignupRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailSignupRequest.kt
@@ -1,0 +1,32 @@
+package com.moongchijang.domain.auth.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+@Schema(description = "이메일 회원가입 요청")
+data class EmailSignupRequest(
+
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아니에요.")
+    @field:Schema(description = "이메일", example = "user@example.com")
+    val email: String,
+
+    @field:NotBlank(message = "비밀번호는 필수입니다.")
+    @field:Size(min = 8, max = 20, message = "8자 이상, 영문+숫자를 포함해주세요.")
+    @field:Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}$",
+        message = "8자 이상, 영문+숫자를 포함해주세요.",
+    )
+    @field:Schema(
+        description = "비밀번호 (8~20자, 영문+숫자 포함, 이메일 아이디와 동일값 불가)",
+        example = "abc12345",
+    )
+    val password: String,
+
+    @field:NotBlank(message = "회원가입 토큰은 필수입니다.")
+    @field:Schema(description = "이메일 인증 완료 후 발급되는 회원가입 진행 토큰")
+    val signupToken: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationCodeSendRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationCodeSendRequest.kt
@@ -1,0 +1,14 @@
+package com.moongchijang.domain.auth.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+@Schema(description = "이메일 인증코드 발송 요청")
+data class EmailVerificationCodeSendRequest(
+
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아니에요.")
+    @field:Schema(description = "이메일", example = "user@example.com")
+    val email: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationCodeSentResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationCodeSentResponse.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.auth.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "이메일 인증코드 발송 응답")
+data class EmailVerificationCodeSentResponse(
+
+    @field:Schema(description = "인증번호 만료까지 남은 시간(초)", example = "180")
+    val expiresInSeconds: Int,
+
+    @field:Schema(description = "재발송 가능까지 남은 시간(초)", example = "60")
+    val resendAvailableInSeconds: Int,
+
+    @field:Schema(description = "오늘 남은 발송 가능 횟수", example = "4")
+    val remainingDailyAttempts: Int,
+)

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationCodeVerifyRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationCodeVerifyRequest.kt
@@ -1,0 +1,23 @@
+package com.moongchijang.domain.auth.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+
+@Schema(description = "이메일 인증코드 확인 요청")
+data class EmailVerificationCodeVerifyRequest(
+
+    @field:NotBlank(message = "이메일은 필수입니다.")
+    @field:Email(message = "올바른 이메일 형식이 아니에요.")
+    @field:Schema(description = "이메일", example = "user@example.com")
+    val email: String,
+
+    @field:NotBlank(message = "인증코드는 필수입니다.")
+    @field:Pattern(
+        regexp = "^[0-9]{6}$",
+        message = "인증코드는 6자리 숫자여야 합니다.",
+    )
+    @field:Schema(description = "6자리 인증코드", example = "123456")
+    val code: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationVerifiedResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/dto/EmailVerificationVerifiedResponse.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.auth.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "이메일 인증코드 확인 응답")
+data class EmailVerificationVerifiedResponse(
+
+    @field:Schema(description = "이메일 인증 완료 여부", example = "true")
+    val verified: Boolean,
+
+    @field:Schema(description = "이메일 회원가입 단계 진행용 임시 토큰", example = "eyJhbGciOiJIUzI1NiJ9...")
+    val signupToken: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/port/EmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/port/EmailSender.kt
@@ -1,0 +1,5 @@
+package com.moongchijang.domain.auth.application.port
+
+interface EmailSender {
+    fun sendVerificationCode(toEmail: String, code: String, expiresInSeconds: Long)
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/port/EmailSignupTokenStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/port/EmailSignupTokenStore.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.auth.application.port
+
+interface EmailSignupTokenStore {
+    fun save(email: String, signupToken: String, expiresInSeconds: Long)
+    fun isValid(email: String, signupToken: String): Boolean
+    fun delete(email: String)
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/port/EmailVerificationStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/port/EmailVerificationStore.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.auth.application.port
+
+interface EmailVerificationStore {
+    fun saveCode(email: String, code: String, expiresInSeconds: Long)
+    fun getCode(email: String): String?
+    fun deleteCode(email: String)
+
+    fun getResendAvailableInSeconds(email: String): Long
+    fun setResendCooldown(email: String, cooldownSeconds: Long)
+
+    fun incrementDailySendCount(email: String): Long
+    fun getDailySendCount(email: String): Long
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/NoopEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/NoopEmailSender.kt
@@ -1,0 +1,20 @@
+package com.moongchijang.domain.auth.infrastructure.email
+
+import com.moongchijang.domain.auth.application.port.EmailSender
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "ses", name = ["enabled"], havingValue = "false", matchIfMissing = true)
+class NoopEmailSender : EmailSender {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    override fun sendVerificationCode(toEmail: String, code: String, expiresInSeconds: Long) {
+        log.info(
+            "[NoopEmailSender] ses.enabled=false, 이메일 발송 생략: toEmail={}, expiresInSeconds={}",
+            toEmail,
+            expiresInSeconds,
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/ses/SesEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/ses/SesEmailSender.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.domain.auth.infrastructure.email.ses
+
+import com.moongchijang.domain.auth.application.port.EmailSender
+import com.moongchijang.global.config.SesProperties
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.services.sesv2.SesV2Client
+import software.amazon.awssdk.services.sesv2.model.Body
+import software.amazon.awssdk.services.sesv2.model.Content
+import software.amazon.awssdk.services.sesv2.model.Destination
+import software.amazon.awssdk.services.sesv2.model.EmailContent
+import software.amazon.awssdk.services.sesv2.model.Message
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest
+
+@Component
+@ConditionalOnProperty(prefix = "ses", name = ["enabled"], havingValue = "true")
+class SesEmailSender(
+    private val sesV2Client: SesV2Client,
+    private val sesProperties: SesProperties,
+) : EmailSender {
+
+    override fun sendVerificationCode(toEmail: String, code: String, expiresInSeconds: Long) {
+        val expiresMinutes = expiresInSeconds / 60
+
+        val subject = "[뭉치장] 이메일 인증코드를 확인해주세요"
+        val bodyText = """
+            안녕하세요, 뭉치장입니다.
+
+            이메일 인증코드는 아래와 같습니다.
+            $code
+
+            인증코드는 ${expiresMinutes}분간 유효합니다.
+        """.trimIndent()
+
+        val request = SendEmailRequest.builder()
+            .fromEmailAddress(sesProperties.fromEmail)
+            .destination(
+                Destination.builder()
+                    .toAddresses(toEmail)
+                    .build(),
+            )
+            .content(
+                EmailContent.builder()
+                    .simple(
+                        Message.builder()
+                            .subject(Content.builder().data(subject).charset("UTF-8").build())
+                            .body(
+                                Body.builder()
+                                    .text(Content.builder().data(bodyText).charset("UTF-8").build())
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+
+        sesV2Client.sendEmail(request)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/ses/SesEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/ses/SesEmailSender.kt
@@ -2,6 +2,10 @@ package com.moongchijang.domain.auth.infrastructure.email.ses
 
 import com.moongchijang.domain.auth.application.port.EmailSender
 import com.moongchijang.global.config.SesProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.MaskingUtils.maskEmail
+import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import software.amazon.awssdk.services.sesv2.SesV2Client
@@ -18,6 +22,7 @@ class SesEmailSender(
     private val sesV2Client: SesV2Client,
     private val sesProperties: SesProperties,
 ) : EmailSender {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun sendVerificationCode(toEmail: String, code: String, expiresInSeconds: Long) {
         val expiresMinutes = expiresInSeconds / 60
@@ -55,6 +60,12 @@ class SesEmailSender(
             )
             .build()
 
-        sesV2Client.sendEmail(request)
+        try {
+            sesV2Client.sendEmail(request)
+            log.info("[SesEmailSender] 이메일 발송 완료: toEmail={}", maskEmail(toEmail))
+        } catch (e: Exception) {
+            log.error("[SesEmailSender] 이메일 발송 실패: toEmail={}", maskEmail(toEmail), e)
+            throw CustomException(ErrorCode.EMAIL_SEND_FAILED)
+        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/store/RedisEmailSignupTokenStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/store/RedisEmailSignupTokenStore.kt
@@ -1,0 +1,27 @@
+package com.moongchijang.domain.auth.infrastructure.email.store
+
+import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RedisEmailSignupTokenStore(
+    private val redisTemplate: StringRedisTemplate
+) : EmailSignupTokenStore {
+
+    override fun save(email: String, signupToken: String, expiresInSeconds: Long) {
+        redisTemplate.opsForValue().set(tokenKey(email), signupToken, Duration.ofSeconds(expiresInSeconds))
+    }
+
+    override fun isValid(email: String, signupToken: String): Boolean {
+        val saved = redisTemplate.opsForValue().get(tokenKey(email)) ?: return false
+        return saved == signupToken
+    }
+
+    override fun delete(email: String) {
+        redisTemplate.delete(tokenKey(email))
+    }
+
+    private fun tokenKey(email: String): String = "auth:email:signup-token:$email"
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/store/RedisEmailVerificationStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/store/RedisEmailVerificationStore.kt
@@ -1,0 +1,54 @@
+package com.moongchijang.domain.auth.infrastructure.email.store
+
+import com.moongchijang.domain.auth.application.port.EmailVerificationStore
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Component
+class RedisEmailVerificationStore(
+    private val redisTemplate: StringRedisTemplate,
+) : EmailVerificationStore {
+
+    override fun saveCode(email: String, code: String, expiresInSeconds: Long) {
+        redisTemplate.opsForValue().set(codeKey(email), code, Duration.ofSeconds(expiresInSeconds))
+    }
+
+    override fun getCode(email: String): String? = redisTemplate.opsForValue().get(codeKey(email))
+
+    override fun deleteCode(email: String) {
+        redisTemplate.delete(codeKey(email))
+    }
+
+    override fun getResendAvailableInSeconds(email: String): Long {
+        val ttl = redisTemplate.getExpire(cooldownKey(email))
+        return if (ttl > 0) ttl else 0L
+    }
+
+    override fun setResendCooldown(email: String, cooldownSeconds: Long) {
+        redisTemplate.opsForValue().set(cooldownKey(email), "1", Duration.ofSeconds(cooldownSeconds))
+    }
+
+    override fun incrementDailySendCount(email: String): Long {
+        val key = dailyCountKey(email)
+        val count = redisTemplate.opsForValue().increment(key) ?: 0L
+        if (count == 1L) {
+            redisTemplate.expire(key, Duration.ofDays(2))
+        }
+        return count
+    }
+
+    override fun getDailySendCount(email: String): Long {
+        return redisTemplate.opsForValue().get(dailyCountKey(email))?.toLongOrNull() ?: 0L
+    }
+
+    private fun codeKey(email: String): String = "auth:email:verification:code:$email"
+    private fun cooldownKey(email: String): String = "auth:email:verification:cooldown:$email"
+
+    private fun dailyCountKey(email: String): String {
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        return "auth:email:verification:daily:$today:$email"
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
@@ -5,6 +5,8 @@ import com.moongchijang.domain.auth.application.TokenService
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
 import com.moongchijang.domain.auth.application.dto.AccessTokenResponse
 import com.moongchijang.domain.auth.application.dto.AuthLoginResponse
+import com.moongchijang.domain.user.application.UserService
+import com.moongchijang.domain.user.application.dto.EmailAvailabilityResponse
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
@@ -20,9 +22,11 @@ import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -31,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val authService: AuthService,
     private val tokenService: TokenService,
+    private val userService: UserService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -103,5 +108,22 @@ class AuthController(
 
         log.info("[AuthController] 로그아웃 응답 완료: userId={}", userId)
         return ApiResponse.success()
+    }
+
+    @GetMapping("/email/availability")
+    @Operation(summary = "이메일 중복 확인", description = "이메일 회원가입 전 가입 가능 이메일인지 확인합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "이메일 사용 가능 여부 반환"),
+            SwaggerApiResponse(responseCode = "400", description = "이메일 형식 오류", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun checkEmailAvailability(
+        @RequestParam email: String,
+    ): ApiResponse<EmailAvailabilityResponse> {
+        log.info("[AuthController] 이메일 중복 확인 요청 수신")
+        val response = userService.checkEmailAvailability(email)
+        log.info("[AuthController] 이메일 중복 확인 응답 완료")
+        return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.auth.presentation
 import com.moongchijang.domain.auth.application.AuthService
 import com.moongchijang.domain.auth.application.TokenService
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
+import com.moongchijang.domain.auth.application.dto.EmailSignupRequest
 import com.moongchijang.domain.auth.application.dto.AccessTokenResponse
 import com.moongchijang.domain.auth.application.dto.AuthLoginResponse
 import com.moongchijang.domain.user.application.UserService
@@ -60,6 +61,32 @@ class AuthController(
             refreshToken = refreshToken,
         )
         log.info("[AuthController] 카카오 로그인 응답 완료: userId={}", authLoginResponse.user.id)
+
+        return ApiResponse.success(authLoginResponse)
+    }
+
+    @PostMapping("/email/signup")
+    @Operation(summary = "이메일 회원가입", description = "이메일 인증 완료 후 비밀번호를 설정해 회원가입하고 로그인 처리합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "회원가입 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "요청값 검증 실패", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "회원가입 인증정보 유효성 실패", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "409", description = "이미 가입된 이메일", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun signupWithEmail(
+        @Valid @RequestBody request: EmailSignupRequest,
+        response: HttpServletResponse,
+    ): ApiResponse<AuthLoginResponse> {
+        log.info("[AuthController] 이메일 회원가입 요청 수신")
+        val (authLoginResponse, refreshToken) = authService.signupWithEmail(request)
+
+        tokenService.addRefreshTokenCookie(
+            response = response,
+            refreshToken = refreshToken,
+        )
+        log.info("[AuthController] 이메일 회원가입 응답 완료: userId={}", authLoginResponse.user.id)
 
         return ApiResponse.success(authLoginResponse)
     }

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.auth.application.AuthService
 import com.moongchijang.domain.auth.application.TokenService
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
 import com.moongchijang.domain.auth.application.dto.EmailSignupRequest
+import com.moongchijang.domain.auth.application.dto.EmailLoginRequest
 import com.moongchijang.domain.auth.application.dto.AccessTokenResponse
 import com.moongchijang.domain.auth.application.dto.AuthLoginResponse
 import com.moongchijang.domain.user.application.UserService
@@ -87,6 +88,31 @@ class AuthController(
             refreshToken = refreshToken,
         )
         log.info("[AuthController] 이메일 회원가입 응답 완료: userId={}", authLoginResponse.user.id)
+
+        return ApiResponse.success(authLoginResponse)
+    }
+
+    @PostMapping("/email/login")
+    @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호를 검증해 로그인 처리합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "로그인 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "요청값 검증 실패", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "이메일 또는 비밀번호 불일치", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun loginWithEmail(
+        @Valid @RequestBody request: EmailLoginRequest,
+        response: HttpServletResponse,
+    ): ApiResponse<AuthLoginResponse> {
+        log.info("[AuthController] 이메일 로그인 요청 수신")
+        val (authLoginResponse, refreshToken) = authService.loginWithEmail(request)
+
+        tokenService.addRefreshTokenCookie(
+            response = response,
+            refreshToken = refreshToken,
+        )
+        log.info("[AuthController] 이메일 로그인 응답 완료: userId={}", authLoginResponse.user.id)
 
         return ApiResponse.success(authLoginResponse)
     }

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/EmailVerificationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/EmailVerificationController.kt
@@ -1,0 +1,64 @@
+package com.moongchijang.domain.auth.presentation
+
+import com.moongchijang.domain.auth.application.EmailVerificationService
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeSendRequest
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeSentResponse
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeVerifyRequest
+import com.moongchijang.domain.auth.application.dto.EmailVerificationVerifiedResponse
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth/email/verification-codes")
+@Tag(name = "Auth", description = "인증 API")
+class EmailVerificationController(
+    private val emailVerificationService: EmailVerificationService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping
+    @Operation(summary = "이메일 인증코드 발송", description = "입력한 이메일로 6자리 인증코드를 발송합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "인증코드 발송 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "잘못된 요청", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "429", description = "일일 발송 횟수 초과", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun sendVerificationCode(
+        @Valid @RequestBody request: EmailVerificationCodeSendRequest,
+    ): ApiResponse<EmailVerificationCodeSentResponse> {
+        log.info("[EmailVerificationController] 이메일 인증코드 발송 요청 수신")
+        val response = emailVerificationService.sendEmailVerificationCode(request)
+        log.info("[EmailVerificationController] 이메일 인증코드 발송 응답 완료")
+        return ApiResponse.success(response)
+    }
+
+    @PostMapping("/verify")
+    @Operation(summary = "이메일 인증코드 확인", description = "이메일과 인증코드를 검증해 인증 완료 상태를 처리합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "인증코드 확인 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "인증코드 불일치/만료", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun verifyCode(
+        @Valid @RequestBody request: EmailVerificationCodeVerifyRequest,
+    ): ApiResponse<EmailVerificationVerifiedResponse> {
+        log.info("[EmailVerificationController] 이메일 인증코드 검증 요청 수신")
+        val response = emailVerificationService.verifyEmailVerificationCode(request)
+        log.info("[EmailVerificationController] 이메일 인증코드 검증 응답 완료")
+        return ApiResponse.success(response)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -12,6 +12,7 @@ import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.util.MaskingUtils.maskEmail
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -48,7 +49,7 @@ class UserService(
         log.info("[UserService] 이메일 사용자 생성 시작: email={}", maskEmail(normalizedEmail))
         validateEmailFormat(normalizedEmail)
 
-        if (userRepository.existsByEmailAndDeletedAtIsNull(normalizedEmail)) {
+        if (userRepository.existsByProviderAndEmailAndDeletedAtIsNull(AuthProvider.EMAIL, normalizedEmail)) {
             throw CustomException(ErrorCode.DUPLICATE_EMAIL)
         }
 
@@ -56,7 +57,12 @@ class UserService(
             email = normalizedEmail,
             passwordHash = passwordHash,
         )
-        val savedUser = userRepository.save(user)
+        val savedUser = try {
+            userRepository.save(user)
+        } catch (e: DataIntegrityViolationException) {
+            // provider+email 유니크 인덱스 충돌(동시성 가입 요청) 시 도메인 예외로 변환
+            throw CustomException(ErrorCode.DUPLICATE_EMAIL)
+        }
         log.info("[UserService] 이메일 사용자 생성 완료: userId={}", savedUser.id)
 
         return savedUser
@@ -89,7 +95,7 @@ class UserService(
         log.info("[UserService] 이메일 중복 확인 시작: email={}", maskEmail(normalizedEmail))
         validateEmailFormat(normalizedEmail)
 
-        val duplicated = userRepository.existsByEmailAndDeletedAtIsNull(normalizedEmail)
+        val duplicated = userRepository.existsByProviderAndEmailAndDeletedAtIsNull(AuthProvider.EMAIL, normalizedEmail)
         val response = EmailAvailabilityResponse(
             email = normalizedEmail,
             available = !duplicated,

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.user.application
 import com.moongchijang.domain.auth.application.PhoneVerificationService
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpdatedResponse
+import com.moongchijang.domain.user.application.dto.EmailAvailabilityResponse
 import com.moongchijang.domain.user.application.dto.NicknameAvailabilityResponse
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
@@ -51,8 +52,23 @@ class UserService(
     }
 
     @Transactional(readOnly = true)
-    fun existsByEmail(email: String): Boolean {
-        return userRepository.existsByEmailAndDeletedAtIsNull(email)
+    fun checkEmailAvailability(email: String): EmailAvailabilityResponse {
+        val normalizedEmail = normalizeEmail(email)
+        log.info("[UserService] 이메일 중복 확인 시작: email={}", maskEmail(normalizedEmail))
+        validateEmailFormat(normalizedEmail)
+
+        val duplicated = userRepository.existsByEmailAndDeletedAtIsNull(normalizedEmail)
+        val response = EmailAvailabilityResponse(
+            email = normalizedEmail,
+            available = !duplicated,
+        )
+
+        log.info(
+            "[UserService] 이메일 중복 확인 완료: email={}, available={}",
+            maskEmail(normalizedEmail),
+            response.available,
+        )
+        return response
     }
 
     @Transactional
@@ -145,5 +161,29 @@ class UserService(
         if (!phoneRegex.matches(phoneNumber)) {
             throw CustomException(ErrorCode.INVALID_PHONE_NUMBER_FORMAT)
         }
+    }
+
+    private fun validateEmailFormat(email: String) {
+        if (!EMAIL_REGEX.matches(email)) {
+            throw CustomException(ErrorCode.INVALID_EMAIL_FORMAT)
+        }
+    }
+
+    private fun normalizeEmail(raw: String): String = raw.trim().lowercase()
+
+    private fun maskEmail(email: String): String {
+        val parts = email.split("@")
+        if (parts.size != 2) return "***"
+        val local = parts[0]
+        val domain = parts[1]
+        val maskedLocal = when {
+            local.length <= 2 -> "${local.firstOrNull() ?: '*'}*"
+            else -> local.take(2) + "*".repeat(local.length - 2)
+        }
+        return "$maskedLocal@$domain"
+    }
+
+    companion object {
+        private val EMAIL_REGEX = Regex("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -10,6 +10,7 @@ import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.MaskingUtils.maskEmail
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -170,18 +171,6 @@ class UserService(
     }
 
     private fun normalizeEmail(raw: String): String = raw.trim().lowercase()
-
-    private fun maskEmail(email: String): String {
-        val parts = email.split("@")
-        if (parts.size != 2) return "***"
-        val local = parts[0]
-        val domain = parts[1]
-        val maskedLocal = when {
-            local.length <= 2 -> "${local.firstOrNull() ?: '*'}*"
-            else -> local.take(2) + "*".repeat(local.length - 2)
-        }
-        return "$maskedLocal@$domain"
-    }
 
     companion object {
         private val EMAIL_REGEX = Regex("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -42,6 +42,37 @@ class UserService(
         return createNewKakaoUser(providerId, email, nickname) to true
     }
 
+    @Transactional
+    fun createEmailUser(email: String, passwordHash: String): User {
+        val normalizedEmail = normalizeEmail(email)
+        log.info("[UserService] 이메일 사용자 생성 시작: email={}", maskEmail(normalizedEmail))
+        validateEmailFormat(normalizedEmail)
+
+        if (userRepository.existsByEmailAndDeletedAtIsNull(normalizedEmail)) {
+            throw CustomException(ErrorCode.DUPLICATE_EMAIL)
+        }
+
+        val user = User.newEmailUser(
+            email = normalizedEmail,
+            passwordHash = passwordHash,
+        )
+        val savedUser = userRepository.save(user)
+        log.info("[UserService] 이메일 사용자 생성 완료: userId={}", savedUser.id)
+
+        return savedUser
+    }
+
+    @Transactional(readOnly = true)
+    fun findActiveEmailUser(email: String): User? {
+        val normalizedEmail = normalizeEmail(email)
+        validateEmailFormat(normalizedEmail)
+
+        return userRepository.findByProviderAndEmailAndDeletedAtIsNull(
+            provider = AuthProvider.EMAIL,
+            email = normalizedEmail,
+        )
+    }
+
     @Transactional(readOnly = true)
     fun checkNicknameAvailability(nickname: String): NicknameAvailabilityResponse {
         validateNicknameFormat(nickname)

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/EmailAvailabilityResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/EmailAvailabilityResponse.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.user.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "이메일 중복 확인 응답")
+data class EmailAvailabilityResponse(
+
+    @field:Schema(description = "확인한 이메일", example = "user@example.com")
+    val email: String,
+
+    @field:Schema(description = "사용 가능 여부", example = "true")
+    val available: Boolean,
+)

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
@@ -16,7 +16,7 @@ import java.time.LocalDateTime
 @Table(name = "users",
     indexes = [
         Index(name = "idx_users_provider_provider_id", columnList = "provider,provider_id"),
-        Index(name = "idx_users_email", columnList = "email")
+        Index(name = "uidx_users_provider_email", columnList = "provider,email", unique = true)
     ]
 )
 class User(

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
@@ -79,5 +79,19 @@ class User(
                 signupCompleted = false,
             )
         }
+
+        fun newEmailUser(
+            email: String,
+            passwordHash: String,
+        ): User {
+            return User(
+                provider = AuthProvider.EMAIL,
+                providerId = null,
+                email = email,
+                passwordHash = passwordHash,
+                role = UserRole.BUYER,
+                signupCompleted = false,
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
@@ -18,6 +18,11 @@ interface UserRepository : JpaRepository<User, Long> {
         providerId: String,
     ): User?
 
+    fun findByProviderAndEmailAndDeletedAtIsNull(
+        provider: AuthProvider,
+        email: String,
+    ): User?
+
     fun existsByNicknameAndDeletedAtIsNull(nickname: String): Boolean
 
     fun existsByEmailAndDeletedAtIsNull(email: String): Boolean

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
@@ -23,9 +23,12 @@ interface UserRepository : JpaRepository<User, Long> {
         email: String,
     ): User?
 
-    fun existsByNicknameAndDeletedAtIsNull(nickname: String): Boolean
+    fun existsByProviderAndEmailAndDeletedAtIsNull(
+        provider: AuthProvider,
+        email: String,
+    ): Boolean
 
-    fun existsByEmailAndDeletedAtIsNull(email: String): Boolean
+    fun existsByNicknameAndDeletedAtIsNull(nickname: String): Boolean
 
     fun findByIdAndDeletedAtIsNull(id: Long): User?
 }

--- a/src/main/kotlin/com/moongchijang/global/config/SesConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SesConfig.kt
@@ -1,0 +1,17 @@
+package com.moongchijang.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sesv2.SesV2Client
+
+@Configuration
+class SesConfig(
+    private val sesProperties: SesProperties,
+) {
+
+    @Bean(destroyMethod = "close")
+    fun sesV2Client(): SesV2Client = SesV2Client.builder()
+        .region(Region.of(sesProperties.region))
+        .build()
+}

--- a/src/main/kotlin/com/moongchijang/global/config/SesConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SesConfig.kt
@@ -2,10 +2,12 @@ package com.moongchijang.global.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sesv2.SesV2Client
 
 @Configuration
+@ConditionalOnProperty(prefix = "ses", name = ["enabled"], havingValue = "true")
 class SesConfig(
     private val sesProperties: SesProperties,
 ) {

--- a/src/main/kotlin/com/moongchijang/global/config/SesProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SesProperties.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "ses")
+data class SesProperties(
+    val enabled: Boolean,
+    val region: String,
+    val fromEmail: String,
+)

--- a/src/main/kotlin/com/moongchijang/global/config/SesProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SesProperties.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "ses")
 data class SesProperties(
-    val enabled: Boolean,
-    val region: String,
-    val fromEmail: String,
+    val enabled: Boolean = false,
+    val region: String = "ap-northeast-2",
+    val fromEmail: String = "",
 )

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -46,6 +46,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     EMAIL_VERIFICATION_CODE_EXPIRED(400_105, "인증코드가 만료됐어요. 재발송해주세요.", 400),
     EMAIL_VERIFICATION_RESEND_COOLDOWN(400_106, "인증코드 재발송은 잠시 후 다시 시도해주세요.", 400),
     EMAIL_VERIFICATION_DAILY_LIMIT_EXCEEDED(429_101, "내일 다시 시도해주세요.", 429),
+    INVALID_SIGNUP_TOKEN(401_107, "회원가입 인증정보가 유효하지 않습니다. 이메일 인증을 다시 진행해주세요.", 401),
     KAKAO_TOKEN_REQUEST_INVALID(401_101, "카카오 토큰 요청 파라미터가 올바르지 않습니다.", 401),
     KAKAO_TOKEN_EXCHANGE_FAILED(401_102, "카카오 토큰 교환에 실패했습니다.", 401),
     KAKAO_TOKEN_RESPONSE_INVALID(401_103, "카카오 토큰 응답이 올바르지 않습니다.", 401),

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -45,6 +45,8 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     EMAIL_VERIFICATION_CODE_MISMATCH(400_104, "인증코드가 일치하지 않아요.", 400),
     EMAIL_VERIFICATION_CODE_EXPIRED(400_105, "인증코드가 만료됐어요. 재발송해주세요.", 400),
     EMAIL_VERIFICATION_RESEND_COOLDOWN(400_106, "인증코드 재발송은 잠시 후 다시 시도해주세요.", 400),
+    INVALID_PASSWORD_FORMAT(400_107, "8자 이상, 영문+숫자를 포함해주세요.", 400),
+    INVALID_PASSWORD_SAME_AS_EMAIL_ID(400_108, "이메일 아이디와 동일한 비밀번호는 사용할 수 없습니다.", 400),
     EMAIL_VERIFICATION_DAILY_LIMIT_EXCEEDED(429_101, "내일 다시 시도해주세요.", 429),
     INVALID_SIGNUP_TOKEN(401_107, "회원가입 인증정보가 유효하지 않습니다. 이메일 인증을 다시 진행해주세요.", 401),
     KAKAO_TOKEN_REQUEST_INVALID(401_101, "카카오 토큰 요청 파라미터가 올바르지 않습니다.", 401),

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -78,6 +78,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PHONE_VERIFICATION_CODE_MISMATCH(400_202, "인증번호가 올바르지 않습니다.", 400),
     PHONE_VERIFICATION_REQUIRED(400_203, "전화번호 인증이 필요합니다.", 400),
     SMS_SEND_FAILED(500_201, "문자 발송에 실패했습니다. 잠시 후 다시 시도해주세요.", 500),
+    EMAIL_SEND_FAILED(500_202, "이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.", 500),
 
     // Store(250~299)
     STORE_SEARCH_FAILED(502_250, "매장 검색 중 오류가 발생했습니다.", 502),

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -41,6 +41,11 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     // Auth, User (100~149)
     INVALID_NICKNAME_FORMAT(400_101, "2~10자, 한글/영문/숫자만 입력 가능해요.", 400),
     INVALID_PHONE_NUMBER_FORMAT(400_102, "올바른 전화번호를 입력해주세요.", 400),
+    INVALID_EMAIL_FORMAT(400_103, "올바른 이메일 형식이 아니에요.", 400),
+    EMAIL_VERIFICATION_CODE_MISMATCH(400_104, "인증코드가 일치하지 않아요.", 400),
+    EMAIL_VERIFICATION_CODE_EXPIRED(400_105, "인증코드가 만료됐어요. 재발송해주세요.", 400),
+    EMAIL_VERIFICATION_RESEND_COOLDOWN(400_106, "인증코드 재발송은 잠시 후 다시 시도해주세요.", 400),
+    EMAIL_VERIFICATION_DAILY_LIMIT_EXCEEDED(429_101, "내일 다시 시도해주세요.", 429),
     KAKAO_TOKEN_REQUEST_INVALID(401_101, "카카오 토큰 요청 파라미터가 올바르지 않습니다.", 401),
     KAKAO_TOKEN_EXCHANGE_FAILED(401_102, "카카오 토큰 교환에 실패했습니다.", 401),
     KAKAO_TOKEN_RESPONSE_INVALID(401_103, "카카오 토큰 응답이 올바르지 않습니다.", 401),

--- a/src/main/kotlin/com/moongchijang/global/util/MaskingUtils.kt
+++ b/src/main/kotlin/com/moongchijang/global/util/MaskingUtils.kt
@@ -1,0 +1,18 @@
+package com.moongchijang.global.util
+
+object MaskingUtils {
+    fun maskEmail(email: String): String {
+        val parts = email.split("@")
+        if (parts.size != 2) return "***"
+
+        val local = parts[0]
+        val domain = parts[1]
+        val maskedLocal = when {
+            local.isEmpty() -> "***"
+            local.length <= 2 -> "${local.first()}*"
+            else -> local.take(2) + "*".repeat(local.length - 2)
+        }
+
+        return "$maskedLocal@$domain"
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/util/MaskingUtils.kt
+++ b/src/main/kotlin/com/moongchijang/global/util/MaskingUtils.kt
@@ -9,8 +9,8 @@ object MaskingUtils {
         val domain = parts[1]
         val maskedLocal = when {
             local.isEmpty() -> "***"
-            local.length <= 2 -> "${local.first()}*"
-            else -> local.take(2) + "*".repeat(local.length - 2)
+            local.length == 1 -> "${local.first()}*"
+            else -> "${local.first()}" + "*".repeat(local.length - 1)
         }
 
         return "$maskedLocal@$domain"

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -3,6 +3,8 @@ package com.moongchijang.security.config
 import com.moongchijang.security.jwt.JwtAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -65,4 +67,7 @@ class SecurityConfig(
         source.registerCorsConfiguration("/**", configuration)
         return source
     }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -69,3 +69,8 @@ aligo:
   sender-key: ${ALIGO_SENDER_KEY}
   template-code: ${ALIGO_TEMPLATE_CODE}
   sender: ${ALIGO_SENDER}
+
+ses:
+  enabled: ${SES_ENABLED:false}
+  region: ${SES_REGION}
+  from-email: ${SES_FROM_EMAIL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,58 @@
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:mysql://localhost:3306/moongchijang_local?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${DB_USERNAME:moongchijang}
+    password: ${DB_PASSWORD:moongchijang}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  flyway:
+    enabled: true
+    locations:
+      - classpath:db/migration
+
+app:
+  s3:
+    bucket: local-bucket
+    prefix: local
+
+oauth:
+  kakao:
+    client-id: test-client-id
+    client-secret: test-client-secret
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+    redirect-uri: http://localhost:8080/auth/kakao/callback
+
+coolsms:
+  api-key: ${COOLSMS_API_KEY:test-api-key}
+  api-secret: ${COOLSMS_API_SECRET:test-api-secret}
+  sender: ${COOLSMS_SENDER:010-0000-0000}
+
+jwt:
+  secret: jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret
+  access-token:
+    expiration-minutes: 60
+
+auth:
+  refresh:
+    expiration-days: ${AUTH_REFRESH_EXPIRATION_DAYS:14}
+
+naver:
+  api:
+    client-id: ${NAVER_CLIENT_ID:local-client-id}
+    client-secret: ${NAVER_CLIENT_SECRET:local-client-secret}
+
+ses:
+  enabled: ${SES_ENABLED:false}
+  region: ${SES_REGION:ap-northeast-2}
+  from-email: ${SES_FROM_EMAIL:no-reply@moongchijang.com}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -56,3 +56,10 @@ ses:
   enabled: ${SES_ENABLED:false}
   region: ${SES_REGION:ap-northeast-2}
   from-email: ${SES_FROM_EMAIL:no-reply@moongchijang.com}
+
+aligo:
+  api-key: ${ALIGO_API_KEY}
+  user-id: ${ALIGO_USER_ID}
+  sender-key: ${ALIGO_SENDER_KEY}
+  template-code: ${ALIGO_TEMPLATE_CODE}
+  sender: ${ALIGO_SENDER}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -59,3 +59,8 @@ aligo:
   sender-key: ${ALIGO_SENDER_KEY}
   template-code: ${ALIGO_TEMPLATE_CODE}
   sender: ${ALIGO_SENDER}
+
+ses:
+  enabled: ${SES_ENABLED:false}
+  region: ${SES_REGION}
+  from-email: ${SES_FROM_EMAIL}

--- a/src/main/resources/db/migration/V8__alter_users_add_unique_provider_email.sql
+++ b/src/main/resources/db/migration/V8__alter_users_add_unique_provider_email.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD CONSTRAINT uidx_users_provider_email UNIQUE (provider, email);

--- a/src/test/kotlin/com/moongchijang/domain/auth/application/AuthServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/auth/application/AuthServiceTest.kt
@@ -1,8 +1,12 @@
 package com.moongchijang.domain.auth.application
 
 import com.moongchijang.domain.auth.application.dto.KakaoAuthUser
+import com.moongchijang.domain.auth.application.dto.EmailLoginRequest
+import com.moongchijang.domain.auth.application.dto.EmailSignupRequest
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
+import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
 import com.moongchijang.domain.user.application.UserService
+import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -13,20 +17,25 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
+import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 
 class AuthServiceTest {
 
     private val kakaoAuthService: KakaoAuthService = Mockito.mock(KakaoAuthService::class.java)
     private val userService: UserService = Mockito.mock(UserService::class.java)
+    private val emailSignupTokenStore: EmailSignupTokenStore = Mockito.mock(EmailSignupTokenStore::class.java)
     private val tokenService: TokenService = Mockito.mock(TokenService::class.java)
     private val jwtTokenProvider: JwtTokenProvider = Mockito.mock(JwtTokenProvider::class.java)
+    private val passwordEncoder: PasswordEncoder = Mockito.mock(PasswordEncoder::class.java)
 
     private val authService = AuthService(
         kakaoAuthService = kakaoAuthService,
         userService = userService,
+        emailSignupTokenStore = emailSignupTokenStore,
         tokenService = tokenService,
         jwtTokenProvider = jwtTokenProvider,
+        passwordEncoder = passwordEncoder,
     )
 
     @Test
@@ -92,6 +101,218 @@ class AuthServiceTest {
     fun `로그아웃 시 리프레시 토큰 삭제 호출`() {
         authService.logout(9L)
         Mockito.verify(tokenService).deleteByUserId(9L)
+    }
+
+    @Test
+    fun `이메일 회원가입 성공 시 사용자 생성 및 토큰 반환`() {
+        val now = LocalDateTime.of(2026, 5, 11, 12, 0)
+        val user = User(
+            id = 11L,
+            provider = AuthProvider.EMAIL,
+            providerId = null,
+            email = "new@example.com",
+            passwordHash = "hashed-password",
+            nickname = null,
+            phoneNumber = null,
+            signupCompleted = false,
+        )
+        setAuditFields(user, now, now)
+
+        Mockito.`when`(emailSignupTokenStore.isValid("new@example.com", "signup-token")).thenReturn(true)
+        Mockito.`when`(passwordEncoder.encode("abc12345")).thenReturn("hashed-password")
+        Mockito.`when`(userService.createEmailUser("new@example.com", "hashed-password")).thenReturn(user)
+        Mockito.`when`(jwtTokenProvider.generateAccessToken(11L)).thenReturn("email-access-token")
+        Mockito.`when`(tokenService.issueRefreshToken(11L)).thenReturn("email-refresh-token")
+        Mockito.`when`(jwtTokenProvider.getAccessTokenExpiresInSeconds()).thenReturn(3600L)
+
+        val result = authService.signupWithEmail(
+            EmailSignupRequest(
+                email = "new@example.com",
+                password = "abc12345",
+                signupToken = "signup-token",
+            )
+        )
+
+        Assertions.assertEquals("email-access-token", result.response.accessToken)
+        Assertions.assertEquals("email-refresh-token", result.refreshToken)
+        Assertions.assertTrue(result.response.isNewUser)
+        Assertions.assertEquals(11L, result.response.user.id)
+        Mockito.verify(emailSignupTokenStore).delete("new@example.com")
+    }
+
+    @Test
+    fun `이메일 회원가입 시 signupToken 불일치면 예외`() {
+        Mockito.`when`(emailSignupTokenStore.isValid("new@example.com", "bad-token")).thenReturn(false)
+
+        val exception = assertThrows<CustomException> {
+            authService.signupWithEmail(
+                EmailSignupRequest(
+                    email = "new@example.com",
+                    password = "abc12345",
+                    signupToken = "bad-token",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_SIGNUP_TOKEN, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 로그인 성공 시 토큰 반환`() {
+        val now = LocalDateTime.of(2026, 5, 11, 12, 0)
+        val user = User(
+            id = 22L,
+            provider = AuthProvider.EMAIL,
+            providerId = null,
+            email = "login@example.com",
+            passwordHash = "hashed-password",
+            nickname = "테스트유저",
+            phoneNumber = null,
+            signupCompleted = true,
+        )
+        setAuditFields(user, now, now)
+
+        Mockito.`when`(userService.findActiveEmailUser("login@example.com")).thenReturn(user)
+        Mockito.`when`(passwordEncoder.matches("abc12345", "hashed-password")).thenReturn(true)
+        Mockito.`when`(jwtTokenProvider.generateAccessToken(22L)).thenReturn("login-access-token")
+        Mockito.`when`(tokenService.issueRefreshToken(22L)).thenReturn("login-refresh-token")
+        Mockito.`when`(jwtTokenProvider.getAccessTokenExpiresInSeconds()).thenReturn(3600L)
+
+        val result = authService.loginWithEmail(
+            EmailLoginRequest(
+                email = "login@example.com",
+                password = "abc12345",
+            )
+        )
+
+        Assertions.assertEquals("login-access-token", result.response.accessToken)
+        Assertions.assertEquals("login-refresh-token", result.refreshToken)
+        Assertions.assertFalse(result.response.isNewUser)
+        Assertions.assertEquals(22L, result.response.user.id)
+    }
+
+    @Test
+    fun `이메일 로그인 시 비밀번호 불일치면 예외`() {
+        val user = User(
+            id = 33L,
+            provider = AuthProvider.EMAIL,
+            providerId = null,
+            email = "login@example.com",
+            passwordHash = "hashed-password",
+            nickname = null,
+            phoneNumber = null,
+            signupCompleted = false,
+        )
+
+        Mockito.`when`(userService.findActiveEmailUser("login@example.com")).thenReturn(user)
+        Mockito.`when`(passwordEncoder.matches("wrong1234", "hashed-password")).thenReturn(false)
+
+        val exception = assertThrows<CustomException> {
+            authService.loginWithEmail(
+                EmailLoginRequest(
+                    email = "login@example.com",
+                    password = "wrong1234",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_CREDENTIALS, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 회원가입 시 비밀번호 형식 불일치면 예외`() {
+        Mockito.`when`(emailSignupTokenStore.isValid("new@example.com", "signup-token")).thenReturn(true)
+
+        val exception = assertThrows<CustomException> {
+            authService.signupWithEmail(
+                EmailSignupRequest(
+                    email = "new@example.com",
+                    password = "password-only",
+                    signupToken = "signup-token",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_PASSWORD_FORMAT, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 회원가입 시 이메일 아이디와 동일한 비밀번호면 예외`() {
+        Mockito.`when`(emailSignupTokenStore.isValid("new12345@example.com", "signup-token")).thenReturn(true)
+
+        val exception = assertThrows<CustomException> {
+            authService.signupWithEmail(
+                EmailSignupRequest(
+                    email = "new12345@example.com",
+                    password = "new12345",
+                    signupToken = "signup-token",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_PASSWORD_SAME_AS_EMAIL_ID, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 회원가입 시 중복 이메일이면 예외`() {
+        Mockito.`when`(emailSignupTokenStore.isValid("dup@example.com", "signup-token")).thenReturn(true)
+        Mockito.`when`(passwordEncoder.encode("abc12345")).thenReturn("hashed-password")
+        Mockito.`when`(userService.createEmailUser("dup@example.com", "hashed-password"))
+            .thenThrow(CustomException(ErrorCode.DUPLICATE_EMAIL))
+
+        val exception = assertThrows<CustomException> {
+            authService.signupWithEmail(
+                EmailSignupRequest(
+                    email = "dup@example.com",
+                    password = "abc12345",
+                    signupToken = "signup-token",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.DUPLICATE_EMAIL, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 로그인 시 사용자 미존재면 예외`() {
+        Mockito.`when`(userService.findActiveEmailUser("none@example.com")).thenReturn(null)
+
+        val exception = assertThrows<CustomException> {
+            authService.loginWithEmail(
+                EmailLoginRequest(
+                    email = "none@example.com",
+                    password = "abc12345",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_CREDENTIALS, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 로그인 시 비밀번호 해시가 없으면 예외`() {
+        val user = User(
+            id = 44L,
+            provider = AuthProvider.EMAIL,
+            providerId = null,
+            email = "login@example.com",
+            passwordHash = null,
+            nickname = null,
+            phoneNumber = null,
+            signupCompleted = false,
+        )
+        Mockito.`when`(userService.findActiveEmailUser("login@example.com")).thenReturn(user)
+
+        val exception = assertThrows<CustomException> {
+            authService.loginWithEmail(
+                EmailLoginRequest(
+                    email = "login@example.com",
+                    password = "abc12345",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_CREDENTIALS, exception.errorCode)
     }
 
     private fun setAuditFields(user: User, createdAt: LocalDateTime, updatedAt: LocalDateTime) {

--- a/src/test/kotlin/com/moongchijang/domain/auth/application/EmailVerificationServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/auth/application/EmailVerificationServiceTest.kt
@@ -1,0 +1,157 @@
+package com.moongchijang.domain.auth.application
+
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeSendRequest
+import com.moongchijang.domain.auth.application.dto.EmailVerificationCodeVerifyRequest
+import com.moongchijang.domain.auth.application.port.EmailSender
+import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
+import com.moongchijang.domain.auth.application.port.EmailVerificationStore
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
+import java.util.concurrent.atomic.AtomicReference
+
+class EmailVerificationServiceTest {
+
+    private val emailVerificationStore: EmailVerificationStore = Mockito.mock(EmailVerificationStore::class.java)
+    private val emailSignupTokenStore: EmailSignupTokenStore = Mockito.mock(EmailSignupTokenStore::class.java)
+    private val emailSender: EmailSender = Mockito.mock(EmailSender::class.java)
+
+    private val emailVerificationService = EmailVerificationService(
+        emailVerificationStore = emailVerificationStore,
+        emailSignupTokenStore = emailSignupTokenStore,
+        emailSender = emailSender,
+    )
+
+    @Test
+    fun `이메일 인증코드 발송 성공 시 저장 및 발송 호출`() {
+        val request = EmailVerificationCodeSendRequest(email = "new@example.com")
+        val savedEmail = AtomicReference<String>()
+        val savedCode = AtomicReference<String>()
+        val sentEmail = AtomicReference<String>()
+        val sentCode = AtomicReference<String>()
+
+        Mockito.`when`(emailVerificationStore.getDailySendCount("new@example.com")).thenReturn(0L)
+        Mockito.`when`(emailVerificationStore.getResendAvailableInSeconds("new@example.com")).thenReturn(0L)
+        Mockito.`when`(emailVerificationStore.incrementDailySendCount("new@example.com")).thenReturn(1L)
+
+        Mockito.doAnswer { invocation ->
+            savedEmail.set(invocation.getArgument(0))
+            savedCode.set(invocation.getArgument(1))
+            null
+        }.`when`(emailVerificationStore).saveCode(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong())
+
+        Mockito.doAnswer { invocation ->
+            sentEmail.set(invocation.getArgument(0))
+            sentCode.set(invocation.getArgument(1))
+            null
+        }.`when`(emailSender).sendVerificationCode(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong())
+
+        val response = emailVerificationService.sendEmailVerificationCode(request)
+
+        Assertions.assertEquals(180, response.expiresInSeconds)
+        Assertions.assertEquals(60, response.resendAvailableInSeconds)
+        Assertions.assertEquals(4, response.remainingDailyAttempts)
+
+        Mockito.verify(emailVerificationStore).saveCode(Mockito.anyString(), Mockito.anyString(), Mockito.eq(180L))
+        Mockito.verify(emailVerificationStore).setResendCooldown("new@example.com", 60L)
+        Mockito.verify(emailSender).sendVerificationCode(Mockito.anyString(), Mockito.anyString(), Mockito.eq(180L))
+
+        Assertions.assertEquals("new@example.com", savedEmail.get())
+        Assertions.assertEquals("new@example.com", sentEmail.get())
+        Assertions.assertTrue(savedCode.get().matches(Regex("^[0-9]{6}$")))
+        Assertions.assertTrue(sentCode.get().matches(Regex("^[0-9]{6}$")))
+        Assertions.assertEquals(savedCode.get(), sentCode.get())
+    }
+
+    @Test
+    fun `이메일 인증코드 발송 시 재발송 쿨다운이면 예외`() {
+        Mockito.`when`(emailVerificationStore.getDailySendCount("new@example.com")).thenReturn(0L)
+        Mockito.`when`(emailVerificationStore.getResendAvailableInSeconds("new@example.com")).thenReturn(30L)
+
+        val exception = assertThrows<CustomException> {
+            emailVerificationService.sendEmailVerificationCode(
+                EmailVerificationCodeSendRequest(email = "new@example.com")
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.EMAIL_VERIFICATION_RESEND_COOLDOWN, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 인증코드 발송 시 일일 한도 초과면 예외`() {
+        Mockito.`when`(emailVerificationStore.getDailySendCount("new@example.com")).thenReturn(5L)
+
+        val exception = assertThrows<CustomException> {
+            emailVerificationService.sendEmailVerificationCode(
+                EmailVerificationCodeSendRequest(email = "new@example.com")
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.EMAIL_VERIFICATION_DAILY_LIMIT_EXCEEDED, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 인증코드 검증 성공 시 코드 삭제 및 signupToken 저장`() {
+        Mockito.`when`(emailVerificationStore.getCode("new@example.com")).thenReturn("123456")
+        val savedEmail = AtomicReference<String>()
+        val savedSignupToken = AtomicReference<String>()
+        val savedTtl = AtomicReference<Long>()
+
+        Mockito.doAnswer { invocation ->
+            savedEmail.set(invocation.getArgument(0))
+            savedSignupToken.set(invocation.getArgument(1))
+            savedTtl.set(invocation.getArgument(2))
+            null
+        }.`when`(emailSignupTokenStore).save(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong())
+
+        val response = emailVerificationService.verifyEmailVerificationCode(
+            EmailVerificationCodeVerifyRequest(
+                email = "new@example.com",
+                code = "123456",
+            )
+        )
+
+        Assertions.assertTrue(response.verified)
+        Assertions.assertFalse(response.signupToken.isBlank())
+        Mockito.verify(emailVerificationStore).deleteCode("new@example.com")
+        Mockito.verify(emailSignupTokenStore).save(Mockito.anyString(), Mockito.anyString(), Mockito.anyLong())
+        Assertions.assertEquals("new@example.com", savedEmail.get())
+        Assertions.assertEquals(response.signupToken, savedSignupToken.get())
+        Assertions.assertEquals(1800L, savedTtl.get())
+    }
+
+    @Test
+    fun `이메일 인증코드 검증 시 코드 만료면 예외`() {
+        Mockito.`when`(emailVerificationStore.getCode("new@example.com")).thenReturn(null)
+
+        val exception = assertThrows<CustomException> {
+            emailVerificationService.verifyEmailVerificationCode(
+                EmailVerificationCodeVerifyRequest(
+                    email = "new@example.com",
+                    code = "123456",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.EMAIL_VERIFICATION_CODE_EXPIRED, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 인증코드 검증 시 코드 불일치면 예외`() {
+        Mockito.`when`(emailVerificationStore.getCode("new@example.com")).thenReturn("111111")
+
+        val exception = assertThrows<CustomException> {
+            emailVerificationService.verifyEmailVerificationCode(
+                EmailVerificationCodeVerifyRequest(
+                    email = "new@example.com",
+                    code = "222222",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.EMAIL_VERIFICATION_CODE_MISMATCH, exception.errorCode)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -135,4 +135,98 @@ class UserServiceTest {
 
         Assertions.assertEquals(ErrorCode.REJOIN_NOT_AVAILABLE_YET, exception.errorCode)
     }
+
+    @Test
+    fun `이메일 중복 확인 시 사용 가능하면 true`() {
+        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("new@example.com")).thenReturn(false)
+
+        val response = userService.checkEmailAvailability("new@example.com")
+
+        Assertions.assertTrue(response.available)
+        Assertions.assertEquals("new@example.com", response.email)
+    }
+
+    @Test
+    fun `이메일 중복 확인 시 중복이면 false`() {
+        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("dup@example.com")).thenReturn(true)
+
+        val response = userService.checkEmailAvailability("dup@example.com")
+
+        Assertions.assertFalse(response.available)
+        Assertions.assertEquals("dup@example.com", response.email)
+    }
+
+    @Test
+    fun `이메일 중복 확인 시 형식 오류 예외`() {
+        val exception = assertThrows<CustomException> {
+            userService.checkEmailAvailability("invalid-email")
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_EMAIL_FORMAT, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 사용자 생성 성공`() {
+        val savedUser = UserFixture.createEmailUser(
+            id = 30L,
+            email = "new@example.com",
+            passwordHash = "hashed-password",
+        )
+
+        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("new@example.com")).thenReturn(false)
+        Mockito.`when`(userRepository.save(Mockito.any(User::class.java))).thenReturn(savedUser)
+
+        val user = userService.createEmailUser("new@example.com", "hashed-password")
+
+        Assertions.assertEquals(30L, user.id)
+        Assertions.assertEquals(AuthProvider.EMAIL, user.provider)
+        Assertions.assertEquals("new@example.com", user.email)
+        Assertions.assertEquals("hashed-password", user.passwordHash)
+    }
+
+    @Test
+    fun `이메일 사용자 생성 시 중복 이메일 예외`() {
+        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("dup@example.com")).thenReturn(true)
+
+        val exception = assertThrows<CustomException> {
+            userService.createEmailUser("dup@example.com", "hashed-password")
+        }
+
+        Assertions.assertEquals(ErrorCode.DUPLICATE_EMAIL, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 사용자 생성 시 이메일 형식 오류 예외`() {
+        val exception = assertThrows<CustomException> {
+            userService.createEmailUser("invalid-email", "hashed-password")
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_EMAIL_FORMAT, exception.errorCode)
+    }
+
+    @Test
+    fun `이메일 사용자 조회 성공`() {
+        val user = UserFixture.createEmailUser(
+            id = 31L,
+            email = "login@example.com",
+            passwordHash = "hashed-password",
+        )
+        Mockito.`when`(
+            userRepository.findByProviderAndEmailAndDeletedAtIsNull(AuthProvider.EMAIL, "login@example.com"),
+        ).thenReturn(user)
+
+        val found = userService.findActiveEmailUser("login@example.com")
+
+        Assertions.assertEquals(31L, found?.id)
+        Assertions.assertEquals("login@example.com", found?.email)
+    }
+
+    @Test
+    fun `이메일 사용자 조회 시 이메일 형식 오류 예외`() {
+        val exception = assertThrows<CustomException> {
+            userService.findActiveEmailUser("invalid-email")
+        }
+
+        Assertions.assertEquals(ErrorCode.INVALID_EMAIL_FORMAT, exception.errorCode)
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -138,7 +138,9 @@ class UserServiceTest {
 
     @Test
     fun `이메일 중복 확인 시 사용 가능하면 true`() {
-        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("new@example.com")).thenReturn(false)
+        Mockito.`when`(
+            userRepository.existsByProviderAndEmailAndDeletedAtIsNull(AuthProvider.EMAIL, "new@example.com"),
+        ).thenReturn(false)
 
         val response = userService.checkEmailAvailability("new@example.com")
 
@@ -148,7 +150,9 @@ class UserServiceTest {
 
     @Test
     fun `이메일 중복 확인 시 중복이면 false`() {
-        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("dup@example.com")).thenReturn(true)
+        Mockito.`when`(
+            userRepository.existsByProviderAndEmailAndDeletedAtIsNull(AuthProvider.EMAIL, "dup@example.com"),
+        ).thenReturn(true)
 
         val response = userService.checkEmailAvailability("dup@example.com")
 
@@ -173,7 +177,9 @@ class UserServiceTest {
             passwordHash = "hashed-password",
         )
 
-        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("new@example.com")).thenReturn(false)
+        Mockito.`when`(
+            userRepository.existsByProviderAndEmailAndDeletedAtIsNull(AuthProvider.EMAIL, "new@example.com"),
+        ).thenReturn(false)
         Mockito.`when`(userRepository.save(Mockito.any(User::class.java))).thenReturn(savedUser)
 
         val user = userService.createEmailUser("new@example.com", "hashed-password")
@@ -186,7 +192,9 @@ class UserServiceTest {
 
     @Test
     fun `이메일 사용자 생성 시 중복 이메일 예외`() {
-        Mockito.`when`(userRepository.existsByEmailAndDeletedAtIsNull("dup@example.com")).thenReturn(true)
+        Mockito.`when`(
+            userRepository.existsByProviderAndEmailAndDeletedAtIsNull(AuthProvider.EMAIL, "dup@example.com"),
+        ).thenReturn(true)
 
         val exception = assertThrows<CustomException> {
             userService.createEmailUser("dup@example.com", "hashed-password")

--- a/src/test/kotlin/com/moongchijang/support/UserFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/UserFixture.kt
@@ -25,5 +25,24 @@ object UserFixture {
             deletedAt = deletedAt,
         )
     }
-}
 
+    fun createEmailUser(
+        id: Long = 2L,
+        email: String = "email@example.com",
+        passwordHash: String = "hashed-password",
+        nickname: String? = null,
+        deletedAt: LocalDateTime? = null,
+    ): User {
+        return User(
+            id = id,
+            provider = AuthProvider.EMAIL,
+            providerId = null,
+            email = email,
+            passwordHash = passwordHash,
+            nickname = nickname,
+            role = UserRole.BUYER,
+            signupCompleted = false,
+            deletedAt = deletedAt,
+        )
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,3 +35,8 @@ aligo:
   sender-key: test-dummy
   template-code: test-dummy
   sender: 010-0000-0000
+
+ses:
+  enabled: false
+  region: ap-northeast-2
+  from-email: no-reply@test.com


### PR DESCRIPTION
## 📌 작업한 내용
- 이메일 회원가입 API를 구현했습니다. (`signupToken` 검증, 비밀번호 정책 검증, 비밀번호 해시 저장, 토큰 발급/쿠키 연동)
- 이메일 로그인 API를 구현했습니다. (이메일/비밀번호 검증, 실패 공통 에러 처리, 토큰 발급/쿠키 연동)
- 이메일 중복확인 API를 연결하고, 이메일 형식 검증 및 로그를 보강했습니다.
- 이메일 인증코드 발송/검증 API를 구현했습니다.
  - 6자리 코드 생성
  - 만료 3분
  - 재발송 쿨다운 60초
  - 일 5회 제한
  - 코드 불일치/만료 예외 처리
- 이메일 인증 성공 시 회원가입 진행용 `signupToken` 저장/반환 로직을 추가했습니다.
- SES 기반 메일 발송을 위한 설정/구조를 추가했습니다.
  - `SesProperties`, `SesConfig`, `SesEmailSender`
  - `ses.enabled=false` 환경에서도 동작하도록 `NoopEmailSender` fallback 추가
  - 테스트 프로필 `ses` 설정 반영
- 공통 유틸(`MaskingUtils`)로 이메일 마스킹 로직을 분리했습니다.
- 테스트를 보강했습니다.
  - `AuthServiceTest`: 이메일 회원가입/로그인 정상 및 예외 케이스 추가
  - `EmailVerificationServiceTest`: 발송/검증 정상 및 예외 케이스 추가
  - `UserServiceTest`: 이메일 중복확인/생성/조회 정상 및 예외 케이스 추가

## 🔍 참고 사항
- 이메일 인증/회원가입 플로우는 `카카오 로그인`과 동일하게 Access Token 응답 + Refresh Token HttpOnly 쿠키 발급 방식으로 맞췄습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #64 
 
## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인