### PR TITLE
FIX: Jira 이슈 생성 워크플로 차단 action 제거

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -79,8 +79,8 @@ jobs:
           git push origin "$BRANCH_NAME"
 
       - name: Update issue title
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: "update-issue"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: "[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --title "[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}"


### PR DESCRIPTION
## 작업 내용
- GitHub에서 blocked 된 actions-cool/issues-helper@v3 사용을 제거했습니다.
- 이슈 제목 업데이트는 GitHub CLI의 gh issue edit로 대체했습니다.

## 배경
- Create Jira issue 워크플로가 Set up job 단계에서 Repository access blocked로 실패했습니다.
- 차단 원인은 actions-cool/issues-helper repository의 GitHub TOS block입니다.

## 확인
- git diff --check 통과