### PR TITLE
HOTFIX: PortOne 결제 응답 시간 파싱 예외 처리

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -40,6 +40,8 @@ class PortOnePaymentClient(
                 paidAt = parseDateTime(response["paidAt"] as? String ?: response["approvedAt"] as? String),
                 cancelledAt = parseDateTime(response["cancelledAt"] as? String ?: response["canceledAt"] as? String),
             )
+        } catch (e: CustomException) {
+            throw e
         } catch (e: RuntimeException) {
             throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
         }

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -10,6 +10,7 @@ import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import java.time.format.DateTimeParseException
 
 @Component
 class PortOnePaymentClient(
@@ -30,14 +31,18 @@ class PortOnePaymentClient(
             throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
         }
 
-        return PortOnePaymentResult(
-            paymentId = response["id"] as? String ?: paymentId,
-            status = response["status"] as? String ?: "",
-            totalAmount = extractTotalAmount(response),
-            method = extractPaymentMethod(response),
-            paidAt = parseDateTime(response["paidAt"] as? String ?: response["approvedAt"] as? String),
-            cancelledAt = parseDateTime(response["cancelledAt"] as? String ?: response["canceledAt"] as? String),
-        )
+        return try {
+            PortOnePaymentResult(
+                paymentId = response["id"] as? String ?: paymentId,
+                status = response["status"] as? String ?: "",
+                totalAmount = extractTotalAmount(response),
+                method = extractPaymentMethod(response),
+                paidAt = parseDateTime(response["paidAt"] as? String ?: response["approvedAt"] as? String),
+                cancelledAt = parseDateTime(response["cancelledAt"] as? String ?: response["canceledAt"] as? String),
+            )
+        } catch (e: RuntimeException) {
+            throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -58,6 +63,12 @@ class PortOnePaymentClient(
     }
 
     private fun parseDateTime(value: String?): LocalDateTime? {
-        return value?.let { OffsetDateTime.parse(it).toLocalDateTime() }
+        return value?.let {
+            try {
+                OffsetDateTime.parse(it).toLocalDateTime()
+            } catch (e: DateTimeParseException) {
+                LocalDateTime.parse(it)
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
@@ -1,0 +1,62 @@
+package com.moongchijang.domain.payment.infrastructure.portone
+
+import com.moongchijang.global.config.PortOneProperties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.ExpectedCount.once
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+import java.time.LocalDateTime
+
+class PortOnePaymentClientTest {
+
+    @Test
+    fun `offset 없는 결제 승인 시각도 파싱한다`() {
+        val builder = RestClient.builder()
+        val server = MockRestServiceServer.bindTo(builder).build()
+        val client = PortOnePaymentClient(
+            portOneProperties = PortOneProperties(
+                storeId = "store-test",
+                channelKey = "channel-test",
+                apiSecret = "secret-test",
+                paymentApiBaseUrl = "https://api.portone.test"
+            ),
+            restClientBuilder = builder
+        )
+        val paymentId = "MCJ-901003-da4c41e875f7431dbfa3"
+
+        server.expect(once(), requestTo("https://api.portone.test/payments/$paymentId"))
+            .andExpect(method(HttpMethod.GET))
+            .andExpect(header(HttpHeaders.AUTHORIZATION, "PortOne secret-test"))
+            .andRespond(
+                withSuccess(
+                    """
+                    {
+                      "id": "$paymentId",
+                      "status": "PAID",
+                      "amount": { "total": 1000 },
+                      "method": { "card": {} },
+                      "paidAt": "2026-05-19T06:20:00"
+                    }
+                    """.trimIndent(),
+                    MediaType.APPLICATION_JSON
+                )
+            )
+
+        val result = client.getPayment(paymentId)
+
+        assertEquals(paymentId, result.paymentId)
+        assertEquals("PAID", result.status)
+        assertEquals(1000, result.totalAmount)
+        assertEquals("card", result.method)
+        assertEquals(LocalDateTime.of(2026, 5, 19, 6, 20), result.paidAt)
+        server.verify()
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- PortOne 결제 조회 응답의 승인/취소 시각이 offset 없는 ISO datetime으로 와도 파싱되도록 fallback 처리를 추가했습니다.
- PortOne 응답 파싱 중 런타임 예외가 발생하면 500 대신 기존 결제 승인 실패 예외로 처리되도록 방어했습니다.
- offset 없는 paidAt 응답 파싱 단위 테스트를 추가했습니다.

## 🔍 참고 사항
- dev 결제 완료 검증 호출에서 INTERNAL_SERVER_ERROR가 발생한 케이스 대응입니다.
- 문서/seed 변경은 이번 PR에 포함하지 않았습니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- 없음

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인