### PR TITLE
[MCJ-1462] FEAT: ngram FULLTEXT 검색 엔진 도입 

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -3,10 +3,47 @@ package com.moongchijang.domain.groupbuy.domain.repository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 import java.util.Optional
 
 interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepositoryCustom {
 
     @EntityGraph(attributePaths = ["store"])
     fun findWithStoreById(id: Long): Optional<GroupBuy>
+
+    /**
+     * ngram FULLTEXT 인덱스를 사용한 공구 검색.
+     *
+     * group_buys.product_name 매칭과 stores.name/address 매칭을 UNION 으로 합쳐
+     * 중복 제거한 뒤, status/deadline 으로 노출 가능한 공구만 반환한다.
+     *
+     * @param query   FullTextQueryBuilder.toBooleanQuery 로 변환된 BOOLEAN MODE 쿼리. 빈 문자열이면 빈 결과.
+     * @param status  노출 허용 상태 (보통 IN_PROGRESS)
+     * @param now     마감 비교 기준 시각 (deadline > now 인 공구만 반환)
+     * @param limit   반환할 최대 결과 수
+     */
+    @Query(
+        value = """
+            SELECT * FROM (
+                SELECT gb.* FROM group_buys gb
+                WHERE MATCH(gb.product_name) AGAINST(:query IN BOOLEAN MODE)
+                UNION
+                SELECT gb.* FROM group_buys gb
+                JOIN stores s ON gb.store_id = s.id
+                WHERE MATCH(s.name, s.address) AGAINST(:query IN BOOLEAN MODE)
+            ) AS merged
+            WHERE merged.status = :status
+              AND merged.deadline > :now
+            LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun searchByFullText(
+        @Param("query") query: String,
+        @Param("status") status: String,
+        @Param("now") now: LocalDateTime,
+        @Param("limit") limit: Int,
+    ): List<GroupBuy>
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
@@ -1,0 +1,26 @@
+package com.moongchijang.domain.groupbuy.infrastructure.search
+
+/**
+ * 사용자 검색어를 MySQL FULLTEXT BOOLEAN MODE 쿼리 문자열로 변환한다.
+ *
+ * - BOOLEAN MODE 연산자 문자(+, -, >, <, (, ), ~, *, ", @, \)는 사용자 입력에서 제거한다.
+ * - 토큰별 prefix wildcard(`*`)와 필수(`+`) 연산자를 붙여 모든 토큰이 매칭되는 AND 의미를 만든다.
+ * - ngram_token_size(기본 2) 미만의 한 글자 토큰은 매칭되지 않으므로 제외한다.
+ *
+ * 모든 토큰이 제거되면 빈 문자열을 반환한다. 호출 측에서 빈 문자열이면 검색을 스킵해야 한다.
+ */
+object FullTextQueryBuilder {
+
+    private val FORBIDDEN_CHARS = Regex("""[+\-><()~*"@\\]""")
+    private val WHITESPACE = Regex("""\s+""")
+    private const val MIN_TOKEN_LENGTH = 2
+
+    fun toBooleanQuery(rawQuery: String): String {
+        val tokens = rawQuery
+            .replace(FORBIDDEN_CHARS, " ")
+            .trim()
+            .split(WHITESPACE)
+            .filter { it.length >= MIN_TOKEN_LENGTH }
+        return tokens.joinToString(" ") { "+$it*" }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -1,0 +1,61 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.infrastructure.search.FullTextQueryBuilder
+import com.moongchijang.domain.search.application.dto.GroupBuyCardDto
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.application.dto.SearchResponse
+import com.moongchijang.domain.search.domain.SearchUiState
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+/**
+ * ngram FULLTEXT 인덱스만 사용하는 단순 검색 엔진.
+ *
+ * 기존 SearchOrchestrator (Gemini 키워드 추출 + Qdrant 벡터 + reranker) 와 달리
+ * 외부 호출 없이 BOOLEAN MODE 쿼리만으로 결과를 반환한다.
+ * 검색어가 BOOLEAN MODE 로 변환했을 때 토큰이 하나도 없으면 검색을 스킵한다.
+ */
+@Component
+class FullTextSearchEngine(
+    private val groupBuyRepository: GroupBuyRepository,
+) {
+    companion object {
+        private const val DEFAULT_LIMIT = 50
+    }
+
+    fun search(query: String): SearchResponse {
+        val booleanQuery = FullTextQueryBuilder.toBooleanQuery(query)
+        if (booleanQuery.isEmpty()) {
+            return emptyResponse()
+        }
+
+        val matches = groupBuyRepository.searchByFullText(
+            query = booleanQuery,
+            status = GroupBuyStatus.IN_PROGRESS.name,
+            now = LocalDateTime.now(),
+            limit = DEFAULT_LIMIT,
+        )
+
+        return SearchResponse(
+            searchCase = SearchCase.NONE_DETECTED,
+            detectedRegion = null,
+            detectedProduct = null,
+            confidence = 0.0,
+            uiState = if (matches.isEmpty()) SearchUiState.EMPTY_CAN_REQUEST else SearchUiState.RESULTS,
+            totalCount = matches.size,
+            results = matches.map { GroupBuyCardDto.from(it) },
+        )
+    }
+
+    private fun emptyResponse() = SearchResponse(
+        searchCase = SearchCase.NONE_DETECTED,
+        detectedRegion = null,
+        detectedProduct = null,
+        confidence = 0.0,
+        uiState = SearchUiState.EMPTY_CAN_REQUEST,
+        totalCount = 0,
+        results = emptyList(),
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.search.application
 
 import com.moongchijang.domain.search.application.dto.SearchResponse
 import com.moongchijang.domain.search.infrastructure.SearchHistoryRepository
+import com.moongchijang.global.config.SearchProperties
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,16 +14,18 @@ import java.time.Duration
 @Transactional(readOnly = true)
 class SearchService(
     private val searchOrchestrator: SearchOrchestrator,
+    private val fullTextSearchEngine: FullTextSearchEngine,
     private val searchHistoryRepository: SearchHistoryRepository,
     private val searchIndexVersionService: SearchIndexVersionService,
+    private val searchProperties: SearchProperties,
     private val redisTemplate: StringRedisTemplate,
     private val objectMapper: ObjectMapper
 ) {
     companion object {
         private const val CACHE_TTL_MINUTES = 10L  // keys(*) 블로킹 대신 짧은 TTL로 freshness 확보
-        private const val SEARCH_VERSION = "hybrid-v1"
-        private fun cacheKey(query: String, indexVersion: String) =
-            "search:result:$SEARCH_VERSION:$indexVersion:${sha256(query)}"
+        private const val ENGINE_FULLTEXT = "fulltext"
+        private fun cacheKey(query: String, engine: String, indexVersion: String) =
+            "search:result:$engine:$indexVersion:${sha256(query)}"
 
         private fun sha256(value: String): String =
             MessageDigest.getInstance("SHA-256")
@@ -31,14 +34,18 @@ class SearchService(
     }
 
     fun search(query: String, userId: Long?): SearchResponse {
+        val engine = searchProperties.engine
         val indexVersion = searchIndexVersionService.currentVersion()
-        val cacheKey = cacheKey(query, indexVersion)
+        val cacheKey = cacheKey(query, engine, indexVersion)
         val cached = redisTemplate.opsForValue().get(cacheKey)
         if (cached != null) return objectMapper.readValue(cached, SearchResponse::class.java)
 
         userId?.let { searchHistoryRepository.save(it, query) }
 
-        val response = searchOrchestrator.search(query)
+        val response = when (engine) {
+            ENGINE_FULLTEXT -> fullTextSearchEngine.search(query)
+            else -> searchOrchestrator.search(query)
+        }
 
         redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(response), Duration.ofMinutes(CACHE_TTL_MINUTES))
         return response

--- a/src/main/kotlin/com/moongchijang/global/config/SearchProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/SearchProperties.kt
@@ -4,6 +4,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "search")
 data class SearchProperties(
+    /**
+     * 검색 엔진 선택 플래그.
+     * - "legacy": 기존 Gemini + Qdrant 하이브리드 경로 (SearchOrchestrator)
+     * - "fulltext": ngram FULLTEXT 단일 경로 (FullTextSearchEngine)
+     * 단계적 전환을 위해 도입. 안정화 후 별도 PR 에서 legacy 코드와 함께 제거.
+     */
+    val engine: String = "legacy",
     val retrieval: Retrieval = Retrieval(),
     val guard: Guard = Guard(),
     val observability: Observability = Observability()

--- a/src/main/resources/db/migration/V10__add_fulltext_indexes_for_search.sql
+++ b/src/main/resources/db/migration/V10__add_fulltext_indexes_for_search.sql
@@ -1,0 +1,13 @@
+-- 공구 검색용 ngram parser 기반 FULLTEXT 인덱스 추가
+-- 대상:
+--   - group_buys.product_name      : 상품명 검색
+--   - stores.name, stores.address  : 매장명 + 주소(동 단위) 검색
+-- stores.region/district는 enum name(VARCHAR)으로 저장되어 한글 검색어와 매칭되지 않으므로 비대상.
+-- 검색어의 동(예: "성수")은 stores.address의 한글 주소 텍스트에서 매칭된다.
+-- ngram_token_size는 MySQL 기본값(2)을 사용한다.
+
+ALTER TABLE group_buys
+    ADD FULLTEXT INDEX idx_group_buys_product_name (product_name) WITH PARSER ngram;
+
+ALTER TABLE stores
+    ADD FULLTEXT INDEX idx_stores_name_address (name, address) WITH PARSER ngram;

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
@@ -1,0 +1,96 @@
+package com.moongchijang.domain.groupbuy.infrastructure.search
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class FullTextQueryBuilderTest {
+
+    @Test
+    @DisplayName("단일 한글 토큰은 +token* 형태로 변환된다")
+    fun `single korean token produces required prefix wildcard`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("소금빵")
+
+        assertThat(result).isEqualTo("+소금빵*")
+    }
+
+    @Test
+    @DisplayName("여러 토큰은 모두 +token* 형태로 AND 결합된다")
+    fun `multiple tokens are joined as AND with required prefix wildcards`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("성수 소금빵")
+
+        assertThat(result).isEqualTo("+성수* +소금빵*")
+    }
+
+    @Test
+    @DisplayName("연속된 공백은 단일 구분자로 처리된다")
+    fun `consecutive whitespace is collapsed`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("  성수   소금빵  ")
+
+        assertThat(result).isEqualTo("+성수* +소금빵*")
+    }
+
+    @Test
+    @DisplayName("빈 문자열은 빈 문자열로 반환된다")
+    fun `empty input returns empty string`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("공백만 있는 입력은 빈 문자열로 반환된다")
+    fun `whitespace only input returns empty string`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("   ")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("한 글자 토큰은 ngram_token_size 미만이므로 제외된다")
+    fun `single character tokens are filtered out`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("성 수 빵")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("한 글자와 두 글자가 섞이면 두 글자 이상만 남는다")
+    fun `mixed length tokens keep only tokens of length two or more`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("성 성수 빵")
+
+        assertThat(result).isEqualTo("+성수*")
+    }
+
+    @Test
+    @DisplayName("BOOLEAN MODE 연산자 문자는 제거된다")
+    fun `boolean mode operator characters are stripped`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("성수+빵집*\"소금빵\"")
+
+        assertThat(result).isEqualTo("+성수* +빵집* +소금빵*")
+    }
+
+    @Test
+    @DisplayName("괄호와 물결 등 모든 금지 문자가 제거된다")
+    fun `all forbidden characters are removed`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("(성수)~소금빵<홍대>@빵집\\카페")
+
+        assertThat(result).isEqualTo("+성수* +소금빵* +홍대* +빵집* +카페*")
+    }
+
+    @Test
+    @DisplayName("금지 문자만 입력되면 빈 문자열로 반환된다")
+    fun `input containing only forbidden characters returns empty string`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("+-*()~\"")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("영문/숫자 토큰도 동일하게 변환된다")
+    fun `latin and digit tokens are handled the same way`() {
+        val result = FullTextQueryBuilder.toBooleanQuery("seongsu cafe 2024")
+
+        assertThat(result).isEqualTo("+seongsu* +cafe* +2024*")
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -1,0 +1,73 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.domain.SearchUiState
+import com.moongchijang.support.search.MockitoKotlinMatchers.anyLocalDateTime
+import com.moongchijang.support.search.SearchTestFixtures
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito
+
+class FullTextSearchEngineTest {
+
+    private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
+    private val engine = FullTextSearchEngine(groupBuyRepository)
+
+    private fun stubSearch(result: List<GroupBuy>) {
+        Mockito.`when`(
+            groupBuyRepository.searchByFullText(
+                anyString(),
+                anyString(),
+                anyLocalDateTime(),
+                anyInt(),
+            )
+        ).thenReturn(result)
+    }
+
+    @Test
+    @DisplayName("토큰이 하나도 없으면 Repository를 호출하지 않고 EMPTY_CAN_REQUEST를 반환한다")
+    fun `empty boolean query short circuits without repository call`() {
+        val response = engine.search("+-*()")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
+        assertThat(response.totalCount).isZero
+        assertThat(response.results).isEmpty()
+        assertThat(response.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+        Mockito.verifyNoInteractions(groupBuyRepository)
+    }
+
+    @Test
+    @DisplayName("매칭 결과가 있으면 RESULTS와 카드 DTO 리스트를 반환한다")
+    fun `non empty match list produces RESULTS with mapped cards`() {
+        val match = SearchTestFixtures.groupBuy(id = 1L, productName = "소금빵")
+        stubSearch(listOf(match))
+
+        val response = engine.search("소금빵")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(1)
+        assertThat(response.results).hasSize(1)
+        assertThat(response.results[0].id).isEqualTo(1L)
+        assertThat(response.results[0].productName).isEqualTo("소금빵")
+        assertThat(response.detectedRegion).isNull()
+        assertThat(response.detectedProduct).isNull()
+    }
+
+    @Test
+    @DisplayName("Repository가 빈 결과를 반환하면 EMPTY_CAN_REQUEST를 반환한다")
+    fun `empty match list produces EMPTY_CAN_REQUEST`() {
+        stubSearch(emptyList())
+
+        val response = engine.search("존재하지않는상품")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
+        assertThat(response.totalCount).isZero
+        assertThat(response.results).isEmpty()
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -55,6 +55,7 @@ qdrant:
   distance: Cosine
 
 search:
+  engine: legacy
   retrieval:
     vector-candidate-limit: 10
     vector-min-score: 0.5


### PR DESCRIPTION
## 📌 작업한 내용
- `group_buys.product_name` / `stores(name, address)` 에 ngram parser FULLTEXT 인덱스 추가 (V10 마이그레이션)
- `FullTextQueryBuilder`: 입력 검색어를 BOOLEAN MODE 토큰(`+token*`)으로 정규화
- `GroupBuyRepository.searchByFullText`: 상품명/매장명+주소를 UNION 으로 합치고 status/deadline 필터링
- `FullTextSearchEngine`: 빈 토큰 short-circuit, 매칭 결과를 카드 DTO로 매핑
- `SearchService`: `search.engine` 프로퍼티(`legacy`/`fulltext`)로 분기, 캐시 키에 엔진 prefix 포함

## 🔍 참고 사항
- `fulltext` 전환은 환경변수 `SEARCH_ENGINE=fulltext` 또는 yml 한 줄로 토글
- 캐시 키에 엔진명을 포함시켜 플래그 전환 시 stale 캐시 히트 방지
- 결과가 0건이면 `EMPTY_CAN_REQUEST` 반환 → 후속 PR2(Naver Local 매장 추천)의 진입점
- 한글 ngram 시드/검색 시 mysql 클라이언트에 `--default-character-set=utf8mb4` 필수 (mojibake 회피)

## 🖼 스크린샷
없음

## 🔗 관련 이슈
- Closes #91

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료 (`./gradlew classes testClasses test`)
- [ ] V10 마이그레이션 로컬 적용 + `SHOW INDEX` 로 FULLTEXT 인덱스 확인
- [ ] `SEARCH_ENGINE=fulltext` 핸드테스트 (RESULTS / EMPTY_CAN_REQUEST 양쪽 확인)
- [ ] `SEARCH_ENGINE=legacy` 회귀 확인 (detectedRegion/confidence 채워짐)
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인