### PR TITLE
[MCJ-1450] FEAT: 결제 취소 환불 정합성 및 경계 시점 처리 강화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -184,17 +184,24 @@ class PaymentService(
             return
         }
 
-        transactionTemplate().execute {
-            val lockedOrder = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
-            when (paymentResult.status) {
-                PORTONE_STATUS_CANCELLED -> cancelPayment(lockedOrder, paymentResult, partial = false)
-                PORTONE_STATUS_PARTIAL_CANCELLED -> cancelPayment(lockedOrder, paymentResult, partial = true)
-                PORTONE_STATUS_FAILED -> {
-                    if (lockedOrder.status == PaymentOrderStatus.READY) {
-                        lockedOrder.fail(LocalDateTime.now())
-                        paymentOrderRepository.save(lockedOrder)
+        if (paymentResult.status == PORTONE_STATUS_CANCELLED || paymentResult.status == PORTONE_STATUS_PARTIAL_CANCELLED) {
+            withGroupBuyLock(order.groupBuy.id) {
+                transactionTemplate().execute {
+                    val lockedOrder = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
+                    when (paymentResult.status) {
+                        PORTONE_STATUS_CANCELLED -> cancelPayment(lockedOrder, paymentResult, partial = false)
+                        PORTONE_STATUS_PARTIAL_CANCELLED -> cancelPayment(lockedOrder, paymentResult, partial = true)
                     }
                 }
+            }
+            return
+        }
+
+        transactionTemplate().execute {
+            val lockedOrder = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
+            if (paymentResult.status == PORTONE_STATUS_FAILED && lockedOrder.status == PaymentOrderStatus.READY) {
+                lockedOrder.fail(LocalDateTime.now())
+                paymentOrderRepository.save(lockedOrder)
             }
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -354,13 +354,40 @@ class PaymentService(
     private fun applyParticipationRefundConsistency(order: PaymentOrder, cancelledAt: LocalDateTime) {
         val userId = order.user.id ?: return
         val participation = participationRepository.findByUserIdAndGroupBuyId(userId, order.groupBuy.id) ?: return
-        if (participation.status == ParticipationStatus.REFUNDED) return
+        if (participation.status == ParticipationStatus.REFUNDED) {
+            log.info(
+                "[PaymentService] 환불 멱등 처리: orderId={}, userId={}, groupBuyId={}, participationId={}",
+                order.orderId, userId, order.groupBuy.id, participation.id
+            )
+            return
+        }
 
         // 취소 반영 시점의 최신 공구 상태를 락으로 재확인해서 수량 차감 정합성을 맞춘다.
         val groupBuy = groupBuyRepository.findWithLockById(order.groupBuy.id).orElse(participation.groupBuy)
+        val beforeQuantity = groupBuy.currentQuantity
         groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)
         participation.status = ParticipationStatus.REFUNDED
         participation.refundedAt = cancelledAt
+        reconcileGroupBuyStatusAfterRefund(groupBuy)
+        log.info(
+            "[PaymentService] 환불 정합성 반영 완료: orderId={}, groupBuyId={}, participationId={}, quantity={}=>{}, refundedAt={}",
+            order.orderId,
+            groupBuy.id,
+            participation.id,
+            beforeQuantity,
+            groupBuy.currentQuantity,
+            cancelledAt
+        )
+    }
+
+    private fun reconcileGroupBuyStatusAfterRefund(groupBuy: GroupBuy) {
+        if (groupBuy.status == GroupBuyStatus.ACHIEVED && groupBuy.currentQuantity < groupBuy.targetQuantity) {
+            groupBuy.status = GroupBuyStatus.IN_PROGRESS
+            log.info(
+                "[PaymentService] 환불로 공구 상태 조정: groupBuyId={}, ACHIEVED->IN_PROGRESS, currentQuantity={}, targetQuantity={}",
+                groupBuy.id, groupBuy.currentQuantity, groupBuy.targetQuantity
+            )
+        }
     }
 
     private fun buildAlreadyApprovedResponse(order: PaymentOrder): ConfirmPaymentResponse {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -328,26 +328,39 @@ class PaymentService(
         val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
             ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
 
+        updateOrderAndPaymentCancellationState(order, payment, cancelledAt, partial)
+
+        if (!partial) {
+            applyParticipationRefundConsistency(order, cancelledAt)
+        }
+    }
+
+    private fun updateOrderAndPaymentCancellationState(
+        order: PaymentOrder,
+        payment: Payment,
+        cancelledAt: LocalDateTime,
+        partial: Boolean
+    ) {
         if (partial) {
             order.partialCancel(cancelledAt)
-        } else {
-            order.cancel(cancelledAt)
+            payment.partialCancel(cancelledAt)
+            return
         }
 
-        if (partial) {
-            payment.partialCancel(cancelledAt)
-        } else {
-            payment.cancel(cancelledAt)
-            val userId = order.user.id ?: return
-            participationRepository.findByUserIdAndGroupBuyId(userId, order.groupBuy.id)?.let { participation ->
-                if (participation.status != ParticipationStatus.REFUNDED) {
-                    val groupBuy = groupBuyRepository.findWithLockById(order.groupBuy.id).orElse(participation.groupBuy)
-                    groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)
-                    participation.status = ParticipationStatus.REFUNDED
-                    participation.refundedAt = cancelledAt
-                }
-            }
-        }
+        order.cancel(cancelledAt)
+        payment.cancel(cancelledAt)
+    }
+
+    private fun applyParticipationRefundConsistency(order: PaymentOrder, cancelledAt: LocalDateTime) {
+        val userId = order.user.id ?: return
+        val participation = participationRepository.findByUserIdAndGroupBuyId(userId, order.groupBuy.id) ?: return
+        if (participation.status == ParticipationStatus.REFUNDED) return
+
+        // 취소 반영 시점의 최신 공구 상태를 락으로 재확인해서 수량 차감 정합성을 맞춘다.
+        val groupBuy = groupBuyRepository.findWithLockById(order.groupBuy.id).orElse(participation.groupBuy)
+        groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)
+        participation.status = ParticipationStatus.REFUNDED
+        participation.refundedAt = cancelledAt
     }
 
     private fun buildAlreadyApprovedResponse(order: PaymentOrder): ConfirmPaymentResponse {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -328,11 +328,11 @@ class PaymentService(
         val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
             ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
 
-        updateOrderAndPaymentCancellationState(order, payment, cancelledAt, partial)
-
         if (!partial) {
             applyParticipationRefundConsistency(order, cancelledAt)
         }
+
+        updateOrderAndPaymentCancellationState(order, payment, cancelledAt, partial)
     }
 
     private fun updateOrderAndPaymentCancellationState(
@@ -364,6 +364,7 @@ class PaymentService(
 
         // 취소 반영 시점의 최신 공구 상태를 락으로 재확인해서 수량 차감 정합성을 맞춘다.
         val groupBuy = groupBuyRepository.findWithLockById(order.groupBuy.id).orElse(participation.groupBuy)
+        validateRefundEligibility(groupBuy, order)
         val beforeQuantity = groupBuy.currentQuantity
         groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)
         participation.status = ParticipationStatus.REFUNDED
@@ -387,6 +388,16 @@ class PaymentService(
                 "[PaymentService] 환불로 공구 상태 조정: groupBuyId={}, ACHIEVED->IN_PROGRESS, currentQuantity={}, targetQuantity={}",
                 groupBuy.id, groupBuy.currentQuantity, groupBuy.targetQuantity
             )
+        }
+    }
+
+    private fun validateRefundEligibility(groupBuy: GroupBuy, order: PaymentOrder) {
+        if (groupBuy.status == GroupBuyStatus.ACHIEVED) {
+            log.info(
+                "[PaymentService] 환불 거절(달성 완료): orderId={}, groupBuyId={}, status={}",
+                order.orderId, groupBuy.id, groupBuy.status
+            )
+            throw CustomException(ErrorCode.PAYMENT_REFUND_NOT_ALLOWED_AFTER_ACHIEVED)
         }
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -369,7 +369,6 @@ class PaymentService(
         groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)
         participation.status = ParticipationStatus.REFUNDED
         participation.refundedAt = cancelledAt
-        reconcileGroupBuyStatusAfterRefund(groupBuy)
         log.info(
             "[PaymentService] 환불 정합성 반영 완료: orderId={}, groupBuyId={}, participationId={}, quantity={}=>{}, refundedAt={}",
             order.orderId,
@@ -379,16 +378,6 @@ class PaymentService(
             groupBuy.currentQuantity,
             cancelledAt
         )
-    }
-
-    private fun reconcileGroupBuyStatusAfterRefund(groupBuy: GroupBuy) {
-        if (groupBuy.status == GroupBuyStatus.ACHIEVED && groupBuy.currentQuantity < groupBuy.targetQuantity) {
-            groupBuy.status = GroupBuyStatus.IN_PROGRESS
-            log.info(
-                "[PaymentService] 환불로 공구 상태 조정: groupBuyId={}, ACHIEVED->IN_PROGRESS, currentQuantity={}, targetQuantity={}",
-                groupBuy.id, groupBuy.currentQuantity, groupBuy.targetQuantity
-            )
-        }
     }
 
     private fun validateRefundEligibility(groupBuy: GroupBuy, order: PaymentOrder) {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -363,7 +363,8 @@ class PaymentService(
         }
 
         // 취소 반영 시점의 최신 공구 상태를 락으로 재확인해서 수량 차감 정합성을 맞춘다.
-        val groupBuy = groupBuyRepository.findWithLockById(order.groupBuy.id).orElse(participation.groupBuy)
+        val groupBuy = groupBuyRepository.findWithLockById(order.groupBuy.id)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
         validateRefundEligibility(groupBuy, order)
         val beforeQuantity = groupBuy.currentQuantity
         groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -107,4 +107,5 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PAYMENT_APPROVAL_FAILED(502_350, "결제 승인에 실패했습니다.", 502),
     PAYMENT_DUPLICATE_PARTICIPATION(409_352, "이미 참여한 공구입니다.", 409),
     PAYMENT_WEBHOOK_INVALID(400_354, "결제 웹훅 요청이 올바르지 않습니다.", 400),
+    PAYMENT_REFUND_NOT_ALLOWED_AFTER_ACHIEVED(409_355, "달성 완료된 공구는 환불할 수 없습니다.", 409),
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -342,6 +342,56 @@ class PaymentServiceTest {
         assertEquals(35, groupBuy.currentQuantity)
     }
 
+    @Test
+    fun `웹훅 취소 재요청 시 이미 환불된 참여는 멱등 처리`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(currentQuantity = 35)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = order.orderId,
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        val refundedAt = LocalDateTime.of(2026, 5, 18, 10, 0)
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 6000,
+            feeAmount = 0,
+            totalAmount = 6000,
+            status = ParticipationStatus.REFUNDED,
+            refundedAt = refundedAt,
+        )
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "MCJ-10-test",
+                    status = "CANCELLED",
+                    totalAmount = 6000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                    cancelledAt = LocalDateTime.of(2026, 5, 19, 10, 0),
+                )
+            )
+        `when`(paymentRepository.findByPaymentOrderOrderId("MCJ-10-test")).thenReturn(payment)
+        `when`(participationRepository.findByUserIdAndGroupBuyId(1L, 10L)).thenReturn(participation)
+
+        service.handlePortOneWebhook(PortOneWebhookRequest(storeId = "store-test", paymentId = "MCJ-10-test"))
+
+        assertEquals(35, groupBuy.currentQuantity)
+        assertEquals(ParticipationStatus.REFUNDED, participation.status)
+        assertEquals(refundedAt, participation.refundedAt)
+    }
+
     private fun stubTransaction() {
         `when`(transactionManager.getTransaction(any(TransactionDefinition::class.java))).thenReturn(transactionStatus)
         lenient().`when`(redisLockUtil.lockKey(anyLong())).thenAnswer { "groupBuy:${it.arguments[0]}" }

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -392,6 +392,59 @@ class PaymentServiceTest {
         assertEquals(refundedAt, participation.refundedAt)
     }
 
+    @Test
+    fun `웹훅 취소 시 달성 완료 공구는 환불 거절`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(currentQuantity = 50, status = GroupBuyStatus.ACHIEVED)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = order.orderId,
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 6000,
+            feeAmount = 0,
+            totalAmount = 6000,
+            status = ParticipationStatus.CONFIRMED,
+        )
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "MCJ-10-test",
+                    status = "CANCELLED",
+                    totalAmount = 6000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                    cancelledAt = LocalDateTime.of(2026, 5, 19, 10, 0),
+                )
+            )
+        `when`(paymentRepository.findByPaymentOrderOrderId("MCJ-10-test")).thenReturn(payment)
+        `when`(participationRepository.findByUserIdAndGroupBuyId(1L, 10L)).thenReturn(participation)
+        `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
+
+        val ex = assertThrows<CustomException> {
+            service.handlePortOneWebhook(PortOneWebhookRequest(storeId = "store-test", paymentId = "MCJ-10-test"))
+        }
+
+        assertEquals(ErrorCode.PAYMENT_REFUND_NOT_ALLOWED_AFTER_ACHIEVED, ex.errorCode)
+        assertEquals(PaymentOrderStatus.APPROVED, order.status)
+        assertEquals(PaymentStatus.APPROVED, payment.status)
+        assertEquals(ParticipationStatus.CONFIRMED, participation.status)
+        assertEquals(50, groupBuy.currentQuantity)
+    }
+
     private fun stubTransaction() {
         `when`(transactionManager.getTransaction(any(TransactionDefinition::class.java))).thenReturn(transactionStatus)
         lenient().`when`(redisLockUtil.lockKey(anyLong())).thenAnswer { "groupBuy:${it.arguments[0]}" }

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -294,17 +294,7 @@ class PaymentServiceTest {
     fun `웹훅 취소 상태는 결제와 참여를 환불 처리`() {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy()
-        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1).apply {
-            approve(LocalDateTime.now().minusMinutes(5))
-        }
-        val payment = Payment(
-            paymentOrder = order,
-            pgPaymentId = order.orderId,
-            orderId = order.orderId,
-            amount = order.totalAmount,
-            method = "CARD",
-            approvedAt = order.approvedAt!!,
-        )
+        val (order, payment) = createApprovedOrderAndPayment(user, groupBuy)
         val participation = Participation(
             user = user,
             groupBuy = groupBuy,
@@ -316,19 +306,7 @@ class PaymentServiceTest {
         )
         val cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0)
         stubTransaction()
-        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
-        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
-        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
-            .thenReturn(
-                PortOnePaymentResult(
-                    paymentId = "MCJ-10-test",
-                    status = "CANCELLED",
-                    totalAmount = 6000,
-                    method = "CARD",
-                    paidAt = order.approvedAt,
-                    cancelledAt = cancelledAt,
-                )
-            )
+        stubCancelledWebhook(order, cancelledAt)
         `when`(paymentRepository.findByPaymentOrderOrderId("MCJ-10-test")).thenReturn(payment)
         `when`(participationRepository.findByUserIdAndGroupBuyId(1L, 10L)).thenReturn(participation)
         `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
