### PR TITLE
[MCJ-1489] FEAT: 마이페이지 픽업 대기 참여 내역 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
@@ -1,9 +1,13 @@
 package com.moongchijang.domain.mypage.application
 
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.participation.application.dto.InProgressParticipationItemResponse
 import com.moongchijang.domain.participation.application.dto.InProgressParticipationPageResponse
+import com.moongchijang.domain.participation.application.dto.PickupWaitingParticipationItemResponse
+import com.moongchijang.domain.participation.application.dto.PickupWaitingParticipationPageResponse
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import org.slf4j.LoggerFactory
@@ -46,6 +50,34 @@ class MyPageParticipationQueryService(
         return InProgressParticipationPageResponse.from(mapped)
     }
 
+    @Transactional(readOnly = true)
+    fun getPickupWaitingParticipations(userId: Long, pageable: Pageable): PickupWaitingParticipationPageResponse {
+        log.info(
+            "[MyPageParticipationQueryService] 픽업 대기 참여 내역 조회 시작: userId={}, page={}, size={}",
+            userId,
+            pageable.pageNumber,
+            pageable.pageSize
+        )
+
+        val page = participationRepository.findPickupWaitingByUserId(
+            userId = userId,
+            participationStatuses = PICKUP_WAITING_PARTICIPATION_STATUSES,
+            pickupStatuses = PICKUP_WAITING_PICKUP_STATUSES,
+            pageable = pageable
+        )
+
+        log.info(
+            "[MyPageParticipationQueryService] 픽업 대기 참여 내역 조회 완료: userId={}, contentSize={}, totalElements={}, totalPages={}",
+            userId,
+            page.content.size,
+            page.totalElements,
+            page.totalPages
+        )
+
+        val mapped = page.map { participation -> toPickupWaitingItem(participation) }
+        return PickupWaitingParticipationPageResponse.from(mapped)
+    }
+
     private fun toInProgressItem(participation: Participation): InProgressParticipationItemResponse {
         val groupBuy = participation.groupBuy
         val dDay = ChronoUnit.DAYS.between(
@@ -72,10 +104,35 @@ class MyPageParticipationQueryService(
         )
     }
 
+    private fun toPickupWaitingItem(participation: Participation): PickupWaitingParticipationItemResponse {
+        val groupBuy = participation.groupBuy
+
+        return PickupWaitingParticipationItemResponse(
+            participationId = participation.id,
+            groupBuyId = groupBuy.id,
+            productName = groupBuy.productName,
+            storeName = groupBuy.store.name,
+            pickupAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart),
+            paidAmount = participation.totalAmount,
+            quantity = participation.quantity,
+            isClosed = groupBuy.status == GroupBuyStatus.CLOSED,
+            participatedAt = requireNotNull(participation.createdAt) {
+                "[MyPageParticipationQueryService] 참여 생성일시 누락: participationId=${participation.id}"
+            }
+        )
+    }
+
     companion object {
         private val IN_PROGRESS_STATUSES = listOf(
             ParticipationStatus.PAID_WAITING_GOAL,
             ParticipationStatus.CONFIRMED
+        )
+        private val PICKUP_WAITING_PARTICIPATION_STATUSES = listOf(
+            ParticipationStatus.CONFIRMED
+        )
+        private val PICKUP_WAITING_PICKUP_STATUSES = listOf(
+            PickupStatus.NOT_READY,
+            PickupStatus.READY
         )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class MyPageParticipationQueryService(
@@ -41,7 +42,8 @@ class MyPageParticipationQueryService(
             page.totalPages
         )
 
-        val mapped = page.map { participation -> InProgressParticipationItemResponse.from(participation) }
+        val now = LocalDateTime.now()
+        val mapped = page.map { participation -> InProgressParticipationItemResponse.from(participation, now) }
         return InProgressParticipationPageResponse.from(mapped)
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
@@ -1,12 +1,9 @@
 package com.moongchijang.domain.mypage.application
 
-import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.participation.application.dto.InProgressParticipationItemResponse
 import com.moongchijang.domain.participation.application.dto.InProgressParticipationPageResponse
 import com.moongchijang.domain.participation.application.dto.PickupWaitingParticipationItemResponse
 import com.moongchijang.domain.participation.application.dto.PickupWaitingParticipationPageResponse
-import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
@@ -14,8 +11,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @Service
 class MyPageParticipationQueryService(
@@ -46,7 +41,7 @@ class MyPageParticipationQueryService(
             page.totalPages
         )
 
-        val mapped = page.map { participation -> toInProgressItem(participation) }
+        val mapped = page.map { participation -> InProgressParticipationItemResponse.from(participation) }
         return InProgressParticipationPageResponse.from(mapped)
     }
 
@@ -74,52 +69,8 @@ class MyPageParticipationQueryService(
             page.totalPages
         )
 
-        val mapped = page.map { participation -> toPickupWaitingItem(participation) }
+        val mapped = page.map { participation -> PickupWaitingParticipationItemResponse.from(participation) }
         return PickupWaitingParticipationPageResponse.from(mapped)
-    }
-
-    private fun toInProgressItem(participation: Participation): InProgressParticipationItemResponse {
-        val groupBuy = participation.groupBuy
-        val dDay = ChronoUnit.DAYS.between(
-            LocalDateTime.now().toLocalDate(),
-            groupBuy.deadline.toLocalDate()
-        ).toInt()
-
-        return InProgressParticipationItemResponse(
-            participationId = participation.id,
-            groupBuyId = groupBuy.id,
-            productName = groupBuy.productName,
-            storeName = groupBuy.store.name,
-            pickupAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart),
-            paidAmount = participation.totalAmount,
-            quantity = participation.quantity,
-            achievementRate = GroupBuyProgressCalculator.achievementRate(
-                currentQuantity = groupBuy.currentQuantity,
-                targetQuantity = groupBuy.targetQuantity
-            ),
-            dDay = dDay,
-            participatedAt = requireNotNull(participation.createdAt) {
-                "[MyPageParticipationQueryService] 참여 생성일시 누락: participationId=${participation.id}"
-            }
-        )
-    }
-
-    private fun toPickupWaitingItem(participation: Participation): PickupWaitingParticipationItemResponse {
-        val groupBuy = participation.groupBuy
-
-        return PickupWaitingParticipationItemResponse(
-            participationId = participation.id,
-            groupBuyId = groupBuy.id,
-            productName = groupBuy.productName,
-            storeName = groupBuy.store.name,
-            pickupAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart),
-            paidAmount = participation.totalAmount,
-            quantity = participation.quantity,
-            isClosed = groupBuy.status == GroupBuyStatus.CLOSED,
-            participatedAt = requireNotNull(participation.createdAt) {
-                "[MyPageParticipationQueryService] 참여 생성일시 누락: participationId=${participation.id}"
-            }
-        )
     }
 
     companion object {

--- a/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MyPageParticipationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MyPageParticipationController.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.mypage.presentation
 
 import com.moongchijang.domain.mypage.application.MyPageParticipationQueryService
 import com.moongchijang.domain.participation.application.dto.InProgressParticipationPageResponse
+import com.moongchijang.domain.participation.application.dto.PickupWaitingParticipationPageResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -52,6 +53,37 @@ class MyPageParticipationController(
 
         log.info(
             "[MyPageParticipationController] 진행 중 참여 내역 조회 응답 완료: userId={}, totalElements={}",
+            userId,
+            response.totalElements
+        )
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/pickup-waiting")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "픽업 대기 탭 참여 완료 공구 이력 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))])
+        ]
+    )
+    fun getPickupWaitingParticipations(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<PickupWaitingParticipationPageResponse>> {
+        val userId = principal.id
+        log.info(
+            "[MyPageParticipationController] 픽업 대기 참여 내역 조회 요청 수신: userId={}, page={}, size={}",
+            userId,
+            pageable.pageNumber,
+            pageable.pageSize
+        )
+
+        val response = myPageParticipationQueryService.getPickupWaitingParticipations(userId, pageable)
+
+        log.info(
+            "[MyPageParticipationController] 픽업 대기 참여 내역 조회 응답 완료: userId={}, totalElements={}",
             userId,
             response.totalElements
         )

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
@@ -21,8 +21,8 @@ data class InProgressParticipationItemResponse(
     @field:Schema(description = "매장명", example = "사이드템포")
     val storeName: String,
 
-    @field:Schema(description = "픽업 일시", example = "2026-04-15T14:00:00", nullable = true)
-    val pickupAt: LocalDateTime?,
+    @field:Schema(description = "픽업 일시", example = "2026-04-15T14:00:00")
+    val pickupAt: LocalDateTime,
 
     @field:Schema(description = "결제 금액", example = "36000")
     val paidAmount: Int,

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
@@ -1,7 +1,10 @@
 package com.moongchijang.domain.participation.application.dto
 
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
+import com.moongchijang.domain.participation.domain.entity.Participation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @Schema(description = "마이페이지 진행 중 탭 참여 카드 아이템")
 data class InProgressParticipationItemResponse(
@@ -35,4 +38,32 @@ data class InProgressParticipationItemResponse(
 
     @field:Schema(description = "참여 일시", example = "2026-04-12T10:30:00")
     val participatedAt: LocalDateTime
-)
+) {
+    companion object {
+        fun from(participation: Participation, now: LocalDateTime = LocalDateTime.now()): InProgressParticipationItemResponse {
+            val groupBuy = participation.groupBuy
+            val dDay = ChronoUnit.DAYS.between(
+                now.toLocalDate(),
+                groupBuy.deadline.toLocalDate()
+            ).toInt()
+
+            return InProgressParticipationItemResponse(
+                participationId = participation.id,
+                groupBuyId = groupBuy.id,
+                productName = groupBuy.productName,
+                storeName = groupBuy.store.name,
+                pickupAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart),
+                paidAmount = participation.totalAmount,
+                quantity = participation.quantity,
+                achievementRate = GroupBuyProgressCalculator.achievementRate(
+                    currentQuantity = groupBuy.currentQuantity,
+                    targetQuantity = groupBuy.targetQuantity
+                ),
+                dDay = dDay,
+                participatedAt = requireNotNull(participation.createdAt) {
+                    "[InProgressParticipationItemResponse] 참여 생성일시 누락: participationId=${participation.id}"
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationItemResponse.kt
@@ -1,0 +1,35 @@
+package com.moongchijang.domain.participation.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "마이페이지 픽업 대기 탭 참여 카드 아이템")
+data class PickupWaitingParticipationItemResponse(
+
+    @field:Schema(description = "참여 ID", example = "1201")
+    val participationId: Long,
+
+    @field:Schema(description = "공구 ID", example = "101")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "상품명", example = "버터떡 플레인 5개입")
+    val productName: String,
+
+    @field:Schema(description = "매장명", example = "모모왕국")
+    val storeName: String,
+
+    @field:Schema(description = "픽업 일시", example = "2026-04-15T14:00:00", nullable = true)
+    val pickupAt: LocalDateTime?,
+
+    @field:Schema(description = "결제 금액", example = "18000")
+    val paidAmount: Int,
+
+    @field:Schema(description = "수량", example = "1")
+    val quantity: Int,
+
+    @field:Schema(description = "마감 공구 여부", example = "false")
+    val isClosed: Boolean,
+
+    @field:Schema(description = "참여 일시", example = "2026-04-12T10:30:00")
+    val participatedAt: LocalDateTime
+)

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationItemResponse.kt
@@ -20,8 +20,8 @@ data class PickupWaitingParticipationItemResponse(
     @field:Schema(description = "매장명", example = "모모왕국")
     val storeName: String,
 
-    @field:Schema(description = "픽업 일시", example = "2026-04-15T14:00:00", nullable = true)
-    val pickupAt: LocalDateTime?,
+    @field:Schema(description = "픽업 일시", example = "2026-04-15T14:00:00")
+    val pickupAt: LocalDateTime,
 
     @field:Schema(description = "결제 금액", example = "18000")
     val paidAmount: Int,

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationItemResponse.kt
@@ -1,5 +1,7 @@
 package com.moongchijang.domain.participation.application.dto
 
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -32,4 +34,24 @@ data class PickupWaitingParticipationItemResponse(
 
     @field:Schema(description = "참여 일시", example = "2026-04-12T10:30:00")
     val participatedAt: LocalDateTime
-)
+) {
+    companion object {
+        fun from(participation: Participation): PickupWaitingParticipationItemResponse {
+            val groupBuy = participation.groupBuy
+
+            return PickupWaitingParticipationItemResponse(
+                participationId = participation.id,
+                groupBuyId = groupBuy.id,
+                productName = groupBuy.productName,
+                storeName = groupBuy.store.name,
+                pickupAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart),
+                paidAmount = participation.totalAmount,
+                quantity = participation.quantity,
+                isClosed = groupBuy.status == GroupBuyStatus.CLOSED,
+                participatedAt = requireNotNull(participation.createdAt) {
+                    "[PickupWaitingParticipationItemResponse] 참여 생성일시 누락: participationId=${participation.id}"
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationPageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/PickupWaitingParticipationPageResponse.kt
@@ -1,0 +1,27 @@
+package com.moongchijang.domain.participation.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
+
+@Schema(description = "마이페이지 픽업 대기 탭 참여 내역 페이지 응답")
+data class PickupWaitingParticipationPageResponse(
+
+    @field:Schema(description = "목록 데이터")
+    val content: List<PickupWaitingParticipationItemResponse>,
+
+    @field:Schema(description = "전체 데이터 수", example = "12")
+    val totalElements: Long,
+
+    @field:Schema(description = "전체 페이지 수", example = "2")
+    val totalPages: Int
+) {
+    companion object {
+        fun from(page: Page<PickupWaitingParticipationItemResponse>): PickupWaitingParticipationPageResponse {
+            return PickupWaitingParticipationPageResponse(
+                content = page.content,
+                totalElements = page.totalElements,
+                totalPages = page.totalPages
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.participation.domain.repository
 
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -37,6 +38,32 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     fun findInProgressByUserId(
         @Param("userId") userId: Long,
         @Param("statuses") statuses: Collection<ParticipationStatus>,
+        pageable: Pageable
+    ): Page<Participation>
+
+    @Query(
+        value = """
+            select p
+            from Participation p
+            join fetch p.groupBuy gb
+            join fetch gb.store
+            where p.user.id = :userId
+              and p.status in :participationStatuses
+              and p.pickupStatus in :pickupStatuses
+            order by p.createdAt desc
+        """,
+        countQuery = """
+            select count(p)
+            from Participation p
+            where p.user.id = :userId
+              and p.status in :participationStatuses
+              and p.pickupStatus in :pickupStatuses
+        """
+    )
+    fun findPickupWaitingByUserId(
+        @Param("userId") userId: Long,
+        @Param("participationStatuses") participationStatuses: Collection<ParticipationStatus>,
+        @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
         pageable: Pageable
     ): Page<Participation>
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1246,6 +1246,26 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /api/v1/users/me/participations/pickup-waiting:
+    get:
+      tags: [MyPage]
+      summary: 픽업 대기 탭 참여 완료 공구 이력 조회
+      description: 페이지네이션 기반으로 픽업 대기 탭 카드를 조회한다. 정렬 기준은 참여일시(participatedAt) 내림차순이다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 픽업 대기 참여 공구 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponsePickupWaitingParticipationPage'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/v1/users/me/group-buy-requests:
     get:
       tags: [MyPage]
@@ -2948,6 +2968,34 @@ components:
                   quantity: { type: integer }
                   achievementRate: { type: integer, description: 0~100 정수 퍼센트 }
                   dDay: { type: integer, description: 마감일까지 남은 일수 }
+                  participatedAt: { type: string, format: date-time }
+            totalElements: { type: integer }
+            totalPages: { type: integer }
+        error: { nullable: true, example: null }
+
+    ApiResponsePickupWaitingParticipationPage:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [content, totalElements, totalPages]
+          properties:
+            content:
+              type: array
+              items:
+                type: object
+                required: [participationId, groupBuyId, productName, storeName, pickupAt, paidAmount, quantity, isClosed, participatedAt]
+                properties:
+                  participationId: { type: integer, format: int64 }
+                  groupBuyId: { type: integer, format: int64 }
+                  productName: { type: string }
+                  storeName: { type: string }
+                  pickupAt: { type: string, format: date-time, nullable: true }
+                  paidAmount: { type: integer }
+                  quantity: { type: integer }
+                  isClosed: { type: boolean, description: 마감 공구 여부 }
                   participatedAt: { type: string, format: date-time }
             totalElements: { type: integer }
             totalPages: { type: integer }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2963,7 +2963,7 @@ components:
                   groupBuyId: { type: integer, format: int64 }
                   productName: { type: string }
                   storeName: { type: string }
-                  pickupAt: { type: string, format: date-time, nullable: true }
+                  pickupAt: { type: string, format: date-time }
                   paidAmount: { type: integer }
                   quantity: { type: integer }
                   achievementRate: { type: integer, description: 0~100 정수 퍼센트 }
@@ -2992,7 +2992,7 @@ components:
                   groupBuyId: { type: integer, format: int64 }
                   productName: { type: string }
                   storeName: { type: string }
-                  pickupAt: { type: string, format: date-time, nullable: true }
+                  pickupAt: { type: string, format: date-time }
                   paidAmount: { type: integer }
                   quantity: { type: integer }
                   isClosed: { type: boolean, description: 마감 공구 여부 }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -6,15 +6,13 @@ import com.moongchijang.domain.groupbuy.application.dto.StoreRecommendationReque
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
-import com.moongchijang.domain.store.domain.entity.DistrictType
-import com.moongchijang.domain.store.domain.entity.RegionType
-import com.moongchijang.domain.store.domain.entity.Store
 import com.moongchijang.domain.store.domain.repository.StoreRepository
 import com.moongchijang.domain.store.infrastructure.naver.NaverLocalSearchClient
-import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchItem
 import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchResponse
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.NaverFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -91,7 +89,7 @@ class GroupBuyOpenRequestServiceTest {
     @Test
     fun `매장 추천 시 네이버 결과를 중복 제거하고 추천 점수 순으로 반환한다`() {
         val request = StoreRecommendationRequest(region = "성수", productName = "소금빵")
-        val loaf = naverItem(
+        val loaf = NaverFixture.naverItem(
             title = "<b>LOAF</b>",
             link = "https://map.naver.com/p/entry/place/100",
             category = "음식점>카페,디저트",
@@ -99,18 +97,16 @@ class GroupBuyOpenRequestServiceTest {
             roadAddress = "서울 성동구 성수이로 1"
         )
         val duplicateLoaf = loaf.copy(description = "duplicate")
-        val other = naverItem(
+        val other = NaverFixture.naverItem(
             title = "다른 가게",
             link = "https://map.naver.com/p/entry/place/200",
             category = "생활,편의",
             address = "서울 마포구 망원동 1",
             roadAddress = "서울 마포구 월드컵로 1"
         )
-        val registeredStore = Store(
+        val registeredStore = GroupBuyFixture.createStore(
             name = "LOAF",
-            address = "서울 성동구 성수이로 1",
-            region = RegionType.SEOUL,
-            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
+            address = "서울 성동구 성수이로 1"
         ).apply { id = 10L }
 
         `when`(naverLocalSearchClient.search("성수 소금빵", 20)).thenReturn(
@@ -175,22 +171,4 @@ class GroupBuyOpenRequestServiceTest {
         assertTrue(response.stores.isEmpty())
         verifyNoInteractions(storeRepository, groupBuyRepository)
     }
-
-    private fun naverItem(
-        title: String,
-        link: String,
-        category: String,
-        address: String,
-        roadAddress: String
-    ) = NaverLocalSearchItem(
-        title = title,
-        link = link,
-        category = category,
-        description = "",
-        telephone = "",
-        address = address,
-        roadAddress = roadAddress,
-        mapx = "1270000000",
-        mapy = "375000000"
-    )
 }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -9,6 +9,7 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestReposit
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyRequestFixture
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -36,7 +37,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `유효한 입력으로 요청 시 requestId 반환`() {
         val userId = 1L
-        val request = createRequest(
+        val request = GroupBuyRequestFixture.createRequest(
             desiredPickupDate = LocalDate.now().plusDays(3),
             contactPhone = "010-1234-5678",
             contactInstagram = "moongchi.bread"
@@ -74,7 +75,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `네이버 장소 선택 정보가 있으면 요청에 함께 저장한다`() {
         val userId = 1L
-        val request = createRequest(
+        val request = GroupBuyRequestFixture.createRequest(
             storeAddress = "서울 성동구 성수동1가 1",
             placeId = "naver-place-1",
             roadAddress = "서울 성동구 성수이로 1",
@@ -120,7 +121,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `도로명 주소가 빈 값이면 기존 매장 주소를 저장한다`() {
         val userId = 1L
-        val request = createRequest(
+        val request = GroupBuyRequestFixture.createRequest(
             storeAddress = "서울 성동구 성수동1가 1",
             placeId = " ",
             roadAddress = " ",
@@ -157,7 +158,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `도로명 주소가 빈 값이면 지번 주소를 매장 주소로 저장한다`() {
         val userId = 1L
-        val request = createRequest(
+        val request = GroupBuyRequestFixture.createRequest(
             storeAddress = "서울 성동구 기존 주소",
             placeId = "naver-place-2",
             roadAddress = " ",
@@ -188,7 +189,7 @@ class GroupBuyRequestServiceTest {
 
     @Test
     fun `오늘 날짜로 요청 시 GROUPBUY_REQUEST_INVALID_DATE 예외`() {
-        val request = createRequest(desiredPickupDate = LocalDate.now())
+        val request = GroupBuyRequestFixture.createRequest(desiredPickupDate = LocalDate.now())
 
         val ex = assertThrows<CustomException> { service.create(1L, request) }
         assertEquals(ErrorCode.GROUPBUY_REQUEST_INVALID_DATE, ex.errorCode)
@@ -196,7 +197,7 @@ class GroupBuyRequestServiceTest {
 
     @Test
     fun `과거 날짜로 요청 시 GROUPBUY_REQUEST_INVALID_DATE 예외`() {
-        val request = createRequest(desiredPickupDate = LocalDate.now().minusDays(1))
+        val request = GroupBuyRequestFixture.createRequest(desiredPickupDate = LocalDate.now().minusDays(1))
 
         val ex = assertThrows<CustomException> { service.create(1L, request) }
         assertEquals(ErrorCode.GROUPBUY_REQUEST_INVALID_DATE, ex.errorCode)
@@ -289,34 +290,6 @@ class GroupBuyRequestServiceTest {
         val ex = assertThrows<CustomException> { service.getDetail(1L, requestId) }
         assertEquals(ErrorCode.GROUPBUY_REQUEST_FORBIDDEN, ex.errorCode)
     }
-
-    private fun createRequest(
-        storeName: String = "성심당",
-        storeAddress: String? = null,
-        placeId: String? = null,
-        roadAddress: String? = null,
-        lotAddress: String? = null,
-        latitude: Double? = null,
-        longitude: Double? = null,
-        productName: String = "튀김소보로",
-        desiredQuantity: Int = 2,
-        desiredPickupDate: LocalDate = LocalDate.now().plusDays(3),
-        contactPhone: String? = null,
-        contactInstagram: String? = null
-    ) = GroupBuyRequestCreateRequest(
-        storeName = storeName,
-        storeAddress = storeAddress,
-        placeId = placeId,
-        roadAddress = roadAddress,
-        lotAddress = lotAddress,
-        latitude = latitude,
-        longitude = longitude,
-        productName = productName,
-        desiredQuantity = desiredQuantity,
-        desiredPickupDate = desiredPickupDate,
-        contactPhone = contactPhone,
-        contactInstagram = contactInstagram
-    )
 
     private inline fun <reified T> argumentCaptor() = org.mockito.ArgumentCaptor.forClass(T::class.java)
 }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -2,19 +2,15 @@ package com.moongchijang.domain.groupbuy.service
 
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
 import com.moongchijang.domain.groupbuy.application.GroupBuyService
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.store.domain.entity.DistrictType
-import com.moongchijang.domain.store.domain.entity.RegionType
-import com.moongchijang.domain.store.domain.entity.Store
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -55,7 +51,7 @@ class GroupBuyServiceTest {
 
     @Test
     fun `공구 피드 keyword 제외 조회 검증`() {
-        val groupBuy = createGroupBuy(id = 21L, status = GroupBuyStatus.IN_PROGRESS)
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = 21L, status = GroupBuyStatus.IN_PROGRESS)
         val pageable = PageRequest.of(0, 20)
         val request = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest(
             filter = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter.ALL,
@@ -91,7 +87,7 @@ class GroupBuyServiceTest {
             filter = com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter.ALL,
             districts = listOf(regionalDistrict)
         )
-        val fallbackGroupBuy = createGroupBuy(id = 31L, status = GroupBuyStatus.IN_PROGRESS)
+        val fallbackGroupBuy = GroupBuyFixture.createGroupBuy(id = 31L, status = GroupBuyStatus.IN_PROGRESS)
 
         `when`(
             groupBuyRepository.searchFeed(
@@ -169,8 +165,8 @@ class GroupBuyServiceTest {
     fun `로그인 사용자 상세 조회 시 찜 여부와 참여 여부 반환`() {
         val groupBuyId = 10L
         val userId = 1L
-        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
-        val images = listOf(createImage(groupBuy, "https://image1.jpg"), createImage(groupBuy, "https://image2.jpg"))
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
+        val images = listOf(GroupBuyFixture.createImage(groupBuy, "https://image1.jpg"), GroupBuyFixture.createImage(groupBuy, "https://image2.jpg"))
 
         `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
         `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(images)
@@ -189,7 +185,7 @@ class GroupBuyServiceTest {
     @Test
     fun `비로그인 사용자 상세 조회 시 찜 여부와 참여 여부 false 반환`() {
         val groupBuyId = 11L
-        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
 
         `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
         `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(emptyList())
@@ -205,7 +201,7 @@ class GroupBuyServiceTest {
     fun `마감된 공구 상세 조회 시 참여 가능 여부 false 반환`() {
         val groupBuyId = 12L
         val userId = 3L
-        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.CLOSED)
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.CLOSED)
 
         `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
         `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(emptyList())
@@ -221,7 +217,7 @@ class GroupBuyServiceTest {
     fun `마감 시간이 지난 공구 상세 조회 시 참여 가능 여부 false 반환`() {
         val groupBuyId = 13L
         val userId = 4L
-        val groupBuy = createGroupBuy(
+        val groupBuy = GroupBuyFixture.createGroupBuy(
             id = groupBuyId,
             status = GroupBuyStatus.IN_PROGRESS,
             deadline = LocalDateTime.now().minusMinutes(1)
@@ -241,7 +237,7 @@ class GroupBuyServiceTest {
     fun `달성 완료 공구 상세 조회 시 최대 수량 전이면 참여 가능 여부 true 반환`() {
         val groupBuyId = 14L
         val userId = 5L
-        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.ACHIEVED).apply {
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.ACHIEVED).apply {
             currentQuantity = 50
             maxQuantity = 100
         }
@@ -261,7 +257,7 @@ class GroupBuyServiceTest {
     fun `달성 완료 공구 상세 조회 시 최대 수량 도달이면 참여 가능 여부 false 반환`() {
         val groupBuyId = 15L
         val userId = 6L
-        val groupBuy = createGroupBuy(id = groupBuyId, status = GroupBuyStatus.ACHIEVED).apply {
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.ACHIEVED).apply {
             currentQuantity = 100
             maxQuantity = 100
         }
@@ -281,7 +277,7 @@ class GroupBuyServiceTest {
     fun `달성 완료 공구라도 마감 시간이 지나면 참여 가능 여부 false 반환`() {
         val groupBuyId = 16L
         val userId = 7L
-        val groupBuy = createGroupBuy(
+        val groupBuy = GroupBuyFixture.createGroupBuy(
             id = groupBuyId,
             status = GroupBuyStatus.ACHIEVED,
             deadline = LocalDateTime.now().minusMinutes(1)
@@ -313,7 +309,7 @@ class GroupBuyServiceTest {
     @Test
     fun `단건 progress 조회 성공`() {
         val groupBuyId = 21L
-        val groupBuy = createGroupBuy(
+        val groupBuy = GroupBuyFixture.createGroupBuy(
             id = groupBuyId,
             status = GroupBuyStatus.IN_PROGRESS
         ).apply {
@@ -334,7 +330,7 @@ class GroupBuyServiceTest {
     @Test
     fun `달성 완료 공구 progress 조회 시 마감 여부 false 반환`() {
         val groupBuyId = 22L
-        val groupBuy = createGroupBuy(
+        val groupBuy = GroupBuyFixture.createGroupBuy(
             id = groupBuyId,
             status = GroupBuyStatus.ACHIEVED
         ).apply {
@@ -360,11 +356,11 @@ class GroupBuyServiceTest {
 
     @Test
     fun `다건 progress 조회 시 요청 순서를 유지하고 존재하지 않는 id 는 제외한다`() {
-        val first = createGroupBuy(id = 101L, status = GroupBuyStatus.IN_PROGRESS).apply {
+        val first = GroupBuyFixture.createGroupBuy(id = 101L, status = GroupBuyStatus.IN_PROGRESS).apply {
             currentQuantity = 20
             targetQuantity = 50
         }
-        val second = createGroupBuy(id = 202L, status = GroupBuyStatus.IN_PROGRESS).apply {
+        val second = GroupBuyFixture.createGroupBuy(id = 202L, status = GroupBuyStatus.IN_PROGRESS).apply {
             currentQuantity = 45
             targetQuantity = 50
         }
@@ -388,58 +384,4 @@ class GroupBuyServiceTest {
         assertTrue(result.isEmpty())
     }
 
-    private fun createGroupBuy(
-        id: Long,
-        status: GroupBuyStatus,
-        deadline: LocalDateTime = LocalDateTime.now().plusDays(3)
-    ): GroupBuy {
-        val store = createStore()
-        val request = createGroupBuyRequest()
-        return GroupBuy(
-            store = store,
-            groupBuyRequest = request,
-            thumbnailUrl = "https://example.jpg",
-            productName = "두쫀쿠 1개",
-            productDescription = "설명",
-            price = 6000,
-            targetQuantity = 50,
-            currentQuantity = 36,
-            maxQuantity = 100,
-            status = status,
-            deadline = deadline,
-            pickupDate = LocalDate.now().plusDays(5),
-            pickupTimeStart = LocalTime.of(14, 0),
-            pickupTimeEnd = LocalTime.of(18, 0),
-            pickupLocation = "서울 성동구 성수동",
-            shareCount = 0
-        ).apply { this.id = id }
-    }
-
-    private fun createStore(): Store =
-        Store(
-            name = "뭉치장 베이커리",
-            address = "서울 성동구",
-            region = RegionType.SEOUL,
-            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
-        ).apply {
-            id = 1L
-            latitude = 37.544
-            longitude = 127.055
-        }
-
-    private fun createGroupBuyRequest(): GroupBuyRequest =
-        GroupBuyRequest(
-            userId = 1L,
-            storeName = "뭉치장 베이커리",
-            storeAddress = "서울 성동구",
-            productName = "두쫀쿠 1개",
-            desiredQuantity = 50,
-            desiredPickupDate = LocalDate.now().plusDays(5)
-        ).apply { id = 20L }
-
-    private fun createImage(groupBuy: GroupBuy, imageUrl: String): GroupBuyImage =
-        GroupBuyImage(
-            groupBuy = groupBuy,
-            imageUrl = imageUrl
-        )
 }

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
@@ -1,16 +1,10 @@
 package com.moongchijang.domain.mypage.application
 
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
-import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
-import com.moongchijang.domain.store.domain.entity.DistrictType
-import com.moongchijang.domain.store.domain.entity.RegionType
-import com.moongchijang.domain.store.domain.entity.Store
-import com.moongchijang.support.UserFixture
+import com.moongchijang.support.ParticipationFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -40,7 +34,7 @@ class MyPageParticipationQueryServiceTest {
         val userId = 1L
         val pageable = PageRequest.of(0, 20)
         val now = LocalDateTime.now()
-        val participation = createParticipation(
+        val participation = ParticipationFixture.createParticipation(
             participationId = 101L,
             groupBuyId = 501L,
             quantity = 2,
@@ -88,7 +82,7 @@ class MyPageParticipationQueryServiceTest {
         val pickupTimeStart = LocalTime.of(14, 0)
         val deadline = LocalDateTime.now().plusDays(2)
 
-        val participation = createParticipation(
+        val participation = ParticipationFixture.createParticipation(
             participationId = 202L,
             groupBuyId = 777L,
             quantity = 2,
@@ -129,7 +123,7 @@ class MyPageParticipationQueryServiceTest {
         val userId = 3L
         val pageable = PageRequest.of(0, 20)
         val now = LocalDateTime.now()
-        val participation = createParticipation(
+        val participation = ParticipationFixture.createParticipation(
             participationId = 301L,
             groupBuyId = 901L,
             quantity = 1,
@@ -178,7 +172,7 @@ class MyPageParticipationQueryServiceTest {
         val pickupTimeStart = LocalTime.of(14, 0)
         val deadline = LocalDateTime.now().plusDays(2)
 
-        val participation = createParticipation(
+        val participation = ParticipationFixture.createParticipation(
             participationId = 402L,
             groupBuyId = 977L,
             quantity = 1,
@@ -216,94 +210,5 @@ class MyPageParticipationQueryServiceTest {
         assertEquals(1, item.quantity)
         assertEquals(true, item.isClosed)
         assertEquals(createdAt, item.participatedAt)
-    }
-
-    private fun createParticipation(
-        participationId: Long,
-        groupBuyId: Long,
-        quantity: Int,
-        totalAmount: Int,
-        currentQuantity: Int,
-        targetQuantity: Int,
-        deadline: LocalDateTime,
-        pickupDate: LocalDate,
-        pickupTimeStart: LocalTime,
-        createdAt: LocalDateTime,
-        participationStatus: ParticipationStatus = ParticipationStatus.PAID_WAITING_GOAL,
-        pickupStatus: PickupStatus = PickupStatus.NOT_READY,
-        groupBuyStatus: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
-    ): Participation {
-        val user = UserFixture.createKakaoUser(id = 1L, nickname = "테스터")
-        val groupBuy = createGroupBuy(
-            groupBuyId = groupBuyId,
-            currentQuantity = currentQuantity,
-            targetQuantity = targetQuantity,
-            deadline = deadline,
-            pickupDate = pickupDate,
-            pickupTimeStart = pickupTimeStart,
-            groupBuyStatus = groupBuyStatus
-        )
-
-        return Participation(
-            user = user,
-            groupBuy = groupBuy,
-            quantity = quantity,
-            productAmount = totalAmount,
-            feeAmount = 0,
-            totalAmount = totalAmount,
-            status = participationStatus,
-            pickupStatus = pickupStatus
-        ).apply {
-            id = participationId
-            setCreatedAt(this, createdAt)
-        }
-    }
-
-    private fun createGroupBuy(
-        groupBuyId: Long,
-        currentQuantity: Int,
-        targetQuantity: Int,
-        deadline: LocalDateTime,
-        pickupDate: LocalDate,
-        pickupTimeStart: LocalTime,
-        groupBuyStatus: GroupBuyStatus
-    ): GroupBuy {
-        val store = Store(
-            name = "사이드템포",
-            address = "서울 강남구 OO길 1",
-            region = RegionType.SEOUL,
-            district = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG
-        )
-        val request = GroupBuyRequest(
-            userId = 1L,
-            storeName = "사이드템포",
-            productName = "두쫀쿠 오리지널 1개",
-            desiredQuantity = 50,
-            desiredPickupDate = pickupDate
-        )
-        return GroupBuy(
-            store = store,
-            groupBuyRequest = request,
-            productName = "두쫀쿠 오리지널 1개",
-            productDescription = "테스트 상품 설명",
-            price = 18000,
-            targetQuantity = targetQuantity,
-            currentQuantity = currentQuantity,
-            maxQuantity = 100,
-            status = groupBuyStatus,
-            deadline = deadline,
-            pickupDate = pickupDate,
-            pickupTimeStart = pickupTimeStart,
-            pickupTimeEnd = pickupTimeStart.plusHours(4),
-            pickupLocation = "매장 앞"
-        ).apply {
-            id = groupBuyId
-        }
-    }
-
-    private fun setCreatedAt(participation: Participation, createdAt: LocalDateTime) {
-        val field = participation.javaClass.superclass.getDeclaredField("createdAt")
-        field.isAccessible = true
-        field.set(participation, createdAt)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.store.domain.entity.DistrictType
@@ -123,6 +124,100 @@ class MyPageParticipationQueryServiceTest {
         assertEquals(createdAt, item.participatedAt)
     }
 
+    @Test
+    fun `픽업 대기 참여 내역 조회 시 상태 조건 페이지 반환`() {
+        val userId = 3L
+        val pageable = PageRequest.of(0, 20)
+        val now = LocalDateTime.now()
+        val participation = createParticipation(
+            participationId = 301L,
+            groupBuyId = 901L,
+            quantity = 1,
+            totalAmount = 18000,
+            currentQuantity = 50,
+            targetQuantity = 50,
+            deadline = now.plusDays(1),
+            pickupDate = now.toLocalDate().plusDays(2),
+            pickupTimeStart = LocalTime.of(13, 0),
+            createdAt = now.minusDays(1),
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatus = PickupStatus.READY
+        )
+        val page = PageImpl(listOf(participation), pageable, 1)
+
+        `when`(
+            participationRepository.findPickupWaitingByUserId(
+                userId = userId,
+                participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                pageable = pageable
+            )
+        ).thenReturn(page)
+
+        val result = service.getPickupWaitingParticipations(userId, pageable)
+
+        verify(participationRepository).findPickupWaitingByUserId(
+            userId = userId,
+            participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+            pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+            pageable = pageable
+        )
+
+        assertEquals(1L, result.totalElements)
+        assertEquals(1, result.totalPages)
+        assertEquals(1, result.content.size)
+        assertTrue(result.content.isNotEmpty())
+    }
+
+    @Test
+    fun `픽업 대기 참여 내역 조회 결과 카드 DTO 매핑 반환`() {
+        val userId = 4L
+        val pageable = PageRequest.of(0, 10)
+        val createdAt = LocalDateTime.of(2026, 4, 12, 10, 30)
+        val pickupDate = LocalDate.of(2026, 4, 15)
+        val pickupTimeStart = LocalTime.of(14, 0)
+        val deadline = LocalDateTime.now().plusDays(2)
+
+        val participation = createParticipation(
+            participationId = 402L,
+            groupBuyId = 977L,
+            quantity = 1,
+            totalAmount = 18000,
+            currentQuantity = 50,
+            targetQuantity = 50,
+            deadline = deadline,
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart,
+            createdAt = createdAt,
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatus = PickupStatus.NOT_READY,
+            groupBuyStatus = GroupBuyStatus.CLOSED
+        )
+        val page = PageImpl(listOf(participation), pageable, 1)
+
+        `when`(
+            participationRepository.findPickupWaitingByUserId(
+                userId = userId,
+                participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                pageable = pageable
+            )
+        ).thenReturn(page)
+
+        val result = service.getPickupWaitingParticipations(userId, pageable)
+        val item = result.content.first()
+
+        assertEquals(402L, item.participationId)
+        assertEquals(977L, item.groupBuyId)
+        assertEquals("두쫀쿠 오리지널 1개", item.productName)
+        assertEquals("사이드템포", item.storeName)
+        assertEquals(LocalDateTime.of(pickupDate, pickupTimeStart), item.pickupAt)
+        assertEquals(18000, item.paidAmount)
+        assertEquals(1, item.quantity)
+        assertEquals(true, item.isClosed)
+        assertEquals(createdAt, item.participatedAt)
+    }
+
     private fun createParticipation(
         participationId: Long,
         groupBuyId: Long,
@@ -133,7 +228,10 @@ class MyPageParticipationQueryServiceTest {
         deadline: LocalDateTime,
         pickupDate: LocalDate,
         pickupTimeStart: LocalTime,
-        createdAt: LocalDateTime
+        createdAt: LocalDateTime,
+        participationStatus: ParticipationStatus = ParticipationStatus.PAID_WAITING_GOAL,
+        pickupStatus: PickupStatus = PickupStatus.NOT_READY,
+        groupBuyStatus: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
     ): Participation {
         val user = UserFixture.createKakaoUser(id = 1L, nickname = "테스터")
         val groupBuy = createGroupBuy(
@@ -142,7 +240,8 @@ class MyPageParticipationQueryServiceTest {
             targetQuantity = targetQuantity,
             deadline = deadline,
             pickupDate = pickupDate,
-            pickupTimeStart = pickupTimeStart
+            pickupTimeStart = pickupTimeStart,
+            groupBuyStatus = groupBuyStatus
         )
 
         return Participation(
@@ -152,7 +251,8 @@ class MyPageParticipationQueryServiceTest {
             productAmount = totalAmount,
             feeAmount = 0,
             totalAmount = totalAmount,
-            status = ParticipationStatus.PAID_WAITING_GOAL
+            status = participationStatus,
+            pickupStatus = pickupStatus
         ).apply {
             id = participationId
             setCreatedAt(this, createdAt)
@@ -165,7 +265,8 @@ class MyPageParticipationQueryServiceTest {
         targetQuantity: Int,
         deadline: LocalDateTime,
         pickupDate: LocalDate,
-        pickupTimeStart: LocalTime
+        pickupTimeStart: LocalTime,
+        groupBuyStatus: GroupBuyStatus
     ): GroupBuy {
         val store = Store(
             name = "사이드템포",
@@ -189,7 +290,7 @@ class MyPageParticipationQueryServiceTest {
             targetQuantity = targetQuantity,
             currentQuantity = currentQuantity,
             maxQuantity = 100,
-            status = GroupBuyStatus.IN_PROGRESS,
+            status = groupBuyStatus,
             deadline = deadline,
             pickupDate = pickupDate,
             pickupTimeStart = pickupTimeStart,

--- a/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
@@ -1,0 +1,88 @@
+package com.moongchijang.support
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+object GroupBuyFixture {
+
+    fun createGroupBuy(
+        id: Long,
+        status: GroupBuyStatus,
+        deadline: LocalDateTime = LocalDateTime.now().plusDays(3),
+        productName: String = "두쫀쿠 1개",
+        price: Int = 6000,
+        targetQuantity: Int = 50,
+        currentQuantity: Int = 36,
+        maxQuantity: Int = 100
+    ): GroupBuy {
+        return GroupBuy(
+            store = createStore(),
+            groupBuyRequest = createGroupBuyRequest(productName = productName, desiredQuantity = targetQuantity),
+            thumbnailUrl = "https://example.jpg",
+            productName = productName,
+            productDescription = "설명",
+            price = price,
+            targetQuantity = targetQuantity,
+            currentQuantity = currentQuantity,
+            maxQuantity = maxQuantity,
+            status = status,
+            deadline = deadline,
+            pickupDate = LocalDate.now().plusDays(5),
+            pickupTimeStart = LocalTime.of(14, 0),
+            pickupTimeEnd = LocalTime.of(18, 0),
+            pickupLocation = "서울 성동구 성수동",
+            shareCount = 0
+        ).apply { this.id = id }
+    }
+
+    fun createStore(
+        name: String = "뭉치장 베이커리",
+        address: String = "서울 성동구",
+        region: RegionType = RegionType.SEOUL,
+        district: DistrictType = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
+    ): Store {
+        return Store(
+            name = name,
+            address = address,
+            region = region,
+            district = district
+        ).apply {
+            id = 1L
+            latitude = 37.544
+            longitude = 127.055
+        }
+    }
+
+    fun createGroupBuyRequest(
+        userId: Long = 1L,
+        storeName: String = "뭉치장 베이커리",
+        storeAddress: String = "서울 성동구",
+        productName: String = "두쫀쿠 1개",
+        desiredQuantity: Int = 50,
+        desiredPickupDate: LocalDate = LocalDate.now().plusDays(5)
+    ): GroupBuyRequest {
+        return GroupBuyRequest(
+            userId = userId,
+            storeName = storeName,
+            storeAddress = storeAddress,
+            productName = productName,
+            desiredQuantity = desiredQuantity,
+            desiredPickupDate = desiredPickupDate
+        ).apply { id = 20L }
+    }
+
+    fun createImage(groupBuy: GroupBuy, imageUrl: String): GroupBuyImage {
+        return GroupBuyImage(
+            groupBuy = groupBuy,
+            imageUrl = imageUrl
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/GroupBuyRequestFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/GroupBuyRequestFixture.kt
@@ -1,0 +1,56 @@
+package com.moongchijang.support
+
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestCreateRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import java.time.LocalDate
+
+object GroupBuyRequestFixture {
+
+    fun createRequest(
+        storeName: String = "성심당",
+        storeAddress: String? = null,
+        placeId: String? = null,
+        roadAddress: String? = null,
+        lotAddress: String? = null,
+        latitude: Double? = null,
+        longitude: Double? = null,
+        productName: String = "튀김소보로",
+        desiredQuantity: Int = 2,
+        desiredPickupDate: LocalDate = LocalDate.now().plusDays(3),
+        contactPhone: String? = null,
+        contactInstagram: String? = null
+    ): GroupBuyRequestCreateRequest {
+        return GroupBuyRequestCreateRequest(
+            storeName = storeName,
+            storeAddress = storeAddress,
+            placeId = placeId,
+            roadAddress = roadAddress,
+            lotAddress = lotAddress,
+            latitude = latitude,
+            longitude = longitude,
+            productName = productName,
+            desiredQuantity = desiredQuantity,
+            desiredPickupDate = desiredPickupDate,
+            contactPhone = contactPhone,
+            contactInstagram = contactInstagram
+        )
+    }
+
+    fun createEntity(
+        userId: Long,
+        storeName: String,
+        productName: String,
+        desiredQuantity: Int,
+        desiredPickupDate: LocalDate,
+        storeAddress: String? = null
+    ): GroupBuyRequest {
+        return GroupBuyRequest(
+            userId = userId,
+            storeName = storeName,
+            storeAddress = storeAddress,
+            productName = productName,
+            desiredQuantity = desiredQuantity,
+            desiredPickupDate = desiredPickupDate
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/NaverFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/NaverFixture.kt
@@ -1,0 +1,25 @@
+package com.moongchijang.support
+
+import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchItem
+
+object NaverFixture {
+    fun naverItem(
+        title: String,
+        link: String,
+        category: String,
+        address: String,
+        roadAddress: String
+    ): NaverLocalSearchItem {
+        return NaverLocalSearchItem(
+            title = title,
+            link = link,
+            category = category,
+            description = "",
+            telephone = "",
+            address = address,
+            roadAddress = roadAddress,
+            mapx = "1270000000",
+            mapy = "375000000"
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
@@ -1,0 +1,106 @@
+package com.moongchijang.support
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+object ParticipationFixture {
+
+    fun createParticipation(
+        participationId: Long,
+        groupBuyId: Long,
+        quantity: Int,
+        totalAmount: Int,
+        currentQuantity: Int,
+        targetQuantity: Int,
+        deadline: LocalDateTime,
+        pickupDate: LocalDate,
+        pickupTimeStart: LocalTime,
+        createdAt: LocalDateTime,
+        participationStatus: ParticipationStatus = ParticipationStatus.PAID_WAITING_GOAL,
+        pickupStatus: PickupStatus = PickupStatus.NOT_READY,
+        groupBuyStatus: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
+    ): Participation {
+        val user = UserFixture.createKakaoUser(id = 1L, nickname = "테스터")
+        val groupBuy = createGroupBuy(
+            groupBuyId = groupBuyId,
+            currentQuantity = currentQuantity,
+            targetQuantity = targetQuantity,
+            deadline = deadline,
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart,
+            groupBuyStatus = groupBuyStatus
+        )
+
+        return Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = quantity,
+            productAmount = totalAmount,
+            feeAmount = 0,
+            totalAmount = totalAmount,
+            status = participationStatus,
+            pickupStatus = pickupStatus
+        ).apply {
+            id = participationId
+            setCreatedAt(this, createdAt)
+        }
+    }
+
+    private fun createGroupBuy(
+        groupBuyId: Long,
+        currentQuantity: Int,
+        targetQuantity: Int,
+        deadline: LocalDateTime,
+        pickupDate: LocalDate,
+        pickupTimeStart: LocalTime,
+        groupBuyStatus: GroupBuyStatus
+    ): GroupBuy {
+        val store = Store(
+            name = "사이드템포",
+            address = "서울 강남구 OO길 1",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG
+        )
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "사이드템포",
+            productName = "두쫀쿠 오리지널 1개",
+            desiredQuantity = 50,
+            desiredPickupDate = pickupDate
+        )
+        return GroupBuy(
+            store = store,
+            groupBuyRequest = request,
+            productName = "두쫀쿠 오리지널 1개",
+            productDescription = "테스트 상품 설명",
+            price = 18000,
+            targetQuantity = targetQuantity,
+            currentQuantity = currentQuantity,
+            maxQuantity = 100,
+            status = groupBuyStatus,
+            deadline = deadline,
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart,
+            pickupTimeEnd = pickupTimeStart.plusHours(4),
+            pickupLocation = "매장 앞"
+        ).apply {
+            id = groupBuyId
+        }
+    }
+
+    private fun setCreatedAt(participation: Participation, createdAt: LocalDateTime) {
+        val field = participation.javaClass.superclass.getDeclaredField("createdAt")
+        field.isAccessible = true
+        field.set(participation, createdAt)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/users/me/participations/pickup-waiting` 엔드포인트 추가
- 픽업 대기 조회 로직 구현 (사용자 기준 상태 필터 + 페이지네이션 + `createdAt DESC`)
- 응답 필드 구현
  - `participationId`, `groupBuyId`, `productName`, `storeName`, `pickupAt`, `paidAmount`, `quantity`, `isClosed`, `participatedAt`

## 🔍 참고 사항

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #135 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인