### PR TITLE
[MCJ-1465] FEAT: 검색 결과 없을 경우 Naver Local 추천 매장 노출

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
@@ -1,8 +1,11 @@
 package com.moongchijang.domain.search.application
 
 import com.moongchijang.domain.search.application.dto.SearchResponse
+import com.moongchijang.domain.search.domain.SearchUiState
 import com.moongchijang.domain.search.infrastructure.SearchHistoryRepository
+import com.moongchijang.domain.store.application.StoreSearchService
 import com.moongchijang.global.config.SearchProperties
+import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,10 +20,13 @@ class SearchService(
     private val fullTextSearchEngine: FullTextSearchEngine,
     private val searchHistoryRepository: SearchHistoryRepository,
     private val searchIndexVersionService: SearchIndexVersionService,
+    private val storeSearchService: StoreSearchService,
     private val searchProperties: SearchProperties,
     private val redisTemplate: StringRedisTemplate,
     private val objectMapper: ObjectMapper
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
         private const val CACHE_TTL_MINUTES = 10L  // keys(*) 블로킹 대신 짧은 TTL로 freshness 확보
         private const val ENGINE_FULLTEXT = "fulltext"
@@ -42,13 +48,30 @@ class SearchService(
 
         userId?.let { searchHistoryRepository.save(it, query) }
 
-        val response = when (engine) {
+        val raw = when (engine) {
             ENGINE_FULLTEXT -> fullTextSearchEngine.search(query)
             else -> searchOrchestrator.search(query)
         }
+        val response = enrichWithRecommendation(query, raw)
 
         redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(response), Duration.ofMinutes(CACHE_TTL_MINUTES))
         return response
+    }
+
+    /**
+     * 결과 0건(EMPTY_CAN_REQUEST)일 때 Naver Local 매장 후보로 응답을 보강한다.
+     * Naver 호출 실패는 검색 전체를 깨뜨리지 않도록 empty list 로 graceful degrade.
+     * cold-start flywheel: 사용자가 추천 매장에 공구 요청 → 다음 검색은 FULLTEXT 엔진이 잡음.
+     */
+    private fun enrichWithRecommendation(query: String, response: SearchResponse): SearchResponse {
+        if (response.uiState != SearchUiState.EMPTY_CAN_REQUEST) return response
+        val stores = try {
+            storeSearchService.search(query).stores
+        } catch (e: Exception) {
+            log.warn("Naver Local 매장 추천 실패, 빈 추천으로 대체 query=$query", e)
+            emptyList()
+        }
+        return response.copy(recommendedStores = stores)
     }
 
     fun getHistory(userId: Long): List<String> = searchHistoryRepository.getHistory(userId)

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchService.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.search.application
 
+import com.moongchijang.domain.search.application.dto.RecommendedStoreDto
 import com.moongchijang.domain.search.application.dto.SearchResponse
 import com.moongchijang.domain.search.domain.SearchUiState
 import com.moongchijang.domain.search.infrastructure.SearchHistoryRepository
@@ -66,7 +67,7 @@ class SearchService(
     private fun enrichWithRecommendation(query: String, response: SearchResponse): SearchResponse {
         if (response.uiState != SearchUiState.EMPTY_CAN_REQUEST) return response
         val stores = try {
-            storeSearchService.search(query).stores
+            storeSearchService.search(query).stores.map(RecommendedStoreDto::from)
         } catch (e: Exception) {
             log.warn("Naver Local 매장 추천 실패, 빈 추천으로 대체 query=$query", e)
             emptyList()

--- a/src/main/kotlin/com/moongchijang/domain/search/application/dto/RecommendedStoreDto.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/dto/RecommendedStoreDto.kt
@@ -1,0 +1,28 @@
+package com.moongchijang.domain.search.application.dto
+
+import com.moongchijang.domain.store.application.dto.StoreSearchResponse
+
+/**
+ * 검색 결과 0건(EMPTY_CAN_REQUEST) 응답에 동봉되는 동네 매장 추천 DTO.
+ * store 도메인 DTO 를 직접 노출하지 않고 search 도메인 안에서 한 번 변환해
+ * 외부(API 스펙) 결합도를 store 도메인 변경으로부터 격리한다.
+ */
+data class RecommendedStoreDto(
+    val placeId: String,
+    val storeName: String,
+    val roadAddress: String,
+    val lotAddress: String?,
+    val latitude: Double,
+    val longitude: Double,
+) {
+    companion object {
+        fun from(item: StoreSearchResponse.StoreItem) = RecommendedStoreDto(
+            placeId = item.placeId,
+            storeName = item.storeName,
+            roadAddress = item.roadAddress,
+            lotAddress = item.lotAddress,
+            latitude = item.latitude,
+            longitude = item.longitude,
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchResponse.kt
@@ -1,7 +1,6 @@
 package com.moongchijang.domain.search.application.dto
 
 import com.moongchijang.domain.search.domain.SearchUiState
-import com.moongchijang.domain.store.application.dto.StoreSearchResponse
 
 data class SearchResponse(
     val searchCase: SearchCase,
@@ -11,5 +10,5 @@ data class SearchResponse(
     val uiState: SearchUiState = SearchUiState.NEED_BOTH,
     val totalCount: Int,
     val results: List<GroupBuyCardDto>,
-    val recommendedStores: List<StoreSearchResponse.StoreItem>? = null,
+    val recommendedStores: List<RecommendedStoreDto>? = null,
 )

--- a/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/dto/SearchResponse.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.search.application.dto
 
 import com.moongchijang.domain.search.domain.SearchUiState
+import com.moongchijang.domain.store.application.dto.StoreSearchResponse
 
 data class SearchResponse(
     val searchCase: SearchCase,
@@ -9,5 +10,6 @@ data class SearchResponse(
     val confidence: Double = 0.0,
     val uiState: SearchUiState = SearchUiState.NEED_BOTH,
     val totalCount: Int,
-    val results: List<GroupBuyCardDto>
+    val results: List<GroupBuyCardDto>,
+    val recommendedStores: List<StoreSearchResponse.StoreItem>? = null,
 )

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchServiceTest.kt
@@ -1,0 +1,140 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.application.dto.GroupBuyCardDto
+import com.moongchijang.domain.search.application.dto.SearchCase
+import com.moongchijang.domain.search.application.dto.SearchResponse
+import com.moongchijang.domain.search.domain.SearchUiState
+import com.moongchijang.domain.search.infrastructure.SearchHistoryRepository
+import com.moongchijang.domain.store.application.StoreSearchService
+import com.moongchijang.domain.store.application.dto.StoreSearchResponse
+import com.moongchijang.global.config.SearchProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import tools.jackson.databind.ObjectMapper
+import java.time.Duration
+
+class SearchServiceTest {
+
+    private val searchOrchestrator: SearchOrchestrator = Mockito.mock(SearchOrchestrator::class.java)
+    private val fullTextSearchEngine: FullTextSearchEngine = Mockito.mock(FullTextSearchEngine::class.java)
+    private val searchHistoryRepository: SearchHistoryRepository = Mockito.mock(SearchHistoryRepository::class.java)
+    private val searchIndexVersionService: SearchIndexVersionService = Mockito.mock(SearchIndexVersionService::class.java)
+    private val storeSearchService: StoreSearchService = Mockito.mock(StoreSearchService::class.java)
+    private val redisTemplate: StringRedisTemplate = Mockito.mock(StringRedisTemplate::class.java)
+
+    @Suppress("UNCHECKED_CAST")
+    private val valueOperations: ValueOperations<String, String> =
+        Mockito.mock(ValueOperations::class.java) as ValueOperations<String, String>
+
+    private val objectMapper = ObjectMapper()
+
+    private val service = SearchService(
+        searchOrchestrator = searchOrchestrator,
+        fullTextSearchEngine = fullTextSearchEngine,
+        searchHistoryRepository = searchHistoryRepository,
+        searchIndexVersionService = searchIndexVersionService,
+        storeSearchService = storeSearchService,
+        searchProperties = SearchProperties(engine = "fulltext"),
+        redisTemplate = redisTemplate,
+        objectMapper = objectMapper
+    )
+
+    @BeforeEach
+    fun setUp() {
+        Mockito.`when`(redisTemplate.opsForValue()).thenReturn(valueOperations)
+        Mockito.`when`(valueOperations.get(anyString())).thenReturn(null)
+        Mockito.`when`(searchIndexVersionService.currentVersion()).thenReturn("v1")
+    }
+
+    private fun emptyResponse() = SearchResponse(
+        searchCase = SearchCase.NONE_DETECTED,
+        detectedRegion = null,
+        detectedProduct = null,
+        confidence = 0.0,
+        uiState = SearchUiState.EMPTY_CAN_REQUEST,
+        totalCount = 0,
+        results = emptyList()
+    )
+
+    private fun resultsResponse() = SearchResponse(
+        searchCase = SearchCase.NONE_DETECTED,
+        detectedRegion = null,
+        detectedProduct = null,
+        confidence = 0.0,
+        uiState = SearchUiState.RESULTS,
+        totalCount = 1,
+        results = listOf<GroupBuyCardDto>()
+    )
+
+    private fun storeItem(name: String) = StoreSearchResponse.StoreItem(
+        placeId = "p-$name",
+        storeName = name,
+        roadAddress = "서울 어딘가",
+        lotAddress = null,
+        latitude = 37.5,
+        longitude = 127.0
+    )
+
+    @Test
+    @DisplayName("EMPTY_CAN_REQUEST면 Naver Local 매장 후보로 recommendedStores를 채운다")
+    fun `empty response is enriched with naver recommendations`() {
+        Mockito.`when`(fullTextSearchEngine.search("없는상품")).thenReturn(emptyResponse())
+        val recs = StoreSearchResponse(stores = listOf(storeItem("동네빵집"), storeItem("뒷골목빵집")))
+        Mockito.`when`(storeSearchService.search("없는상품")).thenReturn(recs)
+
+        val response = service.search("없는상품", userId = null)
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
+        assertThat(response.recommendedStores).extracting("storeName")
+            .containsExactly("동네빵집", "뒷골목빵집")
+    }
+
+    @Test
+    @DisplayName("EMPTY_CAN_REQUEST에서 Naver 호출이 실패해도 검색 전체는 깨지지 않고 빈 리스트로 응답한다")
+    fun `naver failure degrades to empty recommendations`() {
+        Mockito.`when`(fullTextSearchEngine.search("없는상품")).thenReturn(emptyResponse())
+        Mockito.`when`(storeSearchService.search("없는상품"))
+            .thenThrow(CustomException(ErrorCode.STORE_SEARCH_FAILED))
+
+        val response = service.search("없는상품", userId = null)
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
+        assertThat(response.recommendedStores).isEmpty()
+    }
+
+    @Test
+    @DisplayName("RESULTS 응답에는 Naver를 호출하지 않고 recommendedStores는 null로 유지된다")
+    fun `results response does not call naver`() {
+        Mockito.`when`(fullTextSearchEngine.search("소금빵")).thenReturn(resultsResponse())
+
+        val response = service.search("소금빵", userId = null)
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.recommendedStores).isNull()
+        Mockito.verifyNoInteractions(storeSearchService)
+    }
+
+    @Test
+    @DisplayName("enrich된 응답이 그대로 Redis에 캐시된다")
+    fun `enriched response is cached`() {
+        Mockito.`when`(fullTextSearchEngine.search("없는상품")).thenReturn(emptyResponse())
+        Mockito.`when`(storeSearchService.search("없는상품"))
+            .thenReturn(StoreSearchResponse(stores = listOf(storeItem("동네빵집"))))
+
+        service.search("없는상품", userId = null)
+
+        Mockito.verify(valueOperations).set(
+            anyString(),
+            Mockito.contains("동네빵집"),
+            Mockito.eq(Duration.ofMinutes(10L))
+        )
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 공구 검색 결과가 0건(`EMPTY_CAN_REQUEST`)일 때 Naver Local API 로 동네 매장 후보를 추천하도록 응답을 보강한다.
- `SearchResponse` 에 `recommendedStores: List<StoreItem>?` 필드 추가 (RESULTS 응답에는 `null` 유지).
- `SearchService` 가 엔진 결과를 받은 직후 / Redis 캐시 저장 직전에 enrich. 캐시 hit 시 Naver 재호출 없음.
- Naver 호출 실패는 검색 전체를 깨뜨리지 않도록 `emptyList` 로 graceful degrade (warn 로그).
- 기존 `StoreSearchService` / `NaverLocalSearchClient` 재사용. 신규 client 작성 없음.

## 🔍 참고 사항
- PR1 의 `EMPTY_CAN_REQUEST` 분기가 이번 PR 의 진입점.
- enrich 위치는 `FullTextSearchEngine` 내부가 아닌 `SearchService` 레이어. 엔진 책임 경계(검색 결과만 반환) 유지.
- cold-start flywheel: 사용자가 추천 매장에 공구 요청 → 운영자 공구 오픈 → 다음 검색은 FULLTEXT 엔진이 잡음.
- 캐시는 enrich 된 응답을 통째로 저장 (TTL 10분). 동일 키워드 재검색 시 Naver quota 절약.
- `recommendedStores` 가 nullable 이므로 RESULTS 응답을 받는 기존 클라이언트는 변경 없음.

## 🖼 스크린샷
없음

## 🔗 관련 이슈
- Closes #98

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] `SearchServiceTest` 4개 케이스 통과 (EMPTY enrich / Naver 실패 fallback / RESULTS 미호출 / 캐시 저장)
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

[MCJ-1462]: https://moongchijang.atlassian.net/browse/MCJ-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