### PR TITLE
[MCJ-1474] FEAT: 소비자 참여 취소/환불 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
@@ -72,6 +72,13 @@ class Participation(
     @Column(name = "picked_up_at")
     var pickedUpAt: LocalDateTime? = null,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cancel_reason", length = 50)
+    var cancelReason: ParticipationCancelReason? = null,
+
+    @Column(name = "cancel_reason_detail", length = 500)
+    var cancelReasonDetail: String? = null,
+
     @Column(name = "cancelled_at")
     var cancelledAt: LocalDateTime? = null,
 

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/ParticipationCancelReason.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/ParticipationCancelReason.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.participation.domain.entity
+
+enum class ParticipationCancelReason {
+    TIME_UNAVAILABLE,
+    NO_LONGER_WANTED,
+    PREFER_DIRECT_VISIT,
+    BOUGHT_ELSEWHERE,
+    OTHER
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -1,11 +1,20 @@
 package com.moongchijang.domain.participation.domain.repository
 
 import com.moongchijang.domain.participation.domain.entity.Participation
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.Optional
 
 interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     fun existsByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Boolean
 
     fun findByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Participation?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Participation p join fetch p.groupBuy where p.id = :id")
+    fun findByIdForUpdate(@Param("id") id: Long): Optional<Participation>
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -5,8 +5,11 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
+import com.moongchijang.domain.payment.application.dto.CancelParticipationResponse
 import com.moongchijang.domain.payment.application.dto.CheckoutInfoResponse
 import com.moongchijang.domain.payment.application.dto.CompletePortOnePaymentRequest
 import com.moongchijang.domain.payment.application.dto.ConfirmPaymentResponse
@@ -214,6 +217,40 @@ class PaymentService(
         }
     }
 
+    fun cancelParticipation(
+        participationId: Long,
+        userId: Long,
+        request: CancelParticipationRequest,
+    ): CancelParticipationResponse {
+        validateCancelReason(request)
+
+        val groupBuyId = transactionTemplate().execute {
+            val participation = participationRepository.findById(participationId)
+                .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+            validateParticipationOwner(participation, userId)
+            participation.groupBuy.id
+        } ?: throw CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
+
+        return withGroupBuyLock(groupBuyId) {
+            val target = transactionTemplate().execute {
+                findCancellationTarget(participationId, userId)
+            } ?: throw CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
+
+            val paymentResult = portOnePaymentPort.cancelPayment(target.pgPaymentId, cancelReasonMessage(request))
+            if (paymentResult.status != PORTONE_STATUS_CANCELLED) {
+                throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+            }
+
+            transactionTemplate().execute {
+                applyParticipationCancellation(
+                    target = target,
+                    request = request,
+                    cancelledAt = paymentResult.cancelledAt ?: LocalDateTime.now(),
+                )
+            } ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        }
+    }
+
     private fun approvePayment(
         paymentId: String,
         expectedAmount: Int,
@@ -406,6 +443,81 @@ class PaymentService(
         }
     }
 
+    private fun findCancellationTarget(participationId: Long, userId: Long): CancellationTarget {
+        val participation = participationRepository.findByIdForUpdate(participationId)
+            .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+        validateParticipationOwner(participation, userId)
+        validateParticipationCancelable(participation)
+
+        val order = paymentOrderRepository.findByUserIdAndGroupBuyId(userId, participation.groupBuy.id)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+        validateApprovedPaymentOrder(order)
+        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+
+        return CancellationTarget(
+            participationId = participation.id,
+            groupBuyId = participation.groupBuy.id,
+            userId = userId,
+            orderId = order.orderId,
+            pgPaymentId = payment.pgPaymentId,
+        )
+    }
+
+    private fun applyParticipationCancellation(
+        target: CancellationTarget,
+        request: CancelParticipationRequest,
+        cancelledAt: LocalDateTime,
+    ): CancelParticipationResponse {
+        val participation = participationRepository.findByIdForUpdate(target.participationId)
+            .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+        validateParticipationOwner(participation, target.userId)
+        validateParticipationCancelable(participation)
+
+        val order = paymentOrderRepository.findByOrderIdForUpdate(target.orderId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+        validateApprovedPaymentOrder(order)
+        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+        val groupBuy = groupBuyRepository.findWithLockById(target.groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+        validateRefundEligibility(groupBuy, order)
+
+        groupBuy.currentQuantity = (groupBuy.currentQuantity - participation.quantity).coerceAtLeast(0)
+        order.cancel(cancelledAt)
+        payment.cancel(cancelledAt)
+        participation.status = ParticipationStatus.REFUNDED
+        participation.cancelReason = request.reason
+        participation.cancelReasonDetail = normalizedReasonDetail(request)
+        participation.cancelledAt = cancelledAt
+        participation.refundedAt = cancelledAt
+
+        return CancelParticipationResponse(
+            participationId = participation.id,
+            status = participation.status,
+            cancelledAt = cancelledAt,
+            refundedAt = cancelledAt,
+        )
+    }
+
+    private fun validateParticipationOwner(participation: Participation, userId: Long) {
+        if (participation.user.id != userId) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+    }
+
+    private fun validateParticipationCancelable(participation: Participation) {
+        if (participation.status != ParticipationStatus.PAID_WAITING_GOAL) {
+            throw CustomException(ErrorCode.PARTICIPATION_CANCEL_NOT_ALLOWED)
+        }
+    }
+
+    private fun validateApprovedPaymentOrder(order: PaymentOrder) {
+        if (order.status != PaymentOrderStatus.APPROVED) {
+            throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+        }
+    }
+
     private fun buildAlreadyApprovedResponse(order: PaymentOrder): ConfirmPaymentResponse {
         val userId = order.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
         val participation = participationRepository.findByUserIdAndGroupBuyId(userId, order.groupBuy.id)
@@ -453,6 +565,20 @@ class PaymentService(
             throw CustomException(ErrorCode.PAYMENT_DUPLICATE_PARTICIPATION)
         }
     }
+
+    private fun validateCancelReason(request: CancelParticipationRequest) {
+        if (request.reason == ParticipationCancelReason.OTHER && request.reasonDetail.isNullOrBlank()) {
+            throw CustomException(ErrorCode.PARTICIPATION_CANCEL_REASON_DETAIL_REQUIRED)
+        }
+    }
+
+    private fun cancelReasonMessage(request: CancelParticipationRequest): String {
+        val detail = normalizedReasonDetail(request)
+        return listOfNotNull(request.reason.name, detail).joinToString(": ")
+    }
+
+    private fun normalizedReasonDetail(request: CancelParticipationRequest): String? =
+        request.reasonDetail?.trim()?.takeIf { it.isNotBlank() }
 
     private fun calculateAmounts(unitPrice: Int, quantity: Int): PaymentAmounts {
         val productAmount = unitPrice * quantity
@@ -508,6 +634,14 @@ class PaymentService(
         val productAmount: Int,
         val feeAmount: Int,
         val totalAmount: Int,
+    )
+
+    private data class CancellationTarget(
+        val participationId: Long,
+        val groupBuyId: Long,
+        val userId: Long,
+        val orderId: String,
+        val pgPaymentId: String,
     )
 
     companion object {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CancelParticipationRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CancelParticipationRequest.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.payment.application.dto
+
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import jakarta.validation.constraints.Size
+
+data class CancelParticipationRequest(
+    val reason: ParticipationCancelReason,
+
+    @field:Size(max = 500)
+    val reasonDetail: String? = null,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CancelParticipationResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/dto/CancelParticipationResponse.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.payment.application.dto
+
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import java.time.LocalDateTime
+
+data class CancelParticipationResponse(
+    val participationId: Long,
+    val status: ParticipationStatus,
+    val cancelledAt: LocalDateTime,
+    val refundedAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/port/PortOnePaymentPort.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/port/PortOnePaymentPort.kt
@@ -4,6 +4,8 @@ import java.time.LocalDateTime
 
 interface PortOnePaymentPort {
     fun getPayment(paymentId: String): PortOnePaymentResult
+
+    fun cancelPayment(paymentId: String, reason: String): PortOnePaymentResult
 }
 
 data class PortOnePaymentResult(

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
@@ -10,6 +10,8 @@ import org.springframework.data.repository.query.Param
 interface PaymentOrderRepository : JpaRepository<PaymentOrder, Long> {
     fun findByOrderId(orderId: String): PaymentOrder?
 
+    fun findByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): PaymentOrder?
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select po from PaymentOrder po where po.orderId = :orderId")
     fun findByOrderIdForUpdate(@Param("orderId") orderId: String): PaymentOrder?

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -32,19 +32,45 @@ class PortOnePaymentClient(
         }
 
         return try {
-            PortOnePaymentResult(
-                paymentId = response["id"] as? String ?: paymentId,
-                status = response["status"] as? String ?: "",
-                totalAmount = extractTotalAmount(response),
-                method = extractPaymentMethod(response),
-                paidAt = parseDateTime(response["paidAt"] as? String ?: response["approvedAt"] as? String),
-                cancelledAt = parseDateTime(response["cancelledAt"] as? String ?: response["canceledAt"] as? String),
-            )
+            toPaymentResult(paymentId, response)
         } catch (e: CustomException) {
             throw e
         } catch (e: RuntimeException) {
             throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
         }
+    }
+
+    override fun cancelPayment(paymentId: String, reason: String): PortOnePaymentResult {
+        val response = try {
+            restClient.post()
+                .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}/cancel", paymentId)
+                .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
+                .body(mapOf("reason" to reason))
+                .retrieve()
+                .body(Map::class.java)
+                ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        } catch (e: RestClientException) {
+            throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        }
+
+        return try {
+            toPaymentResult(paymentId, response)
+        } catch (e: CustomException) {
+            throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        } catch (e: RuntimeException) {
+            throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        }
+    }
+
+    private fun toPaymentResult(paymentId: String, response: Map<*, *>): PortOnePaymentResult {
+        return PortOnePaymentResult(
+            paymentId = response["id"] as? String ?: paymentId,
+            status = response["status"] as? String ?: "",
+            totalAmount = extractTotalAmount(response),
+            method = extractPaymentMethod(response),
+            paidAt = parseDateTime(response["paidAt"] as? String ?: response["approvedAt"] as? String),
+            cancelledAt = parseDateTime(response["cancelledAt"] as? String ?: response["canceledAt"] as? String),
+        )
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -1,6 +1,8 @@
 package com.moongchijang.domain.payment.presentation
 
 import com.moongchijang.domain.payment.application.PaymentService
+import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
+import com.moongchijang.domain.payment.application.dto.CancelParticipationResponse
 import com.moongchijang.domain.payment.application.dto.CheckoutInfoResponse
 import com.moongchijang.domain.payment.application.dto.CompletePortOnePaymentRequest
 import com.moongchijang.domain.payment.application.dto.ConfirmPaymentResponse
@@ -62,5 +64,15 @@ class PaymentController(
     ): ResponseEntity<ApiResponse<PortOneWebhookResponse>> {
         paymentService.handlePortOneWebhook(request)
         return ResponseEntity.ok(ApiResponse.success(PortOneWebhookResponse()))
+    }
+
+    @PostMapping("/participations/{participationId}/cancel")
+    fun cancelParticipation(
+        @PathVariable participationId: Long,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @Valid @RequestBody request: CancelParticipationRequest,
+    ): ResponseEntity<ApiResponse<CancelParticipationResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelParticipation(participationId, userId, request)))
     }
 }

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -109,4 +109,8 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PAYMENT_DUPLICATE_PARTICIPATION(409_352, "이미 참여한 공구입니다.", 409),
     PAYMENT_WEBHOOK_INVALID(400_354, "결제 웹훅 요청이 올바르지 않습니다.", 400),
     PAYMENT_REFUND_NOT_ALLOWED_AFTER_ACHIEVED(409_355, "달성 완료된 공구는 환불할 수 없습니다.", 409),
+    PAYMENT_CANCEL_FAILED(502_355, "결제 취소에 실패했습니다.", 502),
+    PARTICIPATION_NOT_FOUND(404_356, "참여 정보를 찾을 수 없습니다.", 404),
+    PARTICIPATION_CANCEL_NOT_ALLOWED(409_357, "취소할 수 없는 참여 상태입니다.", 409),
+    PARTICIPATION_CANCEL_REASON_DETAIL_REQUIRED(400_358, "기타 취소 사유를 입력해주세요.", 400),
 }

--- a/src/main/resources/db/migration/V15__alter_participation_add_cancel_reason.sql
+++ b/src/main/resources/db/migration/V15__alter_participation_add_cancel_reason.sql
@@ -1,0 +1,3 @@
+ALTER TABLE participation
+    ADD COLUMN cancel_reason VARCHAR(50) NULL AFTER picked_up_at,
+    ADD COLUMN cancel_reason_detail VARCHAR(500) NULL AFTER cancel_reason;

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -996,9 +996,19 @@ paths:
         - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/ParticipationId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CancelParticipationRequest'
       responses:
         '200':
-          $ref: '#/components/responses/SuccessNoData'
+          description: 참여 취소 및 환불 처리 결과
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseCancelParticipation'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
@@ -2492,6 +2502,20 @@ components:
         agreedNoRefundAfterNoShow: { type: boolean, description: 미수령 환불 불가 동의 }
         agreedNoWithdrawal: { type: boolean, description: 청약철회 불가 동의 }
 
+    CancelParticipationRequest:
+      type: object
+      required: [reason]
+      properties:
+        reason:
+          type: string
+          enum: [TIME_UNAVAILABLE, NO_LONGER_WANTED, PREFER_DIRECT_VISIT, BOUGHT_ELSEWHERE, OTHER]
+          description: 취소 사유. OTHER 선택 시 reasonDetail 필수.
+        reasonDetail:
+          type: string
+          maxLength: 500
+          nullable: true
+          description: 기타 상세 사유
+
     ApiResponseCheckoutInfo:
       type: object
       required: [success, data, error]
@@ -2551,6 +2575,23 @@ components:
             amount: { type: integer }
             method: { type: string, nullable: true, example: CARD }
             approvedAt: { type: string, format: date-time }
+        error: { nullable: true, example: null }
+
+    ApiResponseCancelParticipation:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [participationId, status, cancelledAt, refundedAt]
+          properties:
+            participationId: { type: integer, format: int64 }
+            status:
+              type: string
+              enum: [REFUNDED]
+            cancelledAt: { type: string, format: date-time }
+            refundedAt: { type: string, format: date-time }
         error: { nullable: true, example: null }
 
     PortOneWebhook:

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -6,8 +6,10 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
 import com.moongchijang.domain.payment.application.dto.CompletePortOnePaymentRequest
 import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderRequest
 import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
@@ -392,6 +394,116 @@ class PaymentServiceTest {
         assertEquals(PaymentStatus.APPROVED, payment.status)
         assertEquals(ParticipationStatus.CONFIRMED, participation.status)
         assertEquals(50, groupBuy.currentQuantity)
+    }
+
+    @Test
+    fun `달성 전 참여는 취소 사유 저장 후 환불 처리`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy()
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = "portone-payment-id",
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 2,
+            productAmount = 12000,
+            feeAmount = 0,
+            totalAmount = 12000,
+            status = ParticipationStatus.PAID_WAITING_GOAL,
+        ).apply { id = 77L }
+        val cancelledAt = LocalDateTime.of(2026, 5, 18, 11, 0)
+        stubTransaction()
+        `when`(participationRepository.findById(77L)).thenReturn(Optional.of(participation))
+        `when`(participationRepository.findByIdForUpdate(77L)).thenReturn(Optional.of(participation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyId(1L, 10L)).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(paymentRepository.findByPaymentOrderOrderId("MCJ-10-test")).thenReturn(payment)
+        `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "OTHER: 시간이 맞지 않습니다"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "portone-payment-id",
+                    status = "CANCELLED",
+                    totalAmount = 12000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                    cancelledAt = cancelledAt,
+                )
+            )
+
+        val result = service.cancelParticipation(
+            participationId = 77L,
+            userId = 1L,
+            request = CancelParticipationRequest(
+                reason = ParticipationCancelReason.OTHER,
+                reasonDetail = " 시간이 맞지 않습니다 ",
+            )
+        )
+
+        assertEquals(77L, result.participationId)
+        assertEquals(ParticipationStatus.REFUNDED, result.status)
+        assertEquals(PaymentOrderStatus.CANCELLED, order.status)
+        assertEquals(PaymentStatus.CANCELLED, payment.status)
+        assertEquals(ParticipationStatus.REFUNDED, participation.status)
+        assertEquals(ParticipationCancelReason.OTHER, participation.cancelReason)
+        assertEquals("시간이 맞지 않습니다", participation.cancelReasonDetail)
+        assertEquals(cancelledAt, participation.cancelledAt)
+        assertEquals(cancelledAt, participation.refundedAt)
+        assertEquals(cancelledAt, result.cancelledAt)
+        assertEquals(34, groupBuy.currentQuantity)
+    }
+
+    @Test
+    fun `확정된 참여는 취소할 수 없다`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy()
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 6000,
+            feeAmount = 0,
+            totalAmount = 6000,
+            status = ParticipationStatus.CONFIRMED,
+        ).apply { id = 78L }
+        stubTransaction()
+        `when`(participationRepository.findById(78L)).thenReturn(Optional.of(participation))
+        `when`(participationRepository.findByIdForUpdate(78L)).thenReturn(Optional.of(participation))
+
+        val ex = assertThrows<CustomException> {
+            service.cancelParticipation(
+                participationId = 78L,
+                userId = 1L,
+                request = CancelParticipationRequest(reason = ParticipationCancelReason.TIME_UNAVAILABLE),
+            )
+        }
+
+        assertEquals(ErrorCode.PARTICIPATION_CANCEL_NOT_ALLOWED, ex.errorCode)
+    }
+
+    @Test
+    fun `기타 취소 사유는 상세 내용이 필요하다`() {
+        val ex = assertThrows<CustomException> {
+            service.cancelParticipation(
+                participationId = 77L,
+                userId = 1L,
+                request = CancelParticipationRequest(
+                    reason = ParticipationCancelReason.OTHER,
+                    reasonDetail = " ",
+                ),
+            )
+        }
+
+        assertEquals(ErrorCode.PARTICIPATION_CANCEL_REASON_DETAIL_REQUIRED, ex.errorCode)
     }
 
     private fun stubTransaction() {

--- a/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.test.web.client.ExpectedCount.once
 import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.content
 import org.springframework.test.web.client.match.MockRestRequestMatchers.header
 import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
@@ -57,6 +58,51 @@ class PortOnePaymentClientTest {
         assertEquals(1000, result.totalAmount)
         assertEquals("card", result.method)
         assertEquals(LocalDateTime.of(2026, 5, 19, 6, 20), result.paidAt)
+        server.verify()
+    }
+
+    @Test
+    fun `포트원 결제 취소 요청 결과를 파싱한다`() {
+        val builder = RestClient.builder()
+        val server = MockRestServiceServer.bindTo(builder).build()
+        val client = PortOnePaymentClient(
+            portOneProperties = PortOneProperties(
+                storeId = "store-test",
+                channelKey = "channel-test",
+                apiSecret = "secret-test",
+                paymentApiBaseUrl = "https://api.portone.test"
+            ),
+            restClientBuilder = builder
+        )
+        val paymentId = "portone-payment-id"
+
+        server.expect(once(), requestTo("https://api.portone.test/payments/$paymentId/cancel"))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(header(HttpHeaders.AUTHORIZATION, "PortOne secret-test"))
+            .andExpect(content().json("""{"reason":"OTHER: 시간이 맞지 않습니다"}"""))
+            .andRespond(
+                withSuccess(
+                    """
+                    {
+                      "id": "$paymentId",
+                      "status": "CANCELLED",
+                      "amount": { "total": 12000 },
+                      "method": { "card": {} },
+                      "paidAt": "2026-05-19T06:20:00",
+                      "cancelledAt": "2026-05-19T06:25:00"
+                    }
+                    """.trimIndent(),
+                    MediaType.APPLICATION_JSON
+                )
+            )
+
+        val result = client.cancelPayment(paymentId, "OTHER: 시간이 맞지 않습니다")
+
+        assertEquals(paymentId, result.paymentId)
+        assertEquals("CANCELLED", result.status)
+        assertEquals(12000, result.totalAmount)
+        assertEquals("card", result.method)
+        assertEquals(LocalDateTime.of(2026, 5, 19, 6, 25), result.cancelledAt)
         server.verify()
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- `POST /api/v1/participations/{participationId}/cancel` 참여 취소/환불 API를 추가했습니다.
- 취소 사유 enum/request/response DTO와 `participation.cancel_reason`, `cancel_reason_detail` 저장 필드를 추가했습니다.
- `PortOnePaymentPort`와 PortOne adapter에 결제 취소 호출을 추가했습니다.
- 취소 성공 시 참여 상태 `REFUNDED`, 취소/환불 시각 저장, 결제/주문 취소 처리, 공구 현재 수량 롤백을 처리합니다.
- OpenAPI에 취소 request/response 스키마를 실제 구현과 맞춰 반영했습니다.


## 🔍 참고 사항
- 취소 허용 조건은 `ParticipationStatus.PAID_WAITING_GOAL`입니다.
- `OTHER` 취소 사유는 상세 사유가 필수입니다.
- DB 마이그레이션 `V15__alter_participation_add_cancel_reason.sql`을 포함합니다.


## 🖼️ 스크린샷


## 🔗 관련 이슈
- Closes #112

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
