### PR TITLE
[MCJ-1463] FEAT: PortOne 결제 연동

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -2,8 +2,10 @@ package com.moongchijang.domain.groupbuy.domain.repository
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -30,4 +32,7 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
         @Param("quantity") quantity: Int,
         @Param("status") status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
     ): Int
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findWithLockById(id: Long): Optional<GroupBuy>
 }

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationService.kt
@@ -50,9 +50,8 @@ class ParticipationService(
 
                 val participation = createParticipation(user, groupBuy, request.quantity)
 
-                // TODO(MCJ-1448): 결제 시스템 연동
-                // 결제 요청 생성/승인/검증 로직 연결
-                // 결제 진입 직전 최종 재검증 연결
+                // 결제 플로우에서는 PaymentService가 결제 승인 이후 참여 생성과 수량 증가를 처리한다.
+                // 이 임시 참여 생성 경로는 결제 연동 전 호환용이며, 결제 적용 화면에서는 payment-orders API를 사용한다.
 
                 log.info(
                     "[ParticipationService] 참여 생성 완료: participationId={}, groupBuyId={}, quantity={}",

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/ParticipationStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/ParticipationStatus.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.participation.domain.entity
 
 enum class ParticipationStatus {
     PENDING,
+    PAID_WAITING_GOAL,
     CONFIRMED,
     CANCELLED,
     REFUNDED

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     fun existsByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Boolean
+
+    fun findByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Participation?
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -24,7 +24,10 @@ import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -37,6 +40,7 @@ class PaymentService(
     private val paymentRepository: PaymentRepository,
     private val portOnePaymentPort: PortOnePaymentPort,
     private val portOneProperties: PortOneProperties,
+    private val transactionManager: PlatformTransactionManager,
 ) {
 
     @Transactional(readOnly = true)
@@ -107,13 +111,18 @@ class PaymentService(
         )
     }
 
-    @Transactional
     fun completePortOnePayment(request: CompletePortOnePaymentRequest): ConfirmPaymentResponse {
-        val order = paymentOrderRepository.findByOrderIdForUpdate(request.paymentId)
+        val order = transactionTemplate().execute {
+            paymentOrderRepository.findByOrderId(request.paymentId)
+        }
             ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
 
         if (order.status == PaymentOrderStatus.APPROVED) {
-            return buildAlreadyApprovedResponse(order)
+            return transactionTemplate().execute {
+                val approvedOrder = paymentOrderRepository.findByOrderIdForUpdate(request.paymentId)
+                    ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+                buildAlreadyApprovedResponse(approvedOrder)
+            } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
         }
         if (order.status != PaymentOrderStatus.READY) {
             throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
@@ -122,16 +131,26 @@ class PaymentService(
             throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
         }
 
-        val paymentResult = getPortOnePaymentOrFailOrder(order)
+        val paymentResult = getPortOnePaymentOrFailOrder(order.orderId)
         if (paymentResult.status != PORTONE_STATUS_PAID) {
-            failOrderFromPortOneStatus(order, paymentResult)
+            updateOrderFromPortOneStatus(order.orderId, paymentResult)
             throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
         }
+        if (paymentResult.totalAmount != order.totalAmount || paymentResult.paymentId != order.orderId) {
+            markOrderFailed(order.orderId)
+            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+        }
 
-        return approvePayment(order, paymentResult)
+        return when (
+            val result = transactionTemplate().execute {
+                approvePayment(request.paymentId, request.amount, paymentResult)
+            } ?: PaymentApprovalResult.Failure(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+        ) {
+            is PaymentApprovalResult.Success -> result.response
+            is PaymentApprovalResult.Failure -> throw CustomException(result.errorCode)
+        }
     }
 
-    @Transactional
     fun handlePortOneWebhook(request: PortOneWebhookRequest) {
         if (request.storeId != null && request.storeId != portOneProperties.storeId) {
             throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
@@ -142,39 +161,57 @@ class PaymentService(
             throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
         }
 
-        val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return
-        val paymentResult = getPortOnePaymentOrFailOrder(order)
+        val order = transactionTemplate().execute {
+            paymentOrderRepository.findByOrderId(paymentId)
+        } ?: return
+        val paymentResult = getPortOnePaymentOrFailOrder(order.orderId)
 
-        when (paymentResult.status) {
-            PORTONE_STATUS_PAID -> {
-                if (order.status != PaymentOrderStatus.APPROVED) {
-                    approvePayment(order, paymentResult)
+        transactionTemplate().execute {
+            val lockedOrder = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
+            when (paymentResult.status) {
+                PORTONE_STATUS_PAID -> {
+                    if (lockedOrder.status != PaymentOrderStatus.APPROVED) {
+                        approvePayment(paymentId, lockedOrder.totalAmount, paymentResult)
+                    }
                 }
-            }
-            PORTONE_STATUS_CANCELLED -> cancelPayment(order, paymentResult, partial = false)
-            PORTONE_STATUS_PARTIAL_CANCELLED -> cancelPayment(order, paymentResult, partial = true)
-            PORTONE_STATUS_FAILED -> {
-                if (order.status == PaymentOrderStatus.READY) {
-                    order.fail(LocalDateTime.now())
+                PORTONE_STATUS_CANCELLED -> cancelPayment(lockedOrder, paymentResult, partial = false)
+                PORTONE_STATUS_PARTIAL_CANCELLED -> cancelPayment(lockedOrder, paymentResult, partial = true)
+                PORTONE_STATUS_FAILED -> {
+                    if (lockedOrder.status == PaymentOrderStatus.READY) {
+                        lockedOrder.fail(LocalDateTime.now())
+                        paymentOrderRepository.save(lockedOrder)
+                    }
                 }
             }
         }
     }
 
-    private fun approvePayment(order: PaymentOrder, paymentResult: PortOnePaymentResult): ConfirmPaymentResponse {
+    private fun approvePayment(
+        paymentId: String,
+        expectedAmount: Int,
+        paymentResult: PortOnePaymentResult
+    ): PaymentApprovalResult {
+        val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+
         if (order.status == PaymentOrderStatus.APPROVED) {
-            return buildAlreadyApprovedResponse(order)
+            return PaymentApprovalResult.Success(buildAlreadyApprovedResponse(order))
         }
         if (order.status != PaymentOrderStatus.READY) {
             throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
         }
+        if (order.totalAmount != expectedAmount) {
+            return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+        }
         if (paymentResult.totalAmount != order.totalAmount) {
             order.fail(LocalDateTime.now())
-            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+            paymentOrderRepository.save(order)
+            return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
         }
         if (paymentResult.paymentId != order.orderId) {
             order.fail(LocalDateTime.now())
-            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+            paymentOrderRepository.save(order)
+            return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
         }
 
         val userId = order.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
@@ -183,11 +220,17 @@ class PaymentService(
         val updatedRows = groupBuyRepository.increaseCurrentQuantityIfAvailable(order.groupBuy.id, order.quantity)
         if (updatedRows == 0) {
             order.fail(LocalDateTime.now())
-            throw CustomException(ErrorCode.PAYMENT_QUANTITY_EXCEEDED)
+            paymentOrderRepository.save(order)
+            return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_QUANTITY_EXCEEDED)
         }
 
         val groupBuy = groupBuyRepository.findById(order.groupBuy.id)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+        val participationStatus = if (groupBuy.currentQuantity >= groupBuy.targetQuantity) {
+            ParticipationStatus.CONFIRMED
+        } else {
+            ParticipationStatus.PAID_WAITING_GOAL
+        }
 
         val participation = participationRepository.save(
             Participation(
@@ -197,7 +240,7 @@ class PaymentService(
                 productAmount = order.productAmount,
                 feeAmount = order.feeAmount,
                 totalAmount = order.totalAmount,
-                status = ParticipationStatus.PAID_WAITING_GOAL,
+                status = participationStatus,
             )
         )
 
@@ -206,10 +249,11 @@ class PaymentService(
         }
         val approvedAt = paymentResult.paidAt ?: LocalDateTime.now()
         order.approve(approvedAt)
+        val approvedOrder = paymentOrderRepository.save(order)
 
         paymentRepository.save(
             Payment(
-                paymentOrder = order,
+                paymentOrder = approvedOrder,
                 pgPaymentId = paymentResult.paymentId,
                 orderId = order.orderId,
                 amount = paymentResult.totalAmount,
@@ -218,45 +262,61 @@ class PaymentService(
             )
         )
 
-        return ConfirmPaymentResponse(
-            paymentId = paymentResult.paymentId,
-            participationId = participation.id,
-            participationStatus = participation.status,
-            displayStatus = displayStatus(participation.status),
-            amount = paymentResult.totalAmount,
-            method = paymentResult.method,
-            approvedAt = approvedAt,
+        return PaymentApprovalResult.Success(
+            ConfirmPaymentResponse(
+                paymentId = paymentResult.paymentId,
+                participationId = participation.id,
+                participationStatus = participation.status,
+                displayStatus = displayStatus(participation.status),
+                amount = paymentResult.totalAmount,
+                method = paymentResult.method,
+                approvedAt = approvedAt,
+            )
         )
     }
 
-    private fun getPortOnePaymentOrFailOrder(order: PaymentOrder): PortOnePaymentResult {
+    private fun getPortOnePaymentOrFailOrder(paymentId: String): PortOnePaymentResult {
         return try {
-            portOnePaymentPort.getPayment(order.orderId)
+            portOnePaymentPort.getPayment(paymentId)
         } catch (e: CustomException) {
-            if (order.status == PaymentOrderStatus.READY) {
-                order.fail(LocalDateTime.now())
-            }
+            markOrderFailed(paymentId)
             throw e
         }
     }
 
-    private fun failOrderFromPortOneStatus(order: PaymentOrder, paymentResult: PortOnePaymentResult) {
-        when (paymentResult.status) {
-            PORTONE_STATUS_CANCELLED -> order.cancel(paymentResult.cancelledAt ?: LocalDateTime.now())
-            PORTONE_STATUS_PARTIAL_CANCELLED -> order.partialCancel(paymentResult.cancelledAt ?: LocalDateTime.now())
-            else -> order.fail(LocalDateTime.now())
+    private fun markOrderFailed(paymentId: String) {
+        requiresNewTransactionTemplate().execute {
+            val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
+            if (order.status == PaymentOrderStatus.READY) {
+                order.fail(LocalDateTime.now())
+                paymentOrderRepository.save(order)
+            }
+        }
+    }
+
+    private fun updateOrderFromPortOneStatus(paymentId: String, paymentResult: PortOnePaymentResult) {
+        requiresNewTransactionTemplate().execute {
+            val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
+            when (paymentResult.status) {
+                PORTONE_STATUS_CANCELLED -> order.cancel(paymentResult.cancelledAt ?: LocalDateTime.now())
+                PORTONE_STATUS_PARTIAL_CANCELLED -> order.partialCancel(paymentResult.cancelledAt ?: LocalDateTime.now())
+                else -> order.fail(LocalDateTime.now())
+            }
+            paymentOrderRepository.save(order)
         }
     }
 
     private fun cancelPayment(order: PaymentOrder, paymentResult: PortOnePaymentResult, partial: Boolean) {
         val cancelledAt = paymentResult.cancelledAt ?: LocalDateTime.now()
+        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+
         if (partial) {
             order.partialCancel(cancelledAt)
         } else {
             order.cancel(cancelledAt)
         }
 
-        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId) ?: return
         if (partial) {
             payment.partialCancel(cancelledAt)
         } else {
@@ -339,6 +399,19 @@ class PaymentService(
             ParticipationStatus.REFUNDED -> "환불 완료"
             ParticipationStatus.PENDING -> "결제 대기"
         }
+    }
+
+    private fun transactionTemplate(): TransactionTemplate =
+        TransactionTemplate(transactionManager)
+
+    private fun requiresNewTransactionTemplate(): TransactionTemplate =
+        TransactionTemplate(transactionManager).apply {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        }
+
+    private sealed interface PaymentApprovalResult {
+        data class Success(val response: ConfirmPaymentResponse) : PaymentApprovalResult
+        data class Failure(val errorCode: ErrorCode) : PaymentApprovalResult
     }
 
     private data class PaymentAmounts(

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -1,0 +1,356 @@
+package com.moongchijang.domain.payment.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.application.dto.CheckoutInfoResponse
+import com.moongchijang.domain.payment.application.dto.CompletePortOnePaymentRequest
+import com.moongchijang.domain.payment.application.dto.ConfirmPaymentResponse
+import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderRequest
+import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderResponse
+import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
+import com.moongchijang.domain.payment.application.port.PortOnePaymentPort
+import com.moongchijang.domain.payment.application.port.PortOnePaymentResult
+import com.moongchijang.domain.payment.domain.entity.Payment
+import com.moongchijang.domain.payment.domain.entity.PaymentOrder
+import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
+import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
+import com.moongchijang.domain.payment.domain.repository.PaymentRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.config.PortOneProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Service
+class PaymentService(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val userRepository: UserRepository,
+    private val participationRepository: ParticipationRepository,
+    private val paymentOrderRepository: PaymentOrderRepository,
+    private val paymentRepository: PaymentRepository,
+    private val portOnePaymentPort: PortOnePaymentPort,
+    private val portOneProperties: PortOneProperties,
+) {
+
+    @Transactional(readOnly = true)
+    fun getCheckoutInfo(groupBuyId: Long, quantity: Int): CheckoutInfoResponse {
+        validateQuantity(quantity)
+        val groupBuy = groupBuyRepository.findWithStoreById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+        validateGroupBuyAvailable(groupBuy)
+        validateRemainingQuantity(groupBuy, quantity)
+
+        val amounts = calculateAmounts(groupBuy.price, quantity)
+        return CheckoutInfoResponse(
+            groupBuyId = groupBuy.id,
+            storeName = groupBuy.store.name,
+            productName = groupBuy.productName,
+            thumbnailUrl = groupBuy.thumbnailUrl,
+            pickupDate = groupBuy.pickupDate,
+            pickupTimeStart = groupBuy.pickupTimeStart,
+            pickupTimeEnd = groupBuy.pickupTimeEnd,
+            unitPrice = groupBuy.price,
+            quantity = quantity,
+            productAmount = amounts.productAmount,
+            feeAmount = amounts.feeAmount,
+            totalAmount = amounts.totalAmount,
+            remainingQuantity = groupBuy.maxQuantity - groupBuy.currentQuantity,
+        )
+    }
+
+    @Transactional
+    fun createPaymentOrder(groupBuyId: Long, userId: Long, request: CreatePaymentOrderRequest): CreatePaymentOrderResponse {
+        validateQuantity(request.quantity)
+        validateAgreements(request)
+
+        val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        val groupBuy = groupBuyRepository.findWithLockById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+        validateGroupBuyAvailable(groupBuy)
+        validateRemainingQuantity(groupBuy, request.quantity)
+        validateNotParticipated(userId, groupBuyId)
+
+        val amounts = calculateAmounts(groupBuy.price, request.quantity)
+        val order = paymentOrderRepository.save(
+            PaymentOrder(
+                orderId = generateOrderId(groupBuyId),
+                user = user,
+                groupBuy = groupBuy,
+                quantity = request.quantity,
+                productAmount = amounts.productAmount,
+                feeAmount = amounts.feeAmount,
+                totalAmount = amounts.totalAmount,
+                agreedNoCancelAfterGoal = request.agreedNoCancelAfterGoal,
+                agreedRefundBeforeGoal = request.agreedRefundBeforeGoal,
+                agreedNoRefundAfterNoShow = request.agreedNoRefundAfterNoShow,
+                agreedNoWithdrawal = request.agreedNoWithdrawal,
+            )
+        )
+
+        return CreatePaymentOrderResponse(
+            paymentId = order.orderId,
+            storeId = portOneProperties.storeId,
+            channelKey = portOneProperties.channelKey,
+            orderName = "${groupBuy.productName} ${request.quantity}개",
+            amount = order.totalAmount,
+            customerName = user.nickname,
+        )
+    }
+
+    @Transactional
+    fun completePortOnePayment(request: CompletePortOnePaymentRequest): ConfirmPaymentResponse {
+        val order = paymentOrderRepository.findByOrderIdForUpdate(request.paymentId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+
+        if (order.status == PaymentOrderStatus.APPROVED) {
+            return buildAlreadyApprovedResponse(order)
+        }
+        if (order.status != PaymentOrderStatus.READY) {
+            throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+        }
+        if (order.totalAmount != request.amount) {
+            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+        }
+
+        val paymentResult = getPortOnePaymentOrFailOrder(order)
+        if (paymentResult.status != PORTONE_STATUS_PAID) {
+            failOrderFromPortOneStatus(order, paymentResult)
+            throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+        }
+
+        return approvePayment(order, paymentResult)
+    }
+
+    @Transactional
+    fun handlePortOneWebhook(request: PortOneWebhookRequest) {
+        if (request.storeId != null && request.storeId != portOneProperties.storeId) {
+            throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+        }
+
+        val paymentId = request.paymentId
+        if (paymentId.isNullOrBlank()) {
+            throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+        }
+
+        val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return
+        val paymentResult = getPortOnePaymentOrFailOrder(order)
+
+        when (paymentResult.status) {
+            PORTONE_STATUS_PAID -> {
+                if (order.status != PaymentOrderStatus.APPROVED) {
+                    approvePayment(order, paymentResult)
+                }
+            }
+            PORTONE_STATUS_CANCELLED -> cancelPayment(order, paymentResult, partial = false)
+            PORTONE_STATUS_PARTIAL_CANCELLED -> cancelPayment(order, paymentResult, partial = true)
+            PORTONE_STATUS_FAILED -> {
+                if (order.status == PaymentOrderStatus.READY) {
+                    order.fail(LocalDateTime.now())
+                }
+            }
+        }
+    }
+
+    private fun approvePayment(order: PaymentOrder, paymentResult: PortOnePaymentResult): ConfirmPaymentResponse {
+        if (order.status == PaymentOrderStatus.APPROVED) {
+            return buildAlreadyApprovedResponse(order)
+        }
+        if (order.status != PaymentOrderStatus.READY) {
+            throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+        }
+        if (paymentResult.totalAmount != order.totalAmount) {
+            order.fail(LocalDateTime.now())
+            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+        }
+        if (paymentResult.paymentId != order.orderId) {
+            order.fail(LocalDateTime.now())
+            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+        }
+
+        val userId = order.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        validateNotParticipated(userId, order.groupBuy.id)
+
+        val updatedRows = groupBuyRepository.increaseCurrentQuantityIfAvailable(order.groupBuy.id, order.quantity)
+        if (updatedRows == 0) {
+            order.fail(LocalDateTime.now())
+            throw CustomException(ErrorCode.PAYMENT_QUANTITY_EXCEEDED)
+        }
+
+        val groupBuy = groupBuyRepository.findById(order.groupBuy.id)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+        val participation = participationRepository.save(
+            Participation(
+                user = order.user,
+                groupBuy = groupBuy,
+                quantity = order.quantity,
+                productAmount = order.productAmount,
+                feeAmount = order.feeAmount,
+                totalAmount = order.totalAmount,
+                status = ParticipationStatus.PAID_WAITING_GOAL,
+            )
+        )
+
+        if (groupBuy.currentQuantity >= groupBuy.targetQuantity) {
+            groupBuy.status = GroupBuyStatus.ACHIEVED
+        }
+        val approvedAt = paymentResult.paidAt ?: LocalDateTime.now()
+        order.approve(approvedAt)
+
+        paymentRepository.save(
+            Payment(
+                paymentOrder = order,
+                pgPaymentId = paymentResult.paymentId,
+                orderId = order.orderId,
+                amount = paymentResult.totalAmount,
+                method = paymentResult.method,
+                approvedAt = approvedAt,
+            )
+        )
+
+        return ConfirmPaymentResponse(
+            paymentId = paymentResult.paymentId,
+            participationId = participation.id,
+            participationStatus = participation.status,
+            displayStatus = displayStatus(participation.status),
+            amount = paymentResult.totalAmount,
+            method = paymentResult.method,
+            approvedAt = approvedAt,
+        )
+    }
+
+    private fun getPortOnePaymentOrFailOrder(order: PaymentOrder): PortOnePaymentResult {
+        return try {
+            portOnePaymentPort.getPayment(order.orderId)
+        } catch (e: CustomException) {
+            if (order.status == PaymentOrderStatus.READY) {
+                order.fail(LocalDateTime.now())
+            }
+            throw e
+        }
+    }
+
+    private fun failOrderFromPortOneStatus(order: PaymentOrder, paymentResult: PortOnePaymentResult) {
+        when (paymentResult.status) {
+            PORTONE_STATUS_CANCELLED -> order.cancel(paymentResult.cancelledAt ?: LocalDateTime.now())
+            PORTONE_STATUS_PARTIAL_CANCELLED -> order.partialCancel(paymentResult.cancelledAt ?: LocalDateTime.now())
+            else -> order.fail(LocalDateTime.now())
+        }
+    }
+
+    private fun cancelPayment(order: PaymentOrder, paymentResult: PortOnePaymentResult, partial: Boolean) {
+        val cancelledAt = paymentResult.cancelledAt ?: LocalDateTime.now()
+        if (partial) {
+            order.partialCancel(cancelledAt)
+        } else {
+            order.cancel(cancelledAt)
+        }
+
+        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId) ?: return
+        if (partial) {
+            payment.partialCancel(cancelledAt)
+        } else {
+            payment.cancel(cancelledAt)
+            val userId = order.user.id ?: return
+            participationRepository.findByUserIdAndGroupBuyId(userId, order.groupBuy.id)?.let { participation ->
+                if (participation.status != ParticipationStatus.REFUNDED) {
+                    val groupBuy = groupBuyRepository.findWithLockById(order.groupBuy.id).orElse(participation.groupBuy)
+                    groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)
+                    participation.status = ParticipationStatus.REFUNDED
+                    participation.refundedAt = cancelledAt
+                }
+            }
+        }
+    }
+
+    private fun buildAlreadyApprovedResponse(order: PaymentOrder): ConfirmPaymentResponse {
+        val userId = order.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        val participation = participationRepository.findByUserIdAndGroupBuyId(userId, order.groupBuy.id)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
+        return ConfirmPaymentResponse(
+            paymentId = payment?.pgPaymentId ?: order.orderId,
+            participationId = participation.id,
+            participationStatus = participation.status,
+            displayStatus = displayStatus(participation.status),
+            amount = order.totalAmount,
+            method = payment?.method,
+            approvedAt = order.approvedAt ?: LocalDateTime.now(),
+        )
+    }
+
+    private fun validateQuantity(quantity: Int) {
+        if (quantity < 1) throw CustomException(ErrorCode.PAYMENT_INVALID_QUANTITY)
+    }
+
+    private fun validateAgreements(request: CreatePaymentOrderRequest) {
+        if (!request.agreedNoCancelAfterGoal ||
+            !request.agreedRefundBeforeGoal ||
+            !request.agreedNoRefundAfterNoShow ||
+            !request.agreedNoWithdrawal
+        ) {
+            throw CustomException(ErrorCode.PAYMENT_AGREEMENT_REQUIRED)
+        }
+    }
+
+    private fun validateGroupBuyAvailable(groupBuy: GroupBuy) {
+        if (groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(LocalDateTime.now())) {
+            throw CustomException(ErrorCode.PAYMENT_GROUPBUY_NOT_AVAILABLE)
+        }
+    }
+
+    private fun validateRemainingQuantity(groupBuy: GroupBuy, quantity: Int) {
+        if (groupBuy.currentQuantity + quantity > groupBuy.maxQuantity) {
+            throw CustomException(ErrorCode.PAYMENT_QUANTITY_EXCEEDED)
+        }
+    }
+
+    private fun validateNotParticipated(userId: Long, groupBuyId: Long) {
+        if (participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)) {
+            throw CustomException(ErrorCode.PAYMENT_DUPLICATE_PARTICIPATION)
+        }
+    }
+
+    private fun calculateAmounts(unitPrice: Int, quantity: Int): PaymentAmounts {
+        val productAmount = unitPrice * quantity
+        val feeAmount = 0
+        return PaymentAmounts(productAmount, feeAmount, productAmount + feeAmount)
+    }
+
+    private fun generateOrderId(groupBuyId: Long): String {
+        return "MCJ-${groupBuyId}-${UUID.randomUUID().toString().replace("-", "").take(20)}"
+    }
+
+    private fun displayStatus(status: ParticipationStatus): String {
+        return when (status) {
+            ParticipationStatus.PAID_WAITING_GOAL -> "참여중 / 달성 전"
+            ParticipationStatus.CONFIRMED -> "참여중 / 달성 완료"
+            ParticipationStatus.CANCELLED -> "취소"
+            ParticipationStatus.REFUNDED -> "환불 완료"
+            ParticipationStatus.PENDING -> "결제 대기"
+        }
+    }
+
+    private data class PaymentAmounts(
+        val productAmount: Int,
+        val feeAmount: Int,
+        val totalAmount: Int,
+    )
+
+    companion object {
+        private const val PORTONE_STATUS_PAID = "PAID"
+        private const val PORTONE_STATUS_FAILED = "FAILED"
+        private const val PORTONE_STATUS_CANCELLED = "CANCELLED"
+        private const val PORTONE_STATUS_PARTIAL_CANCELLED = "PARTIAL_CANCELLED"
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CheckoutInfoResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CheckoutInfoResponse.kt
@@ -1,0 +1,20 @@
+package com.moongchijang.domain.payment.application.dto
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class CheckoutInfoResponse(
+    val groupBuyId: Long,
+    val storeName: String,
+    val productName: String,
+    val thumbnailUrl: String?,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: LocalTime,
+    val pickupTimeEnd: LocalTime,
+    val unitPrice: Int,
+    val quantity: Int,
+    val productAmount: Int,
+    val feeAmount: Int,
+    val totalAmount: Int,
+    val remainingQuantity: Int,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CompletePortOnePaymentRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CompletePortOnePaymentRequest.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.payment.application.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+
+data class CompletePortOnePaymentRequest(
+    @field:NotBlank
+    val paymentId: String,
+    @field:Min(1)
+    val amount: Int,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/ConfirmPaymentResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/ConfirmPaymentResponse.kt
@@ -1,0 +1,14 @@
+package com.moongchijang.domain.payment.application.dto
+
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import java.time.LocalDateTime
+
+data class ConfirmPaymentResponse(
+    val paymentId: String,
+    val participationId: Long,
+    val participationStatus: ParticipationStatus,
+    val displayStatus: String,
+    val amount: Int,
+    val method: String?,
+    val approvedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CreatePaymentOrderRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CreatePaymentOrderRequest.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.domain.payment.application.dto
+
+import jakarta.validation.constraints.Min
+
+data class CreatePaymentOrderRequest(
+    @field:Min(1)
+    val quantity: Int,
+    val agreedNoCancelAfterGoal: Boolean,
+    val agreedRefundBeforeGoal: Boolean,
+    val agreedNoRefundAfterNoShow: Boolean,
+    val agreedNoWithdrawal: Boolean,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CreatePaymentOrderResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CreatePaymentOrderResponse.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.payment.application.dto
+
+data class CreatePaymentOrderResponse(
+    val paymentId: String,
+    val storeId: String,
+    val channelKey: String,
+    val orderName: String,
+    val amount: Int,
+    val customerName: String?,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/PortOneWebhookRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/PortOneWebhookRequest.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.payment.application.dto
+
+data class PortOneWebhookRequest(
+    val type: String? = null,
+    val storeId: String? = null,
+    val paymentId: String? = null,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/PortOneWebhookResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/PortOneWebhookResponse.kt
@@ -1,0 +1,5 @@
+package com.moongchijang.domain.payment.application.dto
+
+data class PortOneWebhookResponse(
+    val received: Boolean = true,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/port/PortOnePaymentPort.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/port/PortOnePaymentPort.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.payment.application.port
+
+import java.time.LocalDateTime
+
+interface PortOnePaymentPort {
+    fun getPayment(paymentId: String): PortOnePaymentResult
+}
+
+data class PortOnePaymentResult(
+    val paymentId: String,
+    val status: String,
+    val totalAmount: Int,
+    val method: String?,
+    val paidAt: LocalDateTime?,
+    val cancelledAt: LocalDateTime? = null,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/Payment.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/Payment.kt
@@ -1,0 +1,68 @@
+package com.moongchijang.domain.payment.domain.entity
+
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payments",
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_payments_pg_payment_id", columnNames = ["pg_payment_id"]),
+        UniqueConstraint(name = "uk_payments_payment_order_id", columnNames = ["payment_order_id"])
+    ],
+    indexes = [Index(name = "idx_payments_order_id", columnList = "order_id")]
+)
+class Payment(
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_order_id", nullable = false)
+    var paymentOrder: PaymentOrder,
+
+    @Column(name = "pg_payment_id", nullable = false, length = 200)
+    var pgPaymentId: String,
+
+    @Column(name = "order_id", nullable = false, length = 64)
+    var orderId: String,
+
+    @Column(nullable = false)
+    var amount: Int,
+
+    @Column(length = 50)
+    var method: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    var status: PaymentStatus = PaymentStatus.APPROVED,
+
+    @Column(name = "approved_at", nullable = false)
+    var approvedAt: LocalDateTime,
+
+    @Column(name = "cancelled_at")
+    var cancelledAt: LocalDateTime? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity() {
+    fun cancel(cancelledAt: LocalDateTime) {
+        this.status = PaymentStatus.CANCELLED
+        this.cancelledAt = cancelledAt
+    }
+
+    fun partialCancel(cancelledAt: LocalDateTime) {
+        this.status = PaymentStatus.PARTIAL_CANCELLED
+        this.cancelledAt = cancelledAt
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentOrder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentOrder.kt
@@ -1,0 +1,102 @@
+package com.moongchijang.domain.payment.domain.entity
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payment_orders",
+    uniqueConstraints = [UniqueConstraint(name = "uk_payment_orders_order_id", columnNames = ["order_id"])],
+    indexes = [
+        Index(name = "idx_payment_orders_user_id", columnList = "user_id"),
+        Index(name = "idx_payment_orders_group_buy_id", columnList = "group_buy_id")
+    ]
+)
+class PaymentOrder(
+    @Column(name = "order_id", nullable = false, length = 64)
+    var orderId: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_buy_id", nullable = false)
+    var groupBuy: GroupBuy,
+
+    @Column(nullable = false)
+    var quantity: Int,
+
+    @Column(name = "product_amount", nullable = false)
+    var productAmount: Int,
+
+    @Column(name = "fee_amount", nullable = false)
+    var feeAmount: Int,
+
+    @Column(name = "total_amount", nullable = false)
+    var totalAmount: Int,
+
+    @Column(name = "agreed_no_cancel_after_goal", nullable = false)
+    var agreedNoCancelAfterGoal: Boolean,
+
+    @Column(name = "agreed_refund_before_goal", nullable = false)
+    var agreedRefundBeforeGoal: Boolean,
+
+    @Column(name = "agreed_no_refund_after_no_show", nullable = false)
+    var agreedNoRefundAfterNoShow: Boolean,
+
+    @Column(name = "agreed_no_withdrawal", nullable = false)
+    var agreedNoWithdrawal: Boolean,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    var status: PaymentOrderStatus = PaymentOrderStatus.READY,
+
+    @Column(name = "approved_at")
+    var approvedAt: LocalDateTime? = null,
+
+    @Column(name = "failed_at")
+    var failedAt: LocalDateTime? = null,
+
+    @Column(name = "cancelled_at")
+    var cancelledAt: LocalDateTime? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity() {
+    fun approve(approvedAt: LocalDateTime) {
+        this.status = PaymentOrderStatus.APPROVED
+        this.approvedAt = approvedAt
+    }
+
+    fun fail(failedAt: LocalDateTime) {
+        this.status = PaymentOrderStatus.FAILED
+        this.failedAt = failedAt
+    }
+
+    fun cancel(cancelledAt: LocalDateTime) {
+        this.status = PaymentOrderStatus.CANCELLED
+        this.cancelledAt = cancelledAt
+    }
+
+    fun partialCancel(cancelledAt: LocalDateTime) {
+        this.status = PaymentOrderStatus.PARTIAL_CANCELLED
+        this.cancelledAt = cancelledAt
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentOrderStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentOrderStatus.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.payment.domain.entity
+
+enum class PaymentOrderStatus {
+    READY,
+    APPROVED,
+    FAILED,
+    CANCELLED,
+    PARTIAL_CANCELLED
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentStatus.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.payment.domain.entity
+
+enum class PaymentStatus {
+    APPROVED,
+    CANCELLED,
+    PARTIAL_CANCELLED
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.payment.domain.repository
+
+import com.moongchijang.domain.payment.domain.entity.PaymentOrder
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface PaymentOrderRepository : JpaRepository<PaymentOrder, Long> {
+    fun findByOrderId(orderId: String): PaymentOrder?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select po from PaymentOrder po where po.orderId = :orderId")
+    fun findByOrderIdForUpdate(@Param("orderId") orderId: String): PaymentOrder?
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentRepository.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.payment.domain.repository
+
+import com.moongchijang.domain.payment.domain.entity.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentRepository : JpaRepository<Payment, Long> {
+    fun findByPaymentOrderOrderId(orderId: String): Payment?
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -1,0 +1,63 @@
+package com.moongchijang.domain.payment.infrastructure.portone
+
+import com.moongchijang.domain.payment.application.port.PortOnePaymentPort
+import com.moongchijang.domain.payment.application.port.PortOnePaymentResult
+import com.moongchijang.global.config.PortOneProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+
+@Component
+class PortOnePaymentClient(
+    private val portOneProperties: PortOneProperties,
+    restClientBuilder: RestClient.Builder,
+) : PortOnePaymentPort {
+    private val restClient = restClientBuilder.build()
+
+    override fun getPayment(paymentId: String): PortOnePaymentResult {
+        val response = try {
+            restClient.get()
+                .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}", paymentId)
+                .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
+                .retrieve()
+                .body(Map::class.java)
+                ?: throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+        } catch (e: RestClientException) {
+            throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+        }
+
+        return PortOnePaymentResult(
+            paymentId = response["id"] as? String ?: paymentId,
+            status = response["status"] as? String ?: "",
+            totalAmount = extractTotalAmount(response),
+            method = extractPaymentMethod(response),
+            paidAt = parseDateTime(response["paidAt"] as? String ?: response["approvedAt"] as? String),
+            cancelledAt = parseDateTime(response["cancelledAt"] as? String ?: response["canceledAt"] as? String),
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun extractTotalAmount(response: Map<*, *>): Int {
+        val amount = response["amount"] as? Map<String, Any?>
+        return (amount?.get("total") as? Number)?.toInt()
+            ?: (response["totalAmount"] as? Number)?.toInt()
+            ?: throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun extractPaymentMethod(response: Map<*, *>): String? {
+        val method = response["method"] as? Map<String, Any?>
+        val paymentMethod = response["paymentMethod"] as? Map<String, Any?>
+        return method?.keys?.firstOrNull()?.toString()
+            ?: paymentMethod?.keys?.firstOrNull()?.toString()
+            ?: response["payMethod"] as? String
+    }
+
+    private fun parseDateTime(value: String?): LocalDateTime? {
+        return value?.let { OffsetDateTime.parse(it).toLocalDateTime() }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -1,0 +1,64 @@
+package com.moongchijang.domain.payment.presentation
+
+import com.moongchijang.domain.payment.application.PaymentService
+import com.moongchijang.domain.payment.application.dto.CheckoutInfoResponse
+import com.moongchijang.domain.payment.application.dto.CompletePortOnePaymentRequest
+import com.moongchijang.domain.payment.application.dto.ConfirmPaymentResponse
+import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderRequest
+import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderResponse
+import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
+import com.moongchijang.domain.payment.application.dto.PortOneWebhookResponse
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class PaymentController(
+    private val paymentService: PaymentService,
+) {
+
+    @GetMapping("/group-buys/{groupBuyId}/checkout")
+    fun getCheckoutInfo(
+        @PathVariable groupBuyId: Long,
+        @RequestParam quantity: Int,
+    ): ResponseEntity<ApiResponse<CheckoutInfoResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(paymentService.getCheckoutInfo(groupBuyId, quantity)))
+    }
+
+    @PostMapping("/group-buys/{groupBuyId}/payment-orders")
+    fun createPaymentOrder(
+        @PathVariable groupBuyId: Long,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @Valid @RequestBody request: CreatePaymentOrderRequest,
+    ): ResponseEntity<ApiResponse<CreatePaymentOrderResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        return ResponseEntity.ok(ApiResponse.success(paymentService.createPaymentOrder(groupBuyId, userId, request)))
+    }
+
+    @PostMapping("/payments/portone/complete")
+    fun completePortOnePayment(
+        @Valid @RequestBody request: CompletePortOnePaymentRequest,
+    ): ResponseEntity<ApiResponse<ConfirmPaymentResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request)))
+    }
+
+    @PostMapping("/payments/portone/webhook")
+    fun handlePortOneWebhook(
+        @RequestBody request: PortOneWebhookRequest,
+    ): ResponseEntity<ApiResponse<PortOneWebhookResponse>> {
+        paymentService.handlePortOneWebhook(request)
+        return ResponseEntity.ok(ApiResponse.success(PortOneWebhookResponse()))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/config/PortOneProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/PortOneProperties.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "portone")
+data class PortOneProperties(
+    val storeId: String,
+    val channelKey: String,
+    val apiSecret: String,
+    val paymentApiBaseUrl: String = "https://api.portone.io",
+)

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -95,4 +95,16 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_ALREADY_PARTICIPATED(409_306, "이미 참여한 공구예요.", 409),
     GROUPBUY_LOCK_ACQUISITION_FAILED(409_300, "요청이 많아 잠시 처리 지연 중입니다. 잠시 후 다시 시도해주세요.", 409),
     GROUPBUY_LOCK_INTERRUPTED(500_300, "요청 처리 중 일시적인 오류가 발생했습니다.", 500),
+
+    // Payment(350~399)
+    PAYMENT_INVALID_QUANTITY(400_350, "참여 수량이 올바르지 않습니다.", 400),
+    PAYMENT_GROUPBUY_NOT_AVAILABLE(400_351, "참여할 수 없는 공구입니다.", 400),
+    PAYMENT_QUANTITY_EXCEEDED(409_350, "참여 가능 수량을 초과했습니다.", 409),
+    PAYMENT_AGREEMENT_REQUIRED(400_352, "필수 동의가 필요합니다.", 400),
+    PAYMENT_ORDER_NOT_FOUND(404_350, "결제 주문을 찾을 수 없습니다.", 404),
+    PAYMENT_ORDER_ALREADY_PROCESSED(409_351, "이미 처리된 결제 주문입니다.", 409),
+    PAYMENT_AMOUNT_MISMATCH(400_353, "결제 금액이 일치하지 않습니다.", 400),
+    PAYMENT_APPROVAL_FAILED(502_350, "결제 승인에 실패했습니다.", 502),
+    PAYMENT_DUPLICATE_PARTICIPATION(409_352, "이미 참여한 공구입니다.", 409),
+    PAYMENT_WEBHOOK_INVALID(400_354, "결제 웹훅 요청이 올바르지 않습니다.", 400),
 }

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -37,6 +37,9 @@ class SecurityConfig(
                     "/api/v1/auth/refresh",
                     "/api/v1/auth/phone/verification-codes",
                     "/api/v1/auth/phone/verification-codes/verify",
+                    "/api/v1/payments/portone/webhook",
+                    "/openapi.yaml",
+                    "/dev/openapi.yaml",
                     "/swagger-ui/**",
                     "/v3/api-docs/**",
                 ).permitAll()
@@ -64,7 +67,9 @@ class SecurityConfig(
         configuration.allowedOrigins = listOf(
             "http://localhost:3000",
             "http://localhost:5173",
-            "http://43.203.191.30"
+            "http://43.203.191.30",
+            "https://www.moongchijang.com",
+            "https://api.moongchijang.com"
         )
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
         configuration.allowedHeaders = listOf("Authorization", "Content-Type", "Accept")

--- a/src/main/kotlin/com/moongchijang/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/moongchijang/security/jwt/JwtAuthenticationFilter.kt
@@ -25,6 +25,9 @@ class JwtAuthenticationFilter(
         "/api/v1/auth/refresh",
         "/api/v1/auth/phone/verification-codes",
         "/api/v1/auth/phone/verification-codes/verify",
+        "/api/v1/payments/portone/webhook",
+        "/openapi.yaml",
+        "/dev/openapi.yaml",
     )
 
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,6 +36,12 @@ naver:
     client-id: ${NAVER_CLIENT_ID}
     client-secret: ${NAVER_CLIENT_SECRET}
 
+portone:
+  store-id: ${PORTONE_STORE_ID}
+  channel-key: ${PORTONE_CHANNEL_KEY}
+  api-secret: ${PORTONE_API_SECRET}
+  payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+
 springdoc:
   swagger-ui:
     url: /dev/openapi.yaml

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -54,6 +54,12 @@ naver:
     client-id: ${NAVER_CLIENT_ID:local-client-id}
     client-secret: ${NAVER_CLIENT_SECRET:local-client-secret}
 
+portone:
+  store-id: ${PORTONE_STORE_ID:store-dummy}
+  channel-key: ${PORTONE_CHANNEL_KEY:channel-dummy}
+  api-secret: ${PORTONE_API_SECRET:portone-api-secret-dummy}
+  payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+
 ses:
   enabled: ${SES_ENABLED:false}
   region: ${SES_REGION:ap-northeast-2}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,8 @@ spring:
     enabled: true
     locations:
       - classpath:db/migration
+    ignore-migration-patterns:
+      - "*:missing"
 
 app:
   s3:
@@ -51,6 +53,12 @@ naver:
   api:
     client-id: ${NAVER_CLIENT_ID:local-client-id}
     client-secret: ${NAVER_CLIENT_SECRET:local-client-secret}
+
+portone:
+  store-id: ${PORTONE_STORE_ID:store-dummy}
+  channel-key: ${PORTONE_CHANNEL_KEY:channel-dummy}
+  api-secret: ${PORTONE_API_SECRET:portone-api-secret-dummy}
+  payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
 
 ses:
   enabled: ${SES_ENABLED:false}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,6 +31,12 @@ app:
     bucket: ${S3_BUCKET}
     prefix: ${S3_PREFIX}
 
+portone:
+  store-id: ${PORTONE_STORE_ID}
+  channel-key: ${PORTONE_CHANNEL_KEY}
+  api-secret: ${PORTONE_API_SECRET}
+  payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}

--- a/src/main/resources/db/migration/V11__create_payment_tables.sql
+++ b/src/main/resources/db/migration/V11__create_payment_tables.sql
@@ -1,0 +1,45 @@
+CREATE TABLE payment_orders (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_id VARCHAR(64) NOT NULL,
+    user_id BIGINT NOT NULL,
+    group_buy_id BIGINT NOT NULL,
+    quantity INT NOT NULL,
+    product_amount INT NOT NULL,
+    fee_amount INT NOT NULL,
+    total_amount INT NOT NULL,
+    agreed_no_cancel_after_goal BOOLEAN NOT NULL,
+    agreed_refund_before_goal BOOLEAN NOT NULL,
+    agreed_no_refund_after_no_show BOOLEAN NOT NULL,
+    agreed_no_withdrawal BOOLEAN NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    approved_at DATETIME NULL,
+    failed_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_payment_orders_order_id UNIQUE (order_id),
+    CONSTRAINT fk_payment_orders_user_id FOREIGN KEY (user_id) REFERENCES users (id),
+    CONSTRAINT fk_payment_orders_group_buy_id FOREIGN KEY (group_buy_id) REFERENCES group_buys (id)
+);
+
+CREATE INDEX idx_payment_orders_user_id ON payment_orders (user_id);
+CREATE INDEX idx_payment_orders_group_buy_id ON payment_orders (group_buy_id);
+
+CREATE TABLE payments (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    payment_order_id BIGINT NOT NULL,
+    pg_payment_id VARCHAR(200) NOT NULL,
+    order_id VARCHAR(64) NOT NULL,
+    amount INT NOT NULL,
+    method VARCHAR(50) NULL,
+    status VARCHAR(30) NOT NULL,
+    approved_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_payments_pg_payment_id UNIQUE (pg_payment_id),
+    CONSTRAINT uk_payments_payment_order_id UNIQUE (payment_order_id),
+    CONSTRAINT fk_payments_payment_order_id FOREIGN KEY (payment_order_id) REFERENCES payment_orders (id)
+);
+
+CREATE INDEX idx_payments_order_id ON payments (order_id);

--- a/src/main/resources/db/migration/V12__alter_payment_tables_add_cancelled_at.sql
+++ b/src/main/resources/db/migration/V12__alter_payment_tables_add_cancelled_at.sql
@@ -1,0 +1,5 @@
+ALTER TABLE payment_orders
+    ADD COLUMN cancelled_at DATETIME NULL;
+
+ALTER TABLE payments
+    ADD COLUMN cancelled_at DATETIME NULL;

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -891,10 +891,37 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
-  /api/v1/group-buys/{groupBuyId}/participations:
+  /api/v1/group-buys/{groupBuyId}/checkout:
+    get:
+      tags: [Participation]
+      summary: 참여하기 화면 결제 정보 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/GroupBuyId'
+        - name: quantity
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: 참여 수량
+      responses:
+        '200':
+          description: 상품 요약 및 결제 금액 정보
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseCheckoutInfo'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /api/v1/group-buys/{groupBuyId}/payment-orders:
     post:
       tags: [Participation]
-      summary: 공구 참여 (결제 요청 생성)
+      summary: PortOne 결제 주문 생성
       security:
         - bearerAuth: []
       parameters:
@@ -904,14 +931,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ParticipationCreate'
+              $ref: '#/components/schemas/PaymentOrderCreate'
       responses:
-        '201':
-          description: 참여 생성 및 결제 정보 반환
+        '200':
+          description: PortOne SDK 요청에 필요한 결제 주문 정보 반환
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponseParticipationCreated'
+                $ref: '#/components/schemas/ApiResponsePaymentOrderCreated'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -919,12 +946,10 @@ paths:
         '409':
           $ref: '#/components/responses/Conflict'
 
-  /api/v1/payments/confirm:
+  /api/v1/payments/portone/complete:
     post:
       tags: [Participation]
-      summary: PG 결제 성공 콜백 처리
-      security:
-        - bearerAuth: []
+      summary: PortOne 결제 완료 서버 검증
       requestBody:
         required: true
         content:
@@ -933,23 +958,34 @@ paths:
               $ref: '#/components/schemas/PaymentConfirm'
       responses:
         '200':
-          $ref: '#/components/responses/SuccessNoData'
+          description: 결제 검증 및 참여 확정 처리 결과
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponsePaymentConfirmed'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          $ref: '#/components/responses/Conflict'
 
-  /api/v1/payments/fail:
+  /api/v1/payments/portone/webhook:
     post:
       tags: [Participation]
-      summary: PG 결제 실패 콜백 처리
-      security:
-        - bearerAuth: []
+      summary: PortOne 결제 웹훅 수신
+      description: 웹훅 본문만 신뢰하지 않고 서버에서 PortOne 결제 단건 조회 후 상태를 동기화한다.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PaymentFail'
+              $ref: '#/components/schemas/PortOneWebhook'
       responses:
         '200':
-          $ref: '#/components/responses/SuccessNoData'
+          description: 웹훅 수신 완료
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponsePortOneWebhook'
 
   /api/v1/participations/{participationId}/cancel:
     post:
@@ -2435,7 +2471,7 @@ components:
 
     PaymentConfirm:
       type: object
-      required: [paymentId, participationId, amount]
+      required: [paymentId, amount]
       description: |
         포트원 v2 + 토스페이먼츠 결제 성공 후 서버 검증 요청.
         클라이언트가 PortOne.requestPayment() 완료 시 반환된 paymentId를 전달한다.
@@ -2443,23 +2479,98 @@ components:
       properties:
         paymentId:
           type: string
-          format: uuid
-          description: 포트원 결제 ID (클라이언트가 UUID로 생성하여 SDK 호출 시 사용한 값)
-        participationId: { type: integer, format: int64 }
+          description: 서버가 결제 주문 생성 시 반환한 PortOne paymentId
         amount: { type: integer, description: 결제 요청 금액 — 서버 저장값과 불일치 시 위변조로 처리 }
 
-    PaymentFail:
+    PaymentOrderCreate:
       type: object
-      required: [paymentId, participationId, errorCode, message]
-      description: 포트원 v2 결제 실패/취소 콜백 처리
+      required: [quantity, agreedNoCancelAfterGoal, agreedRefundBeforeGoal, agreedNoRefundAfterNoShow, agreedNoWithdrawal]
       properties:
-        paymentId:
-          type: string
-          format: uuid
-          description: 포트원 결제 ID
-        participationId: { type: integer, format: int64 }
-        errorCode: { type: string, description: 포트원/토스페이먼츠 오류 코드 }
-        message: { type: string, nullable: true, description: 오류 메시지 }
+        quantity: { type: integer, minimum: 1 }
+        agreedNoCancelAfterGoal: { type: boolean, description: 달성 후 취소 불가 동의 }
+        agreedRefundBeforeGoal: { type: boolean, description: 달성 전 이탈 시 전액 환불 동의 }
+        agreedNoRefundAfterNoShow: { type: boolean, description: 미수령 환불 불가 동의 }
+        agreedNoWithdrawal: { type: boolean, description: 청약철회 불가 동의 }
+
+    ApiResponseCheckoutInfo:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [groupBuyId, storeName, productName, thumbnailUrl, pickupDate, pickupTimeStart, pickupTimeEnd, unitPrice, quantity, productAmount, feeAmount, totalAmount, remainingQuantity]
+          properties:
+            groupBuyId: { type: integer, format: int64 }
+            storeName: { type: string }
+            productName: { type: string }
+            thumbnailUrl: { type: string, nullable: true }
+            pickupDate: { type: string, format: date }
+            pickupTimeStart: { type: string, example: "14:00:00" }
+            pickupTimeEnd: { type: string, example: "18:00:00" }
+            unitPrice: { type: integer }
+            quantity: { type: integer }
+            productAmount: { type: integer }
+            feeAmount: { type: integer, example: 0 }
+            totalAmount: { type: integer }
+            remainingQuantity: { type: integer }
+        error: { nullable: true, example: null }
+
+    ApiResponsePaymentOrderCreated:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [paymentId, storeId, channelKey, orderName, amount, customerName]
+          properties:
+            paymentId: { type: string, description: PortOne SDK requestPayment에 전달할 paymentId }
+            storeId: { type: string }
+            channelKey: { type: string }
+            orderName: { type: string }
+            amount: { type: integer }
+            customerName: { type: string, nullable: true }
+        error: { nullable: true, example: null }
+
+    ApiResponsePaymentConfirmed:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [paymentId, participationId, participationStatus, displayStatus, amount, approvedAt]
+          properties:
+            paymentId: { type: string }
+            participationId: { type: integer, format: int64 }
+            participationStatus:
+              type: string
+              enum: [PAID_WAITING_GOAL, CONFIRMED]
+            displayStatus: { type: string, example: "참여중 / 달성 전" }
+            amount: { type: integer }
+            method: { type: string, nullable: true, example: CARD }
+            approvedAt: { type: string, format: date-time }
+        error: { nullable: true, example: null }
+
+    PortOneWebhook:
+      type: object
+      properties:
+        type: { type: string, nullable: true, example: Transaction.Paid }
+        storeId: { type: string, nullable: true }
+        paymentId: { type: string, nullable: true }
+
+    ApiResponsePortOneWebhook:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [received]
+          properties:
+            received: { type: boolean, example: true }
+        error: { nullable: true, example: null }
 
     ApiResponseRefundList:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -37,6 +37,9 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.TransactionStatus
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -63,6 +66,12 @@ class PaymentServiceTest {
     @Mock
     private lateinit var portOnePaymentPort: PortOnePaymentPort
 
+    @Mock
+    private lateinit var transactionManager: PlatformTransactionManager
+
+    @Mock
+    private lateinit var transactionStatus: TransactionStatus
+
     private val portOneProperties = PortOneProperties(
         storeId = "store-test",
         channelKey = "channel-test",
@@ -78,6 +87,7 @@ class PaymentServiceTest {
             paymentRepository = paymentRepository,
             portOnePaymentPort = portOnePaymentPort,
             portOneProperties = portOneProperties,
+            transactionManager = transactionManager,
         )
     }
 
@@ -130,6 +140,8 @@ class PaymentServiceTest {
         val groupBuy = createGroupBuy(currentQuantity = 36)
         val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2)
         val approvedAt = LocalDateTime.of(2026, 5, 17, 12, 0)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
         `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
         `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(10L, 2)).thenAnswer {
             groupBuy.currentQuantity += 2
@@ -142,6 +154,7 @@ class PaymentServiceTest {
         `when`(participationRepository.save(any(Participation::class.java))).thenAnswer {
             (it.arguments[0] as Participation).apply { id = 99L }
         }
+        `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
 
         val result = service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000))
 
@@ -153,10 +166,39 @@ class PaymentServiceTest {
     }
 
     @Test
+    fun `결제 완료로 목표 수량에 도달하면 참여 확정 상태로 생성`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(currentQuantity = 49)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(10L, 1)).thenAnswer {
+            groupBuy.currentQuantity += 1
+            1
+        }
+        `when`(groupBuyRepository.findById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(false)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 6000, "CARD", LocalDateTime.now()))
+        `when`(participationRepository.save(any(Participation::class.java))).thenAnswer {
+            (it.arguments[0] as Participation).apply { id = 100L }
+        }
+        `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
+
+        val result = service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 6000))
+
+        assertEquals(ParticipationStatus.CONFIRMED, result.participationStatus)
+        assertEquals(GroupBuyStatus.ACHIEVED, groupBuy.status)
+    }
+
+    @Test
     fun `승인 시점에 최대 수량을 초과하면 실패`() {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy(currentQuantity = 99, maxQuantity = 100)
         val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
         `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
         `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
             .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 12000, "CARD", LocalDateTime.now()))
@@ -175,6 +217,8 @@ class PaymentServiceTest {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy(currentQuantity = 36)
         val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
         `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
         `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
             .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 6000, "CARD", LocalDateTime.now()))
@@ -187,6 +231,7 @@ class PaymentServiceTest {
         `when`(participationRepository.save(any(Participation::class.java))).thenAnswer {
             (it.arguments[0] as Participation).apply { id = 100L }
         }
+        `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
 
         service.handlePortOneWebhook(
             PortOneWebhookRequest(type = "Transaction.Paid", storeId = "store-test", paymentId = "MCJ-10-test")
@@ -202,6 +247,8 @@ class PaymentServiceTest {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy()
         val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
         `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
         `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
             .thenReturn(PortOnePaymentResult("MCJ-10-test", "FAILED", 6000, "CARD", null))
@@ -236,6 +283,8 @@ class PaymentServiceTest {
             status = ParticipationStatus.PAID_WAITING_GOAL,
         )
         val cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
         `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
         `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
             .thenReturn(
@@ -259,6 +308,10 @@ class PaymentServiceTest {
         assertEquals(ParticipationStatus.REFUNDED, participation.status)
         assertEquals(cancelledAt, participation.refundedAt)
         assertEquals(35, groupBuy.currentQuantity)
+    }
+
+    private fun stubTransaction() {
+        `when`(transactionManager.getTransaction(any(TransactionDefinition::class.java))).thenReturn(transactionStatus)
     }
 
     private fun createOrderRequest(

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -1,0 +1,339 @@
+package com.moongchijang.domain.payment.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.application.dto.CompletePortOnePaymentRequest
+import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderRequest
+import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
+import com.moongchijang.domain.payment.application.port.PortOnePaymentPort
+import com.moongchijang.domain.payment.application.port.PortOnePaymentResult
+import com.moongchijang.domain.payment.domain.entity.Payment
+import com.moongchijang.domain.payment.domain.entity.PaymentOrder
+import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
+import com.moongchijang.domain.payment.domain.entity.PaymentStatus
+import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
+import com.moongchijang.domain.payment.domain.repository.PaymentRepository
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.config.PortOneProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class PaymentServiceTest {
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var paymentOrderRepository: PaymentOrderRepository
+
+    @Mock
+    private lateinit var paymentRepository: PaymentRepository
+
+    @Mock
+    private lateinit var portOnePaymentPort: PortOnePaymentPort
+
+    private val portOneProperties = PortOneProperties(
+        storeId = "store-test",
+        channelKey = "channel-test",
+        apiSecret = "secret-test",
+    )
+
+    private val service: PaymentService by lazy {
+        PaymentService(
+            groupBuyRepository = groupBuyRepository,
+            userRepository = userRepository,
+            participationRepository = participationRepository,
+            paymentOrderRepository = paymentOrderRepository,
+            paymentRepository = paymentRepository,
+            portOnePaymentPort = portOnePaymentPort,
+            portOneProperties = portOneProperties,
+        )
+    }
+
+    @Test
+    fun `체크아웃 정보는 수수료 0원으로 금액 계산`() {
+        val groupBuy = createGroupBuy(price = 6000)
+        `when`(groupBuyRepository.findWithStoreById(10L)).thenReturn(Optional.of(groupBuy))
+
+        val result = service.getCheckoutInfo(10L, 2)
+
+        assertEquals(12000, result.productAmount)
+        assertEquals(0, result.feeAmount)
+        assertEquals(12000, result.totalAmount)
+        assertEquals(64, result.remainingQuantity)
+    }
+
+    @Test
+    fun `필수 동의가 없으면 결제 주문 생성 실패`() {
+        val request = createOrderRequest(agreedNoWithdrawal = false)
+
+        val ex = assertThrows<CustomException> {
+            service.createPaymentOrder(10L, 1L, request)
+        }
+
+        assertEquals(ErrorCode.PAYMENT_AGREEMENT_REQUIRED, ex.errorCode)
+    }
+
+    @Test
+    fun `결제 주문 생성 성공`() {
+        val user = UserFixture.createKakaoUser(id = 1L, nickname = "은서")
+        val groupBuy = createGroupBuy()
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
+        `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(false)
+        `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
+
+        val result = service.createPaymentOrder(10L, 1L, createOrderRequest(quantity = 3))
+
+        assertTrue(result.paymentId.startsWith("MCJ-10-"))
+        assertEquals("store-test", result.storeId)
+        assertEquals("channel-test", result.channelKey)
+        assertEquals("두쫀쿠 3개", result.orderName)
+        assertEquals(18000, result.amount)
+        assertEquals("은서", result.customerName)
+    }
+
+    @Test
+    fun `포트원 결제 완료 시 참여 생성 및 현재 수량 증가`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(currentQuantity = 36)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2)
+        val approvedAt = LocalDateTime.of(2026, 5, 17, 12, 0)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(10L, 2)).thenAnswer {
+            groupBuy.currentQuantity += 2
+            1
+        }
+        `when`(groupBuyRepository.findById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(false)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 12000, "CARD", approvedAt))
+        `when`(participationRepository.save(any(Participation::class.java))).thenAnswer {
+            (it.arguments[0] as Participation).apply { id = 99L }
+        }
+
+        val result = service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000))
+
+        assertEquals(99L, result.participationId)
+        assertEquals(ParticipationStatus.PAID_WAITING_GOAL, result.participationStatus)
+        assertEquals(38, groupBuy.currentQuantity)
+        assertEquals(PaymentOrderStatus.APPROVED, order.status)
+        verify(paymentRepository).save(any())
+    }
+
+    @Test
+    fun `승인 시점에 최대 수량을 초과하면 실패`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(currentQuantity = 99, maxQuantity = 100)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 12000, "CARD", LocalDateTime.now()))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(false)
+        `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(10L, 2)).thenReturn(0)
+
+        val ex = assertThrows<CustomException> {
+            service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000))
+        }
+
+        assertEquals(ErrorCode.PAYMENT_QUANTITY_EXCEEDED, ex.errorCode)
+    }
+
+    @Test
+    fun `웹훅 결제 성공도 서버 검증 후 참여 생성`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(currentQuantity = 36)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 6000, "CARD", LocalDateTime.now()))
+        `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(10L, 1)).thenAnswer {
+            groupBuy.currentQuantity += 1
+            1
+        }
+        `when`(groupBuyRepository.findById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(false)
+        `when`(participationRepository.save(any(Participation::class.java))).thenAnswer {
+            (it.arguments[0] as Participation).apply { id = 100L }
+        }
+
+        service.handlePortOneWebhook(
+            PortOneWebhookRequest(type = "Transaction.Paid", storeId = "store-test", paymentId = "MCJ-10-test")
+        )
+
+        assertEquals(PaymentOrderStatus.APPROVED, order.status)
+        assertEquals(37, groupBuy.currentQuantity)
+        verify(paymentRepository).save(any())
+    }
+
+    @Test
+    fun `웹훅 실패 상태는 준비 중 주문을 실패 처리`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy()
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(PortOnePaymentResult("MCJ-10-test", "FAILED", 6000, "CARD", null))
+
+        service.handlePortOneWebhook(PortOneWebhookRequest(storeId = "store-test", paymentId = "MCJ-10-test"))
+
+        assertEquals(PaymentOrderStatus.FAILED, order.status)
+    }
+
+    @Test
+    fun `웹훅 취소 상태는 결제와 참여를 환불 처리`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy()
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = order.orderId,
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 6000,
+            feeAmount = 0,
+            totalAmount = 6000,
+            status = ParticipationStatus.PAID_WAITING_GOAL,
+        )
+        val cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "MCJ-10-test",
+                    status = "CANCELLED",
+                    totalAmount = 6000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                    cancelledAt = cancelledAt,
+                )
+            )
+        `when`(paymentRepository.findByPaymentOrderOrderId("MCJ-10-test")).thenReturn(payment)
+        `when`(participationRepository.findByUserIdAndGroupBuyId(1L, 10L)).thenReturn(participation)
+        `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
+
+        service.handlePortOneWebhook(PortOneWebhookRequest(storeId = "store-test", paymentId = "MCJ-10-test"))
+
+        assertEquals(PaymentOrderStatus.CANCELLED, order.status)
+        assertEquals(PaymentStatus.CANCELLED, payment.status)
+        assertEquals(ParticipationStatus.REFUNDED, participation.status)
+        assertEquals(cancelledAt, participation.refundedAt)
+        assertEquals(35, groupBuy.currentQuantity)
+    }
+
+    private fun createOrderRequest(
+        quantity: Int = 1,
+        agreedNoCancelAfterGoal: Boolean = true,
+        agreedRefundBeforeGoal: Boolean = true,
+        agreedNoRefundAfterNoShow: Boolean = true,
+        agreedNoWithdrawal: Boolean = true,
+    ) = CreatePaymentOrderRequest(
+        quantity = quantity,
+        agreedNoCancelAfterGoal = agreedNoCancelAfterGoal,
+        agreedRefundBeforeGoal = agreedRefundBeforeGoal,
+        agreedNoRefundAfterNoShow = agreedNoRefundAfterNoShow,
+        agreedNoWithdrawal = agreedNoWithdrawal,
+    )
+
+    private fun createPaymentOrder(
+        user: User,
+        groupBuy: GroupBuy,
+        quantity: Int,
+    ) = PaymentOrder(
+        orderId = "MCJ-10-test",
+        user = user,
+        groupBuy = groupBuy,
+        quantity = quantity,
+        productAmount = 6000 * quantity,
+        feeAmount = 0,
+        totalAmount = 6000 * quantity,
+        agreedNoCancelAfterGoal = true,
+        agreedRefundBeforeGoal = true,
+        agreedNoRefundAfterNoShow = true,
+        agreedNoWithdrawal = true,
+    )
+
+    private fun createGroupBuy(
+        id: Long = 10L,
+        price: Int = 6000,
+        currentQuantity: Int = 36,
+        maxQuantity: Int = 100,
+        status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS,
+    ): GroupBuy {
+        return GroupBuy(
+            store = createStore(),
+            groupBuyRequest = createGroupBuyRequest(),
+            thumbnailUrl = "https://example.com/image.jpg",
+            productName = "두쫀쿠",
+            productDescription = "설명",
+            price = price,
+            targetQuantity = 50,
+            currentQuantity = currentQuantity,
+            maxQuantity = maxQuantity,
+            status = status,
+            deadline = LocalDateTime.now().plusDays(3),
+            pickupDate = LocalDate.now().plusDays(5),
+            pickupTimeStart = LocalTime.of(14, 0),
+            pickupTimeEnd = LocalTime.of(18, 0),
+            pickupLocation = "서울 성동구 성수동",
+        ).apply { this.id = id }
+    }
+
+    private fun createStore(): Store =
+        Store(
+            name = "뭉치장 베이커리",
+            address = "서울 성동구",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
+        ).apply { id = 1L }
+
+    private fun createGroupBuyRequest(): GroupBuyRequest =
+        GroupBuyRequest(
+            userId = 1L,
+            storeName = "뭉치장 베이커리",
+            storeAddress = "서울 성동구",
+            productName = "두쫀쿠",
+            desiredQuantity = 50,
+            desiredPickupDate = LocalDate.now().plusDays(5)
+        ).apply { id = 20L }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,6 +24,12 @@ naver:
     client-id: test-naver-client-id
     client-secret: test-naver-client-secret
 
+portone:
+  store-id: store-test
+  channel-key: channel-test
+  api-secret: portone-api-secret-test
+  payment-api-base-url: https://api.portone.io
+
 coolsms:
   api-key: test-api-key
   api-secret: test-api-secret


### PR DESCRIPTION
## 📌 작업한 내용
- PortOne V2 + 토스페이먼츠 결제 주문 생성/완료 검증 플로우를 추가했습니다.
- 결제 성공 시 `Participation`을 `PAID_WAITING_GOAL` 상태로 생성하고, PR #90의 `increaseCurrentQuantityIfAvailable`를 재사용해 승인 시점 최대 수량을 재검증하도록 반영했습니다.
- PortOne 결제 웹훅을 추가해 `PAID`, `FAILED`, `CANCELLED`, `PARTIAL_CANCELLED` 상태를 서버 조회 기반으로 동기화합니다.
- 결제 취소 웹훅 수신 시 결제/참여 환불 처리 및 공구 참여 수량 차감을 반영했습니다.
- PortOne 환경변수 설정, 결제 API OpenAPI 문서, 결제 플로우 테스트를 추가했습니다.
- `/dev/openapi.yaml` 및 웹훅 경로를 security/JWT whitelist에 추가해 dev Swagger와 PortOne 웹훅 접근이 막히지 않도록 수정했습니다.

## 🔍 참고 사항
- 결제 금액과 수수료는 서버에서 계산하며, 현재 수수료는 명세에 맞춰 `0원`입니다.
- 프론트는 `payment-orders` 응답의 `storeId`, `channelKey`, `paymentId`, `amount`로 PortOne SDK를 호출하면 됩니다. `PORTONE_API_SECRET`은 백엔드 환경변수로만 사용합니다.
- 운영/심사용 결제창 전환은 `PORTONE_CHANNEL_KEY`를 실연동 토스페이먼츠 채널 키로 교체하는 방식입니다.
- 기존 `/group-buys/{groupBuyId}/participations` 경로는 PR #90의 임시 참여 생성 경로로 남아 있으며, 결제 적용 화면에서는 `payment-orders -> PortOne -> complete` 플로우를 사용해야 합니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- closes #92
- MCJ-1463

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인