### PR TITLE
[MCJ-1483] FIX: 달성 완료 공구 추가 참여 가능 조건 반영

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -90,10 +90,7 @@ class GroupBuyService(
 
         val now = LocalDateTime.now()
         val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy, now)
-        val canParticipate = !isParticipated &&
-            GroupBuyProgressCalculator.isParticipationOpenStatus(groupBuy) &&
-            !groupBuy.deadline.isBefore(now) &&
-            groupBuy.currentQuantity < groupBuy.maxQuantity
+        val canParticipate = !isParticipated && !isClosed && groupBuy.currentQuantity < groupBuy.maxQuantity
 
         log.info(
             "[GroupBuyService] 공구 상세 조회 완료: groupBuyId={}, isWishlisted={}, isParticipated={}, canParticipate={}",

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -91,7 +91,7 @@ class GroupBuyService(
         val now = LocalDateTime.now()
         val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy, now)
         val canParticipate = !isParticipated &&
-            GroupBuyProgressCalculator.canParticipateStatus(groupBuy) &&
+            GroupBuyProgressCalculator.isParticipationOpenStatus(groupBuy) &&
             !groupBuy.deadline.isBefore(now) &&
             groupBuy.currentQuantity < groupBuy.maxQuantity
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -6,8 +6,8 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedItemResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedPageResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressItem
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressResponse
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
@@ -88,8 +88,12 @@ class GroupBuyService(
             participationRepository.existsByUserIdAndGroupBuyId(it, groupBuyId)
         } ?: false
 
-        val isClosed = groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(LocalDateTime.now())
-        val canParticipate = !isClosed && !isParticipated
+        val now = LocalDateTime.now()
+        val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy, now)
+        val canParticipate = !isParticipated &&
+            GroupBuyProgressCalculator.canParticipateStatus(groupBuy) &&
+            !groupBuy.deadline.isBefore(now) &&
+            groupBuy.currentQuantity < groupBuy.maxQuantity
 
         log.info(
             "[GroupBuyService] 공구 상세 조회 완료: groupBuyId={}, isWishlisted={}, isParticipated={}, canParticipate={}",

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
@@ -20,7 +20,7 @@ object GroupBuyProgressCalculator {
         return groupBuy.status in CLOSED_STATUSES || groupBuy.deadline.isBefore(now)
     }
 
-    fun canParticipateStatus(groupBuy: GroupBuy): Boolean {
+    fun isParticipationOpenStatus(groupBuy: GroupBuy): Boolean {
         return groupBuy.status == GroupBuyStatus.IN_PROGRESS || groupBuy.status == GroupBuyStatus.ACHIEVED
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressCalculator.kt
@@ -19,4 +19,8 @@ object GroupBuyProgressCalculator {
     fun isClosed(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): Boolean {
         return groupBuy.status in CLOSED_STATUSES || groupBuy.deadline.isBefore(now)
     }
+
+    fun canParticipateStatus(groupBuy: GroupBuy): Boolean {
+        return groupBuy.status == GroupBuyStatus.IN_PROGRESS || groupBuy.status == GroupBuyStatus.ACHIEVED
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -549,9 +550,7 @@ class PaymentService(
     }
 
     private fun validateGroupBuyAvailable(groupBuy: GroupBuy) {
-        val isParticipationOpenStatus =
-            groupBuy.status == GroupBuyStatus.IN_PROGRESS || groupBuy.status == GroupBuyStatus.ACHIEVED
-        if (!isParticipationOpenStatus || groupBuy.deadline.isBefore(LocalDateTime.now())) {
+        if (GroupBuyProgressCalculator.isClosed(groupBuy)) {
             throw CustomException(ErrorCode.PAYMENT_GROUPBUY_NOT_AVAILABLE)
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -549,7 +549,9 @@ class PaymentService(
     }
 
     private fun validateGroupBuyAvailable(groupBuy: GroupBuy) {
-        if (groupBuy.status != GroupBuyStatus.IN_PROGRESS || groupBuy.deadline.isBefore(LocalDateTime.now())) {
+        val isParticipationOpenStatus =
+            groupBuy.status == GroupBuyStatus.IN_PROGRESS || groupBuy.status == GroupBuyStatus.ACHIEVED
+        if (!isParticipationOpenStatus || groupBuy.deadline.isBefore(LocalDateTime.now())) {
             throw CustomException(ErrorCode.PAYMENT_GROUPBUY_NOT_AVAILABLE)
         }
     }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -238,6 +238,46 @@ class GroupBuyServiceTest {
     }
 
     @Test
+    fun `달성 완료 공구 상세 조회 시 최대 수량 전이면 참여 가능 여부 true 반환`() {
+        val groupBuyId = 14L
+        val userId = 5L
+        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.ACHIEVED).apply {
+            currentQuantity = 50
+            maxQuantity = 100
+        }
+
+        `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+        `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(emptyList())
+        `when`(favoriteRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+
+        val result = service.getDetail(groupBuyId, userId)
+
+        assertFalse(result.isClosed)
+        assertTrue(result.canParticipate)
+    }
+
+    @Test
+    fun `달성 완료 공구 상세 조회 시 최대 수량 도달이면 참여 가능 여부 false 반환`() {
+        val groupBuyId = 15L
+        val userId = 6L
+        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.ACHIEVED).apply {
+            currentQuantity = 100
+            maxQuantity = 100
+        }
+
+        `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+        `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(emptyList())
+        `when`(favoriteRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+
+        val result = service.getDetail(groupBuyId, userId)
+
+        assertFalse(result.isClosed)
+        assertFalse(result.canParticipate)
+    }
+
+    @Test
     fun `존재하지 않는 공구 상세 조회 시 GROUPBUY_NOT_FOUND 예외 발생`() {
         `when`(groupBuyRepository.findWithStoreById(999L)).thenReturn(Optional.empty())
 
@@ -264,6 +304,24 @@ class GroupBuyServiceTest {
         assertEquals(72, result.achievementRate)
         assertEquals(36, result.currentQuantity)
         assertEquals(50, result.targetQuantity)
+        assertFalse(result.isClosed)
+    }
+
+    @Test
+    fun `달성 완료 공구 progress 조회 시 마감 여부 false 반환`() {
+        val groupBuyId = 22L
+        val groupBuy = createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.ACHIEVED
+        ).apply {
+            currentQuantity = 50
+            targetQuantity = 50
+        }
+        `when`(groupBuyRepository.findById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+
+        val result = service.getProgress(groupBuyId)
+
+        assertEquals(groupBuyId, result.groupBuyId)
         assertFalse(result.isClosed)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -278,6 +278,30 @@ class GroupBuyServiceTest {
     }
 
     @Test
+    fun `달성 완료 공구라도 마감 시간이 지나면 참여 가능 여부 false 반환`() {
+        val groupBuyId = 16L
+        val userId = 7L
+        val groupBuy = createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.ACHIEVED,
+            deadline = LocalDateTime.now().minusMinutes(1)
+        ).apply {
+            currentQuantity = 50
+            maxQuantity = 100
+        }
+
+        `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+        `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(emptyList())
+        `when`(favoriteRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+
+        val result = service.getDetail(groupBuyId, userId)
+
+        assertTrue(result.isClosed)
+        assertFalse(result.canParticipate)
+    }
+
+    @Test
     fun `존재하지 않는 공구 상세 조회 시 GROUPBUY_NOT_FOUND 예외 발생`() {
         `when`(groupBuyRepository.findWithStoreById(999L)).thenReturn(Optional.empty())
 

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -173,6 +173,40 @@ class PaymentServiceTest {
     }
 
     @Test
+    fun `마감 시간이 지난 ACHIEVED 상태 공구는 체크아웃 정보 조회 불가`() {
+        val groupBuy = createGroupBuy(
+            status = GroupBuyStatus.ACHIEVED,
+            currentQuantity = 50,
+            maxQuantity = 100,
+        ).apply {
+            deadline = LocalDateTime.now().minusMinutes(1)
+        }
+        `when`(groupBuyRepository.findWithStoreById(10L)).thenReturn(Optional.of(groupBuy))
+
+        val ex = assertThrows<CustomException> {
+            service.getCheckoutInfo(10L, 1)
+        }
+
+        assertEquals(ErrorCode.PAYMENT_GROUPBUY_NOT_AVAILABLE, ex.errorCode)
+    }
+
+    @Test
+    fun `마감 시간이 지난 ACHIEVED 상태 공구는 결제 주문 생성 불가`() {
+        val user = UserFixture.createKakaoUser(id = 1L, nickname = "은서")
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.ACHIEVED, currentQuantity = 50, maxQuantity = 100).apply {
+            deadline = LocalDateTime.now().minusMinutes(1)
+        }
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
+        `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
+
+        val ex = assertThrows<CustomException> {
+            service.createPaymentOrder(10L, 1L, createOrderRequest(quantity = 1))
+        }
+
+        assertEquals(ErrorCode.PAYMENT_GROUPBUY_NOT_AVAILABLE, ex.errorCode)
+    }
+
+    @Test
     fun `포트원 결제 완료 시 참여 생성 및 현재 수량 증가`() {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy(currentQuantity = 36)

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -115,6 +115,18 @@ class PaymentServiceTest {
     }
 
     @Test
+    fun `ACHIEVED 상태 공구도 체크아웃 정보 조회 가능`() {
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.ACHIEVED, currentQuantity = 50, maxQuantity = 100)
+        `when`(groupBuyRepository.findWithStoreById(10L)).thenReturn(Optional.of(groupBuy))
+
+        val result = service.getCheckoutInfo(10L, 2)
+
+        assertEquals(10L, result.groupBuyId)
+        assertEquals(50, groupBuy.currentQuantity)
+        assertEquals(50, result.remainingQuantity)
+    }
+
+    @Test
     fun `필수 동의가 없으면 결제 주문 생성 실패`() {
         val request = createOrderRequest(agreedNoWithdrawal = false)
 
@@ -142,6 +154,22 @@ class PaymentServiceTest {
         assertEquals("두쫀쿠 3개", result.orderName)
         assertEquals(18000, result.amount)
         assertEquals("은서", result.customerName)
+    }
+
+    @Test
+    fun `ACHIEVED 상태 공구도 결제 주문 생성 가능`() {
+        val user = UserFixture.createKakaoUser(id = 1L, nickname = "은서")
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.ACHIEVED, currentQuantity = 50, maxQuantity = 100)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
+        `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(false)
+        `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
+
+        val result = service.createPaymentOrder(10L, 1L, createOrderRequest(quantity = 2))
+
+        assertTrue(result.paymentId.startsWith("MCJ-10-"))
+        assertEquals("두쫀쿠 2개", result.orderName)
+        assertEquals(12000, result.amount)
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업한 내용
- 달성 완료 공구도 `deadline`이 지나지 않았고 `maxQuantity`를 초과하지 않은 경우 추가 참여가 가능하도록 상세 응답, 체크아웃, 결제 주문 생성 조건을 함께 수정했습니다.
- 상세/progress/결제 조건 간 참여 가능 여부와 마감 여부 판단이 일관되도록 로직을 정리했습니다.
- 달성 완료 공구의 참여 가능/불가 조건과 `deadline` 경과 케이스에 대한 테스트를 추가했습니다.

## 🔍 참고 사항
- 이번 PR은 달성 완료 이후 추가 참여 허용 정책 반영에 초점을 맞췄습니다.
- 달성 완료 공구는 참여 가능 상태로 열어두되, `deadline`이 지난 경우에는 여전히 참여 불가로 처리합니다.
- `deadline` 경과 시 공구 상태를 자동 전이하는 로직은 이번 PR 범위에 포함하지 않았으며, 후속 이슈로 처리 예정입니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #126 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인