### PR TITLE
[MCJ-1490] REFACTOR: 인증 필수 API principal null 체크 제거 및 @PreAuthorize 적용

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
@@ -23,6 +23,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -142,6 +143,7 @@ class AuthController(
     }
 
     @PostMapping("/logout")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "로그아웃", description = "리프레시 토큰을 폐기하고 쿠키를 제거합니다.")
     @ApiResponses(
         value = [
@@ -150,10 +152,10 @@ class AuthController(
         ],
     )
     fun logout(
-        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
         response: HttpServletResponse,
     ): ApiResponse<Nothing> {
-        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        val userId = principal.id
         log.info("[AuthController] 로그아웃 요청 수신: userId={}", userId)
 
         authService.logout(userId)

--- a/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MyPageParticipationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MyPageParticipationController.kt
@@ -2,8 +2,6 @@ package com.moongchijang.domain.mypage.presentation
 
 import com.moongchijang.domain.mypage.application.MyPageParticipationQueryService
 import com.moongchijang.domain.participation.application.dto.InProgressParticipationPageResponse
-import com.moongchijang.global.exception.CustomException
-import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -15,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -29,6 +28,7 @@ class MyPageParticipationController(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/in-progress")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "진행 중 탭 참여 공구 목록 조회")
     @ApiResponses(
         value = [
@@ -37,10 +37,10 @@ class MyPageParticipationController(
         ]
     )
     fun getInProgressParticipations(
-        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<InProgressParticipationPageResponse>> {
-        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        val userId = principal.id
         log.info(
             "[MyPageParticipationController] 진행 중 참여 내역 조회 요청 수신: userId={}, page={}, size={}",
             userId,

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -10,13 +10,12 @@ import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderRequest
 import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderResponse
 import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
 import com.moongchijang.domain.payment.application.dto.PortOneWebhookResponse
-import com.moongchijang.global.exception.CustomException
-import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -40,22 +39,22 @@ class PaymentController(
     }
 
     @PostMapping("/group-buys/{groupBuyId}/payment-orders")
+    @PreAuthorize("isAuthenticated()")
     fun createPaymentOrder(
         @PathVariable groupBuyId: Long,
-        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CreatePaymentOrderRequest,
     ): ResponseEntity<ApiResponse<CreatePaymentOrderResponse>> {
-        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        return ResponseEntity.ok(ApiResponse.success(paymentService.createPaymentOrder(groupBuyId, userId, request)))
+        return ResponseEntity.ok(ApiResponse.success(paymentService.createPaymentOrder(groupBuyId, principal.id, request)))
     }
 
     @PostMapping("/payments/portone/complete")
+    @PreAuthorize("isAuthenticated()")
     fun completePortOnePayment(
-        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CompletePortOnePaymentRequest,
     ): ResponseEntity<ApiResponse<ConfirmPaymentResponse>> {
-        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        return ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request, userId)))
+        return ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request, principal.id)))
     }
 
     @PostMapping("/payments/portone/webhook")
@@ -67,12 +66,12 @@ class PaymentController(
     }
 
     @PostMapping("/participations/{participationId}/cancel")
+    @PreAuthorize("isAuthenticated()")
     fun cancelParticipation(
         @PathVariable participationId: Long,
-        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CancelParticipationRequest,
     ): ResponseEntity<ApiResponse<CancelParticipationResponse>> {
-        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelParticipation(participationId, userId, request)))
+        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelParticipation(participationId, principal.id, request)))
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
@@ -4,8 +4,6 @@ import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpdatedResponse
 import com.moongchijang.domain.user.application.dto.NicknameAvailabilityResponse
-import com.moongchijang.global.exception.CustomException
-import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -15,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -48,6 +47,7 @@ class UserController(
     }
 
     @PatchMapping("/me/additional-info")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "추가정보 입력", description = "신규 가입자의 닉네임/전화번호를 저장하고 가입 완료 상태를 갱신합니다.")
     @ApiResponses(
         value = [
@@ -58,11 +58,10 @@ class UserController(
         ],
     )
     fun updateAdditionalInfo(
-        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: AdditionalInfoUpsertRequest,
     ): ApiResponse<AdditionalInfoUpdatedResponse> {
-        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        val response = userService.updateAdditionalInfo(request, userId)
+        val response = userService.updateAdditionalInfo(request, principal.id)
         return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -27,9 +27,6 @@ class SecurityConfig(
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
-            .cors {  }
-        http
-            .csrf { it.disable() }
             .cors { }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
@@ -17,6 +18,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
 ) {

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -103,6 +103,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessNoData'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
   /api/v1/users/me:
     get:
@@ -981,6 +983,8 @@ paths:
     post:
       tags: [Participation]
       summary: PortOne 결제 완료 서버 검증
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -996,6 +1000,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponsePaymentConfirmed'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '409':
           $ref: '#/components/responses/Conflict'
 
@@ -1040,6 +1046,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseCancelParticipation'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
@@ -1235,6 +1243,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseInProgressParticipationPage'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
   /api/v1/users/me/group-buy-requests:
     get:


### PR DESCRIPTION
## 📌 작업한 내용
- Method Security 활성화
  - `@EnableMethodSecurity` 추가
- 인증 필수 API에 `@PreAuthorize("isAuthenticated()")` 적용
  - 대상: 결제 주문 생성, 결제 완료 검증, 참여 취소, 추가정보 입력, 마이페이지 진행 중 조회, 로그아웃
- 컨트롤러 내부 수동 인증 체크 제거
  - `principal?.id ?: throw ...` 패턴 제거
  - `@AuthenticationPrincipal`을 non-null principal로 정리
- OpenAPI 보완
  - 인증 필수 엔드포인트의 `401` 응답 및 security 스펙 누락분 정리

## 🔍 참고 사항
- 옵션 로그인 API는 기존 nullable principal 유지
  - 공구 상세 조회, 검색, heartbeat(비로그인 UUID 집계 포함)
- 이번 변경은 인증 필수 엔드포인트의 인증 방식 일관화가 목적이며, 도메인 로직 변경은 없습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #137 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인