### PR TITLE
[MCJ-1422] TEST: 검색 품질 평가 및 통합 테스트 추가

### DIFF
--- a/src/test/kotlin/com/moongchijang/domain/search/application/AliasDictionaryTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/AliasDictionaryTest.kt
@@ -1,0 +1,45 @@
+package com.moongchijang.domain.search.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AliasDictionaryTest {
+
+    private val aliasDictionary = AliasDictionary()
+
+    @Test
+    fun `유효 상품을 query가 직접 포함하면 그 상품을 반환한다`() {
+        val validProducts = listOf("소금빵", "두쫀쿠")
+
+        assertThat(aliasDictionary.resolveProduct("성수 소금빵 추천", validProducts)).isEqualTo("소금빵")
+    }
+
+    @Test
+    fun `대소문자 차이가 있어도 매칭한다`() {
+        val validProducts = listOf("Croissant")
+
+        assertThat(aliasDictionary.resolveProduct("croissant 맛집", validProducts)).isEqualTo("Croissant")
+    }
+
+    @Test
+    fun `alias 매핑이 있고 정식명이 유효 목록에 있으면 정식명을 반환한다`() {
+        val validProducts = listOf("소금빵")
+
+        assertThat(aliasDictionary.resolveProduct("시오빵 먹고싶다", validProducts)).isEqualTo("소금빵")
+        assertThat(aliasDictionary.resolveProduct("salt bread please", validProducts)).isEqualTo("소금빵")
+    }
+
+    @Test
+    fun `alias 정식명이 유효 목록에 없으면 null을 반환한다`() {
+        val validProducts = listOf("두쫀쿠")
+
+        assertThat(aliasDictionary.resolveProduct("시오빵", validProducts)).isNull()
+    }
+
+    @Test
+    fun `isAliasMatch는 query에 alias가 있고 정식명이 일치할 때 true`() {
+        assertThat(aliasDictionary.isAliasMatch("시오빵 추천", "소금빵")).isTrue
+        assertThat(aliasDictionary.isAliasMatch("두쫀쿠", "소금빵")).isFalse
+        assertThat(aliasDictionary.isAliasMatch("시오빵", null)).isFalse
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/application/RetrievalPipelineGuardIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/RetrievalPipelineGuardIntegrationTest.kt
@@ -1,0 +1,162 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.application.port.VectorSearchCandidate
+import com.moongchijang.domain.search.application.port.VectorSearchPort
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.global.config.SearchProperties
+import com.moongchijang.support.search.SearchTestFixtures
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import java.time.LocalDateTime
+
+class RetrievalPipelineGuardIntegrationTest {
+
+    private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
+    private val vectorSearchPort: VectorSearchPort = Mockito.mock(VectorSearchPort::class.java)
+    private val aliasDictionary = AliasDictionary()
+    private val reranker = SearchReranker()
+
+    // Kotlin null-safety 우회용 헬퍼: Mockito 매처를 등록한 뒤 non-null 값을 반환.
+    private fun anyLocalDateTime(): LocalDateTime {
+        ArgumentMatchers.any(LocalDateTime::class.java)
+        return LocalDateTime.MIN
+    }
+    private fun anyGroupBuyStatus(): GroupBuyStatus {
+        ArgumentMatchers.any(GroupBuyStatus::class.java)
+        return GroupBuyStatus.IN_PROGRESS
+    }
+    private fun anyLongList(): List<Long> {
+        ArgumentMatchers.anyList<Long>()
+        return emptyList()
+    }
+
+    private val seoulMatch = SearchTestFixtures.groupBuy(
+        id = 1L,
+        productName = "두쫀쿠",
+        store = SearchTestFixtures.store(region = RegionType.SEOUL)
+    )
+
+    private fun pipeline(guardEnabled: Boolean): RetrievalPipeline {
+        val properties = SearchProperties(guard = SearchProperties.Guard(enabled = guardEnabled))
+        return RetrievalPipeline(
+            groupBuyRepository = groupBuyRepository,
+            vectorSearchPort = vectorSearchPort,
+            aliasDictionary = aliasDictionary,
+            vectorCandidatePromotionGuard = VectorCandidatePromotionGuard(properties),
+            reranker = reranker,
+            searchObservabilityLogger = SearchObservabilityLogger(properties),
+            searchProperties = properties
+        )
+    }
+
+    private fun stubExactReturns(result: List<GroupBuy>) {
+        Mockito.`when`(
+            groupBuyRepository.searchByIntent(
+                ArgumentMatchers.any(),
+                ArgumentMatchers.any(),
+                anyLocalDateTime(),
+                anyGroupBuyStatus()
+            )
+        ).thenReturn(result)
+    }
+
+    private fun stubVectorReturns(candidates: List<VectorSearchCandidate>) {
+        Mockito.`when`(
+            vectorSearchPort.search(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyInt(),
+                ArgumentMatchers.anyDouble()
+            )
+        ).thenReturn(candidates)
+    }
+
+    private fun stubFindAllById(result: List<GroupBuy>) {
+        Mockito.`when`(groupBuyRepository.findAllById(anyLongList()))
+            .thenReturn(result)
+    }
+
+    @Test
+    fun `guard ON - PRODUCT_ONLY 인텐트에서 product 일치 후보는 정당하게 promote된다`() {
+        val intent = SearchIntent(
+            region = null,
+            product = "두쫀쿠",
+            searchCase = SearchCase.PRODUCT_ONLY,
+            confidence = 0.7
+        )
+        stubExactReturns(emptyList())
+        stubVectorReturns(listOf(VectorSearchCandidate(1L, 0.9)))
+        stubFindAllById(listOf(seoulMatch))
+
+        val results = pipeline(guardEnabled = true).retrieve("강남 두쫀쿠", intent)
+
+        assertThat(results).hasSize(1)
+        assertThat(results[0].groupBuy.id).isEqualTo(1L)
+        assertThat(results[0].matchedBy).contains("VECTOR")
+    }
+
+    @Test
+    fun `guard ON - 알 수 없는 인텐트(NONE_DETECTED)는 NO_KNOWN_TOKEN 사유로 벡터 후보를 차단한다`() {
+        val intent = SearchIntent(
+            region = null,
+            product = null,
+            searchCase = SearchCase.NONE_DETECTED,
+            confidence = 0.0
+        )
+        stubExactReturns(emptyList())
+        stubVectorReturns(listOf(VectorSearchCandidate(1L, 0.95)))
+        stubFindAllById(listOf(seoulMatch))
+
+        val results = pipeline(guardEnabled = true).retrieve("asdfqwer", intent)
+
+        assertThat(results).isEmpty()
+    }
+
+    @Test
+    fun `guard OFF - 동일 NONE_DETECTED 인풋에서는 false positive가 그대로 통과한다`() {
+        val intent = SearchIntent(
+            region = null,
+            product = null,
+            searchCase = SearchCase.NONE_DETECTED,
+            confidence = 0.0
+        )
+        stubExactReturns(emptyList())
+        stubVectorReturns(listOf(VectorSearchCandidate(1L, 0.95)))
+        stubFindAllById(listOf(seoulMatch))
+
+        val results = pipeline(guardEnabled = false).retrieve("asdfqwer", intent)
+
+        // guard 비활성 시 벡터 후보가 결과로 노출되어 guard의 가치를 증명
+        assertThat(results).hasSize(1)
+        assertThat(results[0].groupBuy.id).isEqualTo(1L)
+        assertThat(results[0].matchedBy).contains("VECTOR")
+    }
+
+    @Test
+    fun `guard ON - 인텐트 product와 매장 productName 불일치 시 METADATA_MISMATCH로 차단한다`() {
+        val intent = SearchIntent(
+            region = null,
+            product = "두쫀쿠",
+            searchCase = SearchCase.PRODUCT_ONLY,
+            confidence = 0.9
+        )
+        val mismatch = SearchTestFixtures.groupBuy(
+            id = 2L,
+            productName = "소금빵",
+            store = SearchTestFixtures.store(region = RegionType.SEOUL)
+        )
+        stubExactReturns(emptyList())
+        stubVectorReturns(listOf(VectorSearchCandidate(2L, 0.92)))
+        stubFindAllById(listOf(mismatch))
+
+        val results = pipeline(guardEnabled = true).retrieve("두쫀쿠", intent)
+
+        assertThat(results).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/application/RetrievalPipelineGuardIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/RetrievalPipelineGuardIntegrationTest.kt
@@ -1,7 +1,6 @@
 package com.moongchijang.domain.search.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.search.application.dto.SearchCase
 import com.moongchijang.domain.search.application.port.VectorSearchCandidate
@@ -9,12 +8,14 @@ import com.moongchijang.domain.search.application.port.VectorSearchPort
 import com.moongchijang.domain.search.domain.SearchIntent
 import com.moongchijang.domain.store.domain.entity.RegionType
 import com.moongchijang.global.config.SearchProperties
+import com.moongchijang.support.search.MockitoKotlinMatchers.anyGroupBuyStatus
+import com.moongchijang.support.search.MockitoKotlinMatchers.anyLocalDateTime
+import com.moongchijang.support.search.MockitoKotlinMatchers.anyLongList
 import com.moongchijang.support.search.SearchTestFixtures
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
-import java.time.LocalDateTime
 
 class RetrievalPipelineGuardIntegrationTest {
 
@@ -22,20 +23,6 @@ class RetrievalPipelineGuardIntegrationTest {
     private val vectorSearchPort: VectorSearchPort = Mockito.mock(VectorSearchPort::class.java)
     private val aliasDictionary = AliasDictionary()
     private val reranker = SearchReranker()
-
-    // Kotlin null-safety 우회용 헬퍼: Mockito 매처를 등록한 뒤 non-null 값을 반환.
-    private fun anyLocalDateTime(): LocalDateTime {
-        ArgumentMatchers.any(LocalDateTime::class.java)
-        return LocalDateTime.MIN
-    }
-    private fun anyGroupBuyStatus(): GroupBuyStatus {
-        ArgumentMatchers.any(GroupBuyStatus::class.java)
-        return GroupBuyStatus.IN_PROGRESS
-    }
-    private fun anyLongList(): List<Long> {
-        ArgumentMatchers.anyList<Long>()
-        return emptyList()
-    }
 
     private val seoulMatch = SearchTestFixtures.groupBuy(
         id = 1L,

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchDecisionEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchDecisionEngineTest.kt
@@ -1,0 +1,47 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.domain.search.domain.SearchUiState
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SearchDecisionEngineTest {
+
+    private val engine = SearchDecisionEngine()
+
+    @Test
+    fun `결과가 1건 이상이면 항상 RESULTS를 반환한다`() {
+        val intent = SearchIntent(region = null, product = null, searchCase = SearchCase.NONE_DETECTED, confidence = 0.0)
+
+        assertThat(engine.decide(intent, resultCount = 3)).isEqualTo(SearchUiState.RESULTS)
+    }
+
+    @Test
+    fun `결과가 0건이고 BOTH_DETECTED면 EMPTY_CAN_REQUEST`() {
+        val intent = SearchIntent(region = "서울", product = "두쫀쿠", searchCase = SearchCase.BOTH_DETECTED, confidence = 0.9)
+
+        assertThat(engine.decide(intent, 0)).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
+    }
+
+    @Test
+    fun `결과가 0건이고 PRODUCT_ONLY면 NEED_REGION`() {
+        val intent = SearchIntent(region = null, product = "두쫀쿠", searchCase = SearchCase.PRODUCT_ONLY, confidence = 0.65)
+
+        assertThat(engine.decide(intent, 0)).isEqualTo(SearchUiState.NEED_REGION)
+    }
+
+    @Test
+    fun `결과가 0건이고 NEIGHBORHOOD_ONLY면 NEED_PRODUCT`() {
+        val intent = SearchIntent(region = "서울", product = null, searchCase = SearchCase.NEIGHBORHOOD_ONLY, confidence = 0.65)
+
+        assertThat(engine.decide(intent, 0)).isEqualTo(SearchUiState.NEED_PRODUCT)
+    }
+
+    @Test
+    fun `결과가 0건이고 NONE_DETECTED면 NEED_BOTH`() {
+        val intent = SearchIntent(region = null, product = null, searchCase = SearchCase.NONE_DETECTED, confidence = 0.0)
+
+        assertThat(engine.decide(intent, 0)).isEqualTo(SearchUiState.NEED_BOTH)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchOrchestratorIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchOrchestratorIntegrationTest.kt
@@ -11,12 +11,14 @@ import com.moongchijang.domain.search.domain.SearchUiState
 import com.moongchijang.domain.search.infrastructure.gemini.GeminiKeywordExtractionService
 import com.moongchijang.domain.store.domain.entity.RegionType
 import com.moongchijang.global.config.SearchProperties
+import com.moongchijang.support.search.MockitoKotlinMatchers.anyGroupBuyStatus
+import com.moongchijang.support.search.MockitoKotlinMatchers.anyLocalDateTime
+import com.moongchijang.support.search.MockitoKotlinMatchers.anyLongList
 import com.moongchijang.support.search.SearchTestFixtures
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
-import java.time.LocalDateTime
 
 class SearchOrchestratorIntegrationTest {
 
@@ -47,19 +49,6 @@ class SearchOrchestratorIntegrationTest {
         retrievalPipeline = retrievalPipeline,
         decisionEngine = decisionEngine
     )
-
-    private fun anyLocalDateTime(): LocalDateTime {
-        ArgumentMatchers.any(LocalDateTime::class.java)
-        return LocalDateTime.MIN
-    }
-    private fun anyGroupBuyStatus(): GroupBuyStatus {
-        ArgumentMatchers.any(GroupBuyStatus::class.java)
-        return GroupBuyStatus.IN_PROGRESS
-    }
-    private fun anyLongList(): List<Long> {
-        ArgumentMatchers.anyList<Long>()
-        return emptyList()
-    }
 
     private fun stubVocabulary(regions: List<String> = listOf("성수", "홍대"), products: List<String> = listOf("두쫀쿠", "소금빵")) {
         Mockito.`when`(groupBuyRepository.findDistinctRegions(GroupBuyStatus.IN_PROGRESS)).thenReturn(regions)

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchOrchestratorIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchOrchestratorIntegrationTest.kt
@@ -1,0 +1,222 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.search.application.dto.KeywordExtractionResult
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.application.port.VectorSearchCandidate
+import com.moongchijang.domain.search.application.port.VectorSearchPort
+import com.moongchijang.domain.search.domain.SearchUiState
+import com.moongchijang.domain.search.infrastructure.gemini.GeminiKeywordExtractionService
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.global.config.SearchProperties
+import com.moongchijang.support.search.SearchTestFixtures
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import java.time.LocalDateTime
+
+class SearchOrchestratorIntegrationTest {
+
+    private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
+    private val vectorSearchPort: VectorSearchPort = Mockito.mock(VectorSearchPort::class.java)
+    private val keywordExtractor: GeminiKeywordExtractionService =
+        Mockito.mock(GeminiKeywordExtractionService::class.java)
+
+    private val aliasDictionary = AliasDictionary()
+    private val reranker = SearchReranker()
+    private val decisionEngine = SearchDecisionEngine()
+    private val properties = SearchProperties()
+    private val guard = VectorCandidatePromotionGuard(properties)
+    private val observabilityLogger = SearchObservabilityLogger(properties)
+    private val retrievalPipeline = RetrievalPipeline(
+        groupBuyRepository = groupBuyRepository,
+        vectorSearchPort = vectorSearchPort,
+        aliasDictionary = aliasDictionary,
+        vectorCandidatePromotionGuard = guard,
+        reranker = reranker,
+        searchObservabilityLogger = observabilityLogger,
+        searchProperties = properties
+    )
+    private val orchestrator = SearchOrchestrator(
+        groupBuyRepository = groupBuyRepository,
+        keywordExtractor = keywordExtractor,
+        aliasDictionary = aliasDictionary,
+        retrievalPipeline = retrievalPipeline,
+        decisionEngine = decisionEngine
+    )
+
+    private fun anyLocalDateTime(): LocalDateTime {
+        ArgumentMatchers.any(LocalDateTime::class.java)
+        return LocalDateTime.MIN
+    }
+    private fun anyGroupBuyStatus(): GroupBuyStatus {
+        ArgumentMatchers.any(GroupBuyStatus::class.java)
+        return GroupBuyStatus.IN_PROGRESS
+    }
+    private fun anyLongList(): List<Long> {
+        ArgumentMatchers.anyList<Long>()
+        return emptyList()
+    }
+
+    private fun stubVocabulary(regions: List<String> = listOf("성수", "홍대"), products: List<String> = listOf("두쫀쿠", "소금빵")) {
+        Mockito.`when`(groupBuyRepository.findDistinctRegions(GroupBuyStatus.IN_PROGRESS)).thenReturn(regions)
+        Mockito.`when`(groupBuyRepository.findDistinctProductNames(GroupBuyStatus.IN_PROGRESS)).thenReturn(products)
+    }
+
+    private fun stubExact(result: List<GroupBuy>) {
+        Mockito.`when`(
+            groupBuyRepository.searchByIntent(
+                ArgumentMatchers.any(),
+                ArgumentMatchers.any(),
+                anyLocalDateTime(),
+                anyGroupBuyStatus()
+            )
+        ).thenReturn(result)
+    }
+
+    private fun stubVector(candidates: List<VectorSearchCandidate>) {
+        Mockito.`when`(
+            vectorSearchPort.search(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyInt(),
+                ArgumentMatchers.anyDouble()
+            )
+        ).thenReturn(candidates)
+    }
+
+    private fun stubFindAllById(result: List<GroupBuy>) {
+        Mockito.`when`(groupBuyRepository.findAllById(anyLongList())).thenReturn(result)
+    }
+
+    private fun stubExtraction(region: String?, product: String?) {
+        val searchCase = when {
+            region != null && product != null -> SearchCase.BOTH_DETECTED
+            product != null -> SearchCase.PRODUCT_ONLY
+            region != null -> SearchCase.NEIGHBORHOOD_ONLY
+            else -> SearchCase.NONE_DETECTED
+        }
+        Mockito.`when`(
+            keywordExtractor.extract(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyList(),
+                ArgumentMatchers.anyList()
+            )
+        ).thenReturn(KeywordExtractionResult(region, product, searchCase))
+    }
+
+    @Test
+    fun `Case 1 - BOTH_DETECTED 정확 매칭이 있으면 RESULTS와 결과 카드 반환`() {
+        val match = SearchTestFixtures.groupBuy(id = 1L, productName = "두쫀쿠")
+        stubVocabulary()
+        stubExtraction(region = "성수", product = "두쫀쿠")
+        stubExact(listOf(match))
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("성수 두쫀쿠")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+        assertThat(response.detectedRegion).isEqualTo("성수")
+        assertThat(response.detectedProduct).isEqualTo("두쫀쿠")
+        assertThat(response.confidence).isEqualTo(0.9)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(1)
+        assertThat(response.results[0].id).isEqualTo(1L)
+    }
+
+    @Test
+    fun `Case 2 - PRODUCT_ONLY alias 매칭 후 결과가 있으면 RESULTS 반환`() {
+        val match = SearchTestFixtures.groupBuy(id = 1L, productName = "소금빵")
+        stubVocabulary(products = listOf("소금빵"))
+        // LLM은 추출 실패, alias dictionary가 시오빵 → 소금빵으로 보정
+        Mockito.`when`(
+            keywordExtractor.extract(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyList(),
+                ArgumentMatchers.anyList()
+            )
+        ).thenReturn(KeywordExtractionResult(null, null, SearchCase.NONE_DETECTED))
+        stubExact(listOf(match))
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("시오빵")
+
+        assertThat(response.detectedProduct).isEqualTo("소금빵")
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `Case 3 - NEIGHBORHOOD_ONLY 결과가 있으면 RESULTS 반환`() {
+        val match = SearchTestFixtures.groupBuy(id = 1L, store = SearchTestFixtures.store(region = RegionType.SEOUL))
+        stubVocabulary()
+        stubExtraction(region = "성수", product = null)
+        stubExact(listOf(match))
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("성수")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.NEIGHBORHOOD_ONLY)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `Case 4 - BOTH_DETECTED 결과 0건이면 EMPTY_CAN_REQUEST`() {
+        stubVocabulary()
+        stubExtraction(region = "성수", product = "두쫀쿠")
+        stubExact(emptyList())
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("성수 두쫀쿠")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
+        assertThat(response.totalCount).isZero
+    }
+
+    @Test
+    fun `NONE_DETECTED + 결과 0건이면 NEED_BOTH`() {
+        stubVocabulary()
+        stubExtraction(region = null, product = null)
+        stubExact(emptyList())
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("asdfqwer")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+        assertThat(response.confidence).isZero
+        assertThat(response.uiState).isEqualTo(SearchUiState.NEED_BOTH)
+        assertThat(response.totalCount).isZero
+    }
+
+    @Test
+    fun `keywordExtractor가 예외를 던지면 NONE_DETECTED로 폴백한다`() {
+        stubVocabulary()
+        Mockito.`when`(
+            keywordExtractor.extract(
+                ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyList(),
+                ArgumentMatchers.anyList()
+            )
+        ).thenThrow(RuntimeException("LLM down"))
+        stubExact(emptyList())
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("성수 두쫀쿠")
+
+        // LLM 폴백 후에도 aliasDictionary가 "두쫀쿠"를 유효 상품에서 fallback resolve → PRODUCT_ONLY
+        assertThat(response.detectedRegion).isNull()
+        assertThat(response.detectedProduct).isEqualTo("두쫀쿠")
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+        assertThat(response.uiState).isEqualTo(SearchUiState.NEED_REGION)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/application/VectorCandidatePromotionGuardTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/VectorCandidatePromotionGuardTest.kt
@@ -1,0 +1,126 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.application.port.VectorSearchCandidate
+import com.moongchijang.domain.search.domain.SearchIntent
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.global.config.SearchProperties
+import com.moongchijang.support.search.SearchTestFixtures
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class VectorCandidatePromotionGuardTest {
+
+    private val defaultProperties = SearchProperties()
+    private val guard = VectorCandidatePromotionGuard(defaultProperties)
+
+    @Test
+    fun `guard 비활성화 시 모든 후보를 통과시킨다`() {
+        val disabledGuard = VectorCandidatePromotionGuard(
+            SearchProperties(guard = SearchProperties.Guard(enabled = false))
+        )
+        val intent = SearchIntent(region = null, product = null, searchCase = SearchCase.NONE_DETECTED, confidence = 0.0)
+        val groupBuy = SearchTestFixtures.groupBuy(id = 1L, productName = "두쫀쿠")
+        val candidates = listOf(VectorSearchCandidate(1L, 0.3))
+
+        val result = disabledGuard.filterPromotableCandidates(intent, listOf(groupBuy), candidates)
+
+        assertThat(result.vectorCandidates).hasSize(1)
+        assertThat(result.decisions.first().rejectionReason).isNull()
+    }
+
+    @Test
+    fun `known token이 없으면 NO_KNOWN_TOKEN 사유로 거부한다`() {
+        val intent = SearchIntent(region = null, product = null, searchCase = SearchCase.NONE_DETECTED, confidence = 0.9)
+        val groupBuy = SearchTestFixtures.groupBuy(id = 1L)
+        val candidates = listOf(VectorSearchCandidate(1L, 0.9))
+
+        val result = guard.filterPromotableCandidates(intent, listOf(groupBuy), candidates)
+
+        assertThat(result.vectorCandidates).isEmpty()
+        assertThat(result.decisions.first().rejectionReason)
+            .isEqualTo(VectorCandidateRejectionReason.NO_KNOWN_TOKEN)
+    }
+
+    @Test
+    fun `신뢰도가 임계치 미만이면 LOW_CONFIDENCE 사유로 거부한다`() {
+        val intent = SearchIntent(region = "서울", product = "두쫀쿠", searchCase = SearchCase.BOTH_DETECTED, confidence = 0.5)
+        val groupBuy = SearchTestFixtures.groupBuy(id = 1L, productName = "두쫀쿠")
+        val candidates = listOf(VectorSearchCandidate(1L, 0.9))
+
+        val result = guard.filterPromotableCandidates(intent, listOf(groupBuy), candidates)
+
+        assertThat(result.decisions.first().rejectionReason)
+            .isEqualTo(VectorCandidateRejectionReason.LOW_CONFIDENCE)
+    }
+
+    @Test
+    fun `메타데이터(지역 또는 상품)가 불일치하면 METADATA_MISMATCH로 거부한다`() {
+        val intent = SearchIntent(region = "서울", product = "소금빵", searchCase = SearchCase.BOTH_DETECTED, confidence = 0.9)
+        val groupBuy = SearchTestFixtures.groupBuy(id = 1L, productName = "두쫀쿠")
+        val candidates = listOf(VectorSearchCandidate(1L, 0.9))
+
+        val result = guard.filterPromotableCandidates(intent, listOf(groupBuy), candidates)
+
+        assertThat(result.decisions.first().rejectionReason)
+            .isEqualTo(VectorCandidateRejectionReason.METADATA_MISMATCH)
+    }
+
+    @Test
+    fun `vectorMatches에 메타데이터가 없으면 UNAVAILABLE_METADATA로 거부한다`() {
+        val intent = SearchIntent(region = "서울", product = "두쫀쿠", searchCase = SearchCase.BOTH_DETECTED, confidence = 0.9)
+        val candidates = listOf(VectorSearchCandidate(42L, 0.9))
+
+        val result = guard.filterPromotableCandidates(intent, emptyList(), candidates)
+
+        assertThat(result.decisions.first().rejectionReason)
+            .isEqualTo(VectorCandidateRejectionReason.UNAVAILABLE_METADATA)
+    }
+
+    @Test
+    fun `region만 있고 메타데이터가 일치하면 통과시킨다`() {
+        val intent = SearchIntent(region = "서울", product = null, searchCase = SearchCase.NEIGHBORHOOD_ONLY, confidence = 0.7)
+        val groupBuy = SearchTestFixtures.groupBuy(
+            id = 1L,
+            productName = "두쫀쿠",
+            store = SearchTestFixtures.store(region = RegionType.SEOUL)
+        )
+        val candidates = listOf(VectorSearchCandidate(1L, 0.9))
+
+        val result = guard.filterPromotableCandidates(intent, listOf(groupBuy), candidates)
+
+        assertThat(result.vectorCandidates).hasSize(1)
+        assertThat(result.decisions.first().rejectionReason).isNull()
+    }
+
+    @Test
+    fun `product만 있고 일치할 때 통과시킨다`() {
+        val intent = SearchIntent(region = null, product = "두쫀쿠", searchCase = SearchCase.PRODUCT_ONLY, confidence = 0.7)
+        val groupBuy = SearchTestFixtures.groupBuy(id = 1L, productName = "두쫀쿠")
+        val candidates = listOf(VectorSearchCandidate(1L, 0.9))
+
+        val result = guard.filterPromotableCandidates(intent, listOf(groupBuy), candidates)
+
+        assertThat(result.vectorCandidates).hasSize(1)
+    }
+
+    @Test
+    fun `여러 후보 중 통과·거부 사유별 카운트가 정확하다`() {
+        val intent = SearchIntent(region = "서울", product = "두쫀쿠", searchCase = SearchCase.BOTH_DETECTED, confidence = 0.9)
+        val matching = SearchTestFixtures.groupBuy(id = 1L, productName = "두쫀쿠")
+        val mismatch = SearchTestFixtures.groupBuy(id = 2L, productName = "소금빵")
+        val candidates = listOf(
+            VectorSearchCandidate(1L, 0.95),
+            VectorSearchCandidate(2L, 0.9),
+            VectorSearchCandidate(999L, 0.9)
+        )
+
+        val result = guard.filterPromotableCandidates(intent, listOf(matching, mismatch), candidates)
+
+        assertThat(result.vectorCandidates.map { it.groupBuyId }).containsExactly(1L)
+        assertThat(result.rejectedCount).isEqualTo(2)
+        assertThat(result.rejectionReasonCounts)
+            .containsEntry(VectorCandidateRejectionReason.METADATA_MISMATCH, 1)
+            .containsEntry(VectorCandidateRejectionReason.UNAVAILABLE_METADATA, 1)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationMetricsTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationMetricsTest.kt
@@ -1,0 +1,141 @@
+package com.moongchijang.domain.search.evaluation
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import kotlin.math.ln
+
+class SearchEvaluationMetricsTest {
+
+    private val metrics = SearchEvaluationMetrics()
+
+    @Test
+    fun `recallAtK는 top-K 안의 관련 항목 수를 관련 항목 총합으로 나눈다`() {
+        val rankedIds = listOf(1L, 2L, 3L, 4L, 5L)
+        val relevantIds = setOf(2L, 5L, 99L)
+
+        assertThat(metrics.recallAtK(rankedIds, relevantIds, k = 10))
+            .isEqualTo(2.0 / 3.0, within(1e-9))
+    }
+
+    @Test
+    fun `recallAtK는 K 이후 항목을 카운트하지 않는다`() {
+        val rankedIds = listOf(1L, 2L, 3L, 4L, 5L)
+        val relevantIds = setOf(5L)
+
+        assertThat(metrics.recallAtK(rankedIds, relevantIds, k = 3)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `recallAtK는 관련 항목이 없으면 0을 반환한다`() {
+        assertThat(metrics.recallAtK(listOf(1L, 2L), emptySet(), k = 10)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `precisionAtK는 top-K 안의 관련 항목 수를 K로 나눈다`() {
+        val rankedIds = listOf(1L, 2L, 3L, 4L, 5L)
+        val relevantIds = setOf(2L, 3L)
+
+        assertThat(metrics.precisionAtK(rankedIds, relevantIds, k = 5))
+            .isEqualTo(0.4, within(1e-9))
+    }
+
+    @Test
+    fun `precisionAtK는 관련 항목이 없으면 0을 반환한다`() {
+        assertThat(metrics.precisionAtK(listOf(1L, 2L, 3L), emptySet(), k = 3)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `reciprocalRank는 첫 관련 항목의 역순위를 반환한다`() {
+        val rankedIds = listOf(10L, 20L, 30L)
+        val relevantIds = setOf(20L)
+
+        assertThat(metrics.reciprocalRank(rankedIds, relevantIds))
+            .isEqualTo(0.5, within(1e-9))
+    }
+
+    @Test
+    fun `reciprocalRank는 첫 순위가 관련일 때 1을 반환한다`() {
+        assertThat(metrics.reciprocalRank(listOf(1L, 2L), setOf(1L))).isEqualTo(1.0)
+    }
+
+    @Test
+    fun `reciprocalRank는 관련 항목이 없거나 매칭이 없으면 0을 반환한다`() {
+        assertThat(metrics.reciprocalRank(listOf(1L, 2L), emptySet())).isEqualTo(0.0)
+        assertThat(metrics.reciprocalRank(listOf(1L, 2L), setOf(99L))).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `ndcgAtK는 첫 위치 관련 항목에 가장 높은 이득을 부여한다`() {
+        val rankedIds = listOf(2L, 1L, 3L)
+        val relevantIds = setOf(2L)
+
+        assertThat(metrics.ndcgAtK(rankedIds, relevantIds, k = 3)).isEqualTo(1.0, within(1e-9))
+    }
+
+    @Test
+    fun `ndcgAtK는 후순위 관련 항목에 낮은 점수를 부여한다`() {
+        val rankedIds = listOf(1L, 2L, 3L)
+        val relevantIds = setOf(2L)
+
+        val expected = (1.0 / log2(3.0)) / (1.0 / log2(2.0))
+        assertThat(metrics.ndcgAtK(rankedIds, relevantIds, k = 3)).isEqualTo(expected, within(1e-9))
+    }
+
+    @Test
+    fun `ndcgAtK는 관련 항목이 없으면 0을 반환한다`() {
+        assertThat(metrics.ndcgAtK(listOf(1L, 2L, 3L), emptySet(), k = 3)).isEqualTo(0.0)
+    }
+
+    @Test
+    fun `evaluate는 빈 골든 케이스에 대해 0 리포트를 반환한다`() {
+        val report = metrics.evaluate(emptyList(), emptyMap())
+
+        assertThat(report.caseCount).isZero
+        assertThat(report.recallAtK).isZero
+        assertThat(report.precisionAtK).isZero
+        assertThat(report.mrr).isZero
+        assertThat(report.zeroResultRate).isZero
+        assertThat(report.falsePositiveRate).isZero
+    }
+
+    @Test
+    fun `evaluate는 positive와 no-result-expected 케이스를 분리해 집계한다`() {
+        val goldenCases = listOf(
+            GoldenSearchCase("성수 두쫀쿠", setOf(1L)),
+            GoldenSearchCase("홍대 소금빵", setOf(2L, 20L)),
+            GoldenSearchCase("강남 두쫀쿠", emptySet()),
+            GoldenSearchCase("xyz nonsense", emptySet())
+        )
+        val ranked = mapOf(
+            "성수 두쫀쿠" to listOf(1L, 99L, 100L),
+            "홍대 소금빵" to listOf(2L, 20L, 30L),
+            "강남 두쫀쿠" to emptyList(),
+            "xyz nonsense" to listOf(7L, 8L)
+        )
+
+        val report = metrics.evaluate(goldenCases, ranked, k = 10)
+
+        assertThat(report.caseCount).isEqualTo(4)
+        assertThat(report.positiveCaseCount).isEqualTo(2)
+        assertThat(report.noResultExpectedCaseCount).isEqualTo(2)
+        assertThat(report.k).isEqualTo(10)
+        assertThat(report.recallAtK).isEqualTo(1.0, within(1e-9))
+        assertThat(report.mrr).isEqualTo(1.0, within(1e-9))
+        assertThat(report.falsePositiveCount).isEqualTo(1)
+        assertThat(report.falsePositiveRate).isEqualTo(0.5, within(1e-9))
+        assertThat(report.zeroResultRate).isEqualTo(0.25, within(1e-9))
+    }
+
+    @Test
+    fun `evaluate는 누락된 쿼리를 빈 결과로 처리한다`() {
+        val goldenCases = listOf(GoldenSearchCase("두쫀쿠", setOf(1L)))
+        val report = metrics.evaluate(goldenCases, emptyMap(), k = 10)
+
+        assertThat(report.recallAtK).isZero
+        assertThat(report.precisionAtK).isZero
+        assertThat(report.zeroResultRate).isEqualTo(1.0, within(1e-9))
+    }
+
+    private fun log2(value: Double): Double = ln(value) / ln(2.0)
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/evaluation/SearchEvaluationServiceTest.kt
@@ -1,0 +1,46 @@
+package com.moongchijang.domain.search.evaluation
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+
+class SearchEvaluationServiceTest {
+
+    private val service = SearchEvaluationService()
+
+    @Test
+    fun `evaluate는 골든 케이스 쿼리마다 프로바이더를 호출한다`() {
+        val goldenCases = listOf(
+            GoldenSearchCase("성수 두쫀쿠", setOf(1L)),
+            GoldenSearchCase("홍대 소금빵", setOf(2L))
+        )
+        val invoked = mutableListOf<String>()
+        val provider = SearchCandidateProvider { query ->
+            invoked += query
+            when (query) {
+                "성수 두쫀쿠" -> listOf(1L)
+                "홍대 소금빵" -> listOf(2L, 99L)
+                else -> emptyList()
+            }
+        }
+
+        val report = service.evaluate(goldenCases, provider, k = 10)
+
+        assertThat(invoked).containsExactly("성수 두쫀쿠", "홍대 소금빵")
+        assertThat(report.caseCount).isEqualTo(2)
+        assertThat(report.recallAtK).isEqualTo(1.0, within(1e-9))
+        assertThat(report.mrr).isEqualTo(1.0, within(1e-9))
+    }
+
+    @Test
+    fun `evaluate는 사용자 지정 K를 메트릭 계산에 전달한다`() {
+        val goldenCases = listOf(GoldenSearchCase("쿼리", setOf(5L)))
+        val provider = SearchCandidateProvider { listOf(1L, 2L, 3L, 4L, 5L) }
+
+        val reportK3 = service.evaluate(goldenCases, provider, k = 3)
+        val reportK5 = service.evaluate(goldenCases, provider, k = 5)
+
+        assertThat(reportK3.recallAtK).isZero
+        assertThat(reportK5.recallAtK).isEqualTo(1.0, within(1e-9))
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/evaluation/SearchProviderComparisonTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/evaluation/SearchProviderComparisonTest.kt
@@ -1,0 +1,46 @@
+package com.moongchijang.domain.search.evaluation
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+
+class SearchProviderComparisonTest {
+
+    private val runner = SearchProviderComparisonRunner()
+
+    @Test
+    fun `compare는 각 프로바이더별 평가 리포트를 입력 순서대로 반환한다`() {
+        val goldenCases = listOf(
+            GoldenSearchCase("성수 두쫀쿠", setOf(1L)),
+            GoldenSearchCase("홍대 소금빵", setOf(2L))
+        )
+        val providers = linkedMapOf<String, SearchCandidateProvider>(
+            "perfect" to SearchCandidateProvider { query ->
+                when (query) {
+                    "성수 두쫀쿠" -> listOf(1L)
+                    "홍대 소금빵" -> listOf(2L)
+                    else -> emptyList()
+                }
+            },
+            "broken" to SearchCandidateProvider { emptyList() }
+        )
+
+        val report = runner.compare(goldenCases, providers)
+
+        assertThat(report.evaluations).hasSize(2)
+        assertThat(report.evaluations.map { it.providerName })
+            .containsExactly("perfect", "broken")
+        assertThat(report.byProvider("perfect")?.report?.recallAtK)
+            .isEqualTo(1.0, within(1e-9))
+        assertThat(report.byProvider("broken")?.report?.recallAtK).isZero
+        assertThat(report.byProvider("broken")?.report?.zeroResultRate)
+            .isEqualTo(1.0, within(1e-9))
+    }
+
+    @Test
+    fun `byProvider는 존재하지 않는 이름에 null을 반환한다`() {
+        val report = SearchProviderComparisonReport(evaluations = emptyList())
+
+        assertThat(report.byProvider("missing")).isNull()
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionServiceTest.kt
@@ -1,0 +1,120 @@
+package com.moongchijang.domain.search.infrastructure.gemini
+
+import com.moongchijang.domain.search.application.dto.SearchCase
+import dev.langchain4j.model.chat.ChatModel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+class GeminiKeywordExtractionServiceTest {
+
+    private val chatModel: ChatModel = Mockito.mock(ChatModel::class.java)
+    private val objectMapper = jacksonObjectMapper()
+    private val service = GeminiKeywordExtractionService(chatModel, objectMapper)
+
+    private val validRegions = listOf("성수", "홍대", "연남")
+    private val validProducts = listOf("두쫀쿠", "소금빵")
+
+    @Test
+    fun `유효 동네 + 유효 상품이면 BOTH_DETECTED를 반환한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("""{"neighborhood":"성수","product":"두쫀쿠"}""")
+
+        val result = service.extract("성수 두쫀쿠", validRegions, validProducts)
+
+        assertThat(result.region).isEqualTo("성수")
+        assertThat(result.product).isEqualTo("두쫀쿠")
+        assertThat(result.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+    }
+
+    @Test
+    fun `상품만 있으면 PRODUCT_ONLY를 반환한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("""{"neighborhood":null,"product":"소금빵"}""")
+
+        val result = service.extract("소금빵", validRegions, validProducts)
+
+        assertThat(result.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+        assertThat(result.product).isEqualTo("소금빵")
+        assertThat(result.region).isNull()
+    }
+
+    @Test
+    fun `동네만 있으면 NEIGHBORHOOD_ONLY를 반환한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("""{"neighborhood":"홍대","product":null}""")
+
+        val result = service.extract("홍대", validRegions, validProducts)
+
+        assertThat(result.searchCase).isEqualTo(SearchCase.NEIGHBORHOOD_ONLY)
+        assertThat(result.region).isEqualTo("홍대")
+        assertThat(result.product).isNull()
+    }
+
+    @Test
+    fun `둘 다 null이면 NONE_DETECTED를 반환한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("""{"neighborhood":null,"product":null}""")
+
+        val result = service.extract("asdfqwer", validRegions, validProducts)
+
+        assertThat(result.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+    }
+
+    @Test
+    fun `JSON 앞뒤에 텍스트가 있어도 객체를 추출해 파싱한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("```json\n{\"neighborhood\":\"성수\",\"product\":\"두쫀쿠\"}\n```")
+
+        val result = service.extract("성수 두쫀쿠", validRegions, validProducts)
+
+        assertThat(result.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+    }
+
+    @Test
+    fun `LLM이 목록 외 동네를 반환하면 서버에서 null로 재검증한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("""{"neighborhood":"강남","product":"두쫀쿠"}""")
+
+        val result = service.extract("강남 두쫀쿠", validRegions, validProducts)
+
+        assertThat(result.region).isNull()
+        assertThat(result.product).isEqualTo("두쫀쿠")
+        assertThat(result.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+    }
+
+    @Test
+    fun `LLM이 목록 외 상품을 반환하면 서버에서 null로 재검증한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("""{"neighborhood":"성수","product":"마카롱"}""")
+
+        val result = service.extract("성수 마카롱", validRegions, validProducts)
+
+        assertThat(result.region).isEqualTo("성수")
+        assertThat(result.product).isNull()
+        assertThat(result.searchCase).isEqualTo(SearchCase.NEIGHBORHOOD_ONLY)
+    }
+
+    @Test
+    fun `chatModel이 예외를 던지면 NONE_DETECTED로 폴백한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenThrow(RuntimeException("Gemini 호출 실패"))
+
+        val result = service.extract("성수 두쫀쿠", validRegions, validProducts)
+
+        assertThat(result.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+        assertThat(result.region).isNull()
+        assertThat(result.product).isNull()
+    }
+
+    @Test
+    fun `JSON 객체가 없는 응답은 NONE_DETECTED로 폴백한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("자연어로만 응답합니다")
+
+        val result = service.extract("성수 두쫀쿠", validRegions, validProducts)
+
+        assertThat(result.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/infrastructure/gemini/RealGeminiKeywordExtractionTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/infrastructure/gemini/RealGeminiKeywordExtractionTest.kt
@@ -1,0 +1,74 @@
+package com.moongchijang.domain.search.infrastructure.gemini
+
+import com.moongchijang.domain.search.application.dto.SearchCase
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+/**
+ * 실제 Gemini API를 호출하는 통합 테스트.
+ *
+ * 실행 조건: 환경 변수 GEMINI_API_KEY 설정.
+ * CI에서는 시크릿이 없으면 자동 스킵된다.
+ *
+ * 검증 목표:
+ *  - 실제 LLM이 우리 프롬프트로 유효 목록 외 값을 절대 생성하지 않는다 (서버 재검증 외 보장).
+ *  - 다양한 한국어 쿼리에서 적절한 SearchCase로 분류한다.
+ */
+@EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".+")
+class RealGeminiKeywordExtractionTest {
+
+    private val chatModel = GoogleAiGeminiChatModel.builder()
+        .apiKey(System.getenv("GEMINI_API_KEY"))
+        .modelName("gemini-2.0-flash")
+        .temperature(0.1)
+        .build()
+
+    private val service = GeminiKeywordExtractionService(chatModel, jacksonObjectMapper())
+
+    private val validRegions = listOf("성수", "홍대", "연남", "망원")
+    private val validProducts = listOf("두쫀쿠", "소금빵", "크루아상", "마들렌")
+
+    @Test
+    fun `유효 동네와 유효 상품이 모두 포함된 쿼리는 BOTH_DETECTED로 분류된다`() {
+        val result = service.extract("성수 두쫀쿠", validRegions, validProducts)
+
+        assertThat(result.region).isEqualTo("성수")
+        assertThat(result.product).isEqualTo("두쫀쿠")
+        assertThat(result.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+    }
+
+    @Test
+    fun `목록 외 동네가 포함되면 region이 null이거나 서버 검증에 의해 null로 떨어진다`() {
+        val result = service.extract("강남 두쫀쿠", validRegions, validProducts)
+
+        // LLM이 강남을 반환하더라도 서버측 validRegions 재검증으로 null이 되어야 함
+        assertThat(result.region).isNull()
+    }
+
+    @Test
+    fun `목록 외 상품이 포함되면 product가 null로 보정된다`() {
+        val result = service.extract("성수 마카롱", validRegions, validProducts)
+
+        assertThat(result.product).isNull()
+    }
+
+    @Test
+    fun `한국어 자연어 쿼리에서도 hallucination 없이 유효값만 반환한다`() {
+        val result = service.extract("성수에서 맛있는 두쫀쿠 추천해줘", validRegions, validProducts)
+
+        if (result.region != null) assertThat(result.region).isIn(validRegions)
+        if (result.product != null) assertThat(result.product).isIn(validProducts)
+    }
+
+    @Test
+    fun `완전 무의미한 쿼리는 NONE_DETECTED를 반환한다`() {
+        val result = service.extract("asdfqwer1234", validRegions, validProducts)
+
+        assertThat(result.region).isNull()
+        assertThat(result.product).isNull()
+        assertThat(result.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantCrudIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantCrudIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 import java.time.LocalDateTime
+import java.util.UUID
 
 /**
  * Qdrant CRUD 통합 테스트.
@@ -30,7 +31,7 @@ class QdrantCrudIntegrationTest {
 
     private val qdrantUrl = System.getenv("QDRANT_URL")
     private val qdrantApiKey: String? = System.getenv("QDRANT_API_KEY")
-    private val collectionName = "test_groupbuys_${System.currentTimeMillis()}"
+    private val collectionName = "test_groupbuys_${UUID.randomUUID().toString().substring(0, 8)}"
 
     private val embeddingModel = LocalDemoEmbeddingModel(vectorSize = 768)
     private val properties = QdrantProperties(

--- a/src/test/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantCrudIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/infrastructure/vector/qdrant/QdrantCrudIntegrationTest.kt
@@ -1,0 +1,116 @@
+package com.moongchijang.domain.search.infrastructure.vector.qdrant
+
+import com.moongchijang.domain.search.application.port.VectorIndexDocument
+import com.moongchijang.domain.search.infrastructure.demo.LocalDemoEmbeddingModel
+import com.moongchijang.global.config.QdrantProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.client.RestClient
+import java.time.LocalDateTime
+
+/**
+ * Qdrant CRUD 통합 테스트.
+ *
+ * 실행 조건:
+ *  - 환경 변수 QDRANT_URL 설정 (예: http://localhost:6333)
+ *  - 선택: QDRANT_API_KEY
+ *
+ * 로컬에서 docker compose로 qdrant 컨테이너를 띄운 뒤 실행한다.
+ * 테스트마다 고유한 collection을 생성/삭제하므로 운영 데이터에 영향 없다.
+ */
+@EnabledIfEnvironmentVariable(named = "QDRANT_URL", matches = ".+")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class QdrantCrudIntegrationTest {
+
+    private val qdrantUrl = System.getenv("QDRANT_URL")
+    private val qdrantApiKey: String? = System.getenv("QDRANT_API_KEY")
+    private val collectionName = "test_groupbuys_${System.currentTimeMillis()}"
+
+    private val embeddingModel = LocalDemoEmbeddingModel(vectorSize = 768)
+    private val properties = QdrantProperties(
+        enabled = true,
+        url = qdrantUrl,
+        apiKey = qdrantApiKey,
+        collectionName = collectionName,
+        timeoutSeconds = 5
+    )
+    private val rawClient: RestClient = run {
+        var builder = RestClient.builder()
+            .baseUrl(qdrantUrl)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        qdrantApiKey?.takeIf { it.isNotBlank() }?.let {
+            builder = builder.defaultHeader("api-key", it)
+        }
+        builder.build()
+    }
+
+    private val adapter = QdrantVectorSearchAdapter(
+        restClientBuilder = RestClient.builder(),
+        embeddingModel = embeddingModel,
+        properties = properties
+    )
+
+    @BeforeAll
+    fun createCollection() {
+        rawClient.put()
+            .uri("/collections/{name}", collectionName)
+            .body(mapOf("vectors" to mapOf("size" to 768, "distance" to "Cosine")))
+            .retrieve()
+            .toBodilessEntity()
+    }
+
+    @AfterAll
+    fun dropCollection() {
+        rawClient.delete()
+            .uri("/collections/{name}", collectionName)
+            .retrieve()
+            .toBodilessEntity()
+    }
+
+    @Test
+    fun `upsert 후 search로 동일 그룹바이를 검색하면 후보로 반환된다`() {
+        val doc = VectorIndexDocument(
+            groupBuyId = 9001L,
+            vectorText = "성수 두쫀쿠",
+            vector = embeddingModel.embed("성수 두쫀쿠").content().vector(),
+            region = "서울",
+            storeName = "테스트 베이커리",
+            productName = "두쫀쿠",
+            status = "IN_PROGRESS",
+            deadline = LocalDateTime.now().plusDays(3),
+            embeddingVersion = "test-v1"
+        )
+        assertThat(adapter.upsert(doc)).isTrue
+
+        val results = adapter.search(query = "성수 두쫀쿠", topK = 5, minScore = 0.0)
+
+        assertThat(results.map { it.groupBuyId }).contains(9001L)
+    }
+
+    @Test
+    fun `delete 후 search 시 해당 그룹바이가 더 이상 반환되지 않는다`() {
+        val doc = VectorIndexDocument(
+            groupBuyId = 9002L,
+            vectorText = "홍대 소금빵",
+            vector = embeddingModel.embed("홍대 소금빵").content().vector(),
+            region = "서울",
+            storeName = "홍대 빵집",
+            productName = "소금빵",
+            status = "IN_PROGRESS",
+            deadline = LocalDateTime.now().plusDays(3),
+            embeddingVersion = "test-v1"
+        )
+        adapter.upsert(doc)
+
+        assertThat(adapter.delete(9002L)).isTrue
+
+        val results = adapter.search(query = "홍대 소금빵", topK = 5, minScore = 0.0)
+        assertThat(results.map { it.groupBuyId }).doesNotContain(9002L)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/search/GoldenSearchCaseLoader.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/GoldenSearchCaseLoader.kt
@@ -20,10 +20,15 @@ object GoldenSearchCaseLoader {
         }
     }
 
+    // 단순 CSV 포맷: 필드 내부 콤마/따옴표/개행 미지원. relevant_ids는 파이프(|)로 다중값.
+    // 향후 query에 콤마가 필요해지면 정식 CSV 라이브러리 도입을 검토한다.
     private fun parse(line: String): GoldenSearchCase {
         val parts = line.split(",", limit = 3)
         require(parts.size >= 2) { "잘못된 골든 케이스 줄: $line" }
         val query = parts[0]
+        require(!query.contains('"') && !query.contains('\n')) {
+            "query 필드에 따옴표/개행은 지원하지 않습니다: $query"
+        }
         val relevantIds = parts[1]
             .split("|")
             .map { it.trim() }

--- a/src/test/kotlin/com/moongchijang/support/search/GoldenSearchCaseLoader.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/GoldenSearchCaseLoader.kt
@@ -1,0 +1,35 @@
+package com.moongchijang.support.search
+
+import com.moongchijang.domain.search.evaluation.GoldenSearchCase
+
+object GoldenSearchCaseLoader {
+    private const val DEFAULT_PATH = "/search/golden-search-cases.csv"
+
+    fun loadDefault(): List<GoldenSearchCase> = load(DEFAULT_PATH)
+
+    fun load(classpathResource: String): List<GoldenSearchCase> {
+        val stream = checkNotNull(javaClass.getResourceAsStream(classpathResource)) {
+            "golden case CSV를 찾을 수 없습니다: $classpathResource"
+        }
+        return stream.bufferedReader(Charsets.UTF_8).useLines { lines ->
+            lines
+                .drop(1)
+                .filter { it.isNotBlank() }
+                .map(::parse)
+                .toList()
+        }
+    }
+
+    private fun parse(line: String): GoldenSearchCase {
+        val parts = line.split(",", limit = 3)
+        require(parts.size >= 2) { "잘못된 골든 케이스 줄: $line" }
+        val query = parts[0]
+        val relevantIds = parts[1]
+            .split("|")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { it.toLong() }
+            .toSet()
+        return GoldenSearchCase(query = query, relevantGroupBuyIds = relevantIds)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/search/GoldenSearchCaseLoaderTest.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/GoldenSearchCaseLoaderTest.kt
@@ -1,0 +1,34 @@
+package com.moongchijang.support.search
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GoldenSearchCaseLoaderTest {
+
+    @Test
+    fun `loadDefault는 골든 CSV를 파싱해 GoldenSearchCase 리스트를 반환한다`() {
+        val cases = GoldenSearchCaseLoader.loadDefault()
+
+        assertThat(cases).isNotEmpty
+        assertThat(cases.first().query).isEqualTo("성수 두쫀쿠")
+        assertThat(cases.first().relevantGroupBuyIds).containsExactly(1L)
+    }
+
+    @Test
+    fun `loadDefault는 빈 relevant 컬럼을 no-result expected 케이스로 인식한다`() {
+        val cases = GoldenSearchCaseLoader.loadDefault()
+        val noResultCases = cases.filter { it.relevantGroupBuyIds.isEmpty() }
+
+        assertThat(noResultCases).isNotEmpty
+        assertThat(noResultCases.map { it.query })
+            .contains("강남 두쫀쿠", "asdfqwer1234")
+    }
+
+    @Test
+    fun `loadDefault는 파이프 구분 relevant ID를 모두 파싱한다`() {
+        val cases = GoldenSearchCaseLoader.loadDefault()
+        val mangwon = cases.first { it.query == "망원" }
+
+        assertThat(mangwon.relevantGroupBuyIds).containsExactlyInAnyOrder(4L, 5L)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/search/MockitoKotlinMatchers.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/MockitoKotlinMatchers.kt
@@ -1,0 +1,26 @@
+package com.moongchijang.support.search
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import org.mockito.ArgumentMatchers
+import java.time.LocalDateTime
+
+/**
+ * Mockito 매처는 내부적으로 null을 반환하므로 Kotlin의 non-null 매개변수 위치에서 NPE가 발생한다.
+ * 매처를 등록한 뒤 의미 없는 non-null sentinel 값을 반환해 컴파일/런타임 양쪽을 통과시킨다.
+ */
+object MockitoKotlinMatchers {
+    fun anyLocalDateTime(): LocalDateTime {
+        ArgumentMatchers.any(LocalDateTime::class.java)
+        return LocalDateTime.MIN
+    }
+
+    fun anyGroupBuyStatus(): GroupBuyStatus {
+        ArgumentMatchers.any(GroupBuyStatus::class.java)
+        return GroupBuyStatus.IN_PROGRESS
+    }
+
+    fun anyLongList(): List<Long> {
+        ArgumentMatchers.anyList<Long>()
+        return emptyList()
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.support.search
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+object SearchTestFixtures {
+
+    fun store(
+        id: Long = 1L,
+        name: String = "뭉치장 베이커리",
+        region: RegionType = RegionType.SEOUL,
+        district: DistrictType = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
+    ): Store = Store(
+        name = name,
+        address = "서울 성동구",
+        region = region,
+        district = district
+    ).apply { this.id = id }
+
+    fun groupBuyRequest(id: Long = 100L): GroupBuyRequest =
+        GroupBuyRequest(
+            userId = 1L,
+            storeName = "뭉치장 베이커리",
+            storeAddress = "서울 성동구",
+            productName = "두쫀쿠",
+            desiredQuantity = 50,
+            desiredPickupDate = LocalDate.now().plusDays(5)
+        ).apply { this.id = id }
+
+    fun groupBuy(
+        id: Long,
+        productName: String = "두쫀쿠",
+        store: Store = store(),
+        status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
+    ): GroupBuy = GroupBuy(
+        store = store,
+        groupBuyRequest = groupBuyRequest(),
+        thumbnailUrl = "https://example.jpg",
+        productName = productName,
+        productDescription = "설명",
+        price = 6000,
+        targetQuantity = 50,
+        currentQuantity = 10,
+        maxQuantity = 100,
+        status = status,
+        deadline = LocalDateTime.now().plusDays(3),
+        pickupDate = LocalDate.now().plusDays(5),
+        pickupTimeStart = LocalTime.of(14, 0),
+        pickupTimeEnd = LocalTime.of(18, 0),
+        pickupLocation = "서울 성동구 성수동",
+        shareCount = 0
+    ).apply { this.id = id }
+}

--- a/src/test/resources/search/golden-search-cases.csv
+++ b/src/test/resources/search/golden-search-cases.csv
@@ -1,0 +1,17 @@
+query,relevant_ids,note
+성수 두쫀쿠,1,both detected - exact match
+홍대 소금빵,2,both detected - exact match
+연남 마들렌,3,both detected - exact match
+망원 크루아상,4,both detected - exact match
+시오빵,2,alias soulful match -> 소금빵 (PRODUCT_ONLY)
+크로와상,4,alias -> 크루아상 (PRODUCT_ONLY)
+salt bread,2,english alias -> 소금빵 (PRODUCT_ONLY)
+두쫀쿠,1,product only
+마들렌,3,product only
+성수,1,region only
+홍대,2,region only
+망원,4|5,region only - multiple
+강남 두쫀쿠,,unknown region - no-result expected
+존재하지않는상품 성수,,unknown product - no-result expected
+asdfqwer1234,,garbage query - no-result expected
+xyz nonsense,,garbage query - no-result expected


### PR DESCRIPTION
## 📌 작업한 내용
- 골든 케이스 CSV 추가 — BOTH/PRODUCT_ONLY/NEIGHBORHOOD_ONLY/alias/no-result 시나리오
- 평가 메트릭 단위 테스트 — `SearchEvaluationMetrics`(Recall@K · Precision@K · NDCG@K · MRR · zero-result rate · FP rate), `SearchEvaluationService`, `SearchProviderComparison`
- 검색 컴포넌트 단위 테스트 — `VectorCandidatePromotionGuard`(5가지 거부 사유), `AliasDictionary`, `SearchDecisionEngine`, `GeminiKeywordExtractionService`(ChatModel mock)
- 파이프라인 통합 테스트 — `RetrievalPipelineGuard`(guard ON/OFF FP 감소 증명), `SearchOrchestrator`(Case 1~4 + LLM 폴백)
- 조건부 외부 통합 테스트 — `QdrantCrudIntegrationTest`(`QDRANT_URL` 시 활성화), `RealGeminiKeywordExtractionTest`(`GEMINI_API_KEY` 시 활성화)

## 🔍 참고 사항
- 기능 코드는 손대지 않고 테스트만 추가 (회귀 방지 목적)
- Mockito + Kotlin non-null 매개변수 충돌은 `anyLocalDateTime()` / `anyGroupBuyStatus()` 헬퍼 패턴으로 우회 (`mockito-kotlin` 의존성 미추가)
- Jackson 3 + Kotlin 데이터 클래스 디시리얼라이즈에는 `tools.jackson.module.kotlin.jacksonObjectMapper()` 사용
- Qdrant 통합 테스트는 `test_groupbuys_{timestamp}` 형태 임시 collection을 `@BeforeAll`/`@AfterAll`로 생성·삭제하여 운영 데이터 미오염

## 🖼 스크린샷
없음

## 🔗 관련 이슈
- Closes #69

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료 (`./gradlew test` 전체 통과)
- [x] 조건부 테스트가 env 변수 미설정 시 자동 스킵되는지 확인
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인