### PR TITLE
[MCJ-1448] FEAT: 공구 참여 생성 동시성 제어 및 상태 전이 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -1,12 +1,33 @@
 package com.moongchijang.domain.groupbuy.domain.repository
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.Optional
 
 interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepositoryCustom {
 
     @EntityGraph(attributePaths = ["store"])
     fun findWithStoreById(id: Long): Optional<GroupBuy>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        UPDATE GroupBuy gb
+        SET gb.currentQuantity = gb.currentQuantity + :quantity
+        WHERE gb.id = :groupBuyId
+        AND gb.status = :status
+        AND gb.deadline > CURRENT_TIMESTAMP 
+        AND (gb.maxQuantity - gb.currentQuantity) >= :quantity
+        """
+    )
+    fun increaseCurrentQuantityIfAvailable(
+        @Param("groupBuyId") groupBuyId: Long,
+        @Param("quantity") quantity: Int,
+        @Param("status") status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
+    ): Int
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/lock/RedisLockUtil.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/lock/RedisLockUtil.kt
@@ -21,9 +21,9 @@ class RedisLockUtil(
 
     fun tryLockOrThrow(key: String, waitMs: Long, leaseMs: Long): String {
         val token = UUID.randomUUID().toString()
-        val deadline = System.currentTimeMillis() + waitMs
+        val deadlineNanos = System.nanoTime() + java.util.concurrent.TimeUnit.MILLISECONDS.toNanos(waitMs)
 
-        while (System.currentTimeMillis() < deadline) {
+        while (System.nanoTime() < deadlineNanos) {
             val locked = redisTemplate.opsForValue()
                 .setIfAbsent(key, token, Duration.ofMillis(leaseMs))
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/lock/RedisLockUtil.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/lock/RedisLockUtil.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.domain.groupbuy.infrastructure.lock
+
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.Collections
+import java.util.UUID
+
+@Component
+class RedisLockUtil(
+    private val redisTemplate: StringRedisTemplate
+) {
+    companion object {
+        private const val RETRY_INTERVAL_MS = 50L
+    }
+
+    fun lockKey(groupBuyId: Long): String = "groupBuy:$groupBuyId"
+
+    fun tryLockOrThrow(key: String, waitMs: Long, leaseMs: Long): String {
+        val token = UUID.randomUUID().toString()
+        val deadline = System.currentTimeMillis() + waitMs
+
+        while (System.currentTimeMillis() < deadline) {
+            val locked = redisTemplate.opsForValue()
+                .setIfAbsent(key, token, Duration.ofMillis(leaseMs))
+
+            if (locked == true) return token
+
+            try {
+                Thread.sleep(RETRY_INTERVAL_MS)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw CustomException(ErrorCode.GROUPBUY_LOCK_INTERRUPTED)
+            }
+        }
+
+        throw CustomException(ErrorCode.GROUPBUY_LOCK_ACQUISITION_FAILED)
+    }
+
+    fun unlock(key: String, token: String): Boolean {
+        val script = """
+            if redis.call('get', KEYS[1]) == ARGV[1] then
+              return redis.call('del', KEYS[1])
+            else
+              return 0
+            end
+        """.trimIndent()
+
+        val result = redisTemplate.execute(
+            DefaultRedisScript(script, Long::class.java),
+            Collections.singletonList(key),
+            token
+        )
+
+        return result == 1L
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
@@ -1,0 +1,138 @@
+package com.moongchijang.domain.participation.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.domain.participation.application.dto.ParticipationCreateRequest
+import com.moongchijang.domain.participation.application.dto.ParticipationCreatedResponse
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import jakarta.transaction.Transactional
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class ParticipationService(
+    private val redisLockUtil: RedisLockUtil,
+    private val groupBuyRepository: GroupBuyRepository,
+    private val participationRepository: ParticipationRepository,
+    private val userRepository: UserRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun createParticipation(
+        userId: Long,
+        groupBuyId: Long,
+        request: ParticipationCreateRequest
+    ): ParticipationCreatedResponse {
+        val key = redisLockUtil.lockKey(groupBuyId)
+        val token = redisLockUtil.tryLockOrThrow(key, waitMs = 500, leaseMs = 3_000)
+
+        try {
+            val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+            val groupBuy = groupBuyRepository.findById(groupBuyId)
+                .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+            validateCanParticipate(groupBuy, request.quantity)
+
+            // TODO(MCJ-1448): 조건부 차감 쿼리로 교체
+            //  - where id = :groupBuyId and (max_quantity - current_quantity) >= :quantity
+            //  - update current_quantity = current_quantity + :quantity
+            val remaining = groupBuy.maxQuantity - groupBuy.currentQuantity
+            if (remaining < request.quantity) {
+                log.warn(
+                    "[ParticipationService] 참여 불가 - 수량 부족: groupBuyId={}, remaining={}, requestQty={}",
+                    groupBuyId, remaining, request.quantity
+                )
+                throw CustomException(ErrorCode.GROUPBUY_SOLD_OUT)
+            }
+
+            groupBuy.currentQuantity += request.quantity
+            updateStatusIfAchieved(groupBuy)
+
+            val productAmount = groupBuy.price * request.quantity
+            val feeAmount = 0
+            val totalAmount = productAmount + feeAmount
+
+            val participation = participationRepository.save(
+                Participation(
+                    user = user,
+                    groupBuy = groupBuy,
+                    quantity = request.quantity,
+                    productAmount = productAmount,
+                    feeAmount = feeAmount,
+                    totalAmount = totalAmount,
+                    status = ParticipationStatus.PENDING,
+                    pickupStatus = PickupStatus.NOT_READY,
+                )
+            )
+
+            // TODO(MCJ-1448): 결제 시스템 연동
+            // 결제 요청 생성/승인/검증 로직 연결
+            // 결제 진입 직전 최종 재검증 연결
+
+            log.info(
+                "[ParticipationService] 참여 생성 완료: participationId={}, groupBuyId={}, quantity={}",
+                participation.id, groupBuyId, request.quantity
+            )
+
+            return ParticipationCreatedResponse(
+                participationId = participation.id,
+                orderName = "${groupBuy.productName} ${request.quantity}개",
+                totalAmount = totalAmount,
+                productAmount = productAmount,
+                feeAmount = feeAmount
+            )
+        } finally {
+            val unlocked = redisLockUtil.unlock(key, token)
+            if (!unlocked) {
+                log.warn("[ParticipationService] 락 해제 실패: key={}", key)
+            } else {
+                log.debug("[ParticipationService] 락 해제 성공: key={}", key)
+            }
+        }
+    }
+
+    private fun validateCanParticipate(groupBuy: GroupBuy, quantity: Int) {
+        if (groupBuy.status != GroupBuyStatus.IN_PROGRESS) {
+            log.warn(
+                "[ParticipationService] 참여 불가 - 모집 상태 아님: groupBuyId={}, status={}",
+                groupBuy.id, groupBuy.status
+            )
+            throw CustomException(ErrorCode.GROUPBUY_NOT_RECRUITING)
+        }
+
+        if (!LocalDateTime.now().isBefore(groupBuy.deadline)) {
+            log.warn(
+                "[ParticipationService] 참여 불가 - 마감 지남: groupBuyId={}, deadline={}",
+                groupBuy.id, groupBuy.deadline
+            )
+            throw CustomException(ErrorCode.GROUPBUY_DEADLINE_PASSED)
+        }
+
+        if (quantity <= 0) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+
+    private fun updateStatusIfAchieved(groupBuy: GroupBuy) {
+        if (groupBuy.status == GroupBuyStatus.IN_PROGRESS &&
+            groupBuy.currentQuantity >= groupBuy.targetQuantity) {
+            groupBuy.status = GroupBuyStatus.ACHIEVED
+            log.info(
+                "[ParticipationService] 상태 전이: groupBuyId={}, status={}",
+                groupBuy.id, groupBuy.status
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
@@ -10,6 +10,7 @@ import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -33,51 +34,21 @@ class ParticipationService(
         groupBuyId: Long,
         request: ParticipationCreateRequest
     ): ParticipationCreatedResponse {
-        if (participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)) {
-            throw CustomException(ErrorCode.GROUPBUY_ALREADY_PARTICIPATED)
-        }
+        validateNotParticipated(userId, groupBuyId)
 
-        val key = redisLockUtil.lockKey(groupBuyId)
-        val token = redisLockUtil.tryLockOrThrow(key, waitMs = 500, leaseMs = 3_000)
+        val (key, token) = acquireLock(groupBuyId)
 
         try {
-            val user = userRepository.findByIdAndDeletedAtIsNull(userId)
-                ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
-
-            val groupBuy = groupBuyRepository.findById(groupBuyId)
-                .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+            val user = findUser(userId)
+            val groupBuy = findGroupBuy(groupBuyId)
 
             validateCanParticipate(groupBuy, request.quantity)
+            increaseQuantityOrThrow(groupBuyId, request.quantity)
 
-            val updatedRows = groupBuyRepository.increaseCurrentQuantityIfAvailable(groupBuyId, request.quantity)
-            if (updatedRows == 0) {
-                log.warn(
-                    "[ParticipationService] 참여 불가 - 조건부 차감 실패: groupBuyId={}, requestQuantity={}",
-                    groupBuyId, request.quantity
-                )
-                throw CustomException(ErrorCode.GROUPBUY_SOLD_OUT)
-            }
-
-            val updatedGroupBuy = groupBuyRepository.findById(groupBuyId)
-                .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+            val updatedGroupBuy = findGroupBuy(groupBuyId)
             updateStatusIfAchieved(updatedGroupBuy)
 
-            val productAmount = groupBuy.price * request.quantity
-            val feeAmount = 0
-            val totalAmount = productAmount + feeAmount
-
-            val participation = participationRepository.save(
-                Participation(
-                    user = user,
-                    groupBuy = groupBuy,
-                    quantity = request.quantity,
-                    productAmount = productAmount,
-                    feeAmount = feeAmount,
-                    totalAmount = totalAmount,
-                    status = ParticipationStatus.PENDING,
-                    pickupStatus = PickupStatus.NOT_READY,
-                )
-            )
+            val participation = createParticipation(user, groupBuy, request.quantity)
 
             // TODO(MCJ-1448): 결제 시스템 연동
             // 결제 요청 생성/승인/검증 로직 연결
@@ -87,22 +58,79 @@ class ParticipationService(
                 "[ParticipationService] 참여 생성 완료: participationId={}, groupBuyId={}, quantity={}",
                 participation.id, groupBuyId, request.quantity
             )
-
-            return ParticipationCreatedResponse(
-                participationId = participation.id,
-                orderName = "${groupBuy.productName} ${request.quantity}개",
-                totalAmount = totalAmount,
-                productAmount = productAmount,
-                feeAmount = feeAmount
-            )
+            return toCreatedResponse(participation, groupBuy)
         } finally {
-            val unlocked = redisLockUtil.unlock(key, token)
-            if (!unlocked) {
-                log.warn("[ParticipationService] 락 해제 실패: key={}", key)
-            } else {
-                log.debug("[ParticipationService] 락 해제 성공: key={}", key)
-            }
+            releaseLock(key, token)
         }
+    }
+
+    private fun validateNotParticipated(userId: Long, groupBuyId: Long) {
+        if (participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)) {
+            throw CustomException(ErrorCode.GROUPBUY_ALREADY_PARTICIPATED)
+        }
+    }
+
+    private fun acquireLock(groupBuyId: Long): Pair<String, String> {
+        val key = redisLockUtil.lockKey(groupBuyId)
+        val token = redisLockUtil.tryLockOrThrow(key, waitMs = 500, leaseMs = 3_000)
+        return key to token
+    }
+
+    private fun releaseLock(key: String, token: String) {
+        val unlocked = redisLockUtil.unlock(key, token)
+        if (!unlocked) {
+            log.warn("[ParticipationService] 락 해제 실패: key={}", key)
+        } else {
+            log.debug("[ParticipationService] 락 해제 성공: key={}", key)
+        }
+    }
+
+    private fun findUser(userId: Long) =
+        userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+    private fun findGroupBuy(groupBuyId: Long) =
+        groupBuyRepository.findById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+    private fun increaseQuantityOrThrow(groupBuyId: Long, quantity: Int) {
+        val updatedRows = groupBuyRepository.increaseCurrentQuantityIfAvailable(groupBuyId, quantity)
+        if (updatedRows == 0) {
+            log.warn(
+                "[ParticipationService] 참여 불가 - 조건부 차감 실패: groupBuyId={}, requestQuantity={}",
+                groupBuyId, quantity
+            )
+            throw CustomException(ErrorCode.GROUPBUY_SOLD_OUT)
+        }
+    }
+
+    private fun createParticipation(user: User, groupBuy: GroupBuy, quantity: Int): Participation {
+        val productAmount = groupBuy.price * quantity
+        val feeAmount = 0
+        val totalAmount = productAmount + feeAmount
+
+        return participationRepository.save(
+            Participation(
+                user = user,
+                groupBuy = groupBuy,
+                quantity = quantity,
+                productAmount = productAmount,
+                feeAmount = feeAmount,
+                totalAmount = totalAmount,
+                status = ParticipationStatus.PENDING,
+                pickupStatus = PickupStatus.NOT_READY,
+            )
+        )
+    }
+
+    private fun toCreatedResponse(participation: Participation, groupBuy: GroupBuy): ParticipationCreatedResponse {
+        return ParticipationCreatedResponse(
+            participationId = participation.id,
+            orderName = "${groupBuy.productName} ${participation.quantity}개",
+            totalAmount = participation.totalAmount,
+            productAmount = participation.productAmount,
+            feeAmount = participation.feeAmount
+        )
     }
 
     private fun validateCanParticipate(groupBuy: GroupBuy, quantity: Int) {

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
@@ -14,9 +14,9 @@ import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
-import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 
 @Service
@@ -25,40 +25,44 @@ class ParticipationService(
     private val groupBuyRepository: GroupBuyRepository,
     private val participationRepository: ParticipationRepository,
     private val userRepository: UserRepository,
+    private val transactionTemplate: TransactionTemplate,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    @Transactional
     fun createParticipation(
         userId: Long,
         groupBuyId: Long,
         request: ParticipationCreateRequest
     ): ParticipationCreatedResponse {
-        validateNotParticipated(userId, groupBuyId)
-
         val (key, token) = acquireLock(groupBuyId)
 
         try {
-            val user = findUser(userId)
-            val groupBuy = findGroupBuy(groupBuyId)
+            val response = transactionTemplate.execute {
+                validateNotParticipated(userId, groupBuyId)
 
-            validateCanParticipate(groupBuy, request.quantity)
-            increaseQuantityOrThrow(groupBuyId, request.quantity)
+                val user = findUser(userId)
+                val groupBuy = findGroupBuy(groupBuyId)
 
-            val updatedGroupBuy = findGroupBuy(groupBuyId)
-            updateStatusIfAchieved(updatedGroupBuy)
+                validateCanParticipate(groupBuy, request.quantity)
+                increaseQuantityOrThrow(groupBuyId, request.quantity)
 
-            val participation = createParticipation(user, groupBuy, request.quantity)
+                val updatedGroupBuy = findGroupBuy(groupBuyId)
+                updateStatusIfAchieved(updatedGroupBuy)
 
-            // TODO(MCJ-1448): 결제 시스템 연동
-            // 결제 요청 생성/승인/검증 로직 연결
-            // 결제 진입 직전 최종 재검증 연결
+                val participation = createParticipation(user, groupBuy, request.quantity)
 
-            log.info(
-                "[ParticipationService] 참여 생성 완료: participationId={}, groupBuyId={}, quantity={}",
-                participation.id, groupBuyId, request.quantity
-            )
-            return toCreatedResponse(participation, groupBuy)
+                // TODO(MCJ-1448): 결제 시스템 연동
+                // 결제 요청 생성/승인/검증 로직 연결
+                // 결제 진입 직전 최종 재검증 연결
+
+                log.info(
+                    "[ParticipationService] 참여 생성 완료: participationId={}, groupBuyId={}, quantity={}",
+                    participation.id, groupBuyId, request.quantity
+                )
+                toCreatedResponse(participation, groupBuy)
+            }
+
+            return response
         } finally {
             releaseLock(key, token)
         }

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
@@ -17,7 +17,6 @@ import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
-import java.time.LocalDateTime
 
 @Service
 class ParticipationService(
@@ -144,14 +143,6 @@ class ParticipationService(
                 groupBuy.id, groupBuy.status
             )
             throw CustomException(ErrorCode.GROUPBUY_NOT_RECRUITING)
-        }
-
-        if (!LocalDateTime.now().isBefore(groupBuy.deadline)) {
-            log.warn(
-                "[ParticipationService] 참여 불가 - 마감 지남: groupBuyId={}, deadline={}",
-                groupBuy.id, groupBuy.deadline
-            )
-            throw CustomException(ErrorCode.GROUPBUY_DEADLINE_PASSED)
         }
 
         if (quantity <= 0) {

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
@@ -33,6 +33,10 @@ class ParticipationService(
         groupBuyId: Long,
         request: ParticipationCreateRequest
     ): ParticipationCreatedResponse {
+        if (participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)) {
+            throw CustomException(ErrorCode.GROUPBUY_ALREADY_PARTICIPATED)
+        }
+
         val key = redisLockUtil.lockKey(groupBuyId)
         val token = redisLockUtil.tryLockOrThrow(key, waitMs = 500, leaseMs = 3_000)
 

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
@@ -45,20 +45,18 @@ class ParticipationService(
 
             validateCanParticipate(groupBuy, request.quantity)
 
-            // TODO(MCJ-1448): 조건부 차감 쿼리로 교체
-            //  - where id = :groupBuyId and (max_quantity - current_quantity) >= :quantity
-            //  - update current_quantity = current_quantity + :quantity
-            val remaining = groupBuy.maxQuantity - groupBuy.currentQuantity
-            if (remaining < request.quantity) {
+            val updatedRows = groupBuyRepository.increaseCurrentQuantityIfAvailable(groupBuyId, request.quantity)
+            if (updatedRows == 0) {
                 log.warn(
-                    "[ParticipationService] 참여 불가 - 수량 부족: groupBuyId={}, remaining={}, requestQty={}",
-                    groupBuyId, remaining, request.quantity
+                    "[ParticipationService] 참여 불가 - 조건부 차감 실패: groupBuyId={}, requestQuantity={}",
+                    groupBuyId, request.quantity
                 )
                 throw CustomException(ErrorCode.GROUPBUY_SOLD_OUT)
             }
 
-            groupBuy.currentQuantity += request.quantity
-            updateStatusIfAchieved(groupBuy)
+            val updatedGroupBuy = groupBuyRepository.findById(groupBuyId)
+                .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+            updateStatusIfAchieved(updatedGroupBuy)
 
             val productAmount = groupBuy.price * request.quantity
             val feeAmount = 0

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/ParticipationCreateRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/ParticipationCreateRequest.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.participation.application.dto
+
+import jakarta.validation.constraints.Min
+
+data class ParticipationCreateRequest(
+    @field:Min(1, message = "수량은 1개 이상이어야 합니다.")
+    val quantity: Int
+)

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/ParticipationCreatedResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/ParticipationCreatedResponse.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.participation.application.dto
+
+data class ParticipationCreatedResponse(
+    val participationId: Long,
+    val orderName: String,
+    val totalAmount: Int,
+    val productAmount: Int,
+    val feeAmount: Int
+)

--- a/src/main/kotlin/com/moongchijang/domain/participation/presentation/ParticipationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/presentation/ParticipationController.kt
@@ -1,0 +1,82 @@
+package com.moongchijang.domain.participation.presentation
+
+import com.moongchijang.domain.participation.application.ParticipationService
+import com.moongchijang.domain.participation.application.dto.ParticipationCreateRequest
+import com.moongchijang.domain.participation.application.dto.ParticipationCreatedResponse
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/group-buys")
+@Tag(name = "Participation", description = "공구 참여")
+class ParticipationController(
+    private val participationService: ParticipationService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/{groupBuyId}/participations")
+    @Operation(summary = "공구 참여")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "201", description = "공구 참여 성공"),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (수량, 마감, 상태 등)",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구/사용자 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "409",
+                description = "중복 참여/수량 부족/락 획득 실패",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun createParticipation(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable groupBuyId: Long,
+        @Valid @RequestBody request: ParticipationCreateRequest
+    ): ResponseEntity<ApiResponse<ParticipationCreatedResponse>> {
+        log.info(
+            "[ParticipationController] 공구 참여 요청 수신: userId={}, groupBuyId={}, quantity={}",
+            principal.id, groupBuyId, request.quantity
+        )
+
+        val response = participationService.createParticipation(
+            userId = principal.id,
+            groupBuyId = groupBuyId,
+            request = request
+        )
+
+        log.info(
+            "[ParticipationController] 공구 참여 응답 완료: userId={}, groupBuyId={}, participationId={}",
+            principal.id, groupBuyId, response.participationId
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -89,4 +89,6 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_FEED_TOO_MANY_DISTRICTS(400_300, "지역 필터는 최대 10개까지 선택할 수 있습니다.", 400),
     GROUPBUY_FEED_INVALID_DISTRICT_COMBINATION(400_301, "같은 지역의 전체/하위 세부지역은 동시에 선택할 수 없습니다.", 400),
     GROUPBUY_NOT_FOUND(404_302, "공구를 찾을 수 없습니다.", 404),
+    GROUPBUY_LOCK_ACQUISITION_FAILED(409_300, "요청이 많아 잠시 처리 지연 중입니다. 잠시 후 다시 시도해주세요.", 409),
+    GROUPBUY_LOCK_INTERRUPTED(500_300, "요청 처리 중 일시적인 오류가 발생했습니다.", 500),
 }

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -89,6 +89,9 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_FEED_TOO_MANY_DISTRICTS(400_300, "지역 필터는 최대 10개까지 선택할 수 있습니다.", 400),
     GROUPBUY_FEED_INVALID_DISTRICT_COMBINATION(400_301, "같은 지역의 전체/하위 세부지역은 동시에 선택할 수 없습니다.", 400),
     GROUPBUY_NOT_FOUND(404_302, "공구를 찾을 수 없습니다.", 404),
+    GROUPBUY_NOT_RECRUITING(400_303, "모집중인 공구만 참여할 수 있습니다.", 400),
+    GROUPBUY_DEADLINE_PASSED(400_304, "마감된 공구예요.", 400),
+    GROUPBUY_SOLD_OUT(409_305, "참여 가능한 수량이 부족합니다.", 409),
     GROUPBUY_LOCK_ACQUISITION_FAILED(409_300, "요청이 많아 잠시 처리 지연 중입니다. 잠시 후 다시 시도해주세요.", 409),
     GROUPBUY_LOCK_INTERRUPTED(500_300, "요청 처리 중 일시적인 오류가 발생했습니다.", 500),
 }

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -92,6 +92,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_NOT_RECRUITING(400_303, "모집중인 공구만 참여할 수 있습니다.", 400),
     GROUPBUY_DEADLINE_PASSED(400_304, "마감된 공구예요.", 400),
     GROUPBUY_SOLD_OUT(409_305, "참여 가능한 수량이 부족합니다.", 409),
+    GROUPBUY_ALREADY_PARTICIPATED(409_306, "이미 참여한 공구예요.", 409),
     GROUPBUY_LOCK_ACQUISITION_FAILED(409_300, "요청이 많아 잠시 처리 지연 중입니다. 잠시 후 다시 시도해주세요.", 409),
     GROUPBUY_LOCK_INTERRUPTED(500_300, "요청 처리 중 일시적인 오류가 발생했습니다.", 500),
 }

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.http.HttpMethod
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -39,9 +40,15 @@ class SecurityConfig(
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
                 ).permitAll()
+                it.requestMatchers(
+                    HttpMethod.GET,
+                    "/api/v1/group-buys",
+                    "/api/v1/group-buys/*",
+                    "/api/v1/group-buys/progress",
+                    "/api/v1/group-buys/*/progress",
+                ).permitAll()
 
-                // 개발 진행 시에는 모든 경로 허용 후 실제 배포 시 변경 필요
-                it.anyRequest().permitAll()
+                it.anyRequest().authenticated()
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .formLogin { it.disable() }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2350,22 +2350,11 @@ components:
     # ── Participation ──────────────────────────────────────────
     ParticipationCreate:
       type: object
-      required: [quantity, agreedTerms]
+      required: [quantity]
       properties:
         quantity:
           type: integer
           minimum: 1
-        agreedTerms:
-          type: array
-          items:
-            type: string
-            enum:
-              - NO_CANCEL_AFTER_ACHIEVED
-              - FULL_REFUND_BEFORE_ACHIEVED
-              - NO_REFUND_IF_NOT_PICKED_UP
-              - NO_WITHDRAWAL_RIGHT
-          minItems: 4
-          description: 4개 항목 모두 포함 필수
 
     ApiResponseParticipationCreated:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationServiceTest.kt
@@ -1,0 +1,188 @@
+package com.moongchijang.domain.participation.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.domain.participation.application.dto.ParticipationCreateRequest
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.ParticipationFixture.createGroupBuy
+import com.moongchijang.support.ParticipationFixture.createUser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class ParticipationServiceTest {
+
+    @Mock
+    private lateinit var redisLockUtil: RedisLockUtil
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @InjectMocks
+    private lateinit var service: ParticipationService
+
+    @Test
+    fun `이미 참여한 공구면 GROUPBUY_ALREADY_PARTICIPATED 예외 발생`() {
+        val userId = 1L
+        val groupBuyId = 10L
+        val request = ParticipationCreateRequest(quantity = 1)
+
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(true)
+
+        val ex = assertThrows<CustomException> {
+            service.createParticipation(userId, groupBuyId, request)
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_ALREADY_PARTICIPATED, ex.errorCode)
+        verify(redisLockUtil, never()).lockKey(groupBuyId)
+    }
+
+    @Test
+    fun `모집중 상태가 아니면 GROUPBUY_NOT_RECRUITING 예외 발생`() {
+        val userId = 1L
+        val groupBuyId = 11L
+        val request = ParticipationCreateRequest(quantity = 1)
+        val key = "groupBuy:$groupBuyId"
+        val token = "token-1"
+        val user = createUser(userId)
+        val closedGroupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.CLOSED)
+
+        stubBase(userId, groupBuyId, key, token, user, closedGroupBuy)
+
+        val ex = assertThrows<CustomException> {
+            service.createParticipation(userId, groupBuyId, request)
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_NOT_RECRUITING, ex.errorCode)
+        verify(redisLockUtil).unlock(key, token)
+    }
+
+    @Test
+    fun `마감된 공구면 GROUPBUY_DEADLINE_PASSED 예외 발생`() {
+        val userId = 1L
+        val groupBuyId = 12L
+        val request = ParticipationCreateRequest(quantity = 1)
+        val key = "groupBuy:$groupBuyId"
+        val token = "token-2"
+        val user = createUser(userId)
+        val expiredGroupBuy = createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = LocalDateTime.now().minusMinutes(1)
+        )
+
+        stubBase(userId, groupBuyId, key, token, user, expiredGroupBuy)
+
+        val ex = assertThrows<CustomException> {
+            service.createParticipation(userId, groupBuyId, request)
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_DEADLINE_PASSED, ex.errorCode)
+        verify(redisLockUtil).unlock(key, token)
+    }
+
+    @Test
+    fun `조건부 차감 실패면 GROUPBUY_SOLD_OUT 예외 발생`() {
+        val userId = 1L
+        val groupBuyId = 13L
+        val request = ParticipationCreateRequest(quantity = 2)
+        val key = "groupBuy:$groupBuyId"
+        val token = "token-3"
+        val user = createUser(userId)
+        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
+
+        stubBase(userId, groupBuyId, key, token, user, groupBuy)
+        `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(groupBuyId, request.quantity)).thenReturn(0)
+
+        val ex = assertThrows<CustomException> {
+            service.createParticipation(userId, groupBuyId, request)
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_SOLD_OUT, ex.errorCode)
+        verify(redisLockUtil).unlock(key, token)
+    }
+
+    @Test
+    fun `참여 성공 시 응답 반환 및 목표 달성 상태 전이`() {
+        val userId = 1L
+        val groupBuyId = 14L
+        val request = ParticipationCreateRequest(quantity = 2)
+        val key = "groupBuy:$groupBuyId"
+        val token = "token-4"
+        val user = createUser(userId)
+        val beforeUpdate = createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.IN_PROGRESS,
+            currentQuantity = 3,
+            targetQuantity = 5,
+            price = 6000
+        )
+        val afterUpdate = createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.IN_PROGRESS,
+            currentQuantity = 5,
+            targetQuantity = 5,
+            price = 6000
+        )
+
+        stubBase(userId, groupBuyId, key, token, user, beforeUpdate)
+        `when`(groupBuyRepository.findById(groupBuyId)).thenReturn(Optional.of(beforeUpdate), Optional.of(afterUpdate))
+        `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(groupBuyId, request.quantity)).thenReturn(1)
+        `when`(participationRepository.save(any(Participation::class.java))).thenAnswer { invocation ->
+            val saved = invocation.getArgument<Participation>(0)
+            saved.id = 999L
+            saved
+        }
+
+        val result = service.createParticipation(userId, groupBuyId, request)
+
+        assertEquals(999L, result.participationId)
+        assertEquals("두쫀쿠 2개", result.orderName)
+        assertEquals(12_000, result.productAmount)
+        assertEquals(12_000, result.totalAmount)
+        assertEquals(0, result.feeAmount)
+        assertTrue(afterUpdate.status == GroupBuyStatus.ACHIEVED)
+        verify(redisLockUtil).unlock(key, token)
+    }
+
+    private fun stubBase(
+        userId: Long,
+        groupBuyId: Long,
+        key: String,
+        token: String,
+        user: User,
+        groupBuy: GroupBuy
+    ) {
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+        `when`(redisLockUtil.lockKey(groupBuyId)).thenReturn(key)
+        `when`(redisLockUtil.tryLockOrThrow(key, 500, 3_000)).thenReturn(token)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(user)
+        `when`(groupBuyRepository.findById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+        `when`(redisLockUtil.unlock(key, token)).thenReturn(true)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationServiceTest.kt
@@ -97,7 +97,7 @@ class ParticipationServiceTest {
     }
 
     @Test
-    fun `마감된 공구면 GROUPBUY_DEADLINE_PASSED 예외 발생`() {
+    fun `마감된 공구는 조건부 차감 실패로 GROUPBUY_SOLD_OUT 예외 발생`() {
         val userId = 1L
         val groupBuyId = 12L
         val request = ParticipationCreateRequest(quantity = 1)
@@ -116,7 +116,7 @@ class ParticipationServiceTest {
             service.createParticipation(userId, groupBuyId, request)
         }
 
-        assertEquals(ErrorCode.GROUPBUY_DEADLINE_PASSED, ex.errorCode)
+        assertEquals(ErrorCode.GROUPBUY_SOLD_OUT, ex.errorCode)
         verify(redisLockUtil).unlock(key, token)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationServiceTest.kt
@@ -21,10 +21,14 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.any
-import org.mockito.Mockito.never
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.support.TransactionCallback
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 import java.util.Optional
 
@@ -43,6 +47,9 @@ class ParticipationServiceTest {
     @Mock
     private lateinit var userRepository: UserRepository
 
+    @Mock
+    private lateinit var transactionTemplate: TransactionTemplate
+
     @InjectMocks
     private lateinit var service: ParticipationService
 
@@ -51,7 +58,13 @@ class ParticipationServiceTest {
         val userId = 1L
         val groupBuyId = 10L
         val request = ParticipationCreateRequest(quantity = 1)
+        val key = "groupBuy:$groupBuyId"
+        val token = "token-0"
 
+        `when`(redisLockUtil.lockKey(groupBuyId)).thenReturn(key)
+        `when`(redisLockUtil.tryLockOrThrow(key, 500, 3_000)).thenReturn(token)
+        `when`(redisLockUtil.unlock(key, token)).thenReturn(true)
+        stubTransactionExecute()
         `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(true)
 
         val ex = assertThrows<CustomException> {
@@ -59,7 +72,8 @@ class ParticipationServiceTest {
         }
 
         assertEquals(ErrorCode.GROUPBUY_ALREADY_PARTICIPATED, ex.errorCode)
-        verify(redisLockUtil, never()).lockKey(groupBuyId)
+        verify(redisLockUtil).lockKey(groupBuyId)
+        verify(redisLockUtil).unlock(key, token)
     }
 
     @Test
@@ -181,8 +195,16 @@ class ParticipationServiceTest {
         `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
         `when`(redisLockUtil.lockKey(groupBuyId)).thenReturn(key)
         `when`(redisLockUtil.tryLockOrThrow(key, 500, 3_000)).thenReturn(token)
+        stubTransactionExecute()
         `when`(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(user)
         `when`(groupBuyRepository.findById(groupBuyId)).thenReturn(Optional.of(groupBuy))
         `when`(redisLockUtil.unlock(key, token)).thenReturn(true)
+    }
+
+    private fun stubTransactionExecute() {
+        doAnswer { invocation ->
+            val callback = invocation.getArgument<TransactionCallback<Any?>>(0)
+            callback.doInTransaction(mock(TransactionStatus::class.java))
+        }.`when`(transactionTemplate).execute<Any?>(any())
     }
 }

--- a/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
@@ -1,0 +1,80 @@
+package com.moongchijang.support
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+object ParticipationFixture {
+
+    fun createUser(id: Long): User =
+        User(
+            provider = AuthProvider.EMAIL,
+            providerId = null,
+            email = "user$id@example.com",
+            passwordHash = "hashed",
+            nickname = "user$id",
+            phoneNumber = "01000000000",
+            role = UserRole.BUYER,
+            signupCompleted = true,
+            deletedAt = null,
+            id = id,
+        )
+
+    fun createGroupBuy(
+        id: Long,
+        status: GroupBuyStatus,
+        deadline: LocalDateTime = LocalDateTime.now().plusDays(1),
+        currentQuantity: Int = 1,
+        targetQuantity: Int = 10,
+        price: Int = 5000
+    ): GroupBuy {
+        return GroupBuy(
+            store = createStore(),
+            groupBuyRequest = createGroupBuyRequest(),
+            thumbnailUrl = null,
+            productName = "두쫀쿠",
+            productDescription = "설명",
+            price = price,
+            targetQuantity = targetQuantity,
+            currentQuantity = currentQuantity,
+            maxQuantity = 100,
+            status = status,
+            deadline = deadline,
+            pickupDate = LocalDate.now().plusDays(2),
+            pickupTimeStart = LocalTime.of(14, 0),
+            pickupTimeEnd = LocalTime.of(16, 0),
+            pickupLocation = "서울",
+            shareCount = 0,
+            id = id
+        )
+    }
+
+    fun createStore(): Store =
+        Store(
+            name = "테스트 매장",
+            address = "서울 성동구",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN,
+            id = 1L
+        )
+
+    fun createGroupBuyRequest(): GroupBuyRequest =
+        GroupBuyRequest(
+            userId = 1L,
+            storeName = "테스트 매장",
+            storeAddress = "서울 성동구",
+            productName = "두쫀쿠",
+            desiredQuantity = 10,
+            desiredPickupDate = LocalDate.now().plusDays(3),
+            id = 1L
+        )
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 공구 참여 생성 흐름을 구현했습니다.
- 동시성 제어는 `Redis Lock`만으로 의존하지 않고, DB 조건부 차감을 함께 적용해 **애플리케이션/DB 이중 방어** 구조로 설계했습니다.
- 참여 반영 이후 목표 수량 도달 시 공구 상태를 `ACHIEVED`로 전이하도록 구성했습니다.
- `@Transactional` 메서드 단위 처리 대신 `TransactionTemplate`으로 트랜잭션 범위를 명시적으로 분리해, 락 획득 후 트랜잭션 실행 및 커밋 완료 이후 락 해제가 되도록 순서를 보완했습니다.
   - 락이 트랜잭션 커밋 전에 해제되며 발생할 수 있는 경합 구간을 줄이기 위함 
- 중복 참여는 사용자 경험(빠른 실패 응답)을 위해 서비스 선체크를 두고, 최종 무결성은 DB 유니크 제약으로 보완했습니다.

## 🔍 참고 사항
- 이번 PR에서 가장 중요하게 본 부분은 **동시 요청 시 초과 참여 방지**입니다.
- 구현 고민 포인트:
   - `Redis Lock`만으로 끝내지 않고 DB 조건부 차감을 함께 둬서 이중 안전장치를 두는 방향이 맞는지
   - 상태 전이(`IN_PROGRESS` -> `ACHIEVED`) 시점을 참여 반영 직후로 두는 현재 구조가 적절한지
   - 중복 참여는 서비스 선체크 + DB 유니크 제약(최종 방어) 조합으로 가져가는 방식이 적절한지
- 결제 연동은 범위에서 제외했고, 연동 지점만 TODO로 남겨뒀습니다.
- 락 대기/만료 시간(wait/lease)과 락 획득 실패 처리 방식은 우선 기본값으로 넣어두었는데, 이 값들이 적절한지 궁금합니다.
  - 추가로, 제미나이 코드리뷰에서 현재 스핀 락(`Thread.sleep` 재시도) 방식은 대기 스레드가 많아질 때 컨텍스트 스위칭 비용과 Redis 부하가 커질 수 있다는 피드백을 받았습니다.
   - 향후 트래픽 증가를 고려하면 Pub/Sub 기반 대기를 지원하는 Redisson 도입도 검토 포인트로 보이는데, 현재 단계에서 이 방향까지 가져가는 게 적절한지 의견 부탁드립니다.


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #86 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인