### PR TITLE
[MCJ-1486] FIX: nginx /dev 프록시 경로 전달 고정으로 로그인 403 이슈 해결

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -29,8 +29,7 @@ http {
     }
 
     location /dev/ {
-      set $app_dev http://app-dev:8080;
-      proxy_pass $app_dev/;
+      proxy_pass http://app-dev:8080/;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -39,8 +38,7 @@ http {
     }
 
     location / {
-      set $app_prod http://app-prod:8080;
-      proxy_pass $app_prod/;
+      proxy_pass http://app-prod:8080/;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -29,7 +29,9 @@ http {
     }
 
     location /dev/ {
-      proxy_pass http://app-dev:8080/;
+      set $app_dev http://app-dev:8080;
+      rewrite ^/dev/(.*)$ /$1 break;
+      proxy_pass $app_dev;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -38,7 +40,8 @@ http {
     }
 
     location / {
-      proxy_pass http://app-prod:8080/;
+      set $app_prod http://app-prod:8080;
+      proxy_pass $app_prod;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 📌 작업한 내용
- `docker/nginx/nginx.conf`에서 `/dev/` 프록시 설정의 변수 업스트림(`set $app_dev ...`)을 제거하고 `proxy_pass http://app-dev:8080/;`로 고정했습니다.
- `docker/nginx/nginx.conf`에서 `/` 프록시 설정의 변수 업스트림(`set $app_prod ...`)을 제거하고 `proxy_pass http://app-prod:8080/;`로 고정했습니다.
- `/dev` 경로 프록시 시 URI 전달 동작이 일관되도록 설정해, 로그인 API(`/dev/api/v1/auth/email/login`) 호출 시 간헐적 403이 발생하던 경로 처리 이슈를 해소했습니다.

## 🔍 참고 사항
- HTTPS 전환 이후 `/dev` 경로 요청에서 403이 발생하는 케이스가 있었고, 원인 분석 과정에서 변수 기반 `proxy_pass` 사용 시 경로 전달이 의도와 다르게 동작할 여지가 확인되었습니다.
- EC2에서 임시 수정한 nginx 설정을 레포에 반영한 내용이며, 재배포 시 설정이 유실되지 않도록 코드 기준으로 동기화했습니다.
- 배포 후 검증 권장 항목:
  - `POST /dev/api/v1/auth/email/login` 정상 응답 확인
  - `/dev` 경로 API 호출 시 백엔드 로그에서 `/api/...` 형태로 정상 라우팅 확인
  - `http -> https` 리다이렉트 및 인증서 동작 이상 여부 확인

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #130 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인