### PR TITLE
[MCJ-1449] FEAT: 공구 상세 활성 조회자 heartbeat API 및 TTL 집계 도입

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
@@ -45,7 +45,6 @@ class GroupBuyViewerService(
         return response
     }
 
-    @Transactional
     fun heartbeat(groupBuyId: Long, userId: Long?, viewerSessionId: String): GroupBuyViewerCountResponse {
         log.info(
             "[GroupBuyViewerService] heartbeat 처리 시작: groupBuyId={}, userId={}, viewerSessionId={}",

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
@@ -1,0 +1,90 @@
+package com.moongchijang.domain.groupbuy.application
+
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerCountResponse
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyViewerCountRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class GroupBuyViewerService(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val groupBuyViewerCountRepository: GroupBuyViewerCountRepository,
+) {
+    companion object {
+        private const val ACTIVE_VIEWER_TTL_SECONDS = 90L
+        private const val FOMO_THRESHOLD = 10
+    }
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(readOnly = true)
+    fun getActiveViewerCount(groupBuyId: Long): GroupBuyViewerCountResponse {
+        log.info("[GroupBuyViewerService] 활성 조회자 수 조회 시작: groupBuyId={}", groupBuyId)
+        ensureGroupBuyExists(groupBuyId)
+
+        val now = Instant.now().epochSecond
+        val count = groupBuyViewerCountRepository
+            .countActive(groupBuyId, now, ACTIVE_VIEWER_TTL_SECONDS)
+            .toInt()
+
+        val response = GroupBuyViewerCountResponse(
+            activeViewerCount = count,
+            showFomoBadge = count >= FOMO_THRESHOLD,
+            threshold = FOMO_THRESHOLD
+        )
+
+        log.info(
+            "[GroupBuyViewerService] 활성 조회자 수 조회 완료: groupBuyId={}, activeViewerCount={}, showFomoBadge={}",
+            groupBuyId, response.activeViewerCount, response.showFomoBadge
+        )
+        return response
+    }
+
+    @Transactional
+    fun heartbeat(groupBuyId: Long, userId: Long?, viewerSessionId: String): GroupBuyViewerCountResponse {
+        log.info(
+            "[GroupBuyViewerService] heartbeat 처리 시작: groupBuyId={}, userId={}, viewerSessionId={}",
+            groupBuyId, userId, viewerSessionId
+        )
+        ensureGroupBuyExists(groupBuyId)
+
+        val now = Instant.now().epochSecond
+        val viewerKey = if (userId != null) "user:$userId" else "session:$viewerSessionId"
+
+        groupBuyViewerCountRepository.touch(
+            groupBuyId = groupBuyId,
+            viewerKey = viewerKey,
+            nowEpochSeconds = now,
+            ttlSeconds = ACTIVE_VIEWER_TTL_SECONDS
+        )
+
+        val count = groupBuyViewerCountRepository
+            .countActive(groupBuyId, now, ACTIVE_VIEWER_TTL_SECONDS)
+            .toInt()
+
+        val response = GroupBuyViewerCountResponse(
+            activeViewerCount = count,
+            showFomoBadge = count >= FOMO_THRESHOLD,
+            threshold = FOMO_THRESHOLD
+        )
+
+        log.info(
+            "[GroupBuyViewerService] heartbeat 처리 완료: groupBuyId={}, viewerKey={}, activeViewerCount={}, showFomoBadge={}",
+            groupBuyId, viewerKey, response.activeViewerCount, response.showFomoBadge
+        )
+        return response
+    }
+
+    private fun ensureGroupBuyExists(groupBuyId: Long) {
+        if (!groupBuyRepository.existsById(groupBuyId)) {
+            log.warn("[GroupBuyViewerService] 공구 없음: groupBuyId={}", groupBuyId)
+            throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
@@ -1,7 +1,6 @@
 package com.moongchijang.domain.groupbuy.application
 
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerCountResponse
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyViewerCountRepository
 import com.moongchijang.global.exception.CustomException
@@ -57,16 +56,12 @@ class GroupBuyViewerService(
         val now = Instant.now().epochSecond
         val viewerKey = if (userId != null) "user:$userId" else "session:$viewerSessionId"
 
-        groupBuyViewerCountRepository.touch(
+        val count = groupBuyViewerCountRepository.touchAndCount(
             groupBuyId = groupBuyId,
             viewerKey = viewerKey,
             nowEpochSeconds = now,
             ttlSeconds = ACTIVE_VIEWER_TTL_SECONDS
-        )
-
-        val count = groupBuyViewerCountRepository
-            .countActive(groupBuyId, now, ACTIVE_VIEWER_TTL_SECONDS)
-            .toInt()
+        ).toInt()
 
         val response = GroupBuyViewerCountResponse(
             activeViewerCount = count,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyViewerService.kt
@@ -6,18 +6,24 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyViewerCountRep
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.Duration
 
 @Service
 class GroupBuyViewerService(
     private val groupBuyRepository: GroupBuyRepository,
     private val groupBuyViewerCountRepository: GroupBuyViewerCountRepository,
+    private val redisTemplate: StringRedisTemplate,
 ) {
     companion object {
         private const val ACTIVE_VIEWER_TTL_SECONDS = 90L
         private const val FOMO_THRESHOLD = 10
+        private const val EXISTS_CACHE_TTL_SECONDS = 120L
+        private const val EXISTS_CACHE_TRUE = "1"
+        private const val EXISTS_CACHE_FALSE = "0"
     }
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -76,9 +82,27 @@ class GroupBuyViewerService(
     }
 
     private fun ensureGroupBuyExists(groupBuyId: Long) {
-        if (!groupBuyRepository.existsById(groupBuyId)) {
+        val cacheKey = existsCacheKey(groupBuyId)
+        val cached = redisTemplate.opsForValue().get(cacheKey)
+
+        if (cached == EXISTS_CACHE_TRUE) return
+        if (cached == EXISTS_CACHE_FALSE) {
+            log.warn("[GroupBuyViewerService] 공구 없음: groupBuyId={}", groupBuyId)
+            throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
+        }
+
+        val exists = groupBuyRepository.existsById(groupBuyId)
+        redisTemplate.opsForValue().set(
+            cacheKey,
+            if (exists) EXISTS_CACHE_TRUE else EXISTS_CACHE_FALSE,
+            Duration.ofSeconds(EXISTS_CACHE_TTL_SECONDS)
+        )
+
+        if (!exists) {
             log.warn("[GroupBuyViewerService] 공구 없음: groupBuyId={}", groupBuyId)
             throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
         }
     }
+
+    private fun existsCacheKey(groupBuyId: Long): String = "groupBuy:exists:$groupBuyId"
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyViewerCountResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyViewerCountResponse.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "공구 상세 활성 조회자 수 응답")
+data class GroupBuyViewerCountResponse(
+
+    @field:Schema(description = "현재 활성 조회자 수", example = "12")
+    val activeViewerCount: Int,
+
+    @field:Schema(
+        description = "FOMO 문구/뱃지 노출 여부 (activeViewerCount >= threshold)",
+        example = "true"
+    )
+    val showFomoBadge: Boolean,
+
+    @field:Schema(description = "FOMO 노출 기준 인원 수", example = "10")
+    val threshold: Int
+)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyViewerHeartbeatRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyViewerHeartbeatRequest.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "공구 상세 조회자 heartbeat 요청")
+data class GroupBuyViewerHeartbeatRequest(
+    @field:Schema(
+        description = "클라이언트가 생성/보관하는 조회 세션 식별자(UUID 권장)",
+        example = "c89f364e-ef03-40f8-905f-f9a4de2d6d5e"
+    )
+    @field:NotBlank(message = "viewerSessionId는 필수입니다.")
+    @field:Size(min = 8, max = 128, message = "viewerSessionId는 8~128자여야 합니다.")
+    val viewerSessionId: String
+)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyViewerCountRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyViewerCountRepository.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.groupbuy.domain.repository
+
+interface GroupBuyViewerCountRepository {
+
+    fun touch(groupBuyId: Long, viewerKey: String, nowEpochSeconds: Long, ttlSeconds: Long)
+    fun countActive(groupBuyId: Long, nowEpochSeconds: Long, ttlSeconds: Long): Long
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyViewerCountRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyViewerCountRepository.kt
@@ -1,7 +1,6 @@
 package com.moongchijang.domain.groupbuy.domain.repository
 
 interface GroupBuyViewerCountRepository {
-
-    fun touch(groupBuyId: Long, viewerKey: String, nowEpochSeconds: Long, ttlSeconds: Long)
+    fun touchAndCount(groupBuyId: Long, viewerKey: String, nowEpochSeconds: Long, ttlSeconds: Long): Long
     fun countActive(groupBuyId: Long, nowEpochSeconds: Long, ttlSeconds: Long): Long
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/RedisGroupBuyViewerCountRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/RedisGroupBuyViewerCountRepository.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.groupbuy.domain.repository
 
 import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
 import org.springframework.stereotype.Repository
 import java.time.Duration
 
@@ -9,13 +10,20 @@ class RedisGroupBuyViewerCountRepository(
     private val redisTemplate: StringRedisTemplate,
 ) : GroupBuyViewerCountRepository {
 
-    override fun touch(groupBuyId: Long, viewerKey: String, nowEpochSeconds: Long, ttlSeconds: Long) {
+    override fun touchAndCount(groupBuyId: Long, viewerKey: String, nowEpochSeconds: Long, ttlSeconds: Long): Long {
         val key = key(groupBuyId)
-        val ops = redisTemplate.opsForZSet()
+        val expireBefore = (nowEpochSeconds - ttlSeconds).toString()
+        val keyTtlSeconds = (ttlSeconds * 2).toString()
 
-        pruneExpired(key, nowEpochSeconds, ttlSeconds)
-        ops.add(key, viewerKey, nowEpochSeconds.toDouble())
-        redisTemplate.expire(key, Duration.ofSeconds(ttlSeconds * 2))
+        val count = redisTemplate.execute(
+            TOUCH_AND_COUNT_SCRIPT,
+            listOf(key),
+            expireBefore,
+            viewerKey,
+            nowEpochSeconds.toString(),
+            keyTtlSeconds
+        )
+        return count ?: 0L
     }
 
     override fun countActive(groupBuyId: Long, nowEpochSeconds: Long, ttlSeconds: Long): Long {
@@ -32,4 +40,16 @@ class RedisGroupBuyViewerCountRepository(
     }
 
     private fun key(groupBuyId: Long): String = "groupBuy:viewers:$groupBuyId"
+
+    companion object {
+        private val TOUCH_AND_COUNT_SCRIPT = DefaultRedisScript<Long>().apply {
+            resultType = Long::class.java
+            setScriptText("""
+                redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+                redis.call('ZADD', KEYS[1], ARGV[3], ARGV[2])
+                redis.call('EXPIRE', KEYS[1], ARGV[4])
+                return redis.call('ZCARD', KEYS[1])
+            """.trimIndent())
+        }
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/RedisGroupBuyViewerCountRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/RedisGroupBuyViewerCountRepository.kt
@@ -1,0 +1,35 @@
+package com.moongchijang.domain.groupbuy.domain.repository
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Duration
+
+@Repository
+class RedisGroupBuyViewerCountRepository(
+    private val redisTemplate: StringRedisTemplate,
+) : GroupBuyViewerCountRepository {
+
+    override fun touch(groupBuyId: Long, viewerKey: String, nowEpochSeconds: Long, ttlSeconds: Long) {
+        val key = key(groupBuyId)
+        val ops = redisTemplate.opsForZSet()
+
+        pruneExpired(key, nowEpochSeconds, ttlSeconds)
+        ops.add(key, viewerKey, nowEpochSeconds.toDouble())
+        redisTemplate.expire(key, Duration.ofSeconds(ttlSeconds * 2))
+    }
+
+    override fun countActive(groupBuyId: Long, nowEpochSeconds: Long, ttlSeconds: Long): Long {
+        val key = key(groupBuyId)
+        val ops = redisTemplate.opsForZSet()
+
+        pruneExpired(key, nowEpochSeconds, ttlSeconds)
+        return ops.zCard(key) ?: 0L
+    }
+
+    private fun pruneExpired(key: String, nowEpochSeconds: Long, ttlSeconds: Long) {
+        val expireBefore = (nowEpochSeconds - ttlSeconds).toDouble()
+        redisTemplate.opsForZSet().removeRangeByScore(key, Double.NEGATIVE_INFINITY, expireBefore)
+    }
+
+    private fun key(groupBuyId: Long): String = "groupBuy:viewers:$groupBuyId"
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -98,38 +98,11 @@ class GroupBuyController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
-    @GetMapping("/{groupBuyId}/viewers/count")
-    @Operation(summary = "공구 상세 활성 조회자 수 조회")
-    @ApiResponses(
-        value = [
-            SwaggerApiResponse(responseCode = "200", description = "활성 조회자 수 조회 성공"),
-            SwaggerApiResponse(
-                responseCode = "404",
-                description = "공구를 찾을 수 없음",
-                content = [Content(schema = Schema(implementation = ApiResponse::class))]
-            )
-        ]
-    )
-    fun getViewerCount(
-        @PathVariable groupBuyId: Long
-    ): ResponseEntity<ApiResponse<GroupBuyViewerCountResponse>> {
-        log.info("[GroupBuyController] 활성 조회자 수 조회 요청 수신: groupBuyId={}", groupBuyId)
-
-        val response = groupBuyViewerService.getActiveViewerCount(groupBuyId)
-
-        log.info(
-            "[GroupBuyController] 활성 조회자 수 조회 응답 완료: groupBuyId={}, activeViewerCount={}",
-            groupBuyId,
-            response.activeViewerCount
-        )
-        return ResponseEntity.ok(ApiResponse.success(response))
-    }
-
     @PostMapping("/{groupBuyId}/viewers/heartbeat")
-    @Operation(summary = "공구 상세 조회자 heartbeat 갱신")
+    @Operation(summary = "공구 상세 조회자 heartbeat 조회/갱신")
     @ApiResponses(
         value = [
-            SwaggerApiResponse(responseCode = "200", description = "조회자 heartbeat 갱신 성공"),
+            SwaggerApiResponse(responseCode = "200", description = "조회자 heartbeat 조회/갱신 성공"),
             SwaggerApiResponse(
                 responseCode = "400",
                 description = "잘못된 요청 (viewerSessionId 누락/형식 오류)",

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -1,10 +1,13 @@
 package com.moongchijang.domain.groupbuy.presentation
 
 import com.moongchijang.domain.groupbuy.application.GroupBuyService
+import com.moongchijang.domain.groupbuy.application.GroupBuyViewerService
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyDetailResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedPageResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerCountResponse
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerHeartbeatRequest
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
@@ -14,12 +17,15 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,7 +34,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/group-buys")
 @Tag(name = "GroupBuy", description = "공구 피드/상세/달성률")
 class GroupBuyController(
-    private val groupBuyService: GroupBuyService
+    private val groupBuyService: GroupBuyService,
+    private val groupBuyViewerService: GroupBuyViewerService
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -88,6 +95,76 @@ class GroupBuyController(
         )
 
         log.info("[GroupBuyController] 공구 상세 조회 응답 완료: groupBuyId={}", groupBuyId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{groupBuyId}/viewers/count")
+    @Operation(summary = "공구 상세 활성 조회자 수 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "활성 조회자 수 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getViewerCount(
+        @PathVariable groupBuyId: Long
+    ): ResponseEntity<ApiResponse<GroupBuyViewerCountResponse>> {
+        log.info("[GroupBuyController] 활성 조회자 수 조회 요청 수신: groupBuyId={}", groupBuyId)
+
+        val response = groupBuyViewerService.getActiveViewerCount(groupBuyId)
+
+        log.info(
+            "[GroupBuyController] 활성 조회자 수 조회 응답 완료: groupBuyId={}, activeViewerCount={}",
+            groupBuyId,
+            response.activeViewerCount
+        )
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @PostMapping("/{groupBuyId}/viewers/heartbeat")
+    @Operation(summary = "공구 상세 조회자 heartbeat 갱신")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회자 heartbeat 갱신 성공"),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (viewerSessionId 누락/형식 오류)",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun heartbeatViewer(
+        @PathVariable groupBuyId: Long,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @Valid @RequestBody request: GroupBuyViewerHeartbeatRequest
+    ): ResponseEntity<ApiResponse<GroupBuyViewerCountResponse>> {
+        log.info(
+            "[GroupBuyController] 조회자 heartbeat 요청 수신: groupBuyId={}, userId={}, viewerSessionId={}",
+            groupBuyId,
+            principal?.id,
+            request.viewerSessionId
+        )
+
+        val response = groupBuyViewerService.heartbeat(
+            groupBuyId = groupBuyId,
+            userId = principal?.id,
+            viewerSessionId = request.viewerSessionId
+        )
+
+        log.info(
+            "[GroupBuyController] 조회자 heartbeat 응답 완료: groupBuyId={}, activeViewerCount={}",
+            groupBuyId,
+            response.activeViewerCount
+        )
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -582,6 +582,53 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponseGroupBuyProgress'
 
+  /api/v1/group-buys/{groupBuyId}/viewers/count:
+    get:
+      tags: [GroupBuy]
+      summary: 현재 활성 조회자 수 조회
+      description: |
+        공구 상세 화면 진입 시점에 현재 활성 조회자 수를 조회한다.
+        - 활성 조회자 기준: 최근 heartbeat TTL 내 세션
+        - FOMO 노출 기준: `showFomoBadge=true` (activeViewerCount >= 10)
+      parameters:
+        - $ref: '#/components/parameters/GroupBuyId'
+      responses:
+        '200':
+          description: 현재 활성 조회자 수
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseGroupBuyViewerCount'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/group-buys/{groupBuyId}/viewers/heartbeat:
+    post:
+      tags: [GroupBuy]
+      summary: 활성 조회자 heartbeat 갱신
+      description: |
+        공구 상세 화면 체류 중 일정 주기(예: 20~30초)로 호출하여 활성 조회 상태를 갱신한다.
+        서버는 세션 TTL을 연장하고 최신 활성 조회자 수를 반환한다.
+      parameters:
+        - $ref: '#/components/parameters/GroupBuyId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupBuyViewerHeartbeatRequest'
+      responses:
+        '200':
+          description: heartbeat 처리 결과 및 활성 조회자 수
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseGroupBuyViewerCount'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/group-buys/progress:
     get:
       tags: [GroupBuy]
@@ -2050,6 +2097,40 @@ components:
             isClosed: { type: boolean }
             isParticipated: { type: boolean }
             canParticipate: { type: boolean }
+        error: { nullable: true, example: null }
+
+    GroupBuyViewerHeartbeatRequest:
+      type: object
+      required: [viewerSessionId]
+      properties:
+        viewerSessionId:
+          type: string
+          description: 클라이언트가 생성/보관하는 조회 세션 식별자(UUID 권장)
+          minLength: 8
+          maxLength: 128
+          example: c89f364e-ef03-40f8-905f-f9a4de2d6d5e
+
+    ApiResponseGroupBuyViewerCount:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [activeViewerCount, showFomoBadge, threshold]
+          properties:
+            activeViewerCount:
+              type: integer
+              minimum: 0
+              example: 12
+            showFomoBadge:
+              type: boolean
+              description: FOMO 문구/뱃지 노출 여부 (activeViewerCount >= threshold)
+              example: true
+            threshold:
+              type: integer
+              description: 노출 기준 인원 수
+              example: 10
         error: { nullable: true, example: null }
 
     RegionType:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -582,32 +582,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponseGroupBuyProgress'
 
-  /api/v1/group-buys/{groupBuyId}/viewers/count:
-    get:
-      tags: [GroupBuy]
-      summary: 현재 활성 조회자 수 조회
-      description: |
-        공구 상세 화면 진입 시점에 현재 활성 조회자 수를 조회한다.
-        - 활성 조회자 기준: 최근 heartbeat TTL 내 세션
-        - FOMO 노출 기준: `showFomoBadge=true` (activeViewerCount >= 10)
-      parameters:
-        - $ref: '#/components/parameters/GroupBuyId'
-      responses:
-        '200':
-          description: 현재 활성 조회자 수
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseGroupBuyViewerCount'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
   /api/v1/group-buys/{groupBuyId}/viewers/heartbeat:
     post:
       tags: [GroupBuy]
-      summary: 활성 조회자 heartbeat 갱신
+      summary: 활성 조회자 heartbeat 조회/갱신
       description: |
-        공구 상세 화면 체류 중 일정 주기(예: 20~30초)로 호출하여 활성 조회 상태를 갱신한다.
+        공구 상세 화면 진입 시 및 체류 중 일정 주기(예: 20~30초)로 호출한다.
         서버는 세션 TTL을 연장하고 최신 활성 조회자 수를 반환한다.
       parameters:
         - $ref: '#/components/parameters/GroupBuyId'
@@ -619,7 +599,7 @@ paths:
               $ref: '#/components/schemas/GroupBuyViewerHeartbeatRequest'
       responses:
         '200':
-          description: heartbeat 처리 결과 및 활성 조회자 수
+          description: 활성 조회자 수 조회/갱신 결과
           content:
             application/json:
               schema:

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyViewerServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyViewerServiceTest.kt
@@ -17,8 +17,12 @@ import org.mockito.Mockito.anyLong
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.eq
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
 import java.util.concurrent.atomic.AtomicReference
 
 @ExtendWith(MockitoExtension::class)
@@ -30,11 +34,19 @@ class GroupBuyViewerServiceTest {
     @Mock
     private lateinit var groupBuyViewerCountRepository: GroupBuyViewerCountRepository
 
+    @Mock
+    private lateinit var redisTemplate: StringRedisTemplate
+
+    @Mock
+    private lateinit var valueOps: ValueOperations<String, String>
+
     @InjectMocks
     private lateinit var service: GroupBuyViewerService
 
     @Test
     fun `heartbeat 비로그인 사용자 session 키 집계 검증`() {
+        `when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+        `when`(valueOps.get("groupBuy:exists:101")).thenReturn(null)
         `when`(groupBuyRepository.existsById(101L)).thenReturn(true)
         val capturedViewerKey = stubTouchAndCaptureViewerKey(returnCount = 1L)
 
@@ -52,6 +64,8 @@ class GroupBuyViewerServiceTest {
 
     @Test
     fun `heartbeat 로그인 사용자 user 키 집계 검증`() {
+        `when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+        `when`(valueOps.get("groupBuy:exists:102")).thenReturn(null)
         `when`(groupBuyRepository.existsById(102L)).thenReturn(true)
         val capturedViewerKey = stubTouchAndCaptureViewerKey(returnCount = 3L)
 
@@ -68,6 +82,8 @@ class GroupBuyViewerServiceTest {
 
     @Test
     fun `활성 조회자 수 10명 이상 FOMO 뱃지 노출 검증`() {
+        `when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+        `when`(valueOps.get("groupBuy:exists:103")).thenReturn(null)
         stubExistsAndCount(groupBuyId = 103L, count = 12L)
 
         val result = service.heartbeat(
@@ -83,6 +99,8 @@ class GroupBuyViewerServiceTest {
 
     @Test
     fun `존재하지 않는 공구 heartbeat 호출 GROUPBUY_NOT_FOUND 예외 발생 검증`() {
+        `when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+        `when`(valueOps.get("groupBuy:exists:999")).thenReturn(null)
         `when`(groupBuyRepository.existsById(999L)).thenReturn(false)
 
         val ex = assertThrows<CustomException> {
@@ -94,6 +112,23 @@ class GroupBuyViewerServiceTest {
         }
 
         assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
+    }
+
+    @Test
+    fun `존재 여부 캐시 hit 시 DB 조회 우회 검증`() {
+        `when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+        `when`(valueOps.get("groupBuy:exists:104")).thenReturn("1")
+        val capturedViewerKey = stubTouchAndCaptureViewerKey(returnCount = 2L)
+
+        val result = service.heartbeat(
+            groupBuyId = 104L,
+            userId = null,
+            viewerSessionId = "session-cache-hit"
+        )
+
+        assertEquals("session:session-cache-hit", capturedViewerKey.get())
+        assertEquals(2, result.activeViewerCount)
+        verify(groupBuyRepository, never()).existsById(104L)
     }
 
     private fun stubExistsAndCount(groupBuyId: Long, count: Long) {

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyViewerServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyViewerServiceTest.kt
@@ -35,8 +35,8 @@ class GroupBuyViewerServiceTest {
 
     @Test
     fun `heartbeat 비로그인 사용자 session 키 집계 검증`() {
-        stubExistsAndCount(groupBuyId = 101L, count = 1L)
-        val capturedViewerKey = stubTouchAndCaptureViewerKey()
+        `when`(groupBuyRepository.existsById(101L)).thenReturn(true)
+        val capturedViewerKey = stubTouchAndCaptureViewerKey(returnCount = 1L)
 
         val result = service.heartbeat(
             groupBuyId = 101L,
@@ -52,8 +52,8 @@ class GroupBuyViewerServiceTest {
 
     @Test
     fun `heartbeat 로그인 사용자 user 키 집계 검증`() {
-        stubExistsAndCount(groupBuyId = 102L, count = 3L)
-        val capturedViewerKey = stubTouchAndCaptureViewerKey()
+        `when`(groupBuyRepository.existsById(102L)).thenReturn(true)
+        val capturedViewerKey = stubTouchAndCaptureViewerKey(returnCount = 3L)
 
         val result = service.heartbeat(
             groupBuyId = 102L,
@@ -98,15 +98,22 @@ class GroupBuyViewerServiceTest {
 
     private fun stubExistsAndCount(groupBuyId: Long, count: Long) {
         `when`(groupBuyRepository.existsById(groupBuyId)).thenReturn(true)
-        `when`(groupBuyViewerCountRepository.countActive(eq(groupBuyId), anyLong(), eq(90L))).thenReturn(count)
+        `when`(
+            groupBuyViewerCountRepository.touchAndCount(
+                eq(groupBuyId),
+                anyString(),
+                anyLong(),
+                eq(90L)
+            )
+        ).thenReturn(count)
     }
 
-    private fun stubTouchAndCaptureViewerKey(): AtomicReference<String?> {
+    private fun stubTouchAndCaptureViewerKey(returnCount: Long): AtomicReference<String?> {
         val capturedViewerKey = AtomicReference<String?>()
         doAnswer {
             capturedViewerKey.set(it.getArgument(1))
-            null
-        }.`when`(groupBuyViewerCountRepository).touch(anyLong(), anyString(), anyLong(), anyLong())
+            returnCount
+        }.`when`(groupBuyViewerCountRepository).touchAndCount(anyLong(), anyString(), anyLong(), anyLong())
         return capturedViewerKey
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyViewerServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyViewerServiceTest.kt
@@ -1,0 +1,112 @@
+package com.moongchijang.domain.groupbuy.service
+
+import com.moongchijang.domain.groupbuy.application.GroupBuyViewerService
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyViewerCountRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.anyLong
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.eq
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.concurrent.atomic.AtomicReference
+
+@ExtendWith(MockitoExtension::class)
+class GroupBuyViewerServiceTest {
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var groupBuyViewerCountRepository: GroupBuyViewerCountRepository
+
+    @InjectMocks
+    private lateinit var service: GroupBuyViewerService
+
+    @Test
+    fun `heartbeat 비로그인 사용자 session 키 집계 검증`() {
+        stubExistsAndCount(groupBuyId = 101L, count = 1L)
+        val capturedViewerKey = stubTouchAndCaptureViewerKey()
+
+        val result = service.heartbeat(
+            groupBuyId = 101L,
+            userId = null,
+            viewerSessionId = "session-abc-1234"
+        )
+
+        assertEquals("session:session-abc-1234", capturedViewerKey.get())
+        assertEquals(1, result.activeViewerCount)
+        assertFalse(result.showFomoBadge)
+        assertEquals(10, result.threshold)
+    }
+
+    @Test
+    fun `heartbeat 로그인 사용자 user 키 집계 검증`() {
+        stubExistsAndCount(groupBuyId = 102L, count = 3L)
+        val capturedViewerKey = stubTouchAndCaptureViewerKey()
+
+        val result = service.heartbeat(
+            groupBuyId = 102L,
+            userId = 77L,
+            viewerSessionId = "session-ignored"
+        )
+
+        assertEquals("user:77", capturedViewerKey.get())
+        assertEquals(3, result.activeViewerCount)
+        assertFalse(result.showFomoBadge)
+    }
+
+    @Test
+    fun `활성 조회자 수 10명 이상 FOMO 뱃지 노출 검증`() {
+        stubExistsAndCount(groupBuyId = 103L, count = 12L)
+
+        val result = service.heartbeat(
+            groupBuyId = 103L,
+            userId = null,
+            viewerSessionId = "session-fomo-1234"
+        )
+
+        assertEquals(12, result.activeViewerCount)
+        assertTrue(result.showFomoBadge)
+        assertEquals(10, result.threshold)
+    }
+
+    @Test
+    fun `존재하지 않는 공구 heartbeat 호출 GROUPBUY_NOT_FOUND 예외 발생 검증`() {
+        `when`(groupBuyRepository.existsById(999L)).thenReturn(false)
+
+        val ex = assertThrows<CustomException> {
+            service.heartbeat(
+                groupBuyId = 999L,
+                userId = null,
+                viewerSessionId = "session-not-found"
+            )
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
+    }
+
+    private fun stubExistsAndCount(groupBuyId: Long, count: Long) {
+        `when`(groupBuyRepository.existsById(groupBuyId)).thenReturn(true)
+        `when`(groupBuyViewerCountRepository.countActive(eq(groupBuyId), anyLong(), eq(90L))).thenReturn(count)
+    }
+
+    private fun stubTouchAndCaptureViewerKey(): AtomicReference<String?> {
+        val capturedViewerKey = AtomicReference<String?>()
+        doAnswer {
+            capturedViewerKey.set(it.getArgument(1))
+            null
+        }.`when`(groupBuyViewerCountRepository).touch(anyLong(), anyString(), anyLong(), anyLong())
+        return capturedViewerKey
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 공구 상세 활성 조회자 수를 실시간에 가깝게 반영하기 위해 Redis ZSET 기반 heartbeat 집계 로직을 도입했습니다.
- 집계 기준을 최근 **TTL(90초) 내 heartbeat가 갱신된 고유 조회자**로 정의하고, TTL 만료 조회자는 자동 제외되도록 구성했습니다.
- 중복 접속 처리 규칙을 반영했습니다. 
   로그인 사용자는 `user:{userId}` 기준으로, 비로그인 사용자는 `session:{viewerSessionId}` 기준으로 집계합니다.
- 조회 API를 `heartbeat` 단일 엔드포인트로 정리해, 상세 진입 시 1회 호출 + 주기 호출만으로 조회/갱신을 동시에 처리할 수 있도록 했습니다.
- 응답에는 `activeViewerCount`, `showFomoBadge`, `threshold`를 포함해 프론트엔드에서 10명 이상일 때만 문구/뱃지를 노출할 수 있게 했습니다.

## 🔍 참고 사항
- 집계 방식 검토안은 3가지였습니다.
   1. `로그 배치 집계`: 실시간성이 부족해 FOMO 요구사항에 부적합
   2. `입장/퇴장 이벤트 카운팅`: 비정상 이탈 누락 시 과대집계 위험
   3. `heartbeat + TTL`: 실제 체류 흐름 반영과 운영 안정성 측면에서 가장 적합하여 채택

- API 구조도 `count + heartbeat` 분리와 `heartbeat` 단일 API를 비교했으며, 현재 단계에서는 복잡도를 낮추기 위해 단일 API를 선택했습니다.
- 향후 SSE/WebSocket으로 전환하더라도, 현재 집계 코어(세션 식별/TTL/중복 제거)는 그대로 재사용 가능합니다.

## 💡 리뷰 사항
- heartbeat 처리 경로가 `touch + count` 분리 호출이라 Redis round-trip이 늘고, 명령 사이 시점 차로 일시적인 불일치 가능성이 있었습니다.  
  heartbeat 처리 경로를 `touchAndCount` 단일 호출로 바꿨습니다.  
  Redis에서는 Lua로 `ZREMRANGEBYSCORE / ZADD / EXPIRE / ZCARD`를 한 번에 실행하도록 구성해서, 왕복 횟수와 중간 상태 불일치 가능성을 줄였습니다.

- `heartbeat` 메서드가 DB write가 없는 경로임에도 `@Transactional` 경계를 타고 있어 고빈도 호출에서 불필요한 트랜잭션 오버헤드가 발생할 수 있었습니다.  
  `heartbeat` 메서드에서 `@Transactional`을 제거했습니다.  
  이 경로는 DB write가 없고 Redis 갱신 중심이라 JPA 트랜잭션 경계를 유지할 필요가 없다고 판단했습니다.

- heartbeat가 호출마다 `existsById`를 직접 조회해 트래픽 증가 시 DB 부하가 커질 수 있었습니다.  
  heartbeat마다 `existsById`를 직접 치던 부분은 공구 존재 여부 short TTL 캐시를 두는 방식으로 완화했습니다.  
  `groupBuy:exists:{id}` 캐시 hit 시 DB를 건너뛰고, miss일 때만 조회 후 캐시합니다.  
  유효하지 않은 ID 요청 차단은 그대로 유지됩니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #87 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인