### PR TITLE
HOTFIX: Participation 감사 필드 누락 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
@@ -81,4 +81,4 @@ class Participation(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
-)
+) : BaseEntity()

--- a/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
@@ -11,20 +11,24 @@ import com.moongchijang.domain.store.domain.entity.Store
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.global.config.QuerydslConfig
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.context.annotation.Import
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
-@SpringBootTest
-@ActiveProfiles("test")
-@Transactional
+@DataJpaTest(
+    properties = [
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+    ]
+)
+@Import(QuerydslConfig::class)
 class ParticipationAuditingIntegrationTest {
 
     @Autowired
@@ -33,7 +37,7 @@ class ParticipationAuditingIntegrationTest {
     @Test
     fun `참여 저장 시 감사 시간이 채워진다`() {
         val user = persistUser()
-        val groupBuy = persistGroupBuy()
+        val groupBuy = persistGroupBuy(user.id!!)
         val participation = Participation(
             user = user,
             groupBuy = groupBuy,
@@ -64,7 +68,7 @@ class ParticipationAuditingIntegrationTest {
         return user
     }
 
-    private fun persistGroupBuy(): GroupBuy {
+    private fun persistGroupBuy(userId: Long): GroupBuy {
         val store = Store(
             name = "테스트 매장",
             address = "서울 성동구",
@@ -74,7 +78,7 @@ class ParticipationAuditingIntegrationTest {
         em.persist(store)
 
         val request = GroupBuyRequest(
-            userId = 1L,
+            userId = userId,
             storeName = "테스트 매장",
             storeAddress = "서울 성동구",
             productName = "테스트 상품",

--- a/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
@@ -1,0 +1,107 @@
+package com.moongchijang.domain.participation.repository
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class ParticipationAuditingIntegrationTest {
+
+    @Autowired
+    private lateinit var em: EntityManager
+
+    @Test
+    fun `참여 저장 시 감사 시간이 채워진다`() {
+        val user = persistUser()
+        val groupBuy = persistGroupBuy()
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 1000,
+            feeAmount = 0,
+            totalAmount = 1000,
+            status = ParticipationStatus.PAID_WAITING_GOAL
+        )
+
+        em.persist(participation)
+        em.flush()
+
+        assertThat(participation.createdAt).isNotNull()
+        assertThat(participation.updatedAt).isNotNull()
+    }
+
+    private fun persistUser(): User {
+        val user = User(
+            provider = AuthProvider.EMAIL,
+            email = "participation-audit@test.com",
+            passwordHash = "password",
+            nickname = "tester",
+            role = UserRole.BUYER,
+            signupCompleted = true
+        )
+        em.persist(user)
+        return user
+    }
+
+    private fun persistGroupBuy(): GroupBuy {
+        val store = Store(
+            name = "테스트 매장",
+            address = "서울 성동구",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
+        )
+        em.persist(store)
+
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "테스트 매장",
+            storeAddress = "서울 성동구",
+            productName = "테스트 상품",
+            desiredQuantity = 50,
+            desiredPickupDate = LocalDate.now().plusDays(5)
+        )
+        em.persist(request)
+
+        val groupBuy = GroupBuy(
+            store = store,
+            groupBuyRequest = request,
+            thumbnailUrl = "https://example.com/image.jpg",
+            productName = "테스트 상품",
+            productDescription = "설명",
+            price = 1000,
+            targetQuantity = 50,
+            currentQuantity = 0,
+            maxQuantity = 100,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = LocalDateTime.now().plusDays(3),
+            pickupDate = LocalDate.now().plusDays(5),
+            pickupTimeStart = LocalTime.of(14, 0),
+            pickupTimeEnd = LocalTime.of(18, 0),
+            pickupLocation = "서울 성동구",
+            shareCount = 0
+        )
+        em.persist(groupBuy)
+        return groupBuy
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- Participation 엔티티가 BaseEntity를 상속하도록 수정했습니다.
- 결제 승인 시 participation 저장 과정에서 created_at, updated_at NOT NULL 컬럼이 채워지지 않아 500이 발생할 수 있는 문제를 보완했습니다.
- 참여 저장 시 감사 시간이 채워지는 JPA 통합 테스트를 추가했습니다.

## 🔍 참고 사항
- participation 테이블에는 created_at, updated_at이 NOT NULL로 정의되어 있습니다.
- 기존 엔티티는 BaseEntity import만 있고 실제 상속이 빠져 있어 JPA auditing 대상이 아니었습니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- 없음

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
