### PR TITLE
[MCJ-1484] CHORE: EC2 443 오픈 및 Nginx HTTPS/ACME 설정 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ Thumbs.db
 *.key
 credentials.json
 secrets.json
+docker/certbot/conf/
+docker/certbot/www/
 
 ### Local config ###
 local.properties

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -54,8 +54,11 @@ services:
     container_name: moongchijang-nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certbot/www:/var/www/certbot:ro
+      - ./certbot/conf:/etc/letsencrypt:ro
     restart: unless-stopped
 
   qdrant:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -8,6 +8,10 @@ http {
     listen 80;
     server_name _;
 
+    location /.well-known/acme-challenge/ {
+      root /var/www/certbot;
+    }
+
     return 301 https://$host$request_uri;
   }
 
@@ -15,8 +19,8 @@ http {
     listen 443 ssl;
     server_name _;
 
-    ssl_certificate /etc/nginx/certs/fullchain.pem;
-    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/api.moongchijang.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.moongchijang.com/privkey.pem;
 
     location = /dev {
       return 301 https://$host$uri/$is_args$args;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -6,9 +6,20 @@ http {
 
   server {
     listen 80;
+    server_name _;
+
+    return 301 https://$host$request_uri;
+  }
+
+  server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
 
     location = /dev {
-      return 301 $scheme://$http_host$uri/$is_args$args;
+      return 301 https://$host$uri/$is_args$args;
     }
 
     location /dev/ {
@@ -17,7 +28,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto https;
       proxy_set_header X-Forwarded-Prefix /dev;
     }
 
@@ -27,7 +38,7 @@ http {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto https;
     }
   }
 }

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -6,18 +6,20 @@ http {
 
   server {
     listen 80;
-    server_name _;
+    server_name api.moongchijang.com;
 
     location /.well-known/acme-challenge/ {
       root /var/www/certbot;
     }
 
-    return 301 https://$host$request_uri;
+    location / {
+      return 301 https://$host$request_uri;
+    }
   }
 
   server {
     listen 443 ssl;
-    server_name _;
+    server_name api.moongchijang.com;
 
     ssl_certificate /etc/letsencrypt/live/api.moongchijang.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/api.moongchijang.com/privkey.pem;

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -59,6 +59,14 @@ resource "aws_security_group" "app_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
## 📌 작업한 내용
- `infra/terraform/main.tf`에서 EC2 앱 보안 그룹(`app_sg`)에 `443/tcp` 인바운드 규칙을 추가했습니다.
- `docker/nginx/nginx.conf`에 HTTPS 전환 설정을 적용했습니다.
- `80` 포트 요청을 `https`로 리다이렉트하도록 설정했습니다.
- `443 ssl` 리스너를 추가하고 TLS 인증서 경로를 Let’s Encrypt 경로로 지정했습니다.
- `/.well-known/acme-challenge/` 경로를 열어 certbot `webroot` 방식 인증서 발급이 가능하도록 설정했습니다.
- `docker/docker-compose.yml`에서 nginx `443:443` 포트 매핑을 추가했습니다.
- nginx에 certbot 경로 볼륨(`./certbot/www`, `./certbot/conf`)을 마운트하도록 설정했습니다.
- `.gitignore`에 certbot 산출물 디렉터리(`docker/certbot/conf/`, `docker/certbot/www/`)를 추가해 인증서/키 파일이 Git에 포함되지 않도록 했습니다.

## 🔍 참고 사항
- 이 PR은 HTTPS 적용을 위한 인프라/리버스프록시 설정 반영까지 포함합니다.
- 실제 HTTPS 활성화는 머지 후 EC2에서 certbot으로 최초 인증서 발급을 수행해야 완료됩니다.
- 인증서 발급 후 nginx 재시작(또는 reload) 및 `https://api.moongchijang.com` 접속 검증이 필요합니다.
- 인증서 자동 갱신(`certbot renew`)은 운영 서버 cron/systemd로 별도 등록이 필요합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #127 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인