### PR TITLE
[MCJ-1432] FEAT: 검색어 오타 및 유사어 상품명 보정 강화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/search/application/ProductNormalizer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/ProductNormalizer.kt
@@ -1,0 +1,181 @@
+package com.moongchijang.domain.search.application
+
+import org.springframework.stereotype.Component
+import kotlin.math.max
+import kotlin.math.min
+
+@Component
+class ProductNormalizer(
+    private val aliasDictionary: AliasDictionary
+) {
+    fun normalize(query: String, extractedProduct: String?, validProducts: List<String>): String? {
+        if (extractedProduct in validProducts) return extractedProduct
+
+        val aliasProduct = aliasDictionary.resolveProduct(query, validProducts)
+        if (aliasProduct != null) return aliasProduct
+
+        return fuzzyMatch(query, validProducts)
+    }
+
+    private fun fuzzyMatch(query: String, validProducts: List<String>): String? {
+        val tokens = tokenize(query).filter { it.length > MIN_FUZZY_TOKEN_LENGTH }
+        if (tokens.isEmpty() || validProducts.isEmpty()) return null
+
+        val ranked = validProducts
+            .map { product ->
+                product to tokens.maxOf { token -> similarity(token, product) }
+            }
+            .sortedByDescending { it.second }
+
+        val best = ranked.firstOrNull() ?: return null
+        if (best.second < FUZZY_THRESHOLD) return null
+
+        val secondScore = ranked.getOrNull(1)?.second ?: 0.0
+        if (best.second - secondScore < FUZZY_MIN_MARGIN) return null
+
+        return best.first
+    }
+
+    private fun tokenize(query: String): List<String> =
+        TOKEN_REGEX.findAll(query)
+            .map { it.value.trim() }
+            .filter { it.isNotEmpty() }
+            .toList()
+
+    private fun similarity(source: String, target: String): Double =
+        max(
+            max(
+                normalizedLevenshtein(source, target),
+                normalizedLevenshtein(decomposeHangul(source), decomposeHangul(target))
+            ),
+            jaroWinkler(source, target),
+        )
+
+    private fun normalizedLevenshtein(source: String, target: String): Double {
+        val maxLength = max(source.length, target.length)
+        if (maxLength == 0) return 1.0
+
+        return 1.0 - levenshteinDistance(source, target).toDouble() / maxLength
+    }
+
+    private fun levenshteinDistance(source: String, target: String): Int {
+        if (source == target) return 0
+        if (source.isEmpty()) return target.length
+        if (target.isEmpty()) return source.length
+
+        var previous = IntArray(target.length + 1) { it }
+        var current = IntArray(target.length + 1)
+
+        for (i in source.indices) {
+            current[0] = i + 1
+            for (j in target.indices) {
+                val substitutionCost = if (source[i] == target[j]) 0 else 1
+                current[j + 1] = min(
+                    min(current[j] + 1, previous[j + 1] + 1),
+                    previous[j] + substitutionCost
+                )
+            }
+            val temp = previous
+            previous = current
+            current = temp
+        }
+
+        return previous[target.length]
+    }
+
+    private fun jaroWinkler(source: String, target: String): Double {
+        if (source == target) return 1.0
+        if (source.isEmpty() || target.isEmpty()) return 0.0
+
+        val matchDistance = max(source.length, target.length) / 2 - 1
+        val sourceMatches = BooleanArray(source.length)
+        val targetMatches = BooleanArray(target.length)
+        var matches = 0
+
+        for (i in source.indices) {
+            val start = max(0, i - matchDistance)
+            val end = min(i + matchDistance + 1, target.length)
+            for (j in start until end) {
+                if (targetMatches[j] || source[i] != target[j]) continue
+                sourceMatches[i] = true
+                targetMatches[j] = true
+                matches++
+                break
+            }
+        }
+
+        if (matches == 0) return 0.0
+
+        var transpositions = 0
+        var targetIndex = 0
+        for (i in source.indices) {
+            if (!sourceMatches[i]) continue
+            while (!targetMatches[targetIndex]) targetIndex++
+            if (source[i] != target[targetIndex]) transpositions++
+            targetIndex++
+        }
+
+        val jaro = (
+            matches.toDouble() / source.length +
+                matches.toDouble() / target.length +
+                (matches - transpositions / 2.0) / matches
+            ) / 3.0
+        val prefixLength = commonPrefixLength(source, target)
+
+        return jaro + prefixLength * JARO_WINKLER_PREFIX_SCALE * (1.0 - jaro)
+    }
+
+    private fun commonPrefixLength(source: String, target: String): Int {
+        val maxPrefix = min(min(source.length, target.length), JARO_WINKLER_MAX_PREFIX)
+        var count = 0
+        while (count < maxPrefix && source[count] == target[count]) {
+            count++
+        }
+        return count
+    }
+
+    private fun decomposeHangul(value: String): String =
+        buildString {
+            for (char in value) {
+                val syllableIndex = char.code - HANGUL_BASE
+                if (syllableIndex !in 0 until HANGUL_SYLLABLE_COUNT) {
+                    append(char)
+                    continue
+                }
+
+                val choseongIndex = syllableIndex / (JUNGSEONG_COUNT * JONGSEONG_COUNT)
+                val jungseongIndex = syllableIndex % (JUNGSEONG_COUNT * JONGSEONG_COUNT) / JONGSEONG_COUNT
+                val jongseongIndex = syllableIndex % JONGSEONG_COUNT
+
+                append(CHOSEONG[choseongIndex])
+                append(JUNGSEONG[jungseongIndex])
+                if (jongseongIndex > 0) append(JONGSEONG[jongseongIndex])
+            }
+        }
+
+    companion object {
+        private val TOKEN_REGEX = Regex("[\\p{L}\\p{N}]+")
+        private const val MIN_FUZZY_TOKEN_LENGTH = 1
+        private const val FUZZY_THRESHOLD = 0.76
+        private const val FUZZY_MIN_MARGIN = 0.08
+        private const val JARO_WINKLER_PREFIX_SCALE = 0.1
+        private const val JARO_WINKLER_MAX_PREFIX = 4
+        private const val HANGUL_BASE = 0xAC00
+        private const val HANGUL_SYLLABLE_COUNT = 11172
+        private const val JUNGSEONG_COUNT = 21
+        private const val JONGSEONG_COUNT = 28
+        private val CHOSEONG = charArrayOf(
+            'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ',
+            'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+        )
+        private val JUNGSEONG = charArrayOf(
+            'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ',
+            'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ', 'ㅢ', 'ㅣ'
+        )
+        private val JONGSEONG = charArrayOf(
+            '\u0000', 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ',
+            'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ', 'ㅅ',
+            'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/ProductNormalizer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/ProductNormalizer.kt
@@ -18,22 +18,34 @@ class ProductNormalizer(
     }
 
     private fun fuzzyMatch(query: String, validProducts: List<String>): String? {
-        val tokens = tokenize(query).filter { it.length > MIN_FUZZY_TOKEN_LENGTH }
+        if (validProducts.size > MAX_FUZZY_PRODUCT_COUNT) return null
+
+        val tokens = tokenize(query)
+            .filter { it.length > MIN_FUZZY_TOKEN_LENGTH }
+            .filter { it.length <= MAX_FUZZY_TOKEN_LENGTH }
+            .take(MAX_FUZZY_TOKEN_COUNT)
         if (tokens.isEmpty() || validProducts.isEmpty()) return null
 
-        val ranked = validProducts
-            .map { product ->
-                product to tokens.maxOf { token -> similarity(token, product) }
+        var bestProduct: String? = null
+        var bestScore = 0.0
+        var secondScore = 0.0
+
+        for (product in validProducts) {
+            val score = tokens.maxOf { token -> similarity(token, product) }
+            when {
+                score > bestScore -> {
+                    secondScore = bestScore
+                    bestScore = score
+                    bestProduct = product
+                }
+                score > secondScore -> secondScore = score
             }
-            .sortedByDescending { it.second }
+        }
 
-        val best = ranked.firstOrNull() ?: return null
-        if (best.second < FUZZY_THRESHOLD) return null
+        if (bestScore < FUZZY_THRESHOLD) return null
+        if (bestScore - secondScore < FUZZY_MIN_MARGIN) return null
 
-        val secondScore = ranked.getOrNull(1)?.second ?: 0.0
-        if (best.second - secondScore < FUZZY_MIN_MARGIN) return null
-
-        return best.first
+        return bestProduct
     }
 
     private fun tokenize(query: String): List<String> =
@@ -63,13 +75,19 @@ class ProductNormalizer(
         if (source.isEmpty()) return target.length
         if (target.isEmpty()) return source.length
 
-        var previous = IntArray(target.length + 1) { it }
-        var current = IntArray(target.length + 1)
+        val (longer, shorter) = if (source.length > target.length) {
+            source to target
+        } else {
+            target to source
+        }
 
-        for (i in source.indices) {
+        var previous = IntArray(shorter.length + 1) { it }
+        var current = IntArray(shorter.length + 1)
+
+        for (i in longer.indices) {
             current[0] = i + 1
-            for (j in target.indices) {
-                val substitutionCost = if (source[i] == target[j]) 0 else 1
+            for (j in shorter.indices) {
+                val substitutionCost = if (longer[i] == shorter[j]) 0 else 1
                 current[j + 1] = min(
                     min(current[j] + 1, previous[j + 1] + 1),
                     previous[j] + substitutionCost
@@ -80,7 +98,7 @@ class ProductNormalizer(
             current = temp
         }
 
-        return previous[target.length]
+        return previous[shorter.length]
     }
 
     private fun jaroWinkler(source: String, target: String): Double {
@@ -156,6 +174,9 @@ class ProductNormalizer(
     companion object {
         private val TOKEN_REGEX = Regex("[\\p{L}\\p{N}]+")
         private const val MIN_FUZZY_TOKEN_LENGTH = 1
+        private const val MAX_FUZZY_TOKEN_LENGTH = 30
+        private const val MAX_FUZZY_TOKEN_COUNT = 5
+        private const val MAX_FUZZY_PRODUCT_COUNT = 2_000
         private const val FUZZY_THRESHOLD = 0.76
         private const val FUZZY_MIN_MARGIN = 0.08
         private const val JARO_WINKLER_PREFIX_SCALE = 0.1

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchOrchestrator.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchOrchestrator.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 class SearchOrchestrator(
     private val groupBuyRepository: GroupBuyRepository,
     private val keywordExtractor: GeminiKeywordExtractionService,
-    private val aliasDictionary: AliasDictionary,
+    private val productNormalizer: ProductNormalizer,
     private val retrievalPipeline: RetrievalPipeline,
     private val decisionEngine: SearchDecisionEngine
 ) {
@@ -23,7 +23,7 @@ class SearchOrchestrator(
         val validProducts = groupBuyRepository.findDistinctProductNames(GroupBuyStatus.IN_PROGRESS)
 
         val extraction = extract(query, validRegions, validProducts)
-        val product = extraction.product ?: aliasDictionary.resolveProduct(query, validProducts)
+        val product = productNormalizer.normalize(query, extraction.product, validProducts)
         val intent = SearchIntent(
             region = extraction.region,
             product = product,

--- a/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionService.kt
@@ -42,6 +42,7 @@ class GeminiKeywordExtractionService(
         - 반드시 유효 목록에 있는 값만 반환하세요.
         - 목록에 없으면 null을 반환하세요.
         - 절대 목록 외 값을 생성하지 마세요.
+        - 상품 오타, 약어, 유사 발음은 유효 상품 목록 중 가장 가까운 값으로 매핑하세요.
         - JSON 형식으로만 응답하세요: {"neighborhood": "...", "product": "..."}
 
         유효 동네: ${validRegions.joinToString(", ")}

--- a/src/test/kotlin/com/moongchijang/domain/search/application/ProductNormalizerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/ProductNormalizerTest.kt
@@ -53,4 +53,11 @@ class ProductNormalizerTest {
 
         assertThat(normalizer.normalize("마들렝", null, validProducts)).isNull()
     }
+
+    @Test
+    fun `validProducts가 상한을 넘으면 fuzzy match를 수행하지 않는다`() {
+        val validProducts = (1..2_000).map { "상품$it" } + "두쫀쿠"
+
+        assertThat(normalizer.normalize("두쫀크크", null, validProducts)).isNull()
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/search/application/ProductNormalizerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/ProductNormalizerTest.kt
@@ -1,0 +1,56 @@
+package com.moongchijang.domain.search.application
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProductNormalizerTest {
+
+    private val normalizer = ProductNormalizer(AliasDictionary())
+
+    @Test
+    fun `Gemini가 유효 상품을 반환하면 그대로 사용한다`() {
+        val validProducts = listOf("소금빵", "두쫀쿠")
+
+        assertThat(normalizer.normalize("성수 두쫀쿠", "두쫀쿠", validProducts)).isEqualTo("두쫀쿠")
+    }
+
+    @Test
+    fun `alias 매핑으로 canonical 상품명을 반환한다`() {
+        val validProducts = listOf("소금빵", "두쫀쿠")
+
+        assertThat(normalizer.normalize("시오빵 추천", null, validProducts)).isEqualTo("소금빵")
+    }
+
+    @Test
+    fun `토큰 기반 fuzzy match로 오타를 canonical 상품명으로 보정한다`() {
+        val validProducts = listOf("두쫀쿠", "마들렌", "크루아상", "소금빵")
+
+        assertThat(normalizer.normalize("성수 두쫀크크", null, validProducts)).isEqualTo("두쫀쿠")
+        assertThat(normalizer.normalize("마들랜 먹고싶다", null, validProducts)).isEqualTo("마들렌")
+        assertThat(normalizer.normalize("크로와상", null, validProducts)).isEqualTo("크루아상")
+    }
+
+    @Test
+    fun `1글자 token은 fuzzy match 대상에서 제외한다`() {
+        val validProducts = listOf("빵")
+
+        assertThat(normalizer.normalize("빵", null, validProducts)).isEqualTo("빵")
+        assertThat(normalizer.normalize("ㅋ", null, validProducts)).isNull()
+    }
+
+    @Test
+    fun `threshold 미만의 먼 문자열은 null을 반환한다`() {
+        val validProducts = listOf("두쫀쿠", "마들렌", "크루아상", "소금빵")
+
+        assertThat(normalizer.normalize("강남 마카롱", null, validProducts)).isNull()
+        assertThat(normalizer.normalize("이태원 피자", null, validProducts)).isNull()
+        assertThat(normalizer.normalize("없는상품", null, validProducts)).isNull()
+    }
+
+    @Test
+    fun `1등과 2등 후보 점수 차이가 작으면 null을 반환한다`() {
+        val validProducts = listOf("마들렌", "마들랜")
+
+        assertThat(normalizer.normalize("마들렝", null, validProducts)).isNull()
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchOrchestratorIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchOrchestratorIntegrationTest.kt
@@ -28,6 +28,7 @@ class SearchOrchestratorIntegrationTest {
         Mockito.mock(GeminiKeywordExtractionService::class.java)
 
     private val aliasDictionary = AliasDictionary()
+    private val productNormalizer = ProductNormalizer(aliasDictionary)
     private val reranker = SearchReranker()
     private val decisionEngine = SearchDecisionEngine()
     private val properties = SearchProperties()
@@ -45,7 +46,7 @@ class SearchOrchestratorIntegrationTest {
     private val orchestrator = SearchOrchestrator(
         groupBuyRepository = groupBuyRepository,
         keywordExtractor = keywordExtractor,
-        aliasDictionary = aliasDictionary,
+        productNormalizer = productNormalizer,
         retrievalPipeline = retrievalPipeline,
         decisionEngine = decisionEngine
     )
@@ -138,6 +139,37 @@ class SearchOrchestratorIntegrationTest {
         assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
         assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
         assertThat(response.totalCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `Gemini가 null을 반환해도 fuzzy fallback으로 canonical detectedProduct를 채운다`() {
+        val match = SearchTestFixtures.groupBuy(id = 1L, productName = "두쫀쿠")
+        stubVocabulary(products = listOf("두쫀쿠", "소금빵", "마들렌", "크루아상"))
+        stubExtraction(region = null, product = null)
+        stubExact(listOf(match))
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("두쫀크크")
+
+        assertThat(response.detectedProduct).isEqualTo("두쫀쿠")
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+    }
+
+    @Test
+    fun `fuzzy fallback이 먼 문자열을 엉뚱한 상품으로 매칭하지 않는다`() {
+        stubVocabulary(products = listOf("두쫀쿠", "소금빵", "마들렌", "크루아상"))
+        stubExtraction(region = null, product = null)
+        stubExact(emptyList())
+        stubVector(emptyList())
+        stubFindAllById(emptyList())
+
+        val response = orchestrator.search("강남 마카롱")
+
+        assertThat(response.detectedProduct).isNull()
+        assertThat(response.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+        assertThat(response.uiState).isEqualTo(SearchUiState.NEED_BOTH)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/infrastructure/gemini/GeminiKeywordExtractionServiceTest.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.search.application.dto.SearchCase
 import dev.langchain4j.model.chat.ChatModel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
 import tools.jackson.module.kotlin.jacksonObjectMapper
 
@@ -116,5 +117,18 @@ class GeminiKeywordExtractionServiceTest {
         val result = service.extract("성수 두쫀쿠", validRegions, validProducts)
 
         assertThat(result.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+    }
+
+    @Test
+    fun `프롬프트에 오타 약어 유사 발음 보정 지시를 포함한다`() {
+        Mockito.`when`(chatModel.chat(Mockito.anyString()))
+            .thenReturn("""{"neighborhood":null,"product":null}""")
+
+        service.extract("두쫀크크", validRegions, validProducts)
+
+        val promptCaptor = ArgumentCaptor.forClass(String::class.java)
+        Mockito.verify(chatModel).chat(promptCaptor.capture())
+        assertThat(promptCaptor.value).contains("상품 오타, 약어, 유사 발음")
+        assertThat(promptCaptor.value).contains("유효 상품 목록 중 가장 가까운 값")
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 검색어 오타 및 유사어 입력 시 canonical 상품명으로 보정하는 fallback을 추가했습니다.
- AliasDictionary 이후 deterministic fuzzy match를 적용해 validProducts 안의 상품명만 detectedProduct로 반환하도록 했습니다.
- Gemini keyword extraction 프롬프트에 오타/약어/유사 발음 보정 지시를 최소 범위로 보강했습니다.
- 오타/유사어/오매칭 방지 테스트를 추가했습니다.

## 🔍 참고 사항
- 새 검색 API는 추가하지 않았습니다.
- 최종 detectedProduct는 사용자 원문이 아니라 canonical productName입니다.
- fuzzy match 후보는 validProducts 안으로 제한됩니다.

## 🖼️ 스크린샷
없음

## 🔗 관련 이슈
- Closes #81

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인