### PR TITLE
FIX: 기존 이슈 Jira 생성 수동 트리거 추가

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -3,6 +3,11 @@ on:
   issues:
     types:
       - opened
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Jira issue를 생성할 GitHub issue number"
+        required: true
 
 permissions:
   contents: write
@@ -10,6 +15,7 @@ permissions:
 
 jobs:
   create-issue:
+    if: github.event_name == 'issues'
     name: Create Jira issue
     runs-on: ubuntu-latest
     steps:
@@ -84,3 +90,96 @@ jobs:
         run: |
           gh issue edit "${{ github.event.issue.number }}" \
             --title "[${{ steps.create.outputs.issue }}] ${{ github.event.issue.title }}"
+
+  create-issue-manual:
+    if: github.event_name == 'workflow_dispatch'
+    name: Create Jira issue manually
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login
+        uses: atlassian/gajira-login@v3
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+
+      - name: Checkout develop code
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load issue
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" --json title,body,url > issue.json
+          jq -r '.body' issue.json > issue_body.md
+
+          extract_section() {
+            awk -v header="$1" '
+              /^### / { in_section = ($0 == "### " header); next }
+              in_section && NF { print; exit }
+            ' issue_body.md
+          }
+
+          title="$(jq -r '.title' issue.json)"
+          url="$(jq -r '.url' issue.json)"
+          parent_key="$(extract_section "상위 작업 Ticket Number")"
+          branch_prefix="$(extract_section "브랜치 전략(GitFlow)")"
+
+          test -n "$parent_key"
+          test -n "$branch_prefix"
+
+          {
+            echo "title<<ISSUE_TITLE"
+            echo "$title"
+            echo "ISSUE_TITLE"
+            echo "description<<ISSUE_DESCRIPTION"
+            echo "### Github Issue Link"
+            echo "- $url"
+            echo
+            cat issue_body.md
+            echo "ISSUE_DESCRIPTION"
+            echo "parent_key=$parent_key"
+            echo "branch_prefix=$branch_prefix"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Convert markdown to Jira Syntax
+        uses: peter-evans/jira2md@v1
+        id: md2jira
+        with:
+          input-text: ${{ steps.issue.outputs.description }}
+          mode: md2jira
+
+      - name: Create Issue
+        id: create
+        uses: atlassian/gajira-create@v3
+        with:
+          project: SCRUM
+          issuetype: Task
+          summary: "${{ steps.issue.outputs.title }}"
+          description: "${{ steps.md2jira.outputs.output-text }}"
+          fields: |
+            {
+              "parent": {
+                "key": "${{ steps.issue.outputs.parent_key }}"
+              }
+            }
+
+      - name: Create branch with Ticket number
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH_NAME="${{ steps.issue.outputs.branch_prefix }}/#${{ inputs.issue_number }}-${{ steps.create.outputs.issue }}"
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
+
+      - name: Update issue title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit "${{ inputs.issue_number }}" \
+            --title "[${{ steps.create.outputs.issue }}] ${{ steps.issue.outputs.title }}"


### PR DESCRIPTION
## 작업 내용
- Create Jira issue 워크플로에 workflow_dispatch 입력을 추가했습니다.
- 이미 opened 이벤트가 지나간 GitHub issue 번호를 입력해 Jira 티켓/브랜치/제목 업데이트를 수동 복구할 수 있게 했습니다.
- 기존 issues.opened 자동 흐름은 유지했습니다.

## 배경
- #102는 기존 blocked action 상태에서 생성되어 failed run을 rerun해도 생성 당시 워크플로 정의를 사용해 계속 실패합니다.
- 이번 수동 트리거는 #102 같은 기존 이슈 복구용입니다.

## 확인
- git diff --check 통과
- YAML parse 확인