### PR TITLE
[MCJ-1479] FIX: 결제 완료 검증 API에 인가 검증 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -115,11 +115,13 @@ class PaymentService(
         )
     }
 
-    fun completePortOnePayment(request: CompletePortOnePaymentRequest): ConfirmPaymentResponse {
+    fun completePortOnePayment(request: CompletePortOnePaymentRequest, userId: Long): ConfirmPaymentResponse {
         val order = transactionTemplate().execute {
-            paymentOrderRepository.findByOrderId(request.paymentId)
-        }
-            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+            val foundOrder = paymentOrderRepository.findByOrderId(request.paymentId)
+                ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+            validatePaymentOrderOwner(foundOrder, userId)
+            foundOrder
+        } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
 
         if (order.status == PaymentOrderStatus.APPROVED) {
             return transactionTemplate().execute {
@@ -154,6 +156,12 @@ class PaymentService(
         return when (result) {
             is PaymentApprovalResult.Success -> result.response
             is PaymentApprovalResult.Failure -> throw CustomException(result.errorCode)
+        }
+    }
+
+    private fun validatePaymentOrderOwner(order: PaymentOrder, userId: Long) {
+        if (order.user.id != userId) {
+            throw CustomException(ErrorCode.PAYMENT_ORDER_FORBIDDEN)
         }
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -49,9 +49,11 @@ class PaymentController(
 
     @PostMapping("/payments/portone/complete")
     fun completePortOnePayment(
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
         @Valid @RequestBody request: CompletePortOnePaymentRequest,
     ): ResponseEntity<ApiResponse<ConfirmPaymentResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request)))
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        return ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request, userId)))
     }
 
     @PostMapping("/payments/portone/webhook")

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -102,6 +102,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PAYMENT_QUANTITY_EXCEEDED(409_350, "참여 가능 수량을 초과했습니다.", 409),
     PAYMENT_AGREEMENT_REQUIRED(400_352, "필수 동의가 필요합니다.", 400),
     PAYMENT_ORDER_NOT_FOUND(404_350, "결제 주문을 찾을 수 없습니다.", 404),
+    PAYMENT_ORDER_FORBIDDEN(403_350, "본인의 결제 주문만 처리할 수 있습니다.", 403),
     PAYMENT_ORDER_ALREADY_PROCESSED(409_351, "이미 처리된 결제 주문입니다.", 409),
     PAYMENT_AMOUNT_MISMATCH(400_353, "결제 금액이 일치하지 않습니다.", 400),
     PAYMENT_APPROVAL_FAILED(400_355, "결제 승인에 실패했습니다.", 400),

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -164,7 +164,7 @@ class PaymentServiceTest {
         }
         `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
 
-        val result = service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000))
+        val result = service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000), 1L)
 
         assertEquals(99L, result.participationId)
         assertEquals(ParticipationStatus.PAID_WAITING_GOAL, result.participationStatus)
@@ -190,11 +190,26 @@ class PaymentServiceTest {
             .thenThrow(CustomException(ErrorCode.GROUPBUY_LOCK_ACQUISITION_FAILED))
 
         val ex = assertThrows<CustomException> {
-            service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000))
+            service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000), 1L)
         }
 
         assertEquals(ErrorCode.GROUPBUY_LOCK_ACQUISITION_FAILED, ex.errorCode)
         verify(redisLockUtil).lockKey(10L)
+    }
+
+    @Test
+    fun `결제 완료 검증은 주문 소유자만 처리할 수 있다`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy()
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
+
+        val ex = assertThrows<CustomException> {
+            service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 6000), 2L)
+        }
+
+        assertEquals(ErrorCode.PAYMENT_ORDER_FORBIDDEN, ex.errorCode)
     }
 
     @Test
@@ -218,7 +233,7 @@ class PaymentServiceTest {
         }
         `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
 
-        val result = service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 6000))
+        val result = service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 6000), 1L)
 
         assertEquals(ParticipationStatus.CONFIRMED, result.participationStatus)
         assertEquals(GroupBuyStatus.ACHIEVED, groupBuy.status)
@@ -238,7 +253,7 @@ class PaymentServiceTest {
         `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(10L, 2)).thenReturn(0)
 
         val ex = assertThrows<CustomException> {
-            service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000))
+            service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 12000), 1L)
         }
 
         assertEquals(ErrorCode.PAYMENT_QUANTITY_EXCEEDED, ex.errorCode)


### PR DESCRIPTION
## 📌 작업한 내용
- 결제 완료 검증 API(`POST /api/v1/payments/portone/complete`)에서 로그인 사용자를 확인하도록 변경했습니다.
- 결제 주문의 소유자와 로그인 사용자 ID가 다르면 `PAYMENT_ORDER_FORBIDDEN` 403 응답을 반환하도록 검증을 추가했습니다.
- 이미 승인된 주문 재호출 경로에서도 동일하게 주문 소유자 검증을 수행합니다.
- PortOne 웹훅 경로는 외부 서버 호출용이므로 기존 인증 예외 흐름을 유지했습니다.
- 주문 소유자가 아닌 사용자의 complete 호출을 막는 회귀 테스트를 추가했습니다.

## 🔍 참고 사항
- 이 PR은 인증 토큰 존재 여부가 아니라 결제 주문 소유자 인가 검증을 보완합니다.
- 프론트는 기존처럼 로그인 후 받은 `Authorization: Bearer {accessToken}`으로 complete API를 호출하면 됩니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closes #119

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

테스트:
```bash
./gradlew test --tests "com.moongchijang.domain.payment.application.PaymentServiceTest"
```