### PR TITLE
[MCJ-1488] 마이페이지 진행 중 참여 내역 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
@@ -1,4 +1,4 @@
-package com.moongchijang.domain.participation.application
+package com.moongchijang.domain.mypage.application
 
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.participation.application.dto.InProgressParticipationItemResponse
@@ -14,7 +14,7 @@ import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 @Service
-class ParticipationQueryService(
+class MyPageParticipationQueryService(
     private val participationRepository: ParticipationRepository
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -22,7 +22,7 @@ class ParticipationQueryService(
     @Transactional(readOnly = true)
     fun getInProgressParticipations(userId: Long, pageable: Pageable): InProgressParticipationPageResponse {
         log.info(
-            "[ParticipationQueryService] 진행 중 참여 내역 조회 시작: userId={}, page={}, size={}",
+            "[MyPageParticipationQueryService] 진행 중 참여 내역 조회 시작: userId={}, page={}, size={}",
             userId,
             pageable.pageNumber,
             pageable.pageSize
@@ -35,7 +35,7 @@ class ParticipationQueryService(
         )
 
         log.info(
-            "[ParticipationQueryService] 진행 중 참여 내역 조회 완료: userId={}, contentSize={}, totalElements={}, totalPages={}",
+            "[MyPageParticipationQueryService] 진행 중 참여 내역 조회 완료: userId={}, contentSize={}, totalElements={}, totalPages={}",
             userId,
             page.content.size,
             page.totalElements,

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
@@ -66,7 +66,9 @@ class MyPageParticipationQueryService(
                 targetQuantity = groupBuy.targetQuantity
             ),
             dDay = dDay,
-            participatedAt = participation.createdAt!!
+            participatedAt = requireNotNull(participation.createdAt) {
+                "[MyPageParticipationQueryService] 참여 생성일시 누락: participationId=${participation.id}"
+            }
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
@@ -55,7 +55,7 @@ class MyPageParticipationQueryService(
 
         return InProgressParticipationItemResponse(
             participationId = participation.id,
-            groupbuyId = groupBuy.id,
+            groupBuyId = groupBuy.id,
             productName = groupBuy.productName,
             storeName = groupBuy.store.name,
             pickupAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart),

--- a/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MyPageParticipationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MyPageParticipationController.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.domain.mypage.presentation
+
+import com.moongchijang.domain.mypage.application.MyPageParticipationQueryService
+import com.moongchijang.domain.participation.application.dto.InProgressParticipationPageResponse
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/users/me/participations")
+@Tag(name = "MyPage", description = "마이페이지 API")
+class MyPageParticipationController(
+    private val myPageParticipationQueryService: MyPageParticipationQueryService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/in-progress")
+    @Operation(summary = "진행 중 탭 참여 공구 목록 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))])
+        ]
+    )
+    fun getInProgressParticipations(
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<InProgressParticipationPageResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        log.info(
+            "[MyPageParticipationController] 진행 중 참여 내역 조회 요청 수신: userId={}, page={}, size={}",
+            userId,
+            pageable.pageNumber,
+            pageable.pageSize
+        )
+
+        val response = myPageParticipationQueryService.getInProgressParticipations(userId, pageable)
+
+        log.info(
+            "[MyPageParticipationController] 진행 중 참여 내역 조회 응답 완료: userId={}, totalElements={}",
+            userId,
+            response.totalElements
+        )
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationQueryService.kt
@@ -1,0 +1,79 @@
+package com.moongchijang.domain.participation.application
+
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
+import com.moongchijang.domain.participation.application.dto.InProgressParticipationItemResponse
+import com.moongchijang.domain.participation.application.dto.InProgressParticipationPageResponse
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+@Service
+class ParticipationQueryService(
+    private val participationRepository: ParticipationRepository
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(readOnly = true)
+    fun getInProgressParticipations(userId: Long, pageable: Pageable): InProgressParticipationPageResponse {
+        log.info(
+            "[ParticipationQueryService] 진행 중 참여 내역 조회 시작: userId={}, page={}, size={}",
+            userId,
+            pageable.pageNumber,
+            pageable.pageSize
+        )
+
+        val page = participationRepository.findInProgressByUserId(
+            userId = userId,
+            statuses = IN_PROGRESS_STATUSES,
+            pageable = pageable
+        )
+
+        log.info(
+            "[ParticipationQueryService] 진행 중 참여 내역 조회 완료: userId={}, contentSize={}, totalElements={}, totalPages={}",
+            userId,
+            page.content.size,
+            page.totalElements,
+            page.totalPages
+        )
+
+        val mapped = page.map { participation -> toInProgressItem(participation) }
+        return InProgressParticipationPageResponse.from(mapped)
+    }
+
+    private fun toInProgressItem(participation: Participation): InProgressParticipationItemResponse {
+        val groupBuy = participation.groupBuy
+        val dDay = ChronoUnit.DAYS.between(
+            LocalDateTime.now().toLocalDate(),
+            groupBuy.deadline.toLocalDate()
+        ).toInt()
+
+        return InProgressParticipationItemResponse(
+            participationId = participation.id,
+            groupbuyId = groupBuy.id,
+            productName = groupBuy.productName,
+            storeName = groupBuy.store.name,
+            pickupAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart),
+            paidAmount = participation.totalAmount,
+            quantity = participation.quantity,
+            achievementRate = GroupBuyProgressCalculator.achievementRate(
+                currentQuantity = groupBuy.currentQuantity,
+                targetQuantity = groupBuy.targetQuantity
+            ),
+            dDay = dDay,
+            participatedAt = participation.createdAt!!
+        )
+    }
+
+    companion object {
+        private val IN_PROGRESS_STATUSES = listOf(
+            ParticipationStatus.PAID_WAITING_GOAL,
+            ParticipationStatus.CONFIRMED
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
@@ -10,7 +10,7 @@ data class InProgressParticipationItemResponse(
     val participationId: Long,
 
     @field:Schema(description = "공구 ID", example = "101")
-    val groupbuyId: Long,
+    val groupBuyId: Long,
 
     @field:Schema(description = "상품명", example = "두쭌쿠 오리지널 1개")
     val productName: String,

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
@@ -1,0 +1,38 @@
+package com.moongchijang.domain.participation.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "마이페이지 진행 중 탭 참여 카드 아이템")
+data class InProgressParticipationItemResponse(
+
+    @field:Schema(description = "참여 ID", example = "1201")
+    val participationId: Long,
+
+    @field:Schema(description = "공구 ID", example = "101")
+    val groupbuyId: Long,
+
+    @field:Schema(description = "상품명", example = "두쭌쿠 오리지널 1개")
+    val productName: String,
+
+    @field:Schema(description = "매장명", example = "사이드템포")
+    val storeName: String,
+
+    @field:Schema(description = "픽업 일시", example = "2026-04-15T14:00:00", nullable = true)
+    val pickupAt: LocalDateTime?,
+
+    @field:Schema(description = "결제 금액", example = "36000")
+    val paidAmount: Int,
+
+    @field:Schema(description = "수량", example = "2")
+    val quantity: Int,
+
+    @field:Schema(description = "달성률(%)", example = "72")
+    val achievementRate: Int,
+
+    @field:Schema(description = "마감 D-day 숫자", example = "2")
+    val dday: Int,
+
+    @field:Schema(description = "참여 일시", example = "2026-04-12T10:30:00")
+    val participatedAt: LocalDateTime
+)

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
@@ -31,7 +31,7 @@ data class InProgressParticipationItemResponse(
     val achievementRate: Int,
 
     @field:Schema(description = "마감 D-day 숫자", example = "2")
-    val dday: Int,
+    val dDay: Int,
 
     @field:Schema(description = "참여 일시", example = "2026-04-12T10:30:00")
     val participatedAt: LocalDateTime

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationPageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationPageResponse.kt
@@ -1,0 +1,27 @@
+package com.moongchijang.domain.participation.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
+
+@Schema(description = "마이페이지 진행 중 탭 참여 내역 페이지 응답")
+data class InProgressParticipationPageResponse(
+
+    @field:Schema(description = "목록 데이터")
+    val content: List<InProgressParticipationItemResponse>,
+
+    @field:Schema(description = "전체 데이터 수", example = "24")
+    val totalElements: Long,
+
+    @field:Schema(description = "전체 페이지 수", example = "3")
+    val totalPages: Int
+) {
+    companion object {
+        fun from(page: Page<InProgressParticipationItemResponse>): InProgressParticipationPageResponse {
+            return InProgressParticipationPageResponse(
+                content = page.content,
+                totalElements = page.totalElements,
+                totalPages = page.totalPages
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -1,7 +1,10 @@
 package com.moongchijang.domain.participation.domain.repository
 
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import jakarta.persistence.LockModeType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -13,6 +16,29 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     fun existsByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Boolean
 
     fun findByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Participation?
+
+    @Query(
+        value = """
+            select p
+            from Participation p
+            join fetch p.groupBuy gb
+            join fetch gb.store
+            where p.user.id = :userId
+              and p.status in :statuses
+            order by p.createdAt desc
+        """,
+        countQuery = """
+            select count(p)
+            from Participation p
+            where p.user.id = :userId
+              and p.status in :statuses
+        """
+    )
+    fun findInProgressByUserId(
+        @Param("userId") userId: Long,
+        @Param("statuses") statuses: Collection<ParticipationStatus>,
+        pageable: Pageable
+    ): Page<Participation>
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Participation p join fetch p.groupBuy where p.id = :id")

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1218,6 +1218,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponseParticipationPage'
 
+  /api/v1/users/me/participations/in-progress:
+    get:
+      tags: [MyPage]
+      summary: 진행 중 탭 참여 공구 목록 조회
+      description: 페이지네이션 기반으로 진행 중 탭 카드를 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 진행 중 참여 공구 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseInProgressParticipationPage'
+
   /api/v1/users/me/group-buy-requests:
     get:
       tags: [MyPage]
@@ -2892,6 +2910,35 @@ components:
                   canCancel: { type: boolean }
                   canViewPickup: { type: boolean }
                   canViewQr: { type: boolean }
+            totalElements: { type: integer }
+            totalPages: { type: integer }
+        error: { nullable: true, example: null }
+
+    ApiResponseInProgressParticipationPage:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [content, totalElements, totalPages]
+          properties:
+            content:
+              type: array
+              items:
+                type: object
+                required: [participationId, groupbuyId, productName, storeName, pickupAt, paidAmount, quantity, achievementRate, dday, participatedAt]
+                properties:
+                  participationId: { type: integer, format: int64 }
+                  groupbuyId: { type: integer, format: int64 }
+                  productName: { type: string }
+                  storeName: { type: string }
+                  pickupAt: { type: string, format: date-time, nullable: true }
+                  paidAmount: { type: integer }
+                  quantity: { type: integer }
+                  achievementRate: { type: integer, description: 0~100 정수 퍼센트 }
+                  dday: { type: integer, description: 마감일까지 남은 일수 }
+                  participatedAt: { type: string, format: date-time }
             totalElements: { type: integer }
             totalPages: { type: integer }
         error: { nullable: true, example: null }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2927,7 +2927,7 @@ components:
               type: array
               items:
                 type: object
-                required: [participationId, groupbuyId, productName, storeName, pickupAt, paidAmount, quantity, achievementRate, dday, participatedAt]
+                required: [participationId, groupbuyId, productName, storeName, pickupAt, paidAmount, quantity, achievementRate, dDay, participatedAt]
                 properties:
                   participationId: { type: integer, format: int64 }
                   groupbuyId: { type: integer, format: int64 }
@@ -2937,7 +2937,7 @@ components:
                   paidAmount: { type: integer }
                   quantity: { type: integer }
                   achievementRate: { type: integer, description: 0~100 정수 퍼센트 }
-                  dday: { type: integer, description: 마감일까지 남은 일수 }
+                  dDay: { type: integer, description: 마감일까지 남은 일수 }
                   participatedAt: { type: string, format: date-time }
             totalElements: { type: integer }
             totalPages: { type: integer }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2927,10 +2927,10 @@ components:
               type: array
               items:
                 type: object
-                required: [participationId, groupbuyId, productName, storeName, pickupAt, paidAmount, quantity, achievementRate, dDay, participatedAt]
+                required: [participationId, groupBuyId, productName, storeName, pickupAt, paidAmount, quantity, achievementRate, dDay, participatedAt]
                 properties:
                   participationId: { type: integer, format: int64 }
-                  groupbuyId: { type: integer, format: int64 }
+                  groupBuyId: { type: integer, format: int64 }
                   productName: { type: string }
                   storeName: { type: string }
                   pickupAt: { type: string, format: date-time, nullable: true }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1222,7 +1222,7 @@ paths:
     get:
       tags: [MyPage]
       summary: 진행 중 탭 참여 공구 목록 조회
-      description: 페이지네이션 기반으로 진행 중 탭 카드를 조회한다.
+      description: 페이지네이션 기반으로 진행 중 탭 카드를 조회한다. 정렬 기준은 참여일시(participatedAt) 내림차순이다.
       security:
         - bearerAuth: []
       parameters:

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
@@ -113,7 +113,7 @@ class MyPageParticipationQueryServiceTest {
         val item = result.content.first()
 
         assertEquals(202L, item.participationId)
-        assertEquals(777L, item.groupbuyId)
+        assertEquals(777L, item.groupBuyId)
         assertEquals("두쫀쿠 오리지널 1개", item.productName)
         assertEquals("사이드템포", item.storeName)
         assertEquals(LocalDateTime.of(pickupDate, pickupTimeStart), item.pickupAt)

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
@@ -1,0 +1,208 @@
+package com.moongchijang.domain.mypage.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@ExtendWith(MockitoExtension::class)
+class MyPageParticipationQueryServiceTest {
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    private val service by lazy {
+        MyPageParticipationQueryService(participationRepository)
+    }
+
+    @Test
+    fun `진행 중 참여 내역 조회 시 진행 중 상태 조건 페이지 반환`() {
+        val userId = 1L
+        val pageable = PageRequest.of(0, 20)
+        val now = LocalDateTime.now()
+        val participation = createParticipation(
+            participationId = 101L,
+            groupBuyId = 501L,
+            quantity = 2,
+            totalAmount = 36000,
+            currentQuantity = 36,
+            targetQuantity = 50,
+            deadline = now.plusDays(2),
+            pickupDate = now.toLocalDate().plusDays(3),
+            pickupTimeStart = LocalTime.of(14, 0),
+            createdAt = now.minusDays(1)
+        )
+        val page = PageImpl(listOf(participation), pageable, 1)
+
+        `when`(
+            participationRepository.findInProgressByUserId(
+                userId = userId,
+                statuses = listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED),
+                pageable = pageable
+            )
+        ).thenReturn(page)
+
+        val result = service.getInProgressParticipations(userId, pageable)
+
+        verify(participationRepository).findInProgressByUserId(
+            userId = userId,
+            statuses = listOf(
+                ParticipationStatus.PAID_WAITING_GOAL,
+                ParticipationStatus.CONFIRMED
+            ),
+            pageable = pageable
+        )
+
+        assertEquals(1L, result.totalElements)
+        assertEquals(1, result.totalPages)
+        assertEquals(1, result.content.size)
+        assertTrue(result.content.isNotEmpty())
+    }
+
+    @Test
+    fun `진행 중 참여 내역 조회 결과 카드 DTO 매핑 반환`() {
+        val userId = 2L
+        val pageable = PageRequest.of(0, 10)
+        val createdAt = LocalDateTime.of(2026, 4, 12, 10, 30)
+        val pickupDate = LocalDate.of(2026, 4, 15)
+        val pickupTimeStart = LocalTime.of(14, 0)
+        val deadline = LocalDateTime.now().plusDays(2)
+
+        val participation = createParticipation(
+            participationId = 202L,
+            groupBuyId = 777L,
+            quantity = 2,
+            totalAmount = 36000,
+            currentQuantity = 36,
+            targetQuantity = 50,
+            deadline = deadline,
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart,
+            createdAt = createdAt
+        )
+        val page = PageImpl(listOf(participation), pageable, 1)
+
+        `when`(
+            participationRepository.findInProgressByUserId(
+                userId = userId,
+                statuses = listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED),
+                pageable = pageable
+            )
+        ).thenReturn(page)
+
+        val result = service.getInProgressParticipations(userId, pageable)
+        val item = result.content.first()
+
+        assertEquals(202L, item.participationId)
+        assertEquals(777L, item.groupbuyId)
+        assertEquals("두쫀쿠 오리지널 1개", item.productName)
+        assertEquals("사이드템포", item.storeName)
+        assertEquals(LocalDateTime.of(pickupDate, pickupTimeStart), item.pickupAt)
+        assertEquals(36000, item.paidAmount)
+        assertEquals(2, item.quantity)
+        assertEquals(72, item.achievementRate)
+        assertEquals(createdAt, item.participatedAt)
+    }
+
+    private fun createParticipation(
+        participationId: Long,
+        groupBuyId: Long,
+        quantity: Int,
+        totalAmount: Int,
+        currentQuantity: Int,
+        targetQuantity: Int,
+        deadline: LocalDateTime,
+        pickupDate: LocalDate,
+        pickupTimeStart: LocalTime,
+        createdAt: LocalDateTime
+    ): Participation {
+        val user = UserFixture.createKakaoUser(id = 1L, nickname = "테스터")
+        val groupBuy = createGroupBuy(
+            groupBuyId = groupBuyId,
+            currentQuantity = currentQuantity,
+            targetQuantity = targetQuantity,
+            deadline = deadline,
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart
+        )
+
+        return Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = quantity,
+            productAmount = totalAmount,
+            feeAmount = 0,
+            totalAmount = totalAmount,
+            status = ParticipationStatus.PAID_WAITING_GOAL
+        ).apply {
+            id = participationId
+            setCreatedAt(this, createdAt)
+        }
+    }
+
+    private fun createGroupBuy(
+        groupBuyId: Long,
+        currentQuantity: Int,
+        targetQuantity: Int,
+        deadline: LocalDateTime,
+        pickupDate: LocalDate,
+        pickupTimeStart: LocalTime
+    ): GroupBuy {
+        val store = Store(
+            name = "사이드템포",
+            address = "서울 강남구 OO길 1",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG
+        )
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "사이드템포",
+            productName = "두쫀쿠 오리지널 1개",
+            desiredQuantity = 50,
+            desiredPickupDate = pickupDate
+        )
+        return GroupBuy(
+            store = store,
+            groupBuyRequest = request,
+            productName = "두쫀쿠 오리지널 1개",
+            productDescription = "테스트 상품 설명",
+            price = 18000,
+            targetQuantity = targetQuantity,
+            currentQuantity = currentQuantity,
+            maxQuantity = 100,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = deadline,
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart,
+            pickupTimeEnd = pickupTimeStart.plusHours(4),
+            pickupLocation = "매장 앞"
+        ).apply {
+            id = groupBuyId
+        }
+    }
+
+    private fun setCreatedAt(participation: Participation, createdAt: LocalDateTime) {
+        val field = participation.javaClass.superclass.getDeclaredField("createdAt")
+        field.isAccessible = true
+        field.set(participation, createdAt)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 마이페이지 진행 중 탭 조회 API 추가  
  - `GET /api/v1/users/me/participations/in-progress`
- 진행 중 참여 내역 조회 로직 구현  
  - 진행 중 상태(`PAID_WAITING_GOAL`, `CONFIRMED`) 기준 조회
  - 페이지네이션 적용
  - 정렬 기준 `participatedAt(createdAt) DESC` 적용

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #134 
 
## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인