### PR TITLE
[MCJ-1439] FEAT: 공구 목록 지역 fallback 정렬 분기 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -29,19 +29,17 @@ class GroupBuyService(
     @Transactional(readOnly = true)
     fun getFeed(request: GroupBuyFeedRequest, pageable: Pageable): GroupBuyFeedPageResponse {
         log.info(
-            "[GroupBuyService] 공구 피드 조회 시작: filter={}, districts={}, keyword={}, page={}, size={}",
-            request.filter, request.districts, request.keyword, pageable.pageNumber, pageable.pageSize
+            "[GroupBuyService] 공구 피드 조회 시작: filter={}, districts={}, page={}, size={}",
+            request.filter, request.districts, pageable.pageNumber, pageable.pageSize
         )
 
         validateDistrictSelection(request.districts)
 
         val expandedDistricts = expandAllDistricts(request.districts)
-        val keyword = request.keyword?.trim()?.takeIf { it.isNotBlank() }
 
         val resultPage = groupBuyRepository.searchFeed(
             filter = request.filter,
             districtFilters = expandedDistricts,
-            keyword = keyword,
             pageable = pageable
         )
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -6,6 +6,7 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedItemResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedPageResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
@@ -42,7 +43,8 @@ class GroupBuyService(
         var resultPage = groupBuyRepository.searchFeed(
             filter = request.filter,
             districtFilters = expandedDistricts,
-            pageable = pageable
+            pageable = pageable,
+            sortMode = FeedSortMode.REGIONAL
         )
 
         if (expandedDistricts.isNotEmpty() && resultPage.totalElements == 0L) {
@@ -50,7 +52,8 @@ class GroupBuyService(
             resultPage = groupBuyRepository.searchFeed(
                 filter = request.filter,
                 districtFilters = emptySet(), // 전국 fallback
-                pageable = pageable
+                pageable = pageable,
+                sortMode = FeedSortMode.NATIONWIDE_FALLBACK
             )
         }
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -37,11 +37,22 @@ class GroupBuyService(
 
         val expandedDistricts = expandAllDistricts(request.districts)
 
-        val resultPage = groupBuyRepository.searchFeed(
+        var hasRegionalResult = true
+
+        var resultPage = groupBuyRepository.searchFeed(
             filter = request.filter,
             districtFilters = expandedDistricts,
             pageable = pageable
         )
+
+        if (expandedDistricts.isNotEmpty() && resultPage.totalElements == 0L) {
+            hasRegionalResult = false
+            resultPage = groupBuyRepository.searchFeed(
+                filter = request.filter,
+                districtFilters = emptySet(), // 전국 fallback
+                pageable = pageable
+            )
+        }
 
         log.info(
             "[GroupBuyService] 공구 피드 조회 완료: totalElements={}, totalPages={}, currentPage={}",
@@ -49,7 +60,8 @@ class GroupBuyService(
         )
 
         return GroupBuyFeedPageResponse.from(
-            resultPage.map { GroupBuyFeedItemResponse.from(it) }
+            resultPage.map { GroupBuyFeedItemResponse.from(it) },
+            hasRegionalResult = hasRegionalResult
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedPageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedPageResponse.kt
@@ -22,17 +22,21 @@ data class GroupBuyFeedPageResponse(
     val totalElements: Long,
 
     @field:Schema(description = "다음 페이지 존재 여부", example = "true")
-    val hasNext: Boolean
+    val hasNext: Boolean,
+
+    @field:Schema(description = "지역 설정 조건에 맞는 공구 존재 여부 (없으면 false)", example = "true")
+    val hasRegionalResult: Boolean
 ) {
     companion object {
-        fun from(page: Page<GroupBuyFeedItemResponse>): GroupBuyFeedPageResponse {
+        fun from(page: Page<GroupBuyFeedItemResponse>, hasRegionalResult: Boolean = true): GroupBuyFeedPageResponse {
             return GroupBuyFeedPageResponse(
                 content = page.content,
                 page = page.number + 1,
                 size = page.size,
                 totalPages = page.totalPages,
                 totalElements = page.totalElements,
-                hasNext = page.hasNext()
+                hasNext = page.hasNext(),
+                hasRegionalResult = hasRegionalResult
             )
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedRequest.kt
@@ -11,7 +11,4 @@ data class GroupBuyFeedRequest(
 
     @field:Schema(description = "지역/세부지역 통합 필터 코드 목록 (최대 10개)")
     val districts: List<DistrictType> = emptyList(),
-
-    @field:Schema(description = "매장명 또는 상품명 검색어", example = "두쫀쿠")
-    val keyword: String? = null
 )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/FeedSortMode.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/FeedSortMode.kt
@@ -1,0 +1,6 @@
+package com.moongchijang.domain.groupbuy.domain.repository
+
+enum class FeedSortMode {
+    REGIONAL,
+    NATIONWIDE_FALLBACK
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
@@ -18,7 +18,8 @@ interface GroupBuyRepositoryCustom {
     fun searchFeed(
         filter: GroupBuyFeedFilter,
         districtFilters: Set<DistrictType>,
-        pageable: Pageable
+        pageable: Pageable,
+        sortMode: FeedSortMode,
     ): Page<GroupBuy>
 
     fun searchByIntent(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
@@ -18,7 +18,6 @@ interface GroupBuyRepositoryCustom {
     fun searchFeed(
         filter: GroupBuyFeedFilter,
         districtFilters: Set<DistrictType>,
-        keyword: String?,
         pageable: Pageable
     ): Page<GroupBuy>
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
@@ -5,10 +5,15 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.entity.QGroupBuy.groupBuy
 import com.moongchijang.domain.store.domain.entity.QStore.store
+import com.moongchijang.domain.favorite.domain.entity.QFavorite.favorite
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
 import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.NumberExpression
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -25,15 +30,17 @@ class GroupBuyRepositoryImpl(
         filter: GroupBuyFeedFilter,
         districtFilters: Set<DistrictType>,
         pageable: Pageable,
+        sortMode: FeedSortMode,
     ): Page<GroupBuy> {
         val now = LocalDateTime.now()
         val where = buildWhere(filter, districtFilters, now)
+        val orderSpecifiers = buildOrderSpecifiers(sortMode)
 
         val content = queryFactory
             .selectFrom(groupBuy)
             .join(groupBuy.store, store).fetchJoin()
             .where(where)
-            .orderBy(groupBuy.createdAt.desc()) // MVP: 최신순 고정, 추후 sortType 기반 동적 정렬로 확장 예정
+            .orderBy(*orderSpecifiers.toTypedArray())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
@@ -65,6 +72,32 @@ class GroupBuyRepositoryImpl(
 
         filterPredicate(filter, now)?.let { builder.and(it) }
         return builder
+    }
+
+    private fun buildOrderSpecifiers(sortMode: FeedSortMode): List<OrderSpecifier<*>> {
+        val achievementRate: NumberExpression<Int> = groupBuy.currentQuantity.multiply(100).divide(groupBuy.targetQuantity)
+        val favoriteCount: NumberExpression<Long> = Expressions.numberTemplate(
+            Long::class.java,
+            "coalesce(({0}), 0)", // 서브쿼리 결과가 null이면 0으로 대체
+            JPAExpressions.select(favorite.count())
+                .from(favorite)
+                .where(favorite.groupBuy.eq(groupBuy))
+        )
+
+        return when (sortMode) {
+            FeedSortMode.REGIONAL -> listOf(
+                achievementRate.desc(),  // 달성임박
+                groupBuy.deadline.asc(), // 마감임박
+                groupBuy.createdAt.desc(), // 최신
+                groupBuy.id.desc()
+            )
+            FeedSortMode.NATIONWIDE_FALLBACK -> listOf(
+                favoriteCount.desc(),    // 찜(총 찜수)
+                achievementRate.desc(),  // 달성임박
+                groupBuy.deadline.asc(), // 마감임박
+                groupBuy.id.desc()
+            )
+        }
     }
 
     private fun filterPredicate(filter: GroupBuyFeedFilter, now: LocalDateTime): BooleanExpression? {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
@@ -24,11 +24,10 @@ class GroupBuyRepositoryImpl(
     override fun searchFeed(
         filter: GroupBuyFeedFilter,
         districtFilters: Set<DistrictType>,
-        keyword: String?,
         pageable: Pageable,
     ): Page<GroupBuy> {
         val now = LocalDateTime.now()
-        val where = buildWhere(filter, districtFilters, keyword, now)
+        val where = buildWhere(filter, districtFilters, now)
 
         val content = queryFactory
             .selectFrom(groupBuy)
@@ -52,7 +51,6 @@ class GroupBuyRepositoryImpl(
     private fun buildWhere(
         filter: GroupBuyFeedFilter,
         districtFilters: Set<DistrictType>,
-        keyword: String?,
         now: LocalDateTime
     ): BooleanBuilder {
         val builder = BooleanBuilder()
@@ -60,13 +58,6 @@ class GroupBuyRepositoryImpl(
         // 마감 공구 제외하고 진행 중 공고만
         builder.and(groupBuy.status.eq(GroupBuyStatus.IN_PROGRESS))
         builder.and(groupBuy.deadline.goe(now))
-
-        keyword?.trim()?.takeIf { it.isNotEmpty() }?.let {
-            builder.and(
-                groupBuy.productName.containsIgnoreCase(it)
-                        .or(store.name.containsIgnoreCase(it))
-            )
-        }
 
         if (districtFilters.isNotEmpty()) {
             builder.and(store.district.`in`(districtFilters))

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
@@ -75,7 +75,11 @@ class GroupBuyRepositoryImpl(
     }
 
     private fun buildOrderSpecifiers(sortMode: FeedSortMode): List<OrderSpecifier<*>> {
-        val achievementRate: NumberExpression<Int> = groupBuy.currentQuantity.multiply(100).divide(groupBuy.targetQuantity)
+        val achievementRate: NumberExpression<Int> = Expressions.cases()
+            .`when`(groupBuy.targetQuantity.eq(0))
+            .then(0)
+            .otherwise(groupBuy.currentQuantity.multiply(100).divide(groupBuy.targetQuantity))
+
         val favoriteCount: NumberExpression<Long> = Expressions.numberTemplate(
             Long::class.java,
             "coalesce(({0}), 0)", // 서브쿼리 결과가 null이면 0으로 대체

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -49,16 +49,13 @@ class GroupBuyController(
         filter: GroupBuyFeedFilter,
         @RequestParam(required = false)
         districts: List<DistrictType>?,
-        @RequestParam(required = false)
-        keyword: String?,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<GroupBuyFeedPageResponse>> {
-        log.info("[GroupBuyController] 공구 피드 조회 요청 수신: filter={}, districts={}, keyword={}", filter, districts, keyword)
+        log.info("[GroupBuyController] 공구 피드 조회 요청 수신: filter={}, districts={}", filter, districts)
 
         val request = GroupBuyFeedRequest(
             filter = filter,
             districts = districts ?: emptyList(),
-            keyword = keyword
         )
 
         val response = groupBuyService.getFeed(request, pageable)

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -535,11 +535,6 @@ paths:
               $ref: '#/components/schemas/DistrictType'
           style: form
           explode: true
-        - name: keyword
-          in: query
-          description: 매장명 또는 상품명 검색어
-          schema:
-            type: string
         - $ref: '#/components/parameters/Page'
         - $ref: '#/components/parameters/Size'
       responses:
@@ -1999,7 +1994,7 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [content, page, size, totalPages, totalElements, hasNext]
+          required: [content, page, size, totalPages, totalElements, hasNext, hasRegionalResult]
           properties:
             content:
               type: array
@@ -2010,6 +2005,7 @@ components:
             totalPages: { type: integer, description: 전체 페이지 수 }
             totalElements: { type: integer }
             hasNext: { type: boolean, description: 다음 페이지 존재 여부 }
+            hasRegionalResult: { type: boolean, description: 지역 설정 조건에 맞는 공구 존재 여부 (없으면 false) }
         error: { nullable: true, example: null }
 
     ApiResponseGroupBuyDetailResponse:

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
@@ -1,0 +1,232 @@
+package com.moongchijang.domain.groupbuy.repository
+
+import com.moongchijang.domain.favorite.domain.entity.Favorite
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import jakarta.persistence.EntityManager
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class GroupBuyRepositoryImplIntegrationTest {
+    private val pageable = PageRequest.of(0, 10)
+
+    @Autowired
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Autowired
+    private lateinit var em: EntityManager
+
+    @Test
+    fun `전국 fallback 정렬 우선순위 검증`() {
+        val baseStore = persistStore("기준 매장")
+        val request = persistGroupBuyRequest()
+
+        val gbMostFavorite = persistGroupBuy(
+            store = baseStore,
+            request = request,
+            productName = "A",
+            currentQuantity = 20,
+            targetQuantity = 100,
+            deadline = LocalDateTime.now().plusDays(5)
+        )
+        val gbFavoriteTieHighAchieve = persistGroupBuy(
+            store = baseStore,
+            request = request,
+            productName = "B",
+            currentQuantity = 90,
+            targetQuantity = 100,
+            deadline = LocalDateTime.now().plusDays(4)
+        )
+        val gbFavoriteTieLowAchieve = persistGroupBuy(
+            store = baseStore,
+            request = request,
+            productName = "C",
+            currentQuantity = 70,
+            targetQuantity = 100,
+            deadline = LocalDateTime.now().plusDays(3)
+        )
+
+        repeat(3) { persistFavorite(gbMostFavorite) }
+        repeat(1) { persistFavorite(gbFavoriteTieHighAchieve) }
+        repeat(1) { persistFavorite(gbFavoriteTieLowAchieve) }
+
+        flushAndClear()
+        val result = searchFeed(
+            districtFilters = emptySet(),
+            sortMode = FeedSortMode.NATIONWIDE_FALLBACK
+        )
+
+        assertOrder(
+            result.content.map { it.id },
+            gbMostFavorite.id,
+            gbFavoriteTieHighAchieve.id,
+            gbFavoriteTieLowAchieve.id
+        )
+    }
+
+    @Test
+    fun `지역 정렬 우선순위 검증`() {
+        val seoulStore = persistStore("서울 매장", district = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG)
+        val request = persistGroupBuyRequest()
+
+        val highAchievement = persistGroupBuy(
+            store = seoulStore,
+            request = request,
+            productName = "고달성",
+            currentQuantity = 95,
+            targetQuantity = 100,
+            deadline = LocalDateTime.now().plusDays(10)
+        )
+        val sameAchievementEarlyDeadline = persistGroupBuy(
+            store = seoulStore,
+            request = request,
+            productName = "동률-빠른마감",
+            currentQuantity = 80,
+            targetQuantity = 100,
+            deadline = LocalDateTime.now().plusDays(2)
+        )
+        val sameAchievementLateDeadline = persistGroupBuy(
+            store = seoulStore,
+            request = request,
+            productName = "동률-늦은마감",
+            currentQuantity = 80,
+            targetQuantity = 100,
+            deadline = LocalDateTime.now().plusDays(7)
+        )
+
+        flushAndClear()
+        val result = searchFeed(
+            districtFilters = setOf(DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG),
+            sortMode = FeedSortMode.REGIONAL
+        )
+
+        assertOrder(
+            result.content.map { it.id },
+            highAchievement.id,
+            sameAchievementEarlyDeadline.id,
+            sameAchievementLateDeadline.id
+        )
+    }
+
+    private fun searchFeed(
+        districtFilters: Set<DistrictType>,
+        sortMode: FeedSortMode
+    ): org.springframework.data.domain.Page<GroupBuy> {
+        return groupBuyRepository.searchFeed(
+            filter = GroupBuyFeedFilter.ALL,
+            districtFilters = districtFilters,
+            pageable = pageable,
+            sortMode = sortMode
+        )
+    }
+
+    private fun assertOrder(actual: List<Long>, vararg expected: Long) {
+        assertThat(actual).containsExactly(*expected.toTypedArray())
+    }
+
+    private fun flushAndClear() {
+        em.flush()
+        em.clear()
+    }
+
+    private fun persistUser(email: String): User {
+        val user = User(
+            provider = AuthProvider.EMAIL,
+            email = email,
+            passwordHash = "pw",
+            nickname = "tester",
+            role = UserRole.BUYER,
+            signupCompleted = true
+        )
+        em.persist(user)
+        return user
+    }
+
+    private fun persistStore(
+        name: String,
+        district: DistrictType = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG
+    ): Store {
+        val store = Store(
+            name = name,
+            address = "서울 강남구",
+            region = RegionType.SEOUL,
+            district = district
+        )
+        em.persist(store)
+        return store
+    }
+
+    private fun persistGroupBuyRequest(): GroupBuyRequest {
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "테스트 매장",
+            storeAddress = "서울 강남구",
+            productName = "테스트 상품",
+            desiredQuantity = 50,
+            desiredPickupDate = LocalDate.now().plusDays(3)
+        )
+        em.persist(request)
+        return request
+    }
+
+    private fun persistGroupBuy(
+        store: Store,
+        request: GroupBuyRequest,
+        productName: String,
+        currentQuantity: Int,
+        targetQuantity: Int,
+        deadline: LocalDateTime
+    ): GroupBuy {
+        val groupBuy = GroupBuy(
+            store = store,
+            groupBuyRequest = request,
+            thumbnailUrl = "https://example.com/$productName.jpg",
+            productName = productName,
+            productDescription = "설명",
+            price = 10000,
+            targetQuantity = targetQuantity,
+            currentQuantity = currentQuantity,
+            maxQuantity = 200,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = deadline,
+            pickupDate = LocalDate.now().plusDays(5),
+            pickupTimeStart = LocalTime.of(10, 0),
+            pickupTimeEnd = LocalTime.of(12, 0),
+            pickupLocation = "서울 강남구",
+            shareCount = 0
+        )
+        em.persist(groupBuy)
+        return groupBuy
+    }
+
+    private fun persistFavorite(groupBuy: GroupBuy) {
+        val user = persistUser("user-${System.nanoTime()}@test.com")
+        em.persist(
+            Favorite(
+                user = user,
+                groupBuy = groupBuy
+            )
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
@@ -78,6 +80,88 @@ class GroupBuyServiceTest {
             districtFilters = emptySet(),
             pageable = pageable,
             sortMode = FeedSortMode.REGIONAL
+        )
+    }
+
+    @Test
+    fun `지역 조회 결과가 없으면 전국 fallback 재조회 후 hasRegionalResult false를 반환한다`() {
+        val regionalDistrict = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG
+        val pageable = PageRequest.of(0, 20)
+        val request = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest(
+            filter = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter.ALL,
+            districts = listOf(regionalDistrict)
+        )
+        val fallbackGroupBuy = createGroupBuy(id = 31L, status = GroupBuyStatus.IN_PROGRESS)
+
+        `when`(
+            groupBuyRepository.searchFeed(
+                filter = request.filter,
+                districtFilters = setOf(regionalDistrict),
+                pageable = pageable,
+                sortMode = FeedSortMode.REGIONAL
+            )
+        ).thenReturn(PageImpl(emptyList(), pageable, 0))
+
+        `when`(
+            groupBuyRepository.searchFeed(
+                filter = request.filter,
+                districtFilters = emptySet(),
+                pageable = pageable,
+                sortMode = FeedSortMode.NATIONWIDE_FALLBACK
+            )
+        ).thenReturn(PageImpl(listOf(fallbackGroupBuy), pageable, 1))
+
+        val result = service.getFeed(request, pageable)
+
+        assertFalse(result.hasRegionalResult)
+        assertEquals(1, result.content.size)
+        assertEquals(31L, result.content.first().id)
+        verify(groupBuyRepository, times(1)).searchFeed(
+            filter = request.filter,
+            districtFilters = setOf(regionalDistrict),
+            pageable = pageable,
+            sortMode = FeedSortMode.REGIONAL
+        )
+        verify(groupBuyRepository, times(1)).searchFeed(
+            filter = request.filter,
+            districtFilters = emptySet(),
+            pageable = pageable,
+            sortMode = FeedSortMode.NATIONWIDE_FALLBACK
+        )
+    }
+
+    @Test
+    fun `지역 미설정이면 결과가 비어도 fallback 재조회 없이 hasRegionalResult true를 유지한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val request = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest(
+            filter = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter.ALL,
+            districts = emptyList()
+        )
+
+        `when`(
+            groupBuyRepository.searchFeed(
+                filter = request.filter,
+                districtFilters = emptySet(),
+                pageable = pageable,
+                sortMode = FeedSortMode.REGIONAL
+            )
+        ).thenReturn(PageImpl(emptyList(), pageable, 0))
+
+        val result = service.getFeed(request, pageable)
+
+        assertTrue(result.hasRegionalResult)
+        assertEquals(0, result.content.size)
+        verify(groupBuyRepository, times(1)).searchFeed(
+            filter = request.filter,
+            districtFilters = emptySet(),
+            pageable = pageable,
+            sortMode = FeedSortMode.REGIONAL
+        )
+        verify(groupBuyRepository, never()).searchFeed(
+            filter = request.filter,
+            districtFilters = emptySet(),
+            pageable = pageable,
+            sortMode = FeedSortMode.NATIONWIDE_FALLBACK
         )
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -54,7 +54,7 @@ class GroupBuyServiceTest {
     private lateinit var service: GroupBuyService
 
     @Test
-    fun `공구 피드 조회 시 keyword 없이도 정상 조회된다`() {
+    fun `공구 피드 keyword 제외 조회 검증`() {
         val groupBuy = createGroupBuy(id = 21L, status = GroupBuyStatus.IN_PROGRESS)
         val pageable = PageRequest.of(0, 20)
         val request = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest(
@@ -84,7 +84,7 @@ class GroupBuyServiceTest {
     }
 
     @Test
-    fun `지역 조회 결과가 없으면 전국 fallback 재조회 후 hasRegionalResult false를 반환한다`() {
+    fun `지역 결과 없음 fallback 재조회 및 hasRegionalResult false 검증`() {
         val regionalDistrict = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG
         val pageable = PageRequest.of(0, 20)
         val request = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest(
@@ -131,7 +131,7 @@ class GroupBuyServiceTest {
     }
 
     @Test
-    fun `지역 미설정이면 결과가 비어도 fallback 재조회 없이 hasRegionalResult true를 유지한다`() {
+    fun `지역 미설정 시 fallback 미수행 및 hasRegionalResult true 유지 검증`() {
         val pageable = PageRequest.of(0, 20)
         val request = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest(
             filter = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter.ALL,

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -6,6 +6,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
@@ -63,7 +64,8 @@ class GroupBuyServiceTest {
             groupBuyRepository.searchFeed(
                 filter = request.filter,
                 districtFilters = emptySet(),
-                pageable = pageable
+                pageable = pageable,
+                sortMode = FeedSortMode.REGIONAL
             )
         ).thenReturn(PageImpl(listOf(groupBuy), pageable, 1))
 
@@ -74,7 +76,8 @@ class GroupBuyServiceTest {
         verify(groupBuyRepository).searchFeed(
             filter = request.filter,
             districtFilters = emptySet(),
-            pageable = pageable
+            pageable = pageable,
+            sortMode = FeedSortMode.REGIONAL
         )
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -22,8 +22,11 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -46,6 +49,34 @@ class GroupBuyServiceTest {
 
     @InjectMocks
     private lateinit var service: GroupBuyService
+
+    @Test
+    fun `공구 피드 조회 시 keyword 없이도 정상 조회된다`() {
+        val groupBuy = createGroupBuy(id = 21L, status = GroupBuyStatus.IN_PROGRESS)
+        val pageable = PageRequest.of(0, 20)
+        val request = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest(
+            filter = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter.ALL,
+            districts = emptyList()
+        )
+
+        `when`(
+            groupBuyRepository.searchFeed(
+                filter = request.filter,
+                districtFilters = emptySet(),
+                pageable = pageable
+            )
+        ).thenReturn(PageImpl(listOf(groupBuy), pageable, 1))
+
+        val result = service.getFeed(request, pageable)
+
+        assertEquals(1, result.content.size)
+        assertEquals(21L, result.content.first().id)
+        verify(groupBuyRepository).searchFeed(
+            filter = request.filter,
+            districtFilters = emptySet(),
+            pageable = pageable
+        )
+    }
 
     @Test
     fun `로그인 사용자 상세 조회 시 찜 여부와 참여 여부 반환`() {


### PR DESCRIPTION
## 📌 작업한 내용
- 공구 목록 조회(`GET /api/v1/group-buys`)에서 `keyword` 파라미터 제거
- `GroupBuyFeedRequest`에서 `keyword` 필드 제거
- Controller/Service/Repository 시그니처 전반에서 keyword 의존 코드 정리
- 지역 조회 결과 유무를 응답으로 전달하기 위해 `hasRegionalResult` 필드 추가
- 지역 조건 조회 결과가 없을 때 전국 fallback 재조회 로직 추가
- 정렬 모드 분기 도입
  - `REGIONAL`: 달성임박 > 마감임박 > 최신
  - `NATIONWIDE_FALLBACK`: 찜(총 찜수) > 달성임박 > 마감임박
- QueryDSL 동적 정렬(`OrderSpecifier`) 구성 방식으로 리포지토리 정렬 로직 개선
- OpenAPI 문서(`openapi.yaml`)에 위 변경사항 반영
  - group-buys의 keyword 제거
  - 피드 응답에 hasRegionalResult 추가

## 🔍 참고 사항
- 현재 MVP 단계에서는 페이지 요청마다
  1) 지역 조회
  2) 결과 없음 시 전국 fallback 조회
  를 수행하도록 구현했습니다.
- 향후 성능 최적화가 필요하면 `mode`(REGIONAL/NATIONWIDE) 같은 명시 파라미터 도입으로
  불필요한 재판단/재조회 감소를 고려할 수 있습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #84 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

## 💡 구현 시 고민한 사항
1. fallback 판단 위치를 어디에 둘지 정리
- 지역 결과가 없을 때 전국으로 전환하는 판단을 Repository에 둘지 Service에 둘지 먼저 고민했습니다.
- 조회 결과를 해석해 정책적으로 분기하는 성격이 강하다고 봐서, 판단은 Service에서 수행하고 Repository는 조회 실행 책임만 갖도록 분리했습니다.
- 이 구조로 정리하면서 정책 변경 시 영향 범위를 Service 중심으로 제한할 수 있게 했습니다.

2. 정렬 분기 구현 방식 단순화
- 지역 결과와 전국 fallback에서 정렬 우선순위가 다르기 때문에, 조회 메서드를 나눌지 단일 메서드에서 처리할지 비교했습니다.
- 중복 쿼리를 늘리지 않기 위해 `searchFeed + FeedSortMode` 조합을 선택했고, 내부에서 `buildOrderSpecifiers`로 정렬만 분기하도록 구성했습니다.
- 결과적으로 정렬 기준 변경이 생겨도 수정 포인트가 한 곳으로 모이게 정리했습니다.

3. QueryDSL 정렬식 안정성 확보
- 정렬 우선순위를 동적으로 조합하는 과정에서 타입 충돌(`OrderSpecifier`, 서브쿼리 타입)이 발생해 쿼리식 구성을 다시 점검했습니다.
- `OrderSpecifier` 리스트를 명시적으로 조합하고, 서브쿼리 기반 숫자 정렬식은 `numberTemplate + coalesce`로 null-safe하게 변환해 적용했습니다.
