### PR TITLE
[MCJ-1433] FEAT: 공구 개설 요청 매장 추천 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -1,19 +1,48 @@
 package com.moongchijang.domain.groupbuy.application
 
 import com.moongchijang.domain.groupbuy.application.dto.CreateGroupBuyOpenRequestRequest
+import com.moongchijang.domain.groupbuy.application.dto.StoreRecommendationRequest
+import com.moongchijang.domain.groupbuy.application.dto.StoreRecommendationResponse
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.store.domain.repository.StoreRepository
+import com.moongchijang.domain.store.infrastructure.naver.NaverLocalSearchClient
+import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchItem
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import kotlin.math.roundToLong
 
 @Service
 @Transactional
 class GroupBuyOpenRequestService(
-    private val openRequestRepository: GroupBuyOpenRequestRepository
+    private val openRequestRepository: GroupBuyOpenRequestRepository,
+    private val naverLocalSearchClient: NaverLocalSearchClient,
+    private val storeRepository: StoreRepository,
+    private val groupBuyRepository: GroupBuyRepository
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val NAVER_DISPLAY_COUNT = 20
+        private const val RECOMMENDATION_LIMIT = 10
+        private val CATEGORY_KEYWORDS = setOf(
+            "베이커리", "카페", "디저트", "제과", "제빵", "빵", "케이크",
+            "도넛", "떡", "쿠키", "마카롱", "와플", "푸딩", "샌드위치"
+        )
+        private val NORMALIZED_CATEGORY_KEYWORDS = CATEGORY_KEYWORDS.map { normalize(it) }.toSet()
+        private val NORMALIZED_FOOD_KEYWORD = normalize("음식")
+
+        private fun normalize(value: String): String =
+            value.lowercase()
+                .replace(Regex("\\s+"), "")
+    }
+
     fun create(userId: Long, request: CreateGroupBuyOpenRequestRequest) {
         if (openRequestRepository.existsByUserIdAndRegionAndProductName(userId, request.region, request.productName)) {
             throw CustomException(ErrorCode.DUPLICATE_OPEN_REQUEST)
@@ -30,4 +59,226 @@ class GroupBuyOpenRequestService(
             throw CustomException(ErrorCode.DUPLICATE_OPEN_REQUEST)
         }
     }
+
+    @Transactional(readOnly = true)
+    fun recommendStores(request: StoreRecommendationRequest): StoreRecommendationResponse {
+        val startedAt = System.nanoTime()
+        val items = runCatching {
+            naverLocalSearchClient.search(
+                keyword = "${request.region} ${request.productName}",
+                display = NAVER_DISPLAY_COUNT
+            ).items
+        }.onFailure { e ->
+            log.warn(
+                "store_recommendation fallback=true reason=naver_failure regionLength={} productLength={} latencyMs={}",
+                request.region.length,
+                request.productName.length,
+                elapsedMillis(startedAt),
+                e
+            )
+        }.getOrNull() ?: return emptyRecommendation(request, startedAt, fallback = true)
+
+        val candidates = items
+            .mapIndexedNotNull { index, item -> item.toCandidateOrNull(index, request) }
+            .distinctBy { it.duplicateKey }
+
+        if (candidates.isEmpty()) {
+            return emptyRecommendation(request, startedAt, fallback = false)
+        }
+
+        val registeredStores = findRegisteredStores(candidates)
+        val registeredByName = registeredStores.associateBy { normalize(it.name) }
+        val registeredByAddress = registeredStores.associateBy { normalize(it.address) }
+
+        val matchedStoreIds = candidates
+            .mapNotNull { candidate ->
+                candidate.matchedStoreId(registeredByName, registeredByAddress)
+            }
+            .toSet()
+
+        val historyStoreIds = if (matchedStoreIds.isEmpty()) {
+            emptySet()
+        } else {
+            groupBuyRepository.findStoreIdsWithGroupBuyHistory(matchedStoreIds).toSet()
+        }
+
+        val stores = candidates
+            .map { candidate ->
+                candidate.withSignals(
+                    registeredByName = registeredByName,
+                    registeredByAddress = registeredByAddress,
+                    historyStoreIds = historyStoreIds
+                )
+            }
+            .sortedWith(
+                compareByDescending<ScoredStore> { it.score }
+                    .thenBy { it.candidate.naverRank }
+                    .thenBy { it.candidate.storeName }
+            )
+            .take(RECOMMENDATION_LIMIT)
+            .map { it.toResponse() }
+
+        log.info(
+            "store_recommendation fallback=false recommendationCount={} naverCount={} latencyMs={}",
+            stores.size,
+            items.size,
+            elapsedMillis(startedAt)
+        )
+
+        return StoreRecommendationResponse(
+            region = request.region,
+            productName = request.productName,
+            stores = stores
+        )
+    }
+
+    private fun emptyRecommendation(
+        request: StoreRecommendationRequest,
+        startedAt: Long,
+        fallback: Boolean
+    ): StoreRecommendationResponse {
+        log.info(
+            "store_recommendation fallback={} recommendationCount=0 naverCount=0 latencyMs={}",
+            fallback,
+            elapsedMillis(startedAt)
+        )
+        return StoreRecommendationResponse(
+            region = request.region,
+            productName = request.productName,
+            stores = emptyList()
+        )
+    }
+
+    private fun NaverLocalSearchItem.toCandidateOrNull(
+        index: Int,
+        request: StoreRecommendationRequest
+    ): StoreRecommendationCandidate? {
+        return runCatching {
+            val storeName = storeName()
+            val roadAddress = roadAddress.trim()
+            val lotAddress = address.trim().ifBlank { null }
+            val addressMatched = containsNormalized(roadAddress, request.region) ||
+                containsNormalized(lotAddress.orEmpty(), request.region)
+            val categoryMatched = isCategoryMatched(category, request.productName)
+
+            StoreRecommendationCandidate(
+                naverRank = index,
+                placeId = placeId(),
+                storeName = storeName,
+                roadAddress = roadAddress,
+                lotAddress = lotAddress,
+                latitude = latitude(),
+                longitude = longitude(),
+                category = category,
+                addressMatched = addressMatched,
+                categoryMatched = categoryMatched,
+                duplicateKey = duplicateKey(storeName, roadAddress, lotAddress)
+            )
+        }.getOrNull()
+    }
+
+    private fun findRegisteredStores(candidates: List<StoreRecommendationCandidate>): List<Store> {
+        val names = candidates.map { normalize(it.storeName) }.filter { it.isNotBlank() }.toSet()
+        val addresses = candidates
+            .flatMap { listOfNotNull(it.roadAddress.ifBlank { null }, it.lotAddress) }
+            .map { normalize(it) }
+            .toSet()
+
+        val byName = if (names.isEmpty()) emptyList() else storeRepository.findByNormalizedNameIn(names)
+        val byAddress = if (addresses.isEmpty()) emptyList() else storeRepository.findByNormalizedAddressIn(addresses)
+
+        return (byName + byAddress).distinctBy { it.id }
+    }
+
+    private fun StoreRecommendationCandidate.withSignals(
+        registeredByName: Map<String, Store>,
+        registeredByAddress: Map<String, Store>,
+        historyStoreIds: Set<Long>
+    ): ScoredStore {
+        val matchedStoreId = matchedStoreId(registeredByName, registeredByAddress)
+        val registeredStore = matchedStoreId != null
+        val previousGroupBuyStore = matchedStoreId != null && matchedStoreId in historyStoreIds
+
+        val score =
+            (if (addressMatched) 40 else 0) +
+                (if (categoryMatched) 25 else 0) +
+                (if (registeredStore) 20 else 0) +
+                (if (previousGroupBuyStore) 15 else 0)
+
+        return ScoredStore(
+            candidate = this,
+            registeredStore = registeredStore,
+            previousGroupBuyStore = previousGroupBuyStore,
+            score = score
+        )
+    }
+
+    private fun StoreRecommendationCandidate.matchedStoreId(
+        registeredByName: Map<String, Store>,
+        registeredByAddress: Map<String, Store>
+    ): Long? {
+        return registeredByName[normalize(storeName)]?.id
+            ?: registeredByAddress[normalize(roadAddress)]?.id
+            ?: lotAddress?.let { registeredByAddress[normalize(it)]?.id }
+    }
+
+    private fun ScoredStore.toResponse(): StoreRecommendationResponse.RecommendedStore {
+        return StoreRecommendationResponse.RecommendedStore(
+            placeId = candidate.placeId,
+            storeName = candidate.storeName,
+            roadAddress = candidate.roadAddress,
+            lotAddress = candidate.lotAddress,
+            latitude = candidate.latitude,
+            longitude = candidate.longitude,
+            category = candidate.category,
+            addressMatched = candidate.addressMatched,
+            categoryMatched = candidate.categoryMatched,
+            registeredStore = registeredStore,
+            previousGroupBuyStore = previousGroupBuyStore
+        )
+    }
+
+    private fun isCategoryMatched(category: String, productName: String): Boolean {
+        val normalizedCategory = normalize(category)
+        val normalizedProduct = normalize(productName)
+        return NORMALIZED_CATEGORY_KEYWORDS.any { keyword ->
+            normalizedCategory.contains(keyword) ||
+                (normalizedProduct.contains(keyword) && normalizedCategory.contains(NORMALIZED_FOOD_KEYWORD))
+        }
+    }
+
+    private fun duplicateKey(storeName: String, roadAddress: String, lotAddress: String?): String {
+        val addressKey = roadAddress.ifBlank { lotAddress.orEmpty() }
+        return "${normalize(storeName)}:${normalize(addressKey)}"
+    }
+
+    private fun containsNormalized(value: String, keyword: String): Boolean {
+        val normalizedValue = normalize(value)
+        val normalizedKeyword = normalize(keyword)
+        return normalizedKeyword.isNotBlank() && normalizedValue.contains(normalizedKeyword)
+    }
+
+    private fun elapsedMillis(startedAt: Long): Long =
+        ((System.nanoTime() - startedAt) / 1_000_000.0).roundToLong()
+
+    private data class StoreRecommendationCandidate(
+        val naverRank: Int,
+        val placeId: String,
+        val storeName: String,
+        val roadAddress: String,
+        val lotAddress: String?,
+        val latitude: Double,
+        val longitude: Double,
+        val category: String,
+        val addressMatched: Boolean,
+        val categoryMatched: Boolean,
+        val duplicateKey: String
+    )
+
+    private data class ScoredStore(
+        val candidate: StoreRecommendationCandidate,
+        val registeredStore: Boolean,
+        val previousGroupBuyStore: Boolean,
+        val score: Int
+    )
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/StoreRecommendationDto.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/StoreRecommendationDto.kt
@@ -1,0 +1,34 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class StoreRecommendationRequest(
+    @field:NotBlank(message = "지역은 필수입니다")
+    @field:Size(max = 50, message = "지역은 50자 이하이어야 합니다")
+    val region: String,
+
+    @field:NotBlank(message = "상품명은 필수입니다")
+    @field:Size(max = 100, message = "상품명은 100자 이하이어야 합니다")
+    val productName: String
+)
+
+data class StoreRecommendationResponse(
+    val region: String,
+    val productName: String,
+    val stores: List<RecommendedStore>
+) {
+    data class RecommendedStore(
+        val placeId: String,
+        val storeName: String,
+        val roadAddress: String,
+        val lotAddress: String?,
+        val latitude: Double,
+        val longitude: Double,
+        val category: String,
+        val addressMatched: Boolean,
+        val categoryMatched: Boolean,
+        val registeredStore: Boolean,
+        val previousGroupBuyStore: Boolean
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -80,4 +80,7 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
      */
     @Query("SELECT gb FROM GroupBuy gb JOIN FETCH gb.store WHERE gb.id IN :ids")
     fun findAllWithStoreByIdIn(@Param("ids") ids: Collection<Long>): List<GroupBuy>
+
+    @Query("SELECT DISTINCT gb.store.id FROM GroupBuy gb WHERE gb.store.id IN :storeIds")
+    fun findStoreIdsWithGroupBuyHistory(@Param("storeIds") storeIds: Collection<Long>): List<Long>
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
@@ -2,6 +2,8 @@ package com.moongchijang.domain.groupbuy.presentation
 
 import com.moongchijang.domain.groupbuy.application.GroupBuyOpenRequestService
 import com.moongchijang.domain.groupbuy.application.dto.CreateGroupBuyOpenRequestRequest
+import com.moongchijang.domain.groupbuy.application.dto.StoreRecommendationRequest
+import com.moongchijang.domain.groupbuy.application.dto.StoreRecommendationResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -29,5 +31,13 @@ class GroupBuyOpenRequestController(
     ): ResponseEntity<ApiResponse<Nothing>> {
         openRequestService.create(principal.id, request)
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())
+    }
+
+    @PostMapping("/store-recommendations")
+    @Operation(summary = "공구 개설 요청 매장 추천")
+    fun recommendStores(
+        @Valid @RequestBody request: StoreRecommendationRequest
+    ): ResponseEntity<ApiResponse<StoreRecommendationResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(openRequestService.recommendStores(request)))
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/store/application/StoreSearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/application/StoreSearchService.kt
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Service
 class StoreSearchService(
     private val naverLocalSearchClient: NaverLocalSearchClient
 ) {
-    fun search(keyword: String): StoreSearchResponse {
-        val response = naverLocalSearchClient.search(keyword)
+    fun search(keyword: String, display: Int = 5): StoreSearchResponse {
+        val response = naverLocalSearchClient.search(keyword, display)
         return StoreSearchResponse.from(response.items)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/store/domain/repository/StoreRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/domain/repository/StoreRepository.kt
@@ -1,0 +1,14 @@
+package com.moongchijang.domain.store.domain.repository
+
+import com.moongchijang.domain.store.domain.entity.Store
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface StoreRepository : JpaRepository<Store, Long> {
+    @Query("SELECT s FROM Store s WHERE LOWER(s.name) IN :names")
+    fun findByNormalizedNameIn(@Param("names") names: Collection<String>): List<Store>
+
+    @Query("SELECT s FROM Store s WHERE LOWER(s.address) IN :addresses")
+    fun findByNormalizedAddressIn(@Param("addresses") addresses: Collection<String>): List<Store>
+}

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -812,6 +812,36 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/group-buy-open-requests/store-recommendations:
+    post:
+      tags: [GroupBuyRequest]
+      summary: AI 매장 추천 바텀시트용 매장 후보 조회
+      description: |
+        동네와 상품 조건이 확정된 뒤 네이버 Local Search API와 자사 공구 이력을 기반으로
+        최대 10개의 매장 후보를 추천한다.
+
+        네이버 결과가 0건이거나 네이버 API 호출 실패/timeout이 발생하면 `stores=[]`를 반환하며,
+        프론트는 기존 공구 개설 요청 플로우로 fallback한다.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoreRecommendationRequest'
+      responses:
+        '200':
+          description: 추천 매장 후보 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseStoreRecommendation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   # ─────────────────────────────────────────────────────────────
   # Wishlist
   # ─────────────────────────────────────────────────────────────
@@ -3281,4 +3311,95 @@ components:
                     type: number
                     format: double
                     description: 경도
+        error: { nullable: true, example: null }
+
+    StoreRecommendationRequest:
+      type: object
+      required: [region, productName]
+      properties:
+        region:
+          type: string
+          maxLength: 50
+          description: 확정된 동네/지역 조건
+          example: 성수
+        productName:
+          type: string
+          maxLength: 100
+          description: 확정된 상품 조건
+          example: 소금빵
+
+    ApiResponseStoreRecommendation:
+      type: object
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [region, productName, stores]
+          properties:
+            region:
+              type: string
+              example: 성수
+            productName:
+              type: string
+              example: 소금빵
+            stores:
+              type: array
+              description: 추천 매장 후보 목록. 최대 10개이며 fallback 시 빈 배열.
+              items:
+                type: object
+                required:
+                  - placeId
+                  - storeName
+                  - roadAddress
+                  - latitude
+                  - longitude
+                  - category
+                  - addressMatched
+                  - categoryMatched
+                  - registeredStore
+                  - previousGroupBuyStore
+                properties:
+                  placeId:
+                    type: string
+                    description: 네이버 장소 고유 ID
+                    example: "1234567890"
+                  storeName:
+                    type: string
+                    description: HTML 태그가 제거된 매장명
+                    example: LOAF
+                  roadAddress:
+                    type: string
+                    description: 도로명 주소
+                    example: 서울 성동구 성수이로 1
+                  lotAddress:
+                    type: string
+                    nullable: true
+                    description: 지번 주소
+                    example: 서울 성동구 성수동1가 1
+                  latitude:
+                    type: number
+                    format: double
+                    description: 위도
+                    example: 37.5
+                  longitude:
+                    type: number
+                    format: double
+                    description: 경도
+                    example: 127.0
+                  category:
+                    type: string
+                    description: 네이버 Local Search 카테고리
+                    example: 음식점>카페,디저트
+                  addressMatched:
+                    type: boolean
+                    description: 주소가 요청 region을 포함하는지 여부
+                  categoryMatched:
+                    type: boolean
+                    description: 카테고리가 상품 조건과 관련 있는지 여부
+                  registeredStore:
+                    type: boolean
+                    description: 자사 DB 등록 매장 여부
+                  previousGroupBuyStore:
+                    type: boolean
+                    description: 과거 공구 이력이 있는 매장 여부
         error: { nullable: true, example: null }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -2,11 +2,22 @@ package com.moongchijang.domain.groupbuy.service
 
 import com.moongchijang.domain.groupbuy.application.GroupBuyOpenRequestService
 import com.moongchijang.domain.groupbuy.application.dto.CreateGroupBuyOpenRequestRequest
+import com.moongchijang.domain.groupbuy.application.dto.StoreRecommendationRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.store.domain.repository.StoreRepository
+import com.moongchijang.domain.store.infrastructure.naver.NaverLocalSearchClient
+import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchItem
+import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchResponse
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -21,6 +32,15 @@ class GroupBuyOpenRequestServiceTest {
 
     @Mock
     private lateinit var openRequestRepository: GroupBuyOpenRequestRepository
+
+    @Mock
+    private lateinit var naverLocalSearchClient: NaverLocalSearchClient
+
+    @Mock
+    private lateinit var storeRepository: StoreRepository
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
 
     @InjectMocks
     private lateinit var service: GroupBuyOpenRequestService
@@ -67,4 +87,110 @@ class GroupBuyOpenRequestServiceTest {
         val ex = assertThrows<CustomException> { service.create(userId, request) }
         assertEquals(ErrorCode.DUPLICATE_OPEN_REQUEST, ex.errorCode)
     }
+
+    @Test
+    fun `매장 추천 시 네이버 결과를 중복 제거하고 추천 점수 순으로 반환한다`() {
+        val request = StoreRecommendationRequest(region = "성수", productName = "소금빵")
+        val loaf = naverItem(
+            title = "<b>LOAF</b>",
+            link = "https://map.naver.com/p/entry/place/100",
+            category = "음식점>카페,디저트",
+            address = "서울 성동구 성수동1가 1",
+            roadAddress = "서울 성동구 성수이로 1"
+        )
+        val duplicateLoaf = loaf.copy(description = "duplicate")
+        val other = naverItem(
+            title = "다른 가게",
+            link = "https://map.naver.com/p/entry/place/200",
+            category = "생활,편의",
+            address = "서울 마포구 망원동 1",
+            roadAddress = "서울 마포구 월드컵로 1"
+        )
+        val registeredStore = Store(
+            name = "LOAF",
+            address = "서울 성동구 성수이로 1",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
+        ).apply { id = 10L }
+
+        `when`(naverLocalSearchClient.search("성수 소금빵", 20)).thenReturn(
+            NaverLocalSearchResponse(
+                total = 3,
+                start = 1,
+                display = 3,
+                items = listOf(other, loaf, duplicateLoaf)
+            )
+        )
+        `when`(storeRepository.findByNormalizedNameIn(anyCollection())).thenReturn(listOf(registeredStore))
+        `when`(storeRepository.findByNormalizedAddressIn(anyCollection())).thenReturn(emptyList())
+        `when`(groupBuyRepository.findStoreIdsWithGroupBuyHistory(setOf(10L))).thenReturn(listOf(10L))
+
+        val response = service.recommendStores(request)
+
+        assertEquals("성수", response.region)
+        assertEquals("소금빵", response.productName)
+        assertEquals(2, response.stores.size)
+        assertEquals("LOAF", response.stores[0].storeName)
+        assertEquals("100", response.stores[0].placeId)
+        assertTrue(response.stores[0].addressMatched)
+        assertTrue(response.stores[0].categoryMatched)
+        assertTrue(response.stores[0].registeredStore)
+        assertTrue(response.stores[0].previousGroupBuyStore)
+        assertEquals("다른 가게", response.stores[1].storeName)
+        assertFalse(response.stores[1].registeredStore)
+        verify(storeRepository).findByNormalizedNameIn(setOf("다른가게", "loaf"))
+        verify(storeRepository).findByNormalizedAddressIn(
+            setOf(
+                "서울마포구월드컵로1",
+                "서울마포구망원동1",
+                "서울성동구성수이로1",
+                "서울성동구성수동1가1"
+            )
+        )
+    }
+
+    @Test
+    fun `네이버 API 실패 시 빈 추천 목록으로 fallback 한다`() {
+        val request = StoreRecommendationRequest(region = "성수", productName = "소금빵")
+        `when`(naverLocalSearchClient.search("성수 소금빵", 20))
+            .thenThrow(RuntimeException("timeout"))
+
+        val response = service.recommendStores(request)
+
+        assertEquals("성수", response.region)
+        assertEquals("소금빵", response.productName)
+        assertTrue(response.stores.isEmpty())
+        verifyNoInteractions(storeRepository, groupBuyRepository)
+    }
+
+    @Test
+    fun `네이버 결과가 0건이면 빈 추천 목록을 반환한다`() {
+        val request = StoreRecommendationRequest(region = "성수", productName = "소금빵")
+        `when`(naverLocalSearchClient.search("성수 소금빵", 20)).thenReturn(
+            NaverLocalSearchResponse(total = 0, start = 1, display = 0, items = emptyList())
+        )
+
+        val response = service.recommendStores(request)
+
+        assertTrue(response.stores.isEmpty())
+        verifyNoInteractions(storeRepository, groupBuyRepository)
+    }
+
+    private fun naverItem(
+        title: String,
+        link: String,
+        category: String,
+        address: String,
+        roadAddress: String
+    ) = NaverLocalSearchItem(
+        title = title,
+        link = link,
+        category = category,
+        description = "",
+        telephone = "",
+        address = address,
+        roadAddress = roadAddress,
+        mapx = "1270000000",
+        mapy = "375000000"
+    )
 }


### PR DESCRIPTION
## 📌 작업한 내용
- POST /api/v1/group-buy-open-requests/store-recommendations API를 추가했습니다.
- region + productName으로 네이버 Local Search를 조회하고 최대 10개 추천 매장을 반환합니다.
- 네이버 기본 순서를 유지하되 주소 일치, 카테고리 관련성, 자사 Store DB 매칭, 과거 공구 이력 신호로 deterministic ranking을 적용했습니다.
- 중복 매장은 매장명+주소 기준으로 제거하고, 네이버 title의 HTML 태그는 기존 변환 로직으로 제거합니다.
- 네이버 결과 0건 또는 API 실패 시 예외 대신 stores=[]를 반환해 프론트 fallback이 가능하도록 했습니다.
- OpenAPI 명세와 서비스 테스트를 추가했습니다.

## 🔍 참고 사항
- 네이버 raw query, secret, 개인정보는 로그에 남기지 않고 길이/카운트/latency/fallback 여부만 기록합니다.
- 응답에는 후속 공구 요청 장소 저장에 필요한 placeId, roadAddress, lotAddress, latitude, longitude를 포함했습니다.
- 별점/리뷰 수와 개인화 추천은 네이버 Local Search 응답에 없으므로 적용하지 않았습니다.

## 🖼️ 스크린샷
- API 변경 사항이라 스크린샷은 없습니다.

## 🔗 관련 이슈
- Closes #82

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인