### PR TITLE
[MCJ-1471] FIX: 피드 D-day 계산 기준 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class GroupBuyService(
@@ -85,7 +86,7 @@ class GroupBuyService(
             participationRepository.existsByUserIdAndGroupBuyId(it, groupBuyId)
         } ?: false
 
-        val isClosed = groupBuy.status != GroupBuyStatus.IN_PROGRESS
+        val isClosed = groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(LocalDateTime.now())
         val canParticipate = !isClosed && !isParticipated
 
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
@@ -63,7 +63,7 @@ data class GroupBuyFeedItemResponse(
 ) {
     companion object {
         fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyFeedItemResponse {
-            val dDay = ChronoUnit.DAYS.between(now, groupBuy.deadline).toInt()
+            val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()
             val rate = calculateAchievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
 
             return GroupBuyFeedItemResponse(

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -104,7 +104,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PAYMENT_ORDER_NOT_FOUND(404_350, "결제 주문을 찾을 수 없습니다.", 404),
     PAYMENT_ORDER_ALREADY_PROCESSED(409_351, "이미 처리된 결제 주문입니다.", 409),
     PAYMENT_AMOUNT_MISMATCH(400_353, "결제 금액이 일치하지 않습니다.", 400),
-    PAYMENT_APPROVAL_FAILED(502_350, "결제 승인에 실패했습니다.", 502),
+    PAYMENT_APPROVAL_FAILED(400_355, "결제 승인에 실패했습니다.", 400),
     PAYMENT_DUPLICATE_PARTICIPATION(409_352, "이미 참여한 공구입니다.", 409),
     PAYMENT_WEBHOOK_INVALID(400_354, "결제 웹훅 요청이 올바르지 않습니다.", 400),
     PAYMENT_REFUND_NOT_ALLOWED_AFTER_ACHIEVED(409_355, "달성 완료된 공구는 환불할 수 없습니다.", 409),

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
@@ -1,0 +1,64 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class GroupBuyFeedItemResponseTest {
+
+    @Test
+    fun `피드 D-day는 시간 차이가 아니라 날짜 기준으로 계산한다`() {
+        val now = LocalDateTime.of(2026, 5, 20, 16, 50)
+        val groupBuy = createGroupBuy(
+            deadline = LocalDateTime.of(2026, 5, 21, 6, 4, 50)
+        )
+
+        val response = GroupBuyFeedItemResponse.from(groupBuy, now)
+
+        assertEquals(1, response.dDay)
+        assertEquals("D-1", response.dDayLabel)
+    }
+
+    private fun createGroupBuy(deadline: LocalDateTime): GroupBuy {
+        val store = Store(
+            name = "청담 버터룸",
+            address = "서울 강남구 도산대로 420",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SINSA_APGUJEONG_CHEONGDAM
+        ).apply { id = 1L }
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "청담 버터룸",
+            storeAddress = "서울 강남구 도산대로 420",
+            productName = "버터바 4종 세트",
+            desiredQuantity = 30,
+            desiredPickupDate = LocalDate.of(2026, 5, 26)
+        ).apply { id = 1L }
+
+        return GroupBuy(
+            store = store,
+            groupBuyRequest = request,
+            thumbnailUrl = "https://example.com/image.jpg",
+            productName = "버터바 4종 세트",
+            productDescription = "설명",
+            price = 1000,
+            targetQuantity = 30,
+            currentQuantity = 28,
+            maxQuantity = 45,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = deadline,
+            pickupDate = LocalDate.of(2026, 5, 26),
+            pickupTimeStart = LocalTime.of(12, 0),
+            pickupTimeEnd = LocalTime.of(16, 0),
+            pickupLocation = "서울 강남구 도산대로 420"
+        ).apply { id = 901003L }
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -218,6 +218,26 @@ class GroupBuyServiceTest {
     }
 
     @Test
+    fun `마감 시간이 지난 공구 상세 조회 시 참여 가능 여부 false 반환`() {
+        val groupBuyId = 13L
+        val userId = 4L
+        val groupBuy = createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = LocalDateTime.now().minusMinutes(1)
+        )
+
+        `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+        `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(emptyList())
+        `when`(favoriteRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+
+        val result = service.getDetail(groupBuyId, userId)
+
+        assertFalse(result.canParticipate)
+    }
+
+    @Test
     fun `존재하지 않는 공구 상세 조회 시 GROUPBUY_NOT_FOUND 예외 발생`() {
         `when`(groupBuyRepository.findWithStoreById(999L)).thenReturn(Optional.empty())
 


### PR DESCRIPTION
## 📌 작업한 내용
- 피드 D-day 계산을 상세 응답과 동일하게 날짜 기준(`now.toLocalDate()` ~ `deadline.toLocalDate()`)으로 수정했습니다.
- 마감 시간이 지난 공구는 상세 응답의 `canParticipate=false`가 되도록 결제 가능 조건과 맞췄습니다.
- 결제 완료 검증 실패(`PAYMENT_APPROVAL_FAILED`)가 gateway 장애처럼 보이지 않도록 HTTP 502에서 400으로 변경했습니다.
- 피드 D-day 날짜 기준 계산과 마감 지난 공구 상세 참여 불가 회귀 테스트를 추가했습니다.

## 🔍 참고 사항


## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closes #102

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

