### PR TITLE
[MCJ-1421] FEAT: Qdrant 기반 하이브리드 검색 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(platform("software.amazon.awssdk:bom:2.31.18"))
     implementation("software.amazon.awssdk:s3")
     implementation("software.amazon.awssdk:sesv2")
+    implementation("software.amazon.awssdk:sqs")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
 
     // JWT
@@ -51,6 +52,10 @@ dependencies {
     // Flyway
     implementation("org.springframework.boot:spring-boot-starter-flyway")
     implementation("org.flywaydb:flyway-mysql")
+
+    // LangChain4j (검색 MVP)
+    implementation("dev.langchain4j:langchain4j:1.14.0")
+    implementation("dev.langchain4j:langchain4j-google-ai-gemini:1.14.0")
 
     // SOLAPI
     implementation("com.solapi:sdk:1.0.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("tools.jackson.module:jackson-module-kotlin")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testImplementation("org.springframework.boot:spring-boot-starter-security-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("tools.jackson.module:jackson-module-kotlin")
     runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testImplementation("org.springframework.boot:spring-boot-starter-security-test")

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,6 +58,19 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     restart: unless-stopped
 
+  qdrant:
+    # 벡터 검색 평가용. search-eval 프로필에서만 기동
+    profiles: ["search-eval"]
+    image: qdrant/qdrant:latest
+    container_name: moongchijang-qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant-storage:/qdrant/storage
+    restart: unless-stopped
+
 volumes:
   mysql-local-data:
   redis-local-data:
+  qdrant-storage:

--- a/src/main/kotlin/com/moongchijang/MoongchijangApplication.kt
+++ b/src/main/kotlin/com/moongchijang/MoongchijangApplication.kt
@@ -4,10 +4,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableJpaAuditing
+@EnableAsync
+@EnableScheduling
 class MoongchijangApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyIndexingService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyIndexingService.kt
@@ -1,0 +1,86 @@
+package com.moongchijang.domain.groupbuy.application
+
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexRequestedEvent
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexAction
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.search.application.SearchIndexVersionService
+import com.moongchijang.domain.search.application.port.VectorIndexDocument
+import com.moongchijang.domain.search.application.port.VectorIndexPort
+import dev.langchain4j.data.document.Metadata
+import dev.langchain4j.data.segment.TextSegment
+import dev.langchain4j.model.embedding.EmbeddingModel
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Service
+class GroupBuyIndexingService(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val embeddingModel: EmbeddingModel,
+    private val vectorIndexPort: VectorIndexPort,
+    private val searchIndexVersionService: SearchIndexVersionService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val embeddingVersion = "gemini-embedding-001-768-v1"
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: GroupBuyIndexRequestedEvent) {
+        process(event)
+    }
+
+    fun process(event: GroupBuyIndexRequestedEvent): Boolean {
+        if (event.action == GroupBuyIndexAction.DELETE) {
+            val deleted = vectorIndexPort.delete(event.groupBuyId)
+            if (deleted) {
+                searchIndexVersionService.bumpVersion()
+                log.info("공구 인덱싱 삭제 완료: id={}", event.groupBuyId)
+            } else {
+                log.warn("공구 인덱싱 삭제 보류: id={}", event.groupBuyId)
+            }
+            return deleted
+        }
+
+        val groupBuy = groupBuyRepository.findById(event.groupBuyId).orElse(null)
+        if (groupBuy == null) {
+            log.warn("공구 인덱싱 대상 없음: id={}", event.groupBuyId)
+            return true
+        }
+        return index(groupBuy)
+    }
+
+    fun index(groupBuy: GroupBuy): Boolean =
+        try {
+            val regionLabel = groupBuy.store.region.label
+            val storeName = groupBuy.store.name
+            val text = "$regionLabel $storeName ${groupBuy.productName}"
+            val segment = TextSegment.from(text, Metadata.from("groupBuyId", groupBuy.id.toString()))
+            val embedding = embeddingModel.embed(segment).content()
+            val indexed = vectorIndexPort.upsert(
+                VectorIndexDocument(
+                    groupBuyId = groupBuy.id,
+                    vectorText = text,
+                    vector = embedding.vector(),
+                    region = regionLabel,
+                    storeName = storeName,
+                    productName = groupBuy.productName,
+                    status = groupBuy.status.name,
+                    deadline = groupBuy.deadline,
+                    embeddingVersion = embeddingVersion
+                )
+            )
+            if (indexed) {
+                searchIndexVersionService.bumpVersion()
+                log.info("공구 임베딩 인덱싱 완료: id={}", groupBuy.id)
+            } else {
+                log.warn("공구 임베딩 인덱싱 보류: id={}", groupBuy.id)
+            }
+            indexed
+        } catch (e: Exception) {
+            log.error("공구 임베딩 인덱싱 실패: id={}, error={}", groupBuy.id, e.message)
+            false
+        }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/event/GroupBuyIndexRequestedEvent.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/event/GroupBuyIndexRequestedEvent.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.groupbuy.application.event
+
+data class GroupBuyIndexRequestedEvent(
+    val groupBuyId: Long,
+    val action: GroupBuyIndexAction = GroupBuyIndexAction.UPSERT
+)
+
+enum class GroupBuyIndexAction {
+    UPSERT,
+    DELETE
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/port/GroupBuyIndexingEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/port/GroupBuyIndexingEventPublisher.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.groupbuy.application.port
+
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexAction
+
+interface GroupBuyIndexingEventPublisher {
+    fun publishIndexRequested(
+        groupBuyId: Long,
+        action: GroupBuyIndexAction = GroupBuyIndexAction.UPSERT
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyEmbedding.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyEmbedding.kt
@@ -1,0 +1,21 @@
+package com.moongchijang.domain.groupbuy.domain.entity
+
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(
+    name = "group_buy_embeddings",
+    indexes = [Index(name = "idx_group_buy_embeddings_group_buy_id", columnList = "group_buy_id")]
+)
+class GroupBuyEmbedding(
+    @Column(name = "group_buy_id", nullable = false, unique = true)
+    val groupBuyId: Long,
+
+    @Column(columnDefinition = "JSON", nullable = false)
+    var embedding: String,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity()

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyEmbeddingRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyEmbeddingRepository.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.groupbuy.domain.repository
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyEmbedding
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GroupBuyEmbeddingRepository : JpaRepository<GroupBuyEmbedding, Long> {
+    fun findByGroupBuyId(groupBuyId: Long): GroupBuyEmbedding?
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
@@ -2,9 +2,11 @@ package com.moongchijang.domain.groupbuy.domain.repository
 
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import java.time.LocalDateTime
 
 interface GroupBuyRepositoryCustom {
 
@@ -19,4 +21,15 @@ interface GroupBuyRepositoryCustom {
         keyword: String?,
         pageable: Pageable
     ): Page<GroupBuy>
+
+    fun searchByIntent(
+        region: String?,
+        product: String?,
+        now: LocalDateTime,
+        status: GroupBuyStatus
+    ): List<GroupBuy>
+
+    fun findDistinctRegions(status: GroupBuyStatus): List<String>
+
+    fun findDistinctProductNames(status: GroupBuyStatus): List<String>
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.entity.QGroupBuy.groupBuy
 import com.moongchijang.domain.store.domain.entity.QStore.store
 import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -84,5 +85,43 @@ class GroupBuyRepositoryImpl(
                 groupBuy.currentQuantity.multiply(100)
                     .goe(groupBuy.targetQuantity.multiply(GroupBuyRepositoryCustom.ALMOST_ACHIEVED_RATE))
         }
+    }
+
+    override fun searchByIntent(
+        region: String?,
+        product: String?,
+        now: LocalDateTime,
+        status: GroupBuyStatus
+    ): List<GroupBuy> {
+        val regionType = region?.let { runCatching { RegionType.fromLabel(it) }.getOrNull() }
+        val builder = BooleanBuilder()
+        builder.and(groupBuy.status.eq(status))
+        builder.and(groupBuy.deadline.gt(now))
+        regionType?.let { builder.and(store.region.eq(it)) }
+        product?.let { builder.and(groupBuy.productName.eq(it)) }
+
+        return queryFactory
+            .selectFrom(groupBuy)
+            .join(groupBuy.store, store).fetchJoin()
+            .where(builder)
+            .fetch()
+    }
+
+    override fun findDistinctRegions(status: GroupBuyStatus): List<String> {
+        return queryFactory
+            .select(store.region).distinct()
+            .from(groupBuy)
+            .join(groupBuy.store, store)
+            .where(groupBuy.status.eq(status))
+            .fetch()
+            .map { it.label }
+    }
+
+    override fun findDistinctProductNames(status: GroupBuyStatus): List<String> {
+        return queryFactory
+            .select(groupBuy.productName).distinct()
+            .from(groupBuy)
+            .where(groupBuy.status.eq(status))
+            .fetch()
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SpringGroupBuyIndexingEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SpringGroupBuyIndexingEventPublisher.kt
@@ -1,0 +1,18 @@
+package com.moongchijang.domain.groupbuy.infrastructure.event
+
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexAction
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexRequestedEvent
+import com.moongchijang.domain.groupbuy.application.port.GroupBuyIndexingEventPublisher
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "indexing", name = ["publisher"], havingValue = "spring", matchIfMissing = true)
+class SpringGroupBuyIndexingEventPublisher(
+    private val eventPublisher: ApplicationEventPublisher
+) : GroupBuyIndexingEventPublisher {
+    override fun publishIndexRequested(groupBuyId: Long, action: GroupBuyIndexAction) {
+        eventPublisher.publishEvent(GroupBuyIndexRequestedEvent(groupBuyId, action))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventConsumer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventConsumer.kt
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventConsumer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventConsumer.kt
@@ -1,0 +1,63 @@
+package com.moongchijang.domain.groupbuy.infrastructure.event
+
+import com.moongchijang.domain.groupbuy.application.GroupBuyIndexingService
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexRequestedEvent
+import com.moongchijang.global.config.IndexingProperties
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+
+@Component
+@ConditionalOnProperty(prefix = "indexing", name = ["consumer"], havingValue = "sqs")
+class SqsGroupBuyIndexingEventConsumer(
+    private val objectMapper: ObjectMapper,
+    private val properties: IndexingProperties,
+    private val indexingService: GroupBuyIndexingService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val sqsClient: SqsClient = SqsClient.create()
+
+    @Scheduled(fixedDelayString = "\${indexing.sqs.polling-fixed-delay-millis:5000}")
+    fun poll() {
+        val queueUrl = properties.sqs.queueUrl
+        if (queueUrl.isBlank()) {
+            log.warn("SQS 인덱싱 이벤트 수신 생략: queueUrl 미설정")
+            return
+        }
+
+        val messages = sqsClient.receiveMessage(
+            ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .maxNumberOfMessages(properties.sqs.maxMessages.coerceIn(1, 10))
+                .waitTimeSeconds(properties.sqs.waitTimeSeconds.coerceIn(0, 20))
+                .visibilityTimeout(properties.sqs.visibilityTimeoutSeconds)
+                .build()
+        ).messages()
+
+        messages.forEach { message ->
+            try {
+                val event = objectMapper.readValue(message.body(), GroupBuyIndexRequestedEvent::class.java)
+                val processed = indexingService.process(event)
+                if (processed) {
+                    deleteMessage(queueUrl, message.receiptHandle())
+                }
+            } catch (e: Exception) {
+                log.warn("SQS 인덱싱 이벤트 처리 실패, 재시도 예정: messageId={}, error={}", message.messageId(), e.message)
+            }
+        }
+    }
+
+    private fun deleteMessage(queueUrl: String, receiptHandle: String) {
+        sqsClient.deleteMessage(
+            DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .build()
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventConsumer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventConsumer.kt
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
@@ -15,12 +15,12 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 @Component
 @ConditionalOnProperty(prefix = "indexing", name = ["consumer"], havingValue = "sqs")
 class SqsGroupBuyIndexingEventConsumer(
+    private val sqsClient: SqsClient,
     private val objectMapper: ObjectMapper,
     private val properties: IndexingProperties,
     private val indexingService: GroupBuyIndexingService
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val sqsClient: SqsClient = SqsClient.create()
 
     @Scheduled(fixedDelayString = "\${indexing.sqs.polling-fixed-delay-millis:5000}")
     fun poll() {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventPublisher.kt
@@ -1,0 +1,42 @@
+package com.moongchijang.domain.groupbuy.infrastructure.event
+
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexAction
+import com.moongchijang.domain.groupbuy.application.event.GroupBuyIndexRequestedEvent
+import com.moongchijang.domain.groupbuy.application.port.GroupBuyIndexingEventPublisher
+import com.moongchijang.global.config.IndexingProperties
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import software.amazon.awssdk.services.sqs.SqsClient
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+
+@Component
+@ConditionalOnProperty(prefix = "indexing", name = ["publisher"], havingValue = "sqs")
+class SqsGroupBuyIndexingEventPublisher(
+    private val objectMapper: ObjectMapper,
+    private val properties: IndexingProperties
+) : GroupBuyIndexingEventPublisher {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val sqsClient: SqsClient = SqsClient.create()
+
+    override fun publishIndexRequested(groupBuyId: Long, action: GroupBuyIndexAction) {
+        val queueUrl = properties.sqs.queueUrl
+        if (queueUrl.isBlank()) {
+            log.warn("SQS 인덱싱 이벤트 발행 생략: queueUrl 미설정, groupBuyId={}", groupBuyId)
+            return
+        }
+
+        val event = GroupBuyIndexRequestedEvent(groupBuyId, action)
+        val requestBuilder = SendMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .messageBody(objectMapper.writeValueAsString(event))
+
+        properties.sqs.messageGroupId.takeIf { it.isNotBlank() }?.let {
+            requestBuilder.messageGroupId(it)
+        }
+
+        sqsClient.sendMessage(requestBuilder.build())
+        log.info("SQS 인덱싱 이벤트 발행 완료: groupBuyId={}, action={}", groupBuyId, action)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventPublisher.kt
@@ -7,18 +7,18 @@ import com.moongchijang.global.config.IndexingProperties
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 
 @Component
 @ConditionalOnProperty(prefix = "indexing", name = ["publisher"], havingValue = "sqs")
 class SqsGroupBuyIndexingEventPublisher(
+    private val sqsClient: SqsClient,
     private val objectMapper: ObjectMapper,
     private val properties: IndexingProperties
 ) : GroupBuyIndexingEventPublisher {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val sqsClient: SqsClient = SqsClient.create()
 
     override fun publishIndexRequested(groupBuyId: Long, action: GroupBuyIndexAction) {
         val queueUrl = properties.sqs.queueUrl

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/event/SqsGroupBuyIndexingEventPublisher.kt
@@ -7,7 +7,7 @@ import com.moongchijang.global.config.IndexingProperties
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 

--- a/src/main/kotlin/com/moongchijang/domain/search/application/AliasDictionary.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/AliasDictionary.kt
@@ -1,0 +1,31 @@
+package com.moongchijang.domain.search.application
+
+import org.springframework.stereotype.Component
+
+@Component
+class AliasDictionary {
+    private val productAliases = mapOf(
+        "시오빵" to "소금빵",
+        "salt bread" to "소금빵",
+        "소금 빵" to "소금빵",
+        "버터 떡" to "버터떡"
+    )
+
+    fun resolveProduct(query: String, validProducts: List<String>): String? {
+        val direct = validProducts.firstOrNull { query.contains(it, ignoreCase = true) }
+        if (direct != null) return direct
+
+        return productAliases.entries
+            .firstOrNull { (alias, product) ->
+                query.contains(alias, ignoreCase = true) && product in validProducts
+            }
+            ?.value
+    }
+
+    fun isAliasMatch(query: String, product: String?): Boolean {
+        if (product == null) return false
+        return productAliases.any { (alias, canonical) ->
+            canonical == product && query.contains(alias, ignoreCase = true)
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/RetrievalPipeline.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/RetrievalPipeline.kt
@@ -1,0 +1,78 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.search.application.port.VectorSearchPort
+import com.moongchijang.domain.search.domain.SearchCandidate
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.global.config.SearchProperties
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class RetrievalPipeline(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val vectorSearchPort: VectorSearchPort,
+    private val aliasDictionary: AliasDictionary,
+    private val vectorCandidatePromotionGuard: VectorCandidatePromotionGuard,
+    private val reranker: SearchReranker,
+    private val searchObservabilityLogger: SearchObservabilityLogger,
+    private val searchProperties: SearchProperties
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun retrieve(query: String, intent: SearchIntent): List<SearchCandidate> {
+        val now = LocalDateTime.now()
+        val exactMatches = groupBuyRepository.searchByIntent(
+            region = intent.region,
+            product = intent.product,
+            now = now,
+            status = GroupBuyStatus.IN_PROGRESS
+        )
+
+        val vectorCandidates = searchVectorCandidates(query)
+        val vectorMatches = groupBuyRepository.findAllById(vectorCandidates.map { it.groupBuyId })
+            .filter { it.status == GroupBuyStatus.IN_PROGRESS && it.deadline.isAfter(now) }
+            .filter { intent.region == null || it.store.region.label == intent.region }
+        val promotableVectorResult = vectorCandidatePromotionGuard.filterPromotableCandidates(
+            intent = intent,
+            vectorMatches = vectorMatches,
+            vectorCandidates = vectorCandidates
+        )
+
+        val finalResults = reranker.merge(
+            exactMatches = exactMatches,
+            vectorMatches = promotableVectorResult.vectorMatches,
+            vectorCandidates = promotableVectorResult.vectorCandidates,
+            aliasMatched = aliasDictionary.isAliasMatch(query, intent.product)
+        )
+
+        searchObservabilityLogger.logRetrieval(
+            query = query,
+            intent = intent,
+            mysqlResultCount = exactMatches.size,
+            vectorCandidateCount = vectorCandidates.size,
+            promotionResult = promotableVectorResult,
+            finalResults = finalResults
+        )
+
+        return finalResults
+    }
+
+    private fun searchVectorCandidates(query: String) =
+        try {
+            vectorSearchPort.search(
+                query = query,
+                topK = searchProperties.retrieval.vectorCandidateLimit,
+                minScore = searchProperties.retrieval.vectorMinScore
+            )
+        } catch (e: Exception) {
+            log.warn(
+                "Vector search failed, fallbackProvider={} error={}",
+                searchProperties.retrieval.fallbackProvider,
+                e.message
+            )
+            emptyList()
+        }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchDecisionEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchDecisionEngine.kt
@@ -1,0 +1,20 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.domain.search.domain.SearchUiState
+import org.springframework.stereotype.Component
+
+@Component
+class SearchDecisionEngine {
+    fun decide(intent: SearchIntent, resultCount: Int): SearchUiState {
+        if (resultCount > 0) return SearchUiState.RESULTS
+
+        return when (intent.searchCase) {
+            SearchCase.BOTH_DETECTED -> SearchUiState.EMPTY_CAN_REQUEST
+            SearchCase.PRODUCT_ONLY -> SearchUiState.NEED_REGION
+            SearchCase.NEIGHBORHOOD_ONLY -> SearchUiState.NEED_PRODUCT
+            SearchCase.NONE_DETECTED -> SearchUiState.NEED_BOTH
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchIndexVersionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchIndexVersionService.kt
@@ -1,0 +1,31 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.global.config.SearchIndexProperties
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class SearchIndexVersionService(
+    private val redisTemplate: StringRedisTemplate,
+    private val properties: SearchIndexProperties
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun currentVersion(): String =
+        try {
+            redisTemplate.opsForValue().get(properties.versionKey) ?: properties.defaultVersion
+        } catch (e: Exception) {
+            log.warn("검색 인덱스 버전 조회 실패, 기본 버전 사용: error={}", e.message)
+            properties.defaultVersion
+        }
+
+    fun bumpVersion(): String =
+        try {
+            redisTemplate.opsForValue().increment(properties.versionKey)?.toString()
+                ?: properties.defaultVersion
+        } catch (e: Exception) {
+            log.warn("검색 인덱스 버전 증가 실패: error={}", e.message)
+            properties.defaultVersion
+        }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchObservabilityLogger.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchObservabilityLogger.kt
@@ -1,0 +1,74 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.domain.SearchCandidate
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.global.config.SearchProperties
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+
+@Component
+class SearchObservabilityLogger(
+    private val searchProperties: SearchProperties = SearchProperties()
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun logRetrieval(
+        query: String,
+        intent: SearchIntent,
+        mysqlResultCount: Int,
+        vectorCandidateCount: Int,
+        promotionResult: VectorPromotionResult,
+        finalResults: List<SearchCandidate>
+    ) {
+        if (!searchProperties.observability.enabled) return
+        if (!log.isInfoEnabled) return
+
+        log.info(
+            "search_retrieval " +
+                "queryHash={} queryLength={} searchCase={} hasRegion={} hasProduct={} confidenceBucket={} " +
+                "mysqlResultCount={} qdrantCandidateCount={} vectorPromotedCount={} guardRejectedCount={} " +
+                "finalResultCount={} vectorOnlyResultCount={} topCandidateScore={} providerSources={} guardRejectionReasons={}",
+            queryHash(query),
+            query.length,
+            intent.searchCase,
+            intent.region != null,
+            intent.product != null,
+            confidenceBucket(intent.confidence),
+            mysqlResultCount,
+            vectorCandidateCount,
+            promotionResult.vectorCandidates.size,
+            promotionResult.rejectedCount,
+            finalResults.size,
+            vectorOnlyResultCount(finalResults),
+            topCandidateScore(promotionResult),
+            providerSources(finalResults),
+            promotionResult.rejectionReasonCounts.mapKeys { it.key.name }
+        )
+    }
+
+    private fun queryHash(query: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(query.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }.take(16)
+    }
+
+    private fun confidenceBucket(confidence: Double): String =
+        when {
+            confidence >= 0.9 -> "HIGH"
+            confidence >= 0.65 -> "MEDIUM"
+            confidence > 0.0 -> "LOW"
+            else -> "NONE"
+        }
+
+    private fun topCandidateScore(promotionResult: VectorPromotionResult): Double? =
+        promotionResult.decisions.maxOfOrNull { it.score }
+
+    private fun providerSources(finalResults: List<SearchCandidate>): Map<String, Int> =
+        finalResults
+            .flatMap { it.matchedBy }
+            .groupingBy { it }
+            .eachCount()
+
+    private fun vectorOnlyResultCount(finalResults: List<SearchCandidate>): Int =
+        finalResults.count { it.matchedBy == setOf("VECTOR") }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchOrchestrator.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchOrchestrator.kt
@@ -1,0 +1,73 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.search.application.dto.GroupBuyCardDto
+import com.moongchijang.domain.search.application.dto.KeywordExtractionResult
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.application.dto.SearchResponse
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.domain.search.infrastructure.gemini.GeminiKeywordExtractionService
+import org.springframework.stereotype.Component
+
+@Component
+class SearchOrchestrator(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val keywordExtractor: GeminiKeywordExtractionService,
+    private val aliasDictionary: AliasDictionary,
+    private val retrievalPipeline: RetrievalPipeline,
+    private val decisionEngine: SearchDecisionEngine
+) {
+    fun search(query: String): SearchResponse {
+        val validRegions = groupBuyRepository.findDistinctRegions(GroupBuyStatus.IN_PROGRESS)
+        val validProducts = groupBuyRepository.findDistinctProductNames(GroupBuyStatus.IN_PROGRESS)
+
+        val extraction = extract(query, validRegions, validProducts)
+        val product = extraction.product ?: aliasDictionary.resolveProduct(query, validProducts)
+        val intent = SearchIntent(
+            region = extraction.region,
+            product = product,
+            searchCase = determineSearchCase(extraction.region, product),
+            confidence = confidence(extraction.region, product)
+        )
+
+        val candidates = retrievalPipeline.retrieve(query, intent)
+        val uiState = decisionEngine.decide(intent, candidates.size)
+
+        return SearchResponse(
+            searchCase = intent.searchCase,
+            detectedRegion = intent.region,
+            detectedProduct = intent.product,
+            confidence = intent.confidence,
+            uiState = uiState,
+            totalCount = candidates.size,
+            results = candidates.map { GroupBuyCardDto.from(it.groupBuy) }
+        )
+    }
+
+    private fun extract(
+        query: String,
+        validRegions: List<String>,
+        validProducts: List<String>
+    ): KeywordExtractionResult =
+        try {
+            keywordExtractor.extract(query, validRegions, validProducts)
+        } catch (e: Exception) {
+            KeywordExtractionResult(null, null, SearchCase.NONE_DETECTED)
+        }
+
+    private fun determineSearchCase(region: String?, product: String?): SearchCase =
+        when {
+            region != null && product != null -> SearchCase.BOTH_DETECTED
+            product != null -> SearchCase.PRODUCT_ONLY
+            region != null -> SearchCase.NEIGHBORHOOD_ONLY
+            else -> SearchCase.NONE_DETECTED
+        }
+
+    private fun confidence(region: String?, product: String?): Double =
+        when {
+            region != null && product != null -> 0.9
+            region != null || product != null -> 0.65
+            else -> 0.0
+        }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchReranker.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchReranker.kt
@@ -1,0 +1,31 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.search.application.port.VectorSearchCandidate
+import com.moongchijang.domain.search.domain.SearchCandidate
+import org.springframework.stereotype.Component
+
+@Component
+class SearchReranker {
+    fun merge(
+        exactMatches: List<GroupBuy>,
+        vectorMatches: List<GroupBuy>,
+        vectorCandidates: List<VectorSearchCandidate>,
+        aliasMatched: Boolean
+    ): List<SearchCandidate> {
+        val exactIds = exactMatches.map { it.id }.toSet()
+        val vectorScores = vectorCandidates.associate { it.groupBuyId to it.score }
+        val groupBuys = (exactMatches + vectorMatches).associateBy { it.id }.values
+
+        return groupBuys
+            .map { groupBuy ->
+                SearchCandidate(
+                    groupBuy = groupBuy,
+                    exactScore = if (groupBuy.id in exactIds) 1.0 else 0.0,
+                    aliasScore = if (aliasMatched && groupBuy.id in exactIds) 1.0 else 0.0,
+                    vectorScore = vectorScores[groupBuy.id] ?: 0.0
+                )
+            }
+            .sortedByDescending { it.finalScore }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
@@ -1,0 +1,46 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.application.dto.SearchResponse
+import com.moongchijang.domain.search.infrastructure.SearchHistoryRepository
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.ObjectMapper
+import java.time.Duration
+
+@Service
+@Transactional(readOnly = true)
+class SearchService(
+    private val searchOrchestrator: SearchOrchestrator,
+    private val searchHistoryRepository: SearchHistoryRepository,
+    private val searchIndexVersionService: SearchIndexVersionService,
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper
+) {
+    companion object {
+        private const val CACHE_TTL_MINUTES = 10L  // keys(*) 블로킹 대신 짧은 TTL로 freshness 확보
+        private const val SEARCH_VERSION = "hybrid-v1"
+        private fun cacheKey(query: String, indexVersion: String) =
+            "search:result:$SEARCH_VERSION:$indexVersion:${query.hashCode()}"
+    }
+
+    fun search(query: String, userId: Long?): SearchResponse {
+        val indexVersion = searchIndexVersionService.currentVersion()
+        val cacheKey = cacheKey(query, indexVersion)
+        val cached = redisTemplate.opsForValue().get(cacheKey)
+        if (cached != null) return objectMapper.readValue(cached, SearchResponse::class.java)
+
+        userId?.let { searchHistoryRepository.save(it, query) }
+
+        val response = searchOrchestrator.search(query)
+
+        redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(response), Duration.ofMinutes(CACHE_TTL_MINUTES))
+        return response
+    }
+
+    fun getHistory(userId: Long): List<String> = searchHistoryRepository.getHistory(userId)
+
+    fun clearHistory(userId: Long) = searchHistoryRepository.clear(userId)
+
+    fun deleteHistory(userId: Long, keyword: String) = searchHistoryRepository.deleteOne(userId, keyword)
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
@@ -5,7 +5,8 @@ import com.moongchijang.domain.search.infrastructure.SearchHistoryRepository
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.security.MessageDigest
 import java.time.Duration
 
 @Service
@@ -21,7 +22,12 @@ class SearchService(
         private const val CACHE_TTL_MINUTES = 10L  // keys(*) 블로킹 대신 짧은 TTL로 freshness 확보
         private const val SEARCH_VERSION = "hybrid-v1"
         private fun cacheKey(query: String, indexVersion: String) =
-            "search:result:$SEARCH_VERSION:$indexVersion:${query.hashCode()}"
+            "search:result:$SEARCH_VERSION:$indexVersion:${sha256(query)}"
+
+        private fun sha256(value: String): String =
+            MessageDigest.getInstance("SHA-256")
+                .digest(value.toByteArray())
+                .joinToString("") { "%02x".format(it) }
     }
 
     fun search(query: String, userId: Long?): SearchResponse {

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
@@ -5,7 +5,7 @@ import com.moongchijang.domain.search.infrastructure.SearchHistoryRepository
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import java.security.MessageDigest
 import java.time.Duration
 

--- a/src/main/kotlin/com/moongchijang/domain/search/application/VectorCandidatePromotionGuard.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/VectorCandidatePromotionGuard.kt
@@ -1,0 +1,106 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.search.application.port.VectorSearchCandidate
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.global.config.SearchProperties
+import org.springframework.stereotype.Component
+
+@Component
+class VectorCandidatePromotionGuard(
+    private val searchProperties: SearchProperties = SearchProperties()
+) {
+    fun filterPromotableCandidates(
+        intent: SearchIntent,
+        vectorMatches: List<GroupBuy>,
+        vectorCandidates: List<VectorSearchCandidate>
+    ): VectorPromotionResult {
+        if (!searchProperties.guard.enabled) {
+            return VectorPromotionResult(
+                vectorMatches = vectorMatches,
+                vectorCandidates = vectorCandidates,
+                decisions = vectorCandidates.map {
+                    VectorCandidatePromotionDecision(
+                        groupBuyId = it.groupBuyId,
+                        score = it.score,
+                        rejectionReason = null
+                    )
+                }
+            )
+        }
+
+        val scoresById = vectorCandidates.associate { it.groupBuyId to it.score }
+        val vectorMatchesById = vectorMatches.associateBy { it.id }
+        val hasKnownToken = intent.region != null || intent.product != null
+        val hasEnoughConfidence = intent.confidence >= searchProperties.guard.minConfidence
+
+        val decisions = vectorCandidates.map { vectorCandidate ->
+            val groupBuy = vectorMatchesById[vectorCandidate.groupBuyId]
+            val rejectionReason = when {
+                groupBuy == null -> VectorCandidateRejectionReason.UNAVAILABLE_METADATA
+                !hasKnownToken -> VectorCandidateRejectionReason.NO_KNOWN_TOKEN
+                !hasEnoughConfidence -> VectorCandidateRejectionReason.LOW_CONFIDENCE
+                !metadataCompatible(intent, groupBuy) -> VectorCandidateRejectionReason.METADATA_MISMATCH
+                vectorCandidate.score < supportiveScoreFloor(intent) -> VectorCandidateRejectionReason.LOW_SCORE
+                else -> null
+            }
+            VectorCandidatePromotionDecision(
+                groupBuyId = vectorCandidate.groupBuyId,
+                score = vectorCandidate.score,
+                rejectionReason = rejectionReason
+            )
+        }
+        val promotableIds = decisions
+            .filter { it.rejectionReason == null }
+            .map { it.groupBuyId }
+            .toSet()
+
+        return VectorPromotionResult(
+            vectorMatches = vectorMatches.filter { it.id in promotableIds },
+            vectorCandidates = vectorCandidates.filter { it.groupBuyId in promotableIds },
+            decisions = decisions
+        )
+    }
+
+    private fun supportiveScoreFloor(intent: SearchIntent): Double =
+        if (intent.region == null && intent.product == null) {
+            searchProperties.guard.supportiveScoreThreshold
+        } else {
+            0.0
+        }
+
+    private fun metadataCompatible(intent: SearchIntent, groupBuy: GroupBuy): Boolean {
+        val regionMatches = intent.region == null || groupBuy.store.region.label == intent.region
+        val productMatches = intent.product == null || groupBuy.productName == intent.product
+        return regionMatches && productMatches
+    }
+}
+
+data class VectorPromotionResult(
+    val vectorMatches: List<GroupBuy>,
+    val vectorCandidates: List<VectorSearchCandidate>,
+    val decisions: List<VectorCandidatePromotionDecision>
+) {
+    val rejectedCount: Int =
+        decisions.count { it.rejectionReason != null }
+
+    val rejectionReasonCounts: Map<VectorCandidateRejectionReason, Int> =
+        decisions
+            .mapNotNull { it.rejectionReason }
+            .groupingBy { it }
+            .eachCount()
+}
+
+data class VectorCandidatePromotionDecision(
+    val groupBuyId: Long,
+    val score: Double,
+    val rejectionReason: VectorCandidateRejectionReason?
+)
+
+enum class VectorCandidateRejectionReason {
+    NO_KNOWN_TOKEN,
+    LOW_CONFIDENCE,
+    METADATA_MISMATCH,
+    LOW_SCORE,
+    UNAVAILABLE_METADATA
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/dto/GroupBuyCardDto.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/dto/GroupBuyCardDto.kt
@@ -1,0 +1,30 @@
+package com.moongchijang.domain.search.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import java.time.LocalDateTime
+
+data class GroupBuyCardDto(
+    val id: Long,
+    val storeName: String,
+    val region: String,
+    val productName: String,
+    val thumbnailUrl: String?,
+    val price: Int,
+    val currentQuantity: Int,
+    val targetQuantity: Int,
+    val deadline: LocalDateTime
+) {
+    companion object {
+        fun from(groupBuy: GroupBuy) = GroupBuyCardDto(
+            id = groupBuy.id,
+            storeName = groupBuy.store.name,
+            region = groupBuy.store.region.label,
+            productName = groupBuy.productName,
+            thumbnailUrl = groupBuy.thumbnailUrl,
+            price = groupBuy.price,
+            currentQuantity = groupBuy.currentQuantity,
+            targetQuantity = groupBuy.targetQuantity,
+            deadline = groupBuy.deadline
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/dto/KeywordExtractionResult.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/dto/KeywordExtractionResult.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.search.application.dto
+
+data class KeywordExtractionResult(
+    val region: String?,
+    val product: String?,
+    val searchCase: SearchCase
+)

--- a/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchCase.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchCase.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.search.application.dto
+
+enum class SearchCase {
+    BOTH_DETECTED,
+    PRODUCT_ONLY,
+    NEIGHBORHOOD_ONLY,
+    NONE_DETECTED
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchResponse.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.search.application.dto
+
+import com.moongchijang.domain.search.domain.SearchUiState
+
+data class SearchResponse(
+    val searchCase: SearchCase,
+    val detectedRegion: String?,
+    val detectedProduct: String?,
+    val confidence: Double = 0.0,
+    val uiState: SearchUiState = SearchUiState.NEED_BOTH,
+    val totalCount: Int,
+    val results: List<GroupBuyCardDto>
+)

--- a/src/main/kotlin/com/moongchijang/domain/search/application/port/VectorIndexPort.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/port/VectorIndexPort.kt
@@ -1,0 +1,21 @@
+package com.moongchijang.domain.search.application.port
+
+import java.time.LocalDateTime
+
+data class VectorIndexDocument(
+    val groupBuyId: Long,
+    val vectorText: String,
+    val vector: FloatArray,
+    val region: String,
+    val storeName: String,
+    val productName: String,
+    val status: String,
+    val deadline: LocalDateTime,
+    val embeddingVersion: String
+)
+
+interface VectorIndexPort {
+    fun upsert(document: VectorIndexDocument): Boolean
+
+    fun delete(groupBuyId: Long): Boolean
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/port/VectorSearchPort.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/port/VectorSearchPort.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.search.application.port
+
+data class VectorSearchCandidate(
+    val groupBuyId: Long,
+    val score: Double
+)
+
+interface VectorSearchPort {
+    fun search(query: String, topK: Int, minScore: Double): List<VectorSearchCandidate>
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/domain/SearchCandidate.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/domain/SearchCandidate.kt
@@ -1,0 +1,20 @@
+package com.moongchijang.domain.search.domain
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+
+data class SearchCandidate(
+    val groupBuy: GroupBuy,
+    val exactScore: Double = 0.0,
+    val aliasScore: Double = 0.0,
+    val vectorScore: Double = 0.0
+) {
+    val finalScore: Double =
+        exactScore * 0.45 + aliasScore * 0.2 + vectorScore * 0.35
+
+    val matchedBy: Set<String> =
+        buildSet {
+            if (exactScore > 0.0) add("EXACT")
+            if (aliasScore > 0.0) add("ALIAS")
+            if (vectorScore > 0.0) add("VECTOR")
+        }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/domain/SearchIntent.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/domain/SearchIntent.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.search.domain
+
+import com.moongchijang.domain.search.application.dto.SearchCase
+
+data class SearchIntent(
+    val region: String?,
+    val product: String?,
+    val searchCase: SearchCase,
+    val confidence: Double
+)

--- a/src/main/kotlin/com/moongchijang/domain/search/domain/SearchUiState.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/domain/SearchUiState.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.search.domain
+
+enum class SearchUiState {
+    RESULTS,
+    EMPTY_CAN_REQUEST,
+    NEED_REGION,
+    NEED_PRODUCT,
+    NEED_BOTH,
+    AMBIGUOUS_CONFIRMATION
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationMetrics.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationMetrics.kt
@@ -1,0 +1,122 @@
+package com.moongchijang.domain.search.evaluation
+
+import kotlin.math.ln
+import kotlin.math.min
+
+data class GoldenSearchCase(
+    val query: String,
+    val relevantGroupBuyIds: Set<Long>
+)
+
+data class SearchEvaluationReport(
+    val caseCount: Int,
+    val positiveCaseCount: Int,
+    val noResultExpectedCaseCount: Int,
+    val k: Int,
+    val recallAtK: Double,
+    val precisionAtK: Double,
+    val ndcgAtK: Double,
+    val mrr: Double,
+    val zeroResultRate: Double,
+    val falsePositiveRate: Double,
+    val falsePositiveCount: Int
+)
+
+class SearchEvaluationMetrics {
+    fun evaluate(
+        goldenCases: List<GoldenSearchCase>,
+        rankedResultsByQuery: Map<String, List<Long>>,
+        k: Int = 10
+    ): SearchEvaluationReport {
+        require(k > 0) { "k must be positive" }
+        if (goldenCases.isEmpty()) {
+            return SearchEvaluationReport(
+                caseCount = 0,
+                positiveCaseCount = 0,
+                noResultExpectedCaseCount = 0,
+                k = k,
+                recallAtK = 0.0,
+                precisionAtK = 0.0,
+                ndcgAtK = 0.0,
+                mrr = 0.0,
+                zeroResultRate = 0.0,
+                falsePositiveRate = 0.0,
+                falsePositiveCount = 0
+            )
+        }
+
+        val scores = goldenCases.map { goldenCase ->
+            val rankedIds = rankedResultsByQuery[goldenCase.query].orEmpty()
+            val noResultExpected = goldenCase.relevantGroupBuyIds.isEmpty()
+            CaseScores(
+                recallAtK = recallAtK(rankedIds, goldenCase.relevantGroupBuyIds, k),
+                precisionAtK = precisionAtK(rankedIds, goldenCase.relevantGroupBuyIds, k),
+                ndcgAtK = ndcgAtK(rankedIds, goldenCase.relevantGroupBuyIds, k),
+                reciprocalRank = reciprocalRank(rankedIds, goldenCase.relevantGroupBuyIds),
+                zeroResult = rankedIds.isEmpty(),
+                noResultExpected = noResultExpected,
+                falsePositive = noResultExpected && rankedIds.isNotEmpty()
+            )
+        }
+        val positiveScores = scores.filterNot { it.noResultExpected }
+        val noResultExpectedScores = scores.filter { it.noResultExpected }
+        val falsePositiveCount = scores.count { it.falsePositive }
+
+        return SearchEvaluationReport(
+            caseCount = goldenCases.size,
+            positiveCaseCount = positiveScores.size,
+            noResultExpectedCaseCount = noResultExpectedScores.size,
+            k = k,
+            recallAtK = positiveScores.averageOfOrZero { it.recallAtK },
+            precisionAtK = positiveScores.averageOfOrZero { it.precisionAtK },
+            ndcgAtK = positiveScores.averageOfOrZero { it.ndcgAtK },
+            mrr = positiveScores.averageOfOrZero { it.reciprocalRank },
+            zeroResultRate = scores.count { it.zeroResult }.toDouble() / scores.size,
+            falsePositiveRate = if (noResultExpectedScores.isEmpty()) 0.0 else falsePositiveCount.toDouble() / noResultExpectedScores.size,
+            falsePositiveCount = falsePositiveCount
+        )
+    }
+
+    fun recallAtK(rankedIds: List<Long>, relevantIds: Set<Long>, k: Int): Double {
+        if (relevantIds.isEmpty()) return 0.0
+        val hits = rankedIds.take(k).count { it in relevantIds }
+        return hits.toDouble() / relevantIds.size
+    }
+
+    fun precisionAtK(rankedIds: List<Long>, relevantIds: Set<Long>, k: Int): Double {
+        if (relevantIds.isEmpty()) return 0.0
+        val hits = rankedIds.take(k).count { it in relevantIds }
+        return hits.toDouble() / k
+    }
+
+    fun reciprocalRank(rankedIds: List<Long>, relevantIds: Set<Long>): Double {
+        if (relevantIds.isEmpty()) return 0.0
+        val firstRelevantIndex = rankedIds.indexOfFirst { it in relevantIds }
+        return if (firstRelevantIndex >= 0) 1.0 / (firstRelevantIndex + 1) else 0.0
+    }
+
+    fun ndcgAtK(rankedIds: List<Long>, relevantIds: Set<Long>, k: Int): Double {
+        if (relevantIds.isEmpty()) return 0.0
+        val dcg = rankedIds.take(k).mapIndexed { index, id ->
+            if (id in relevantIds) 1.0 / log2(index + 2.0) else 0.0
+        }.sum()
+        val idealHits = min(relevantIds.size, k)
+        val idcg = (0 until idealHits).sumOf { index -> 1.0 / log2(index + 2.0) }
+        return if (idcg == 0.0) 0.0 else dcg / idcg
+    }
+
+    private fun log2(value: Double): Double = ln(value) / ln(2.0)
+
+    private fun List<CaseScores>.averageOfOrZero(selector: (CaseScores) -> Double): Double =
+        if (isEmpty()) 0.0 else map(selector).average()
+
+    private data class CaseScores(
+        val recallAtK: Double,
+        val precisionAtK: Double,
+        val ndcgAtK: Double,
+        val reciprocalRank: Double,
+        val zeroResult: Boolean,
+        val noResultExpected: Boolean,
+        val falsePositive: Boolean
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationService.kt
@@ -1,0 +1,20 @@
+package com.moongchijang.domain.search.evaluation
+
+fun interface SearchCandidateProvider {
+    fun retrieveGroupBuyIds(query: String): List<Long>
+}
+
+class SearchEvaluationService(
+    private val metrics: SearchEvaluationMetrics = SearchEvaluationMetrics()
+) {
+    fun evaluate(
+        goldenCases: List<GoldenSearchCase>,
+        provider: SearchCandidateProvider,
+        k: Int = 10
+    ): SearchEvaluationReport {
+        val results = goldenCases.associate { goldenCase ->
+            goldenCase.query to provider.retrieveGroupBuyIds(goldenCase.query)
+        }
+        return metrics.evaluate(goldenCases, results, k)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/evaluation/SearchProviderComparison.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/evaluation/SearchProviderComparison.kt
@@ -1,0 +1,31 @@
+package com.moongchijang.domain.search.evaluation
+
+data class SearchProviderEvaluation(
+    val providerName: String,
+    val report: SearchEvaluationReport
+)
+
+data class SearchProviderComparisonReport(
+    val evaluations: List<SearchProviderEvaluation>
+) {
+    fun byProvider(providerName: String): SearchProviderEvaluation? =
+        evaluations.firstOrNull { it.providerName == providerName }
+}
+
+class SearchProviderComparisonRunner(
+    private val evaluationService: SearchEvaluationService = SearchEvaluationService()
+) {
+    fun compare(
+        goldenCases: List<GoldenSearchCase>,
+        providers: Map<String, SearchCandidateProvider>,
+        k: Int = 10
+    ): SearchProviderComparisonReport =
+        SearchProviderComparisonReport(
+            evaluations = providers.map { (providerName, provider) ->
+                SearchProviderEvaluation(
+                    providerName = providerName,
+                    report = evaluationService.evaluate(goldenCases, provider, k)
+                )
+            }
+        )
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/SearchHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/SearchHistoryRepository.kt
@@ -1,0 +1,32 @@
+package com.moongchijang.domain.search.infrastructure
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class SearchHistoryRepository(
+    private val redisTemplate: StringRedisTemplate
+) {
+    companion object {
+        private const val MAX_HISTORY = 10L
+        private fun key(userId: Long) = "search:history:$userId"
+    }
+
+    fun save(userId: Long, query: String) {
+        val ops = redisTemplate.opsForList()
+        val key = key(userId)
+        ops.leftPush(key, query)
+        ops.trim(key, 0, MAX_HISTORY - 1)
+    }
+
+    fun getHistory(userId: Long): List<String> =
+        redisTemplate.opsForList().range(key(userId), 0, MAX_HISTORY - 1) ?: emptyList()
+
+    fun clear(userId: Long) {
+        redisTemplate.delete(key(userId))
+    }
+
+    fun deleteOne(userId: Long, keyword: String) {
+        redisTemplate.opsForList().remove(key(userId), 1, keyword)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoChatModel.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoChatModel.kt
@@ -1,7 +1,7 @@
 package com.moongchijang.domain.search.infrastructure.demo
 
 import dev.langchain4j.model.chat.ChatModel
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 
 class LocalDemoChatModel(
     private val objectMapper: ObjectMapper

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoChatModel.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoChatModel.kt
@@ -1,0 +1,17 @@
+package com.moongchijang.domain.search.infrastructure.demo
+
+import dev.langchain4j.model.chat.ChatModel
+import tools.jackson.databind.ObjectMapper
+
+class LocalDemoChatModel(
+    private val objectMapper: ObjectMapper
+) : ChatModel {
+    override fun chat(prompt: String): String {
+        val extraction = LocalDemoSearchVocabulary.detectFromPrompt(prompt)
+        val payload = mapOf(
+            "neighborhood" to extraction.region,
+            "product" to extraction.product
+        )
+        return objectMapper.writeValueAsString(payload)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoChatModel.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoChatModel.kt
@@ -1,7 +1,7 @@
 package com.moongchijang.domain.search.infrastructure.demo
 
 import dev.langchain4j.model.chat.ChatModel
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 
 class LocalDemoChatModel(
     private val objectMapper: ObjectMapper

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoEmbeddingModel.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoEmbeddingModel.kt
@@ -1,0 +1,70 @@
+package com.moongchijang.domain.search.infrastructure.demo
+
+import dev.langchain4j.data.embedding.Embedding
+import dev.langchain4j.data.segment.TextSegment
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.model.output.Response
+import kotlin.math.sqrt
+
+class LocalDemoEmbeddingModel(
+    private val vectorSize: Int = 768
+) : EmbeddingModel {
+    override fun embed(text: String): Response<Embedding> =
+        Response.from(Embedding.from(vectorize(text)))
+
+    override fun embed(textSegment: TextSegment): Response<Embedding> =
+        Response.from(Embedding.from(vectorize(textSegment.text())))
+
+    override fun embedAll(textSegments: List<TextSegment>): Response<List<Embedding>> =
+        Response.from(textSegments.map { TextSegment ->
+            Embedding.from(vectorize(TextSegment.text()))
+        })
+
+    override fun dimension(): Int = vectorSize
+
+    override fun modelName(): String = "local-demo-deterministic-embedding"
+
+    private fun vectorize(text: String): FloatArray {
+        val canonical = LocalDemoSearchVocabulary.embeddingText(text)
+        val compact = canonical.replace(" ", "")
+        val features = buildList {
+            if (canonical.isNotBlank()) add(canonical)
+            if (compact.isNotBlank()) add(compact)
+            canonical.split(" ")
+                .filter { it.isNotBlank() }
+                .forEach { token ->
+                    add(token)
+                    if (token.length >= 2) {
+                        token.windowed(2, 1, partialWindows = false).forEach { add(it) }
+                    }
+                    if (token.length >= 3) {
+                        token.windowed(3, 1, partialWindows = false).forEach { add(it) }
+                    }
+                }
+        }
+
+        val vector = FloatArray(vectorSize)
+        features.forEach { feature ->
+            val hash = feature.hashCode()
+            addFeature(vector, hash, 3.0f)
+            addFeature(vector, hash * 31 + 7, 1.5f)
+            addFeature(vector, hash * 131 + 17, 0.75f)
+        }
+
+        normalize(vector)
+        return vector
+    }
+
+    private fun addFeature(vector: FloatArray, hash: Int, weight: Float) {
+        val index = Math.floorMod(hash, vector.size)
+        vector[index] += weight
+    }
+
+    private fun normalize(vector: FloatArray) {
+        val norm = sqrt(vector.fold(0.0) { acc, value -> acc + value * value })
+        if (norm == 0.0) return
+        for (i in vector.indices) {
+            vector[i] = (vector[i] / norm).toFloat()
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoSearchVocabulary.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/demo/LocalDemoSearchVocabulary.kt
@@ -1,0 +1,86 @@
+package com.moongchijang.domain.search.infrastructure.demo
+
+import java.util.Locale
+
+object LocalDemoSearchVocabulary {
+    private val productAliases = linkedMapOf(
+        "시오빵" to "소금빵",
+        "소금 빵" to "소금빵",
+        "salt bread" to "소금빵",
+        "크로와상" to "크루아상",
+        "croissant" to "크루아상",
+        "버터 떡" to "버터떡",
+        "마들랜" to "마들렌",
+        "madeleine" to "마들렌"
+    )
+
+    fun canonicalize(text: String): String {
+        var normalized = text.lowercase(Locale.getDefault())
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+        productAliases.forEach { (alias, canonical) ->
+            normalized = normalized.replace(alias.lowercase(Locale.getDefault()), canonical)
+            normalized = normalized.replace(alias.replace(" ", "").lowercase(Locale.getDefault()), canonical)
+        }
+
+        return normalized.replace(Regex("\\s+"), " ").trim()
+    }
+
+    fun embeddingText(text: String): String =
+        canonicalize(text).replace(" ", "")
+
+    fun detectRegion(query: String, validRegions: List<String>): String? {
+        val queryText = embeddingText(query)
+        return validRegions.firstOrNull { region ->
+            val canonicalRegion = embeddingText(region)
+            queryText.contains(canonicalRegion)
+        }
+    }
+
+    fun detectProduct(query: String, validProducts: List<String>): String? {
+        val normalizedQuery = canonicalize(query)
+        val compactQuery = embeddingText(query)
+
+        validProducts.firstOrNull { product ->
+            val canonicalProduct = embeddingText(product)
+            normalizedQuery.contains(canonicalProduct) || compactQuery.contains(canonicalProduct)
+        }?.let { return it }
+
+        return productAliases.entries.firstOrNull { (alias, canonical) ->
+            val aliasCanonical = embeddingText(alias)
+            compactQuery.contains(aliasCanonical) && validProducts.any { it == canonical }
+        }?.value
+    }
+
+    fun detectFromPrompt(prompt: String): Extraction {
+        val query = extractQuery(prompt)
+        val validRegions = extractList(prompt, "유효 동네")
+        val validProducts = extractList(prompt, "유효 상품")
+
+        return Extraction(
+            query = query,
+            region = detectRegion(query, validRegions),
+            product = detectProduct(query, validProducts)
+        )
+    }
+
+    private fun extractQuery(prompt: String): String {
+        val match = Regex("""사용자 검색어:\s*"([^"]*)"""").find(prompt)
+        return match?.groupValues?.getOrNull(1).orEmpty()
+    }
+
+    private fun extractList(prompt: String, label: String): List<String> {
+        val match = Regex("""^\s*$label\s*:\s*(.*)$""", RegexOption.MULTILINE).find(prompt)
+        val raw = match?.groupValues?.getOrNull(1).orEmpty()
+        return raw.split(",")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+    }
+
+    data class Extraction(
+        val query: String,
+        val region: String?,
+        val product: String?
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/embedding/MySqlEmbeddingStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/embedding/MySqlEmbeddingStore.kt
@@ -8,7 +8,7 @@ import dev.langchain4j.store.embedding.EmbeddingMatch
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest
 import dev.langchain4j.store.embedding.EmbeddingSearchResult
 import dev.langchain4j.store.embedding.EmbeddingStore
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import kotlin.math.sqrt
 

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/embedding/MySqlEmbeddingStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/embedding/MySqlEmbeddingStore.kt
@@ -8,7 +8,7 @@ import dev.langchain4j.store.embedding.EmbeddingMatch
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest
 import dev.langchain4j.store.embedding.EmbeddingSearchResult
 import dev.langchain4j.store.embedding.EmbeddingStore
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Component
 import kotlin.math.sqrt
 

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/embedding/MySqlEmbeddingStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/embedding/MySqlEmbeddingStore.kt
@@ -1,0 +1,98 @@
+package com.moongchijang.domain.search.infrastructure.embedding
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyEmbedding
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyEmbeddingRepository
+import dev.langchain4j.data.embedding.Embedding
+import dev.langchain4j.data.segment.TextSegment
+import dev.langchain4j.store.embedding.EmbeddingMatch
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest
+import dev.langchain4j.store.embedding.EmbeddingSearchResult
+import dev.langchain4j.store.embedding.EmbeddingStore
+import tools.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Component
+import kotlin.math.sqrt
+
+@Component
+class MySqlEmbeddingStore(
+    private val embeddingRepository: GroupBuyEmbeddingRepository,
+    private val objectMapper: ObjectMapper
+) : EmbeddingStore<TextSegment> {
+
+    override fun add(embedding: Embedding): String {
+        throw UnsupportedOperationException("id 없이 저장하는 방식은 지원하지 않습니다.")
+    }
+
+    override fun add(id: String, embedding: Embedding) {
+        val groupBuyId = id.toLong()
+        val json = objectMapper.writeValueAsString(embedding.vector())
+        val existing = embeddingRepository.findByGroupBuyId(groupBuyId)
+        if (existing != null) {
+            existing.embedding = json
+            embeddingRepository.save(existing)
+        } else {
+            embeddingRepository.save(GroupBuyEmbedding(groupBuyId = groupBuyId, embedding = json))
+        }
+    }
+
+    override fun add(embedding: Embedding, textSegment: TextSegment): String {
+        throw UnsupportedOperationException("id 없이 저장하는 방식은 지원하지 않습니다.")
+    }
+
+    override fun addAll(embeddings: List<Embedding>): List<String> {
+        throw UnsupportedOperationException("id 없이 저장하는 방식은 지원하지 않습니다.")
+    }
+
+    fun delete(id: String) {
+        val groupBuyId = id.toLong()
+        embeddingRepository.findByGroupBuyId(groupBuyId)?.let {
+            embeddingRepository.delete(it)
+        }
+    }
+
+    override fun search(request: EmbeddingSearchRequest): EmbeddingSearchResult<TextSegment> {
+        val queryVector = request.queryEmbedding().vector()
+        val maxResults = request.maxResults()
+        val minScore = request.minScore()
+
+        val matches = embeddingRepository.findAll()
+            .map { stored ->
+                val storedVector = readStoredVector(stored.embedding)
+                val score = cosineSimilarity(queryVector, storedVector)
+                EmbeddingMatch(
+                    score.toDouble(),
+                    stored.groupBuyId.toString(),
+                    Embedding.from(storedVector),
+                    TextSegment.from(stored.groupBuyId.toString())
+                )
+            }
+            .filter { it.score() >= minScore }
+            .sortedByDescending { it.score() }
+            .take(maxResults)
+
+        return EmbeddingSearchResult(matches)
+    }
+
+    private fun readStoredVector(rawEmbedding: String): FloatArray {
+        val trimmed = rawEmbedding.trim()
+
+        return try {
+            objectMapper.readValue(trimmed, FloatArray::class.java)
+        } catch (_: Exception) {
+            val unwrapped = objectMapper.readValue(trimmed, String::class.java).trim()
+            objectMapper.readValue(unwrapped, FloatArray::class.java)
+        }
+    }
+
+    private fun cosineSimilarity(a: FloatArray, b: FloatArray): Float {
+        var dot = 0.0
+        var normA = 0.0
+        var normB = 0.0
+        for (i in a.indices) {
+            dot += a[i] * b[i]
+            normA += a[i] * a[i]
+            normB += b[i] * b[i]
+        }
+        if (normA == 0.0 || normB == 0.0) return 0f
+        return (dot / (sqrt(normA) * sqrt(normB))).toFloat()
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
@@ -5,7 +5,7 @@ import com.moongchijang.domain.search.application.dto.SearchCase
 import dev.langchain4j.model.chat.ChatModel
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 
 @Service
 class GeminiKeywordExtractionService(

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
@@ -1,0 +1,74 @@
+package com.moongchijang.domain.search.infrastructure.gemini
+
+import com.moongchijang.domain.search.application.dto.KeywordExtractionResult
+import com.moongchijang.domain.search.application.dto.SearchCase
+import dev.langchain4j.model.chat.ChatModel
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import tools.jackson.databind.ObjectMapper
+
+@Service
+class GeminiKeywordExtractionService(
+    private val chatModel: ChatModel,
+    private val objectMapper: ObjectMapper
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    private data class ExtractionResponse(
+        val neighborhood: String? = null,
+        val product: String? = null
+    )
+
+    fun extract(
+        query: String,
+        validRegions: List<String>,
+        validProducts: List<String>
+    ): KeywordExtractionResult {
+        return try {
+            val prompt = buildPrompt(query, validRegions, validProducts)
+            val json = chatModel.chat(prompt)
+            parseResult(json, validRegions, validProducts)
+        } catch (e: Exception) {
+            log.warn("키워드 추출 실패, NONE_DETECTED 폴백: query={}, error={}", query, e.message)
+            KeywordExtractionResult(null, null, SearchCase.NONE_DETECTED)
+        }
+    }
+
+    private fun buildPrompt(query: String, validRegions: List<String>, validProducts: List<String>): String =
+        """
+        아래 규칙에 따라 사용자 검색어에서 동네와 상품을 추출하세요.
+
+        규칙:
+        - 반드시 유효 목록에 있는 값만 반환하세요.
+        - 목록에 없으면 null을 반환하세요.
+        - 절대 목록 외 값을 생성하지 마세요.
+        - JSON 형식으로만 응답하세요: {"neighborhood": "...", "product": "..."}
+
+        유효 동네: ${validRegions.joinToString(", ")}
+        유효 상품: ${validProducts.joinToString(", ")}
+
+        사용자 검색어: "$query"
+        """.trimIndent()
+
+    private fun parseResult(
+        json: String,
+        validRegions: List<String>,
+        validProducts: List<String>
+    ): KeywordExtractionResult {
+        val cleanJson = json.trim().removePrefix("```json").removeSuffix("```").trim()
+        val parsed = objectMapper.readValue(cleanJson, ExtractionResponse::class.java)
+
+        // 서버 사이드 재검증: 유효 목록에 없으면 null 처리
+        val neighborhood = parsed.neighborhood?.takeIf { it in validRegions }
+        val product = parsed.product?.takeIf { it in validProducts }
+
+        val searchCase = when {
+            neighborhood != null && product != null -> SearchCase.BOTH_DETECTED
+            product != null -> SearchCase.PRODUCT_ONLY
+            neighborhood != null -> SearchCase.NEIGHBORHOOD_ONLY
+            else -> SearchCase.NONE_DETECTED
+        }
+
+        return KeywordExtractionResult(neighborhood, product, searchCase)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
@@ -5,7 +5,7 @@ import com.moongchijang.domain.search.application.dto.SearchCase
 import dev.langchain4j.model.chat.ChatModel
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 
 @Service
 class GeminiKeywordExtractionService(
@@ -55,7 +55,7 @@ class GeminiKeywordExtractionService(
         validRegions: List<String>,
         validProducts: List<String>
     ): KeywordExtractionResult {
-        val cleanJson = json.trim().removePrefix("```json").removeSuffix("```").trim()
+        val cleanJson = extractJsonObject(json)
         val parsed = objectMapper.readValue(cleanJson, ExtractionResponse::class.java)
 
         // 서버 사이드 재검증: 유효 목록에 없으면 null 처리
@@ -70,5 +70,12 @@ class GeminiKeywordExtractionService(
         }
 
         return KeywordExtractionResult(neighborhood, product, searchCase)
+    }
+
+    private fun extractJsonObject(raw: String): String {
+        val start = raw.indexOf('{')
+        val end = raw.lastIndexOf('}')
+        require(start in 0 until end) { "JSON object not found in LLM response" }
+        return raw.substring(start, end + 1)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/vector/mysql/MySqlVectorSearchAdapter.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/vector/mysql/MySqlVectorSearchAdapter.kt
@@ -1,0 +1,48 @@
+package com.moongchijang.domain.search.infrastructure.vector.mysql
+
+import com.moongchijang.domain.search.application.port.VectorIndexDocument
+import com.moongchijang.domain.search.application.port.VectorIndexPort
+import com.moongchijang.domain.search.application.port.VectorSearchCandidate
+import com.moongchijang.domain.search.application.port.VectorSearchPort
+import com.moongchijang.domain.search.infrastructure.embedding.MySqlEmbeddingStore
+import dev.langchain4j.data.embedding.Embedding
+import dev.langchain4j.model.embedding.EmbeddingModel
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(prefix = "qdrant", name = ["enabled"], havingValue = "false", matchIfMissing = true)
+class MySqlVectorSearchAdapter(
+    private val embeddingModel: EmbeddingModel,
+    private val embeddingStore: MySqlEmbeddingStore
+) : VectorSearchPort, VectorIndexPort {
+    override fun search(query: String, topK: Int, minScore: Double): List<VectorSearchCandidate> {
+        val queryEmbedding = embeddingModel.embed(query).content()
+        val searchRequest = EmbeddingSearchRequest.builder()
+            .queryEmbedding(queryEmbedding)
+            .maxResults(topK)
+            .minScore(minScore)
+            .build()
+
+        return embeddingStore.search(searchRequest).matches()
+            .mapNotNull { match ->
+                match.embedded().text().toLongOrNull()?.let { groupBuyId ->
+                    VectorSearchCandidate(
+                        groupBuyId = groupBuyId,
+                        score = match.score()
+                    )
+                }
+            }
+    }
+
+    override fun upsert(document: VectorIndexDocument): Boolean {
+        embeddingStore.add(document.groupBuyId.toString(), Embedding.from(document.vector))
+        return true
+    }
+
+    override fun delete(groupBuyId: Long): Boolean {
+        embeddingStore.delete(groupBuyId.toString())
+        return true
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantCollectionInitializer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantCollectionInitializer.kt
@@ -1,0 +1,78 @@
+package com.moongchijang.domain.search.infrastructure.vector.qdrant
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.moongchijang.global.config.QdrantProperties
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.time.Duration
+
+@Component
+@ConditionalOnProperty(prefix = "qdrant", name = ["enabled"], havingValue = "true")
+class QdrantCollectionInitializer(
+    restClientBuilder: RestClient.Builder,
+    private val properties: QdrantProperties
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val restClient: RestClient =
+        run {
+            val builder = restClientBuilder
+                .baseUrl(properties.url)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .requestFactory(
+                    SimpleClientHttpRequestFactory().apply {
+                        setConnectTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                        setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                    }
+                )
+
+            properties.apiKey?.takeIf { it.isNotBlank() }?.let {
+                builder.defaultHeader("api-key", it)
+            }
+
+            builder.build()
+        }
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun initialize() {
+        if (!properties.initializeCollection) {
+            log.info("Qdrant collection bootstrap skipped: collection={}", properties.collectionName)
+            return
+        }
+
+        val request = CreateCollectionRequest(
+            vectors = VectorParams(
+                size = properties.vectorSize,
+                distance = properties.distance
+            )
+        )
+
+        try {
+            restClient.put()
+                .uri("/collections/{collectionName}", properties.collectionName)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity()
+            log.info("Qdrant collection bootstrap requested: collection={}", properties.collectionName)
+        } catch (e: Exception) {
+            log.warn("Qdrant collection bootstrap failed: collection={}, error={}", properties.collectionName, e.message)
+        }
+    }
+
+    private data class CreateCollectionRequest(
+        val vectors: VectorParams
+    )
+
+    private data class VectorParams(
+        val size: Int,
+        val distance: String,
+        @JsonProperty("on_disk")
+        val onDisk: Boolean = false
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantVectorSearchAdapter.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantVectorSearchAdapter.kt
@@ -1,0 +1,182 @@
+package com.moongchijang.domain.search.infrastructure.vector.qdrant
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.moongchijang.domain.search.application.port.VectorIndexDocument
+import com.moongchijang.domain.search.application.port.VectorIndexPort
+import com.moongchijang.domain.search.application.port.VectorSearchCandidate
+import com.moongchijang.domain.search.application.port.VectorSearchPort
+import com.moongchijang.global.config.QdrantProperties
+import dev.langchain4j.model.embedding.EmbeddingModel
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import java.time.Duration
+
+@Component
+@ConditionalOnProperty(prefix = "qdrant", name = ["enabled"], havingValue = "true")
+class QdrantVectorSearchAdapter(
+    restClientBuilder: RestClient.Builder,
+    private val embeddingModel: EmbeddingModel,
+    private val properties: QdrantProperties
+) : VectorSearchPort, VectorIndexPort {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val restClient: RestClient =
+        run {
+            val builder = restClientBuilder
+                .baseUrl(properties.url)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .requestFactory(
+                    SimpleClientHttpRequestFactory().apply {
+                        setConnectTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                        setReadTimeout(Duration.ofSeconds(properties.timeoutSeconds))
+                    }
+                )
+
+            properties.apiKey?.takeIf { it.isNotBlank() }?.let {
+                builder.defaultHeader("api-key", it)
+            }
+
+            builder.build()
+        }
+
+    override fun search(query: String, topK: Int, minScore: Double): List<VectorSearchCandidate> {
+        return try {
+            val vector = embeddingModel.embed(query).content().vector().map { it.toDouble() }
+            val request = QdrantQueryRequest(
+                query = vector,
+                limit = topK,
+                scoreThreshold = minScore,
+                withPayload = listOf("groupBuyId", "status", "deadline")
+            )
+
+            val response = restClient.post()
+                .uri("/collections/{collectionName}/points/query", properties.collectionName)
+                .body(request)
+                .retrieve()
+                .body(QdrantQueryResponse::class.java)
+
+            response?.result?.points
+                ?.mapNotNull { point ->
+                    val groupBuyId = point.payload?.groupBuyId ?: point.id.toLongOrNull()
+                    groupBuyId?.let {
+                        VectorSearchCandidate(
+                            groupBuyId = it,
+                            score = point.score
+                        )
+                    }
+                }
+                ?: emptyList()
+        } catch (e: Exception) {
+            log.warn("Qdrant 검색 실패, vector 후보 없이 fallback: error={}", e.message)
+            emptyList()
+        }
+    }
+
+    override fun upsert(document: VectorIndexDocument): Boolean {
+        val request = QdrantUpsertRequest(
+            points = listOf(
+                QdrantPointUpsert(
+                    id = document.groupBuyId,
+                    vector = document.vector.map { it.toDouble() },
+                    payload = QdrantUpsertPayload(
+                        groupBuyId = document.groupBuyId,
+                        vectorText = document.vectorText,
+                        region = document.region,
+                        storeName = document.storeName,
+                        productName = document.productName,
+                        status = document.status,
+                        deadline = document.deadline.toString(),
+                        embeddingVersion = document.embeddingVersion
+                    )
+                )
+            )
+        )
+
+        return try {
+            restClient.put()
+                .uri("/collections/{collectionName}/points?wait=true", properties.collectionName)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity()
+            true
+        } catch (e: Exception) {
+            log.warn("Qdrant upsert 실패: groupBuyId={}, error={}", document.groupBuyId, e.message)
+            false
+        }
+    }
+
+    override fun delete(groupBuyId: Long): Boolean {
+        val request = QdrantDeleteRequest(points = listOf(groupBuyId))
+
+        return try {
+            restClient.post()
+                .uri("/collections/{collectionName}/points/delete?wait=true", properties.collectionName)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity()
+            true
+        } catch (e: Exception) {
+            log.warn("Qdrant delete 실패: groupBuyId={}, error={}", groupBuyId, e.message)
+            false
+        }
+    }
+
+    private data class QdrantQueryRequest(
+        val query: List<Double>,
+        val limit: Int,
+        @JsonProperty("with_payload")
+        val withPayload: List<String>,
+        @JsonProperty("score_threshold")
+        val scoreThreshold: Double
+    )
+
+    private data class QdrantQueryResponse(
+        val result: QdrantQueryResult? = null
+    )
+
+    private data class QdrantQueryResult(
+        val points: List<QdrantPoint> = emptyList()
+    )
+
+    private data class QdrantPoint(
+        val id: String,
+        val score: Double,
+        val payload: QdrantPayload? = null
+    )
+
+    private data class QdrantPayload(
+        val groupBuyId: Long? = null,
+        val status: String? = null,
+        val deadline: String? = null
+    )
+
+    private data class QdrantUpsertRequest(
+        val points: List<QdrantPointUpsert>
+    )
+
+    private data class QdrantPointUpsert(
+        val id: Long,
+        val vector: List<Double>,
+        val payload: QdrantUpsertPayload
+    )
+
+    private data class QdrantUpsertPayload(
+        val groupBuyId: Long,
+        @JsonProperty("vector_text")
+        val vectorText: String,
+        val region: String,
+        val storeName: String,
+        val productName: String,
+        val status: String,
+        val deadline: String,
+        val embeddingVersion: String
+    )
+
+    private data class QdrantDeleteRequest(
+        val points: List<Long>
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.domain.search.presentation
+
+import com.moongchijang.domain.search.application.SearchService
+import com.moongchijang.domain.search.application.dto.SearchResponse
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/search")
+@Tag(name = "Search", description = "공구 검색 (AI 자연어)")
+@Validated
+class SearchController(
+    private val searchService: SearchService
+) {
+    data class SearchRequest(@field:NotBlank val keyword: String)
+
+    @PostMapping
+    @Operation(summary = "검색어 입력 및 AI 분석 (1.1.4-1)")
+    fun search(
+        @Valid @RequestBody request: SearchRequest,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?
+    ): ResponseEntity<ApiResponse<SearchResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(searchService.search(request.keyword, principal?.id)))
+    }
+
+    @GetMapping("/recent")
+    @Operation(summary = "최근 검색어 목록 조회 (1.1.4-10)")
+    fun getRecentSearches(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<String>>> {
+        return ResponseEntity.ok(ApiResponse.success(searchService.getHistory(principal.id)))
+    }
+
+    @DeleteMapping("/recent")
+    @Operation(summary = "최근 검색어 전체 삭제")
+    fun clearRecentSearches(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        searchService.clearHistory(principal.id)
+        return ResponseEntity.ok(ApiResponse.success())
+    }
+
+    @DeleteMapping("/recent/{keyword}")
+    @Operation(summary = "최근 검색어 단건 삭제")
+    fun deleteRecentSearch(
+        @PathVariable keyword: String,
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        searchService.deleteHistory(principal.id, keyword)
+        return ResponseEntity.ok(ApiResponse.success())
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/config/GeminiConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/GeminiConfig.kt
@@ -1,0 +1,32 @@
+package com.moongchijang.global.config
+
+import dev.langchain4j.model.googleai.GoogleAiEmbeddingModel
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.embedding.EmbeddingModel
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("!local-demo")
+class GeminiConfig(
+    @Value("\${gemini.api-key}") private val apiKey: String
+) {
+    @Bean
+    fun chatLanguageModel(): ChatModel =
+        GoogleAiGeminiChatModel.builder()
+            .apiKey(apiKey)
+            .modelName("gemini-2.0-flash")
+            .temperature(0.1)
+            .build()
+
+    @Bean
+    fun embeddingModel(): EmbeddingModel =
+        GoogleAiEmbeddingModel.builder()
+            .apiKey(apiKey)
+            .modelName("gemini-embedding-001")
+            .outputDimensionality(768)
+            .build()
+}

--- a/src/main/kotlin/com/moongchijang/global/config/IndexingProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/IndexingProperties.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "indexing")
+data class IndexingProperties(
+    val publisher: String = "spring",
+    val consumer: String = "none",
+    val sqs: Sqs = Sqs()
+) {
+    data class Sqs(
+        val queueUrl: String = "",
+        val messageGroupId: String = "group-buy-indexing",
+        val maxMessages: Int = 5,
+        val waitTimeSeconds: Int = 10,
+        val visibilityTimeoutSeconds: Int = 60,
+        val pollingFixedDelayMillis: Long = 5_000
+    )
+}

--- a/src/main/kotlin/com/moongchijang/global/config/LocalDemoAiConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/LocalDemoAiConfig.kt
@@ -7,7 +7,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import tools.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectMapper
 
 @Configuration
 @Profile("local-demo")

--- a/src/main/kotlin/com/moongchijang/global/config/LocalDemoAiConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/LocalDemoAiConfig.kt
@@ -1,0 +1,22 @@
+package com.moongchijang.global.config
+
+import com.moongchijang.domain.search.infrastructure.demo.LocalDemoChatModel
+import com.moongchijang.domain.search.infrastructure.demo.LocalDemoEmbeddingModel
+import dev.langchain4j.model.chat.ChatModel
+import dev.langchain4j.model.embedding.EmbeddingModel
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import tools.jackson.databind.ObjectMapper
+
+@Configuration
+@Profile("local-demo")
+class LocalDemoAiConfig(
+    private val objectMapper: ObjectMapper
+) {
+    @Bean
+    fun chatModel(): ChatModel = LocalDemoChatModel(objectMapper)
+
+    @Bean
+    fun embeddingModel(): EmbeddingModel = LocalDemoEmbeddingModel()
+}

--- a/src/main/kotlin/com/moongchijang/global/config/LocalDemoAiConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/LocalDemoAiConfig.kt
@@ -7,7 +7,7 @@ import dev.langchain4j.model.embedding.EmbeddingModel
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 
 @Configuration
 @Profile("local-demo")

--- a/src/main/kotlin/com/moongchijang/global/config/QdrantProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/QdrantProperties.kt
@@ -1,0 +1,15 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "qdrant")
+data class QdrantProperties(
+    val enabled: Boolean = false,
+    val url: String = "http://localhost:6333",
+    val apiKey: String? = null,
+    val collectionName: String = "group_buys",
+    val timeoutSeconds: Long = 2,
+    val initializeCollection: Boolean = false,
+    val vectorSize: Int = 768,
+    val distance: String = "Cosine"
+)

--- a/src/main/kotlin/com/moongchijang/global/config/SearchIndexProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SearchIndexProperties.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "search.index")
+data class SearchIndexProperties(
+    val versionKey: String = "search:index:version",
+    val defaultVersion: String = "v1"
+)

--- a/src/main/kotlin/com/moongchijang/global/config/SearchProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SearchProperties.kt
@@ -1,0 +1,26 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "search")
+data class SearchProperties(
+    val retrieval: Retrieval = Retrieval(),
+    val guard: Guard = Guard(),
+    val observability: Observability = Observability()
+) {
+    data class Retrieval(
+        val vectorCandidateLimit: Int = 10,
+        val vectorMinScore: Double = 0.5,
+        val fallbackProvider: String = "mysql"
+    )
+
+    data class Guard(
+        val enabled: Boolean = true,
+        val minConfidence: Double = 0.65,
+        val supportiveScoreThreshold: Double = 0.7
+    )
+
+    data class Observability(
+        val enabled: Boolean = true
+    )
+}

--- a/src/main/kotlin/com/moongchijang/global/config/SqsConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SqsConfig.kt
@@ -1,0 +1,14 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import software.amazon.awssdk.services.sqs.SqsClient
+
+@Configuration
+@ConditionalOnExpression("'\${indexing.publisher:none}' == 'sqs' or '\${indexing.consumer:none}' == 'sqs'")
+class SqsConfig {
+
+    @Bean(destroyMethod = "close")
+    fun sqsClient(): SqsClient = SqsClient.create()
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -74,3 +74,42 @@ ses:
   enabled: ${SES_ENABLED:false}
   region: ${SES_REGION}
   from-email: ${SES_FROM_EMAIL}
+
+gemini:
+  api-key: ${GEMINI_API_KEY}
+
+qdrant:
+  enabled: ${QDRANT_ENABLED:false}
+  url: ${QDRANT_URL:http://localhost:6333}
+  api-key: ${QDRANT_API_KEY:}
+  collection-name: ${QDRANT_COLLECTION_NAME:group_buys}
+  timeout-seconds: ${QDRANT_TIMEOUT_SECONDS:2}
+  initialize-collection: ${QDRANT_INITIALIZE_COLLECTION:false}
+  vector-size: ${QDRANT_VECTOR_SIZE:768}
+  distance: ${QDRANT_DISTANCE:Cosine}
+
+search:
+  retrieval:
+    vector-candidate-limit: ${SEARCH_VECTOR_CANDIDATE_LIMIT:10}
+    vector-min-score: ${SEARCH_VECTOR_MIN_SCORE:0.5}
+    fallback-provider: ${SEARCH_FALLBACK_PROVIDER:mysql}
+  guard:
+    enabled: ${SEARCH_GUARD_ENABLED:true}
+    min-confidence: ${SEARCH_GUARD_MIN_CONFIDENCE:0.65}
+    supportive-score-threshold: ${SEARCH_GUARD_SUPPORTIVE_SCORE_THRESHOLD:0.7}
+  observability:
+    enabled: ${SEARCH_OBSERVABILITY_ENABLED:true}
+  index:
+    version-key: ${SEARCH_INDEX_VERSION_KEY:search:index:version}
+    default-version: ${SEARCH_INDEX_DEFAULT_VERSION:v1}
+
+indexing:
+  publisher: ${INDEXING_PUBLISHER:spring}
+  consumer: ${INDEXING_CONSUMER:none}
+  sqs:
+    queue-url: ${INDEXING_SQS_QUEUE_URL:}
+    message-group-id: ${INDEXING_SQS_MESSAGE_GROUP_ID:group-buy-indexing}
+    max-messages: ${INDEXING_SQS_MAX_MESSAGES:5}
+    wait-time-seconds: ${INDEXING_SQS_WAIT_TIME_SECONDS:10}
+    visibility-timeout-seconds: ${INDEXING_SQS_VISIBILITY_TIMEOUT_SECONDS:60}
+    polling-fixed-delay-millis: ${INDEXING_SQS_POLLING_FIXED_DELAY_MILLIS:5000}

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -1,0 +1,106 @@
+# 외부 API 키 없이 즉시 실행 가능한 로컬 데모 예시.
+# 사용 방법: cp application-local-demo.yml application-local.yml 후 ./gradlew bootRun (실 키가 있으면 application-local.yml에 덮어쓰기)
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:mysql://localhost:3306/moongchijang_local?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${DB_USERNAME:moongchijang}
+    password: ${DB_PASSWORD:moongchijang}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  flyway:
+    enabled: true
+    locations:
+      - classpath:db/migration
+
+app:
+  s3:
+    bucket: local-bucket
+    prefix: local
+
+oauth:
+  kakao:
+    client-id: test-client-id
+    client-secret: test-client-secret
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+    redirect-uri: http://localhost:8080/auth/kakao/callback
+
+coolsms:
+  api-key: ${COOLSMS_API_KEY:test-api-key}
+  api-secret: ${COOLSMS_API_SECRET:test-api-secret}
+  sender: ${COOLSMS_SENDER:010-0000-0000}
+
+jwt:
+  secret: jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret-jwt-secret
+  access-token:
+    expiration-minutes: 60
+
+auth:
+  refresh:
+    expiration-days: ${AUTH_REFRESH_EXPIRATION_DAYS:14}
+
+naver:
+  api:
+    client-id: ${NAVER_CLIENT_ID:local-client-id}
+    client-secret: ${NAVER_CLIENT_SECRET:local-client-secret}
+
+ses:
+  enabled: ${SES_ENABLED:false}
+  region: ${SES_REGION:ap-northeast-2}
+  from-email: ${SES_FROM_EMAIL:no-reply@moongchijang.com}
+
+aligo:
+  api-key: ${ALIGO_API_KEY:local-aligo-api-key}
+  user-id: ${ALIGO_USER_ID:local-aligo-user-id}
+  sender-key: ${ALIGO_SENDER_KEY:local-aligo-sender-key}
+  template-code: ${ALIGO_TEMPLATE_CODE:local-template-code}
+  sender: ${ALIGO_SENDER:01000000000}
+
+gemini:
+  api-key: ${GEMINI_API_KEY:dummy-gemini-key}
+
+qdrant:
+  enabled: ${QDRANT_ENABLED:false}
+  url: ${QDRANT_URL:http://localhost:6333}
+  api-key: ${QDRANT_API_KEY:}
+  collection-name: ${QDRANT_COLLECTION_NAME:group_buys}
+  timeout-seconds: ${QDRANT_TIMEOUT_SECONDS:2}
+  initialize-collection: ${QDRANT_INITIALIZE_COLLECTION:false}
+  vector-size: ${QDRANT_VECTOR_SIZE:768}
+  distance: ${QDRANT_DISTANCE:Cosine}
+
+search:
+  retrieval:
+    vector-candidate-limit: ${SEARCH_VECTOR_CANDIDATE_LIMIT:10}
+    vector-min-score: ${SEARCH_VECTOR_MIN_SCORE:0.5}
+    fallback-provider: ${SEARCH_FALLBACK_PROVIDER:mysql}
+  guard:
+    enabled: ${SEARCH_GUARD_ENABLED:true}
+    min-confidence: ${SEARCH_GUARD_MIN_CONFIDENCE:0.65}
+    supportive-score-threshold: ${SEARCH_GUARD_SUPPORTIVE_SCORE_THRESHOLD:0.7}
+  observability:
+    enabled: ${SEARCH_OBSERVABILITY_ENABLED:true}
+  index:
+    version-key: ${SEARCH_INDEX_VERSION_KEY:search:index:version}
+    default-version: ${SEARCH_INDEX_DEFAULT_VERSION:v1}
+
+indexing:
+  publisher: ${INDEXING_PUBLISHER:spring}
+  consumer: ${INDEXING_CONSUMER:none}
+  sqs:
+    queue-url: ${INDEXING_SQS_QUEUE_URL:}
+    message-group-id: ${INDEXING_SQS_MESSAGE_GROUP_ID:group-buy-indexing}
+    max-messages: ${INDEXING_SQS_MAX_MESSAGES:5}
+    wait-time-seconds: ${INDEXING_SQS_WAIT_TIME_SECONDS:10}
+    visibility-timeout-seconds: ${INDEXING_SQS_VISIBILITY_TIMEOUT_SECONDS:60}
+    polling-fixed-delay-millis: ${INDEXING_SQS_POLLING_FIXED_DELAY_MILLIS:5000}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -63,3 +63,42 @@ aligo:
   sender-key: ${ALIGO_SENDER_KEY}
   template-code: ${ALIGO_TEMPLATE_CODE}
   sender: ${ALIGO_SENDER}
+
+gemini:
+  api-key: ${GEMINI_API_KEY:dummy-gemini-key}
+
+qdrant:
+  enabled: ${QDRANT_ENABLED:false}
+  url: ${QDRANT_URL:http://localhost:6333}
+  api-key: ${QDRANT_API_KEY:}
+  collection-name: ${QDRANT_COLLECTION_NAME:group_buys}
+  timeout-seconds: ${QDRANT_TIMEOUT_SECONDS:2}
+  initialize-collection: ${QDRANT_INITIALIZE_COLLECTION:false}
+  vector-size: ${QDRANT_VECTOR_SIZE:768}
+  distance: ${QDRANT_DISTANCE:Cosine}
+
+search:
+  retrieval:
+    vector-candidate-limit: ${SEARCH_VECTOR_CANDIDATE_LIMIT:10}
+    vector-min-score: ${SEARCH_VECTOR_MIN_SCORE:0.5}
+    fallback-provider: ${SEARCH_FALLBACK_PROVIDER:mysql}
+  guard:
+    enabled: ${SEARCH_GUARD_ENABLED:true}
+    min-confidence: ${SEARCH_GUARD_MIN_CONFIDENCE:0.65}
+    supportive-score-threshold: ${SEARCH_GUARD_SUPPORTIVE_SCORE_THRESHOLD:0.7}
+  observability:
+    enabled: ${SEARCH_OBSERVABILITY_ENABLED:true}
+  index:
+    version-key: ${SEARCH_INDEX_VERSION_KEY:search:index:version}
+    default-version: ${SEARCH_INDEX_DEFAULT_VERSION:v1}
+
+indexing:
+  publisher: ${INDEXING_PUBLISHER:spring}
+  consumer: ${INDEXING_CONSUMER:none}
+  sqs:
+    queue-url: ${INDEXING_SQS_QUEUE_URL:}
+    message-group-id: ${INDEXING_SQS_MESSAGE_GROUP_ID:group-buy-indexing}
+    max-messages: ${INDEXING_SQS_MAX_MESSAGES:5}
+    wait-time-seconds: ${INDEXING_SQS_WAIT_TIME_SECONDS:10}
+    visibility-timeout-seconds: ${INDEXING_SQS_VISIBILITY_TIMEOUT_SECONDS:60}
+    polling-fixed-delay-millis: ${INDEXING_SQS_POLLING_FIXED_DELAY_MILLIS:5000}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -64,3 +64,42 @@ ses:
   enabled: ${SES_ENABLED:false}
   region: ${SES_REGION}
   from-email: ${SES_FROM_EMAIL}
+
+gemini:
+  api-key: ${GEMINI_API_KEY}
+
+qdrant:
+  enabled: ${QDRANT_ENABLED:false}
+  url: ${QDRANT_URL:http://localhost:6333}
+  api-key: ${QDRANT_API_KEY:}
+  collection-name: ${QDRANT_COLLECTION_NAME:group_buys}
+  timeout-seconds: ${QDRANT_TIMEOUT_SECONDS:2}
+  initialize-collection: ${QDRANT_INITIALIZE_COLLECTION:false}
+  vector-size: ${QDRANT_VECTOR_SIZE:768}
+  distance: ${QDRANT_DISTANCE:Cosine}
+
+search:
+  retrieval:
+    vector-candidate-limit: ${SEARCH_VECTOR_CANDIDATE_LIMIT:10}
+    vector-min-score: ${SEARCH_VECTOR_MIN_SCORE:0.5}
+    fallback-provider: ${SEARCH_FALLBACK_PROVIDER:mysql}
+  guard:
+    enabled: ${SEARCH_GUARD_ENABLED:true}
+    min-confidence: ${SEARCH_GUARD_MIN_CONFIDENCE:0.65}
+    supportive-score-threshold: ${SEARCH_GUARD_SUPPORTIVE_SCORE_THRESHOLD:0.7}
+  observability:
+    enabled: ${SEARCH_OBSERVABILITY_ENABLED:true}
+  index:
+    version-key: ${SEARCH_INDEX_VERSION_KEY:search:index:version}
+    default-version: ${SEARCH_INDEX_DEFAULT_VERSION:v1}
+
+indexing:
+  publisher: ${INDEXING_PUBLISHER:spring}
+  consumer: ${INDEXING_CONSUMER:none}
+  sqs:
+    queue-url: ${INDEXING_SQS_QUEUE_URL:}
+    message-group-id: ${INDEXING_SQS_MESSAGE_GROUP_ID:group-buy-indexing}
+    max-messages: ${INDEXING_SQS_MAX_MESSAGES:5}
+    wait-time-seconds: ${INDEXING_SQS_WAIT_TIME_SECONDS:10}
+    visibility-timeout-seconds: ${INDEXING_SQS_VISIBILITY_TIMEOUT_SECONDS:60}
+    polling-fixed-delay-millis: ${INDEXING_SQS_POLLING_FIXED_DELAY_MILLIS:5000}

--- a/src/main/resources/db/migration/V9__create_group_buy_embeddings_table.sql
+++ b/src/main/resources/db/migration/V9__create_group_buy_embeddings_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE group_buy_embeddings
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    group_buy_id BIGINT NOT NULL UNIQUE,
+    embedding    JSON   NOT NULL,
+    created_at   DATETIME NOT NULL,
+    updated_at   DATETIME NOT NULL,
+    INDEX idx_group_buy_embeddings_group_buy_id (group_buy_id)
+);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -40,3 +40,42 @@ ses:
   enabled: false
   region: ap-northeast-2
   from-email: no-reply@test.com
+
+gemini:
+  api-key: test-dummy-key
+
+qdrant:
+  enabled: false
+  url: http://localhost:6333
+  api-key:
+  collection-name: group_buys
+  timeout-seconds: 2
+  initialize-collection: false
+  vector-size: 768
+  distance: Cosine
+
+search:
+  retrieval:
+    vector-candidate-limit: 10
+    vector-min-score: 0.5
+    fallback-provider: mysql
+  guard:
+    enabled: true
+    min-confidence: 0.65
+    supportive-score-threshold: 0.7
+  observability:
+    enabled: true
+  index:
+    version-key: search:index:version
+    default-version: v1
+
+indexing:
+  publisher: spring
+  consumer: none
+  sqs:
+    queue-url:
+    message-group-id: group-buy-indexing
+    max-messages: 5
+    wait-time-seconds: 10
+    visibility-timeout-seconds: 60
+    polling-fixed-delay-millis: 5000


### PR DESCRIPTION
## 📌 작업한 내용
- `MySQL + Qdrant dense hybrid search pipeline`을 추가했습니다.
- Qdrant는 semantic candidate generator로 사용합니다.
- VectorCandidatePromotionGuard를 통해 metadata/confidence/known-token 기준을 통과한 후보만 최종 결과로 승격합니다.
- Qdrant adapter, collection initializer, vector port를 추가했습니다.
- GroupBuyIndexingService와 SQS / Spring 이벤트 publisher·consumer를 추가했습니다.
- Gemini / Qdrant / Search / Indexing runtime config와 docker-compose qdrant 서비스를 추가했습니다.
- 비동기 인덱싱과 SQS 폴링을 위해 `@EnableAsync` / `@EnableScheduling`을 활성화했습니다.

## 🔍 참고 사항
- ranking weight tuning은 포함하지 않았습니다.
- collection initializer에도 QDRANT_TIMEOUT_SECONDS가 적용되도록 보강했습니다.

## 🖼 스크린샷
없음

## 🔗 관련 이슈
- Closes #68

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] docker-compose --profile search-eval up qdrant 동작 확인
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인