@@ -346,17 +324,7 @@ class PaymentServiceTest {
     fun `웹훅 취소 재요청 시 이미 환불된 참여는 멱등 처리`() {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy(currentQuantity = 35)
-        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1).apply {
-            approve(LocalDateTime.now().minusMinutes(5))
-        }
-        val payment = Payment(
-            paymentOrder = order,
-            pgPaymentId = order.orderId,
-            orderId = order.orderId,
-            amount = order.totalAmount,
-            method = "CARD",
-            approvedAt = order.approvedAt!!,
-        )
+        val (order, payment) = createApprovedOrderAndPayment(user, groupBuy)
         val refundedAt = LocalDateTime.of(2026, 5, 18, 10, 0)
         val participation = Participation(
             user = user,
@@ -369,19 +337,7 @@ class PaymentServiceTest {
             refundedAt = refundedAt,
         )
         stubTransaction()
-        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
-        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
-        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
-            .thenReturn(
-                PortOnePaymentResult(
-                    paymentId = "MCJ-10-test",
-                    status = "CANCELLED",
-                    totalAmount = 6000,
-                    method = "CARD",
-                    paidAt = order.approvedAt,
-                    cancelledAt = LocalDateTime.of(2026, 5, 19, 10, 0),
-                )
-            )
+        stubCancelledWebhook(order, LocalDateTime.of(2026, 5, 19, 10, 0))
         `when`(paymentRepository.findByPaymentOrderOrderId("MCJ-10-test")).thenReturn(payment)
         `when`(participationRepository.findByUserIdAndGroupBuyId(1L, 10L)).thenReturn(participation)
 
@@ -396,17 +352,7 @@ class PaymentServiceTest {
     fun `웹훅 취소 시 달성 완료 공구는 환불 거절`() {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy(currentQuantity = 50, status = GroupBuyStatus.ACHIEVED)
-        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1).apply {
-            approve(LocalDateTime.now().minusMinutes(5))
-        }
-        val payment = Payment(
-            paymentOrder = order,
-            pgPaymentId = order.orderId,
-            orderId = order.orderId,
-            amount = order.totalAmount,
-            method = "CARD",
-            approvedAt = order.approvedAt!!,
-        )
+        val (order, payment) = createApprovedOrderAndPayment(user, groupBuy)
         val participation = Participation(
             user = user,
             groupBuy = groupBuy,
@@ -417,19 +363,7 @@ class PaymentServiceTest {
             status = ParticipationStatus.CONFIRMED,
         )
         stubTransaction()
-        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
-        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
-        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
-            .thenReturn(
-                PortOnePaymentResult(
-                    paymentId = "MCJ-10-test",
-                    status = "CANCELLED",
-                    totalAmount = 6000,
-                    method = "CARD",
-                    paidAt = order.approvedAt,
-                    cancelledAt = LocalDateTime.of(2026, 5, 19, 10, 0),
-                )
-            )
+        stubCancelledWebhook(order, LocalDateTime.of(2026, 5, 19, 10, 0))
         `when`(paymentRepository.findByPaymentOrderOrderId("MCJ-10-test")).thenReturn(payment)
         `when`(participationRepository.findByUserIdAndGroupBuyId(1L, 10L)).thenReturn(participation)
         `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
@@ -483,6 +417,37 @@ class PaymentServiceTest {
         agreedNoRefundAfterNoShow = true,
         agreedNoWithdrawal = true,
     )
+
+    private fun createApprovedOrderAndPayment(user: User, groupBuy: GroupBuy): Pair<PaymentOrder, Payment> {
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = order.orderId,
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        return order to payment
+    }
+
+    private fun stubCancelledWebhook(order: PaymentOrder, cancelledAt: LocalDateTime) {
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "MCJ-10-test",
+                    status = "CANCELLED",
+                    totalAmount = 6000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                    cancelledAt = cancelledAt,
+                )
+            )
+    }
 
     private fun createGroupBuy(
         id: Long = 10L,


### PR DESCRIPTION
## 📌 작업한 내용
- `PaymentService.cancelPayment` 취소 경로에 환불 정합성 로직을 반영했습니다.
- 환불 처리 시 `GroupBuy`를 락 기반으로 최신 조회해, 락이 보장된 엔티티에서만 수량/상태를 변경하도록 했습니다.
- 웹훅 취소(`CANCELLED`/`PARTIAL_CANCELLED`) 처리도 `withGroupBuyLock(groupBuyId)` 범위에서 수행하도록 변경해 승인/취소 간 락 전략을 일관화했습니다.
- `ACHIEVED` 상태는 환불 불가로 거절하도록 추가했습니다. (`PAYMENT_REFUND_NOT_ALLOWED_AFTER_ACHIEVED`)
- 중복 취소 요청은 이미 `REFUNDED` 상태면 no-op(멱등) 처리합니다.
- 환불 시 참여 상태/환불 시각 반영 및 공구 수량 차감 로직을 반영했습니다.

## 🔍 참고 사항
- API 요청 시점 기준이 아니라, **락 획득 후 최신 DB 상태 기준**으로만 환불 가능 여부를 판정하도록 설계했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #88 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인