### PR TITLE
[MCJ-1478] FEAT: 공구 progress 폴링 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -133,10 +133,11 @@ class GroupBuyService(
             return emptyList()
         }
 
+        val now = LocalDateTime.now()
         val groupBuysById = groupBuyRepository.findAllById(groupBuyIds).associateBy { it.id }
 
         val response = groupBuyIds.mapNotNull { id ->
-            groupBuysById[id]?.let { GroupBuyProgressItem.from(it) }
+            groupBuysById[id]?.let { GroupBuyProgressItem.from(it, now) }
         }
         log.debug(
             "[GroupBuyService] 공구 progress 다건 조회 완료: requestedSize={}, returnedSize={}",

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -5,6 +5,8 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyDetailResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedItemResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedPageResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressItem
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressResponse
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
@@ -101,6 +103,47 @@ class GroupBuyService(
             isParticipated = isParticipated,
             canParticipate = canParticipate
         )
+    }
+
+    @Transactional(readOnly = true)
+    fun getProgress(groupBuyId: Long): GroupBuyProgressResponse {
+        log.info("[GroupBuyService] 공구 progress 단건 조회 시작: groupBuyId={}", groupBuyId)
+
+        val groupBuy = groupBuyRepository.findById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+        val response = GroupBuyProgressResponse.from(groupBuy)
+        log.info(
+            "[GroupBuyService] 공구 progress 단건 조회 완료: groupBuyId={}, currentQuantity={}, targetQuantity={}, achievementRate={}, isClosed={}",
+            response.groupBuyId,
+            response.currentQuantity,
+            response.targetQuantity,
+            response.achievementRate,
+            response.isClosed
+        )
+        return response
+    }
+
+    @Transactional(readOnly = true)
+    fun getProgresses(groupBuyIds: List<Long>): List<GroupBuyProgressItem> {
+        log.info("[GroupBuyService] 공구 progress 다건 조회 시작: requestedSize={}", groupBuyIds.size)
+
+        if (groupBuyIds.isEmpty()) {
+            log.info("[GroupBuyService] 공구 progress 다건 조회 완료: requestedSize=0, returnedSize=0")
+            return emptyList()
+        }
+
+        val groupBuysById = groupBuyRepository.findAllById(groupBuyIds).associateBy { it.id }
+
+        val response = groupBuyIds.mapNotNull { id ->
+            groupBuysById[id]?.let { GroupBuyProgressItem.from(it) }
+        }
+        log.info(
+            "[GroupBuyService] 공구 progress 다건 조회 완료: requestedSize={}, returnedSize={}",
+            groupBuyIds.size,
+            response.size
+        )
+        return response
     }
 
     private fun validateDistrictSelection(districts: List<DistrictType>) {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -105,7 +105,7 @@ class GroupBuyService(
         )
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, timeout = 3)
     fun getProgress(groupBuyId: Long): GroupBuyProgressResponse {
         log.info("[GroupBuyService] 공구 progress 단건 조회 시작: groupBuyId={}", groupBuyId)
 
@@ -124,7 +124,7 @@ class GroupBuyService(
         return response
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, timeout = 3)
     fun getProgresses(groupBuyIds: List<Long>): List<GroupBuyProgressItem> {
         log.info("[GroupBuyService] 공구 progress 다건 조회 시작: requestedSize={}", groupBuyIds.size)
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -107,13 +107,13 @@ class GroupBuyService(
 
     @Transactional(readOnly = true, timeout = 3)
     fun getProgress(groupBuyId: Long): GroupBuyProgressResponse {
-        log.info("[GroupBuyService] 공구 progress 단건 조회 시작: groupBuyId={}", groupBuyId)
+        log.debug("[GroupBuyService] 공구 progress 단건 조회 시작: groupBuyId={}", groupBuyId)
 
         val groupBuy = groupBuyRepository.findById(groupBuyId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
 
         val response = GroupBuyProgressResponse.from(groupBuy)
-        log.info(
+        log.debug(
             "[GroupBuyService] 공구 progress 단건 조회 완료: groupBuyId={}, currentQuantity={}, targetQuantity={}, achievementRate={}, isClosed={}",
             response.groupBuyId,
             response.currentQuantity,
@@ -126,10 +126,10 @@ class GroupBuyService(
 
     @Transactional(readOnly = true, timeout = 3)
     fun getProgresses(groupBuyIds: List<Long>): List<GroupBuyProgressItem> {
-        log.info("[GroupBuyService] 공구 progress 다건 조회 시작: requestedSize={}", groupBuyIds.size)
+        log.debug("[GroupBuyService] 공구 progress 다건 조회 시작: requestedSize={}", groupBuyIds.size)
 
         if (groupBuyIds.isEmpty()) {
-            log.info("[GroupBuyService] 공구 progress 다건 조회 완료: requestedSize=0, returnedSize=0")
+            log.debug("[GroupBuyService] 공구 progress 다건 조회 완료: requestedSize=0, returnedSize=0")
             return emptyList()
         }
 
@@ -138,7 +138,7 @@ class GroupBuyService(
         val response = groupBuyIds.mapNotNull { id ->
             groupBuysById[id]?.let { GroupBuyProgressItem.from(it) }
         }
-        log.info(
+        log.debug(
             "[GroupBuyService] 공구 progress 다건 조회 완료: requestedSize={}, returnedSize={}",
             groupBuyIds.size,
             response.size

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyDetailResponse.kt
@@ -2,7 +2,6 @@ package com.moongchijang.domain.groupbuy.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
 import io.swagger.v3.oas.annotations.media.Schema
@@ -118,7 +117,7 @@ data class GroupBuyDetailResponse(
         ): GroupBuyDetailResponse {
             val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()
             val pickupDateLabel = formatPickupLabel(groupBuy.pickupDate)
-            val rate = calculateAchievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
+            val rate = GroupBuyProgressCalculator.achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
 
             return GroupBuyDetailResponse(
                 id = groupBuy.id,
@@ -151,17 +150,10 @@ data class GroupBuyDetailResponse(
                 dDay = dDay,
                 dDayLabel = "D-$dDay",
                 isWishlisted = isWishlisted,
-                isClosed = groupBuy.status in setOf(
-                    GroupBuyStatus.FAILED, GroupBuyStatus.CLOSED, GroupBuyStatus.COMPLETED
-                ),
+                isClosed = GroupBuyProgressCalculator.isClosed(groupBuy, now),
                 isParticipated = isParticipated,
                 canParticipate = canParticipate
             )
-        }
-
-        private fun calculateAchievementRate(current: Int, target: Int): Int {
-            if (target <= 0) return 0
-            return ((current * 100.0) / target).toInt()
         }
 
         private fun formatPickupLabel(date: LocalDate): String {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
@@ -64,7 +64,7 @@ data class GroupBuyFeedItemResponse(
     companion object {
         fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyFeedItemResponse {
             val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()
-            val rate = calculateAchievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
+            val rate = GroupBuyProgressCalculator.achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
 
             return GroupBuyFeedItemResponse(
                 id = groupBuy.id,
@@ -84,11 +84,6 @@ data class GroupBuyFeedItemResponse(
                 currentQuantity = groupBuy.currentQuantity,
                 targetQuantity = groupBuy.targetQuantity
             )
-        }
-
-        private fun calculateAchievementRate(currentQuantity: Int, targetQuantity: Int): Int {
-            if (targetQuantity <= 0) return 0
-            return ((currentQuantity * 100.0) / targetQuantity).toInt()
         }
 
         private fun formatPickupDateLabel(date: LocalDate): String {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import java.time.LocalDateTime
+
+object GroupBuyProgressCalculator {
+    fun achievementRate(currentQuantity: Int, targetQuantity: Int): Int {
+        if (targetQuantity <= 0) return 0
+        return ((currentQuantity * 100.0) / targetQuantity).toInt()
+    }
+
+    fun isClosed(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): Boolean {
+        return groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(now)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
@@ -5,12 +5,18 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import java.time.LocalDateTime
 
 object GroupBuyProgressCalculator {
+    private val CLOSED_STATUSES = setOf(
+        GroupBuyStatus.COMPLETED,
+        GroupBuyStatus.FAILED,
+        GroupBuyStatus.CLOSED
+    )
+
     fun achievementRate(currentQuantity: Int, targetQuantity: Int): Int {
         if (targetQuantity <= 0) return 0
         return ((currentQuantity * 100.0) / targetQuantity).toInt()
     }
 
     fun isClosed(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): Boolean {
-        return groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(now)
+        return groupBuy.status in CLOSED_STATUSES || groupBuy.deadline.isBefore(now)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressItem.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressItem.kt
@@ -1,0 +1,45 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "다건 공구 달성률/참여 수량 아이템")
+data class GroupBuyProgressItem(
+
+    @field:Schema(description = "공구 ID", example = "101")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "달성률(%)", example = "72")
+    val achievementRate: Int,
+
+    @field:Schema(description = "현재 참여 수량", example = "36")
+    val currentQuantity: Int,
+
+    @field:Schema(description = "목표 수량", example = "50")
+    val targetQuantity: Int,
+
+    @field:Schema(description = "마감 여부", example = "false")
+    val isClosed: Boolean
+) {
+    companion object {
+        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyProgressItem {
+            val achievementRate = calculateAchievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
+            val isClosed = groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(now)
+
+            return GroupBuyProgressItem(
+                groupBuyId = groupBuy.id,
+                achievementRate = achievementRate,
+                currentQuantity = groupBuy.currentQuantity,
+                targetQuantity = groupBuy.targetQuantity,
+                isClosed = isClosed
+            )
+        }
+
+        private fun calculateAchievementRate(currentQuantity: Int, targetQuantity: Int): Int {
+            if (targetQuantity <= 0) return 0
+            return ((currentQuantity * 100.0) / targetQuantity).toInt()
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressItem.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressItem.kt
@@ -1,7 +1,6 @@
 package com.moongchijang.domain.groupbuy.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -25,8 +24,8 @@ data class GroupBuyProgressItem(
 ) {
     companion object {
         fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyProgressItem {
-            val achievementRate = calculateAchievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
-            val isClosed = groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(now)
+            val achievementRate = GroupBuyProgressCalculator.achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
+            val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy, now)
 
             return GroupBuyProgressItem(
                 groupBuyId = groupBuy.id,
@@ -35,11 +34,6 @@ data class GroupBuyProgressItem(
                 targetQuantity = groupBuy.targetQuantity,
                 isClosed = isClosed
             )
-        }
-
-        private fun calculateAchievementRate(currentQuantity: Int, targetQuantity: Int): Int {
-            if (targetQuantity <= 0) return 0
-            return ((currentQuantity * 100.0) / targetQuantity).toInt()
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressResponse.kt
@@ -1,7 +1,6 @@
 package com.moongchijang.domain.groupbuy.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -25,8 +24,8 @@ data class GroupBuyProgressResponse(
 ) {
     companion object {
         fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyProgressResponse {
-            val achievementRate = calculateAchievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
-            val isClosed = groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(now)
+            val achievementRate = GroupBuyProgressCalculator.achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
+            val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy, now)
 
             return GroupBuyProgressResponse(
                 groupBuyId = groupBuy.id,
@@ -35,11 +34,6 @@ data class GroupBuyProgressResponse(
                 targetQuantity = groupBuy.targetQuantity,
                 isClosed = isClosed
             )
-        }
-
-        private fun calculateAchievementRate(currentQuantity: Int, targetQuantity: Int): Int {
-            if (targetQuantity <= 0) return 0
-            return ((currentQuantity * 100.0) / targetQuantity).toInt()
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressResponse.kt
@@ -1,0 +1,45 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "단일 공구 달성률/참여 수량 응답")
+data class GroupBuyProgressResponse(
+
+    @field:Schema(description = "공구 ID", example = "101")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "달성률(%)", example = "72")
+    val achievementRate: Int,
+
+    @field:Schema(description = "현재 참여 수량", example = "36")
+    val currentQuantity: Int,
+
+    @field:Schema(description = "목표 수량", example = "50")
+    val targetQuantity: Int,
+
+    @field:Schema(description = "마감 여부", example = "false")
+    val isClosed: Boolean
+) {
+    companion object {
+        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyProgressResponse {
+            val achievementRate = calculateAchievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
+            val isClosed = groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(now)
+
+            return GroupBuyProgressResponse(
+                groupBuyId = groupBuy.id,
+                achievementRate = achievementRate,
+                currentQuantity = groupBuy.currentQuantity,
+                targetQuantity = groupBuy.targetQuantity,
+                isClosed = isClosed
+            )
+        }
+
+        private fun calculateAchievementRate(currentQuantity: Int, targetQuantity: Int): Int {
+            if (targetQuantity <= 0) return 0
+            return ((currentQuantity * 100.0) / targetQuantity).toInt()
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -203,7 +203,7 @@ class GroupBuyController(
     }
 
     private fun validateProgressIds(ids: List<Long>) {
-        if (ids.isEmpty() || ids.size > MAX_PROGRESS_IDS) {
+        if (ids.isEmpty() || ids.size > MAX_PROGRESS_IDS || ids.any { it <= 0L }) {
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -6,9 +6,13 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyDetailResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedPageResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressItem
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerCountResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerHeartbeatRequest
 import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -98,6 +102,63 @@ class GroupBuyController(
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
+    @GetMapping("/{groupBuyId}/progress")
+    @Operation(summary = "단일 공구 달성률 조회 (폴링용)")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "단일 공구 달성률 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getProgress(
+        @PathVariable groupBuyId: Long
+    ): ResponseEntity<ApiResponse<GroupBuyProgressResponse>> {
+        log.info("[GroupBuyController] 공구 progress 단건 조회 요청 수신: groupBuyId={}", groupBuyId)
+
+        val response = groupBuyService.getProgress(groupBuyId)
+
+        log.info("[GroupBuyController] 공구 progress 단건 조회 응답 완료: groupBuyId={}", groupBuyId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/progress")
+    @Operation(summary = "다건 공구 달성률 조회 (피드 갱신용)")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "다건 공구 달성률 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (ids 누락/빈 목록/최대 20개 초과)",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getProgresses(
+        @RequestParam ids: List<Long>
+    ): ResponseEntity<ApiResponse<List<GroupBuyProgressItem>>> {
+        validateProgressIds(ids)
+        val distinctIds = ids.distinct()
+
+        log.info(
+            "[GroupBuyController] 공구 progress 다건 조회 요청 수신: requestedSize={}, distinctSize={}",
+            ids.size,
+            distinctIds.size
+        )
+
+        val response = groupBuyService.getProgresses(distinctIds)
+
+        log.info(
+            "[GroupBuyController] 공구 progress 다건 조회 응답 완료: requestedSize={}, returnedSize={}",
+            distinctIds.size,
+            response.size
+        )
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
     @PostMapping("/{groupBuyId}/viewers/heartbeat")
     @Operation(summary = "공구 상세 조회자 heartbeat 조회/갱신")
     @ApiResponses(
@@ -139,5 +200,15 @@ class GroupBuyController(
             response.activeViewerCount
         )
         return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    private fun validateProgressIds(ids: List<Long>) {
+        if (ids.isEmpty() || ids.size > MAX_PROGRESS_IDS) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+
+    companion object {
+        private const val MAX_PROGRESS_IDS = 20
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -117,11 +117,11 @@ class GroupBuyController(
     fun getProgress(
         @PathVariable groupBuyId: Long
     ): ResponseEntity<ApiResponse<GroupBuyProgressResponse>> {
-        log.info("[GroupBuyController] 공구 progress 단건 조회 요청 수신: groupBuyId={}", groupBuyId)
+        log.debug("[GroupBuyController] 공구 progress 단건 조회 요청 수신: groupBuyId={}", groupBuyId)
 
         val response = groupBuyService.getProgress(groupBuyId)
 
-        log.info("[GroupBuyController] 공구 progress 단건 조회 응답 완료: groupBuyId={}", groupBuyId)
+        log.debug("[GroupBuyController] 공구 progress 단건 조회 응답 완료: groupBuyId={}", groupBuyId)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 
@@ -143,7 +143,7 @@ class GroupBuyController(
         validateProgressIds(ids)
         val distinctIds = ids.distinct()
 
-        log.info(
+        log.debug(
             "[GroupBuyController] 공구 progress 다건 조회 요청 수신: requestedSize={}, distinctSize={}",
             ids.size,
             distinctIds.size
@@ -151,7 +151,7 @@ class GroupBuyController(
 
         val response = groupBuyService.getProgresses(distinctIds)
 
-        log.info(
+        log.debug(
             "[GroupBuyController] 공구 progress 다건 조회 응답 완료: requestedSize={}, returnedSize={}",
             distinctIds.size,
             response.size

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -617,12 +617,13 @@ paths:
         - name: ids
           in: query
           required: true
-          description: 조회할 공구 ID 목록 (최대 20개)
+          description: 조회할 공구 ID 목록 (양수 ID만 허용, 최대 20개)
           schema:
             type: array
             items:
               type: integer
               format: int64
+              minimum: 1
             maxItems: 20
       responses:
         '200':

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -246,6 +246,66 @@ class GroupBuyServiceTest {
         assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
     }
 
+    @Test
+    fun `단건 progress 조회 성공`() {
+        val groupBuyId = 21L
+        val groupBuy = createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.IN_PROGRESS
+        ).apply {
+            currentQuantity = 36
+            targetQuantity = 50
+        }
+        `when`(groupBuyRepository.findById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+
+        val result = service.getProgress(groupBuyId)
+
+        assertEquals(groupBuyId, result.groupBuyId)
+        assertEquals(72, result.achievementRate)
+        assertEquals(36, result.currentQuantity)
+        assertEquals(50, result.targetQuantity)
+        assertFalse(result.isClosed)
+    }
+
+    @Test
+    fun `존재하지 않는 공구 progress 단건 조회 시 GROUPBUY_NOT_FOUND 예외 발생`() {
+        `when`(groupBuyRepository.findById(999L)).thenReturn(Optional.empty())
+
+        val ex = assertThrows<CustomException> { service.getProgress(999L) }
+
+        assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
+    }
+
+    @Test
+    fun `다건 progress 조회 시 요청 순서를 유지하고 존재하지 않는 id 는 제외한다`() {
+        val first = createGroupBuy(id = 101L, status = GroupBuyStatus.IN_PROGRESS).apply {
+            currentQuantity = 20
+            targetQuantity = 50
+        }
+        val second = createGroupBuy(id = 202L, status = GroupBuyStatus.IN_PROGRESS).apply {
+            currentQuantity = 45
+            targetQuantity = 50
+        }
+        val requestIds = listOf(202L, 999L, 101L)
+
+        `when`(groupBuyRepository.findAllById(requestIds)).thenReturn(listOf(first, second))
+
+        val result = service.getProgresses(requestIds)
+
+        assertEquals(2, result.size)
+        assertEquals(202L, result[0].groupBuyId)
+        assertEquals(90, result[0].achievementRate)
+        assertEquals(101L, result[1].groupBuyId)
+        assertEquals(40, result[1].achievementRate)
+    }
+
+    @Test
+    fun `다건 progress 조회 시 빈 id 목록이면 빈 결과를 반환한다`() {
+        val result = service.getProgresses(emptyList())
+
+        assertTrue(result.isEmpty())
+    }
+
     private fun createGroupBuy(
         id: Long,
         status: GroupBuyStatus,


### PR DESCRIPTION
## 📌 작업한 내용
- 공구 progress 폴링용 단건/다건 조회 API를 추가했습니다.
- 공구 상세/피드/progress에서 사용하는 달성률 및 마감 여부 계산 로직을 공통화했습니다.
- progress 다건 조회 요청에 대해 기본 검증을 추가했습니다.
  - `ids` 빈값 불가
  - 최대 20개
  - 양수 ID만 허용
- progress 조회에 read-only 트랜잭션과 timeout 설정을 적용했습니다.

## 🔍 참고 사항
- 이번 PR은 기능 구현과 기본 안정장치 적용에 집중했습니다.
- 조회 성능 최적화(쿼리 플랜/인덱스), 캐시 전략, 고도화된 락 정책은 범위에서 제외했습니다.
- 다건 progress API는 요청 순서를 유지하고, 존재하지 않는 ID는 응답에서 제외하도록 구현했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #116 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인