### PR TITLE
[MCJ-1492] FEAT: 알림 목록 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.ZoneId
 
 @Service
 class NotificationQueryService(
@@ -45,7 +46,7 @@ class NotificationQueryService(
 
         val hasNext = notifications.size > safeLimit
         val content = if (hasNext) notifications.dropLast(1) else notifications
-        val today = LocalDate.now()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
         val items = content.map { NotificationItemResponse.from(it, today) }
         val nextCursor = content.lastOrNull()?.let { NotificationCursor(it.occurredAt, it.id).encode() }
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
@@ -1,0 +1,70 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.dto.NotificationCategory
+import com.moongchijang.domain.notification.application.dto.NotificationCursor
+import com.moongchijang.domain.notification.application.dto.NotificationItemResponse
+import com.moongchijang.domain.notification.application.dto.NotificationListResponse
+import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Service
+class NotificationQueryService(
+    private val notificationRepository: NotificationRepository
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(readOnly = true)
+    fun getNotifications(
+        userId: Long,
+        category: NotificationCategory,
+        cursor: String?,
+        limit: Int
+    ): NotificationListResponse {
+        val safeLimit = limit.coerceIn(MIN_LIMIT, MAX_LIMIT)
+        val decodedCursor = cursor?.let { NotificationCursor.decode(it) }
+        log.info(
+            "[NotificationQueryService] 알림 목록 조회 시작: userId={}, category={}, hasCursor={}, requestedLimit={}, safeLimit={}",
+            userId,
+            category,
+            cursor != null,
+            limit,
+            safeLimit
+        )
+
+        val notifications = notificationRepository.findForList(
+            userId = userId,
+            type = category.toNotificationTypeOrNull(),
+            cursorOccurredAt = decodedCursor?.occurredAt,
+            cursorId = decodedCursor?.id,
+            pageable = PageRequest.of(0, safeLimit + 1)
+        )
+
+        val hasNext = notifications.size > safeLimit
+        val content = if (hasNext) notifications.dropLast(1) else notifications
+        val today = LocalDate.now()
+        val items = content.map { NotificationItemResponse.from(it, today) }
+        val nextCursor = content.lastOrNull()?.let { NotificationCursor(it.occurredAt, it.id).encode() }
+        log.info(
+            "[NotificationQueryService] 알림 목록 조회 완료: userId={}, category={}, contentSize={}, hasNext={}",
+            userId,
+            category,
+            items.size,
+            hasNext
+        )
+
+        return NotificationListResponse(
+            items = items,
+            nextCursor = if (hasNext) nextCursor else null,
+            hasNext = hasNext
+        )
+    }
+
+    companion object {
+        private const val MIN_LIMIT = 1
+        private const val MAX_LIMIT = 100
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCategory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCategory.kt
@@ -1,0 +1,37 @@
+package com.moongchijang.domain.notification.application.dto
+
+import com.moongchijang.domain.notification.domain.entity.NotificationType
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "알림 카테고리 필터")
+enum class NotificationCategory {
+    @Schema(description = "전체 알림")
+    ALL,
+    @Schema(description = "찜 알림")
+    WISH,
+    @Schema(description = "신청 알림")
+    APPLY,
+    @Schema(description = "픽업 알림")
+    PICKUP,
+    @Schema(description = "요청 알림")
+    REQUEST;
+
+    fun toNotificationTypeOrNull(): NotificationType? {
+        return when (this) {
+            ALL -> null
+            WISH -> NotificationType.WISH
+            APPLY -> NotificationType.APPLY
+            PICKUP -> NotificationType.PICKUP
+            REQUEST -> NotificationType.REQUEST
+        }
+    }
+
+    companion object {
+        fun from(value: String): NotificationCategory {
+            return entries.firstOrNull { it.name == value.uppercase() }
+                ?: throw CustomException(ErrorCode.INVALID_INPUT, "category must be one of ALL, WISH, APPLY, PICKUP, REQUEST")
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCursor.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCursor.kt
@@ -1,0 +1,29 @@
+package com.moongchijang.domain.notification.application.dto
+
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import java.time.LocalDateTime
+
+data class NotificationCursor(
+    val occurredAt: LocalDateTime,
+    val id: Long
+) {
+    fun encode(): String = "$occurredAt|$id"
+
+    companion object {
+        fun decode(cursor: String): NotificationCursor {
+            val parts = cursor.split("|", limit = 2)
+            if (parts.size != 2) {
+                throw CustomException(ErrorCode.INVALID_INPUT, "cursor format is invalid")
+            }
+
+            val occurredAt = runCatching { LocalDateTime.parse(parts[0]) }.getOrElse {
+                throw CustomException(ErrorCode.INVALID_INPUT, "cursor occurredAt is invalid")
+            }
+            val id = parts[1].toLongOrNull()
+                ?: throw CustomException(ErrorCode.INVALID_INPUT, "cursor id is invalid")
+
+            return NotificationCursor(occurredAt = occurredAt, id = id)
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
@@ -1,0 +1,63 @@
+package com.moongchijang.domain.notification.application.dto
+
+import com.moongchijang.domain.notification.domain.entity.Notification
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "알림 항목")
+data class NotificationItemResponse(
+
+    @field:Schema(description = "알림 ID", example = "101")
+    val id: Long,
+
+    @field:Schema(description = "알림 종류", example = "PICKUP")
+    val type: NotificationType,
+
+    @field:Schema(description = "알림 제목", example = "픽업 리마인드")
+    val title: String,
+
+    @field:Schema(description = "알림 본문 요약", example = "오늘 오전 9시에 픽업이 시작됩니다.")
+    val body: String,
+
+    @field:Schema(description = "읽음 여부", example = "false")
+    val isRead: Boolean,
+
+    @field:Schema(description = "알림 발생 시각", example = "2026-05-22T09:00:00")
+    val occurredAt: LocalDateTime,
+
+    @field:Schema(description = "연결 대상 ID", example = "2001")
+    val targetId: Long?,
+
+    @field:Schema(description = "딥링크 타입", example = "PICKUP_GUIDE")
+    val deeplinkType: NotificationDeeplinkType,
+
+    @field:Schema(description = "기간 구분", example = "TODAY")
+    val section: NotificationSection
+) {
+    companion object {
+        fun from(notification: Notification, today: LocalDate): NotificationItemResponse {
+            return NotificationItemResponse(
+                id = notification.id,
+                type = notification.type,
+                title = notification.title,
+                body = notification.body,
+                isRead = notification.isRead,
+                occurredAt = notification.occurredAt,
+                targetId = notification.targetId,
+                deeplinkType = notification.deeplinkType,
+                section = resolveSection(notification.occurredAt.toLocalDate(), today)
+            )
+        }
+
+        private fun resolveSection(date: LocalDate, today: LocalDate): NotificationSection {
+            return when (date) {
+                today -> NotificationSection.TODAY
+                today.minusDays(1) -> NotificationSection.YESTERDAY
+                else -> NotificationSection.OLDER
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationListResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationListResponse.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.notification.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "알림 목록 조회 응답")
+data class NotificationListResponse(
+
+    @field:Schema(description = "알림 목록")
+    val items: List<NotificationItemResponse>,
+
+    @field:Schema(description = "다음 조회 커서 (마지막 알림 기준)", example = "2026-05-22T09:00:00|101")
+    val nextCursor: String?,
+
+    @field:Schema(description = "다음 페이지 존재 여부", example = "true")
+    val hasNext: Boolean
+)

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationSection.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationSection.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.notification.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "알림 기간 섹션")
+enum class NotificationSection {
+    @Schema(description = "오늘")
+    TODAY,
+    @Schema(description = "어제")
+    YESTERDAY,
+    @Schema(description = "이전")
+    OLDER
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.domain.notification.domain.entity
+
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "notifications",
+    indexes = [
+        Index(name = "idx_notifications_user_occurred_at", columnList = "user_id,occurred_at"),
+        Index(name = "idx_notifications_user_type_occurred_at", columnList = "user_id,type,occurred_at"),
+        Index(name = "idx_notifications_user_is_read_occurred_at", columnList = "user_id,is_read,occurred_at")
+    ]
+)
+class Notification(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var type: NotificationType,
+
+    @Column(nullable = false, length = 120)
+    var title: String,
+
+    @Column(nullable = false, length = 500)
+    var body: String,
+
+    @Column(name = "is_read", nullable = false)
+    var isRead: Boolean = false,
+
+    @Column(name = "occurred_at", nullable = false)
+    var occurredAt: LocalDateTime,
+
+    @Column(name = "target_id")
+    var targetId: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "deeplink_type", nullable = false, length = 30)
+    var deeplinkType: NotificationDeeplinkType,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity()

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDeeplinkType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDeeplinkType.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.notification.domain.entity
+
+enum class NotificationDeeplinkType {
+    PICKUP_GUIDE,
+    GROUPBUY_DETAIL,
+    MY_APPLYING,
+    REQUEST_STATUS
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationType.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.notification.domain.entity
+
+enum class NotificationType {
+    PICKUP,
+    WISH,
+    APPLY,
+    REQUEST
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
@@ -1,0 +1,33 @@
+package com.moongchijang.domain.notification.domain.repository
+
+import com.moongchijang.domain.notification.domain.entity.Notification
+import com.moongchijang.domain.notification.domain.entity.NotificationType
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+
+interface NotificationRepository : JpaRepository<Notification, Long> {
+
+    @Query(
+        """
+        SELECT n FROM Notification n
+        WHERE n.user.id = :userId
+          AND (:type IS NULL OR n.type = :type)
+          AND (
+                :cursorOccurredAt IS NULL
+                OR n.occurredAt < :cursorOccurredAt
+                OR (n.occurredAt = :cursorOccurredAt AND n.id < :cursorId)
+          )
+        ORDER BY n.occurredAt DESC, n.id DESC
+        """
+    )
+    fun findForList(
+        @Param("userId") userId: Long,
+        @Param("type") type: NotificationType?,
+        @Param("cursorOccurredAt") cursorOccurredAt: LocalDateTime?,
+        @Param("cursorId") cursorId: Long?,
+        pageable: Pageable
+    ): List<Notification>
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/presentation/NotificationController.kt
@@ -1,0 +1,79 @@
+package com.moongchijang.domain.notification.presentation
+
+import com.moongchijang.domain.notification.application.NotificationQueryService
+import com.moongchijang.domain.notification.application.dto.NotificationCategory
+import com.moongchijang.domain.notification.application.dto.NotificationListResponse
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@Tag(name = "Notification", description = "알림 목록 조회")
+class NotificationController(
+    private val notificationQueryService: NotificationQueryService
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping
+    @Operation(summary = "알림 목록 조회 (폴링용)")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "알림 목록 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (category/cursor/limit 형식 오류)",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "로그인 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getNotifications(
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @RequestParam(required = false, defaultValue = "ALL") category: String,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(required = false, defaultValue = "20") limit: Int
+    ): ResponseEntity<ApiResponse<NotificationListResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        log.info(
+            "[NotificationController] 알림 목록 조회 요청 수신: userId={}, category={}, hasCursor={}, limit={}",
+            userId,
+            category,
+            cursor != null,
+            limit
+        )
+        val response = notificationQueryService.getNotifications(
+            userId = userId,
+            category = NotificationCategory.from(category),
+            cursor = cursor,
+            limit = limit
+        )
+        log.info(
+            "[NotificationController] 알림 목록 조회 응답 완료: userId={}, category={}, size={}, hasNext={}",
+            userId,
+            category,
+            response.items.size,
+            response.hasNext
+        )
+
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+}

--- a/src/main/resources/db/migration/V17__create_notifications_table.sql
+++ b/src/main/resources/db/migration/V17__create_notifications_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE notifications (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    title VARCHAR(120) NOT NULL,
+    body VARCHAR(500) NOT NULL,
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    occurred_at DATETIME NOT NULL,
+    target_id BIGINT NULL,
+    deeplink_type VARCHAR(30) NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_notifications_user_id FOREIGN KEY (user_id) REFERENCES users (id)
+);
+
+CREATE INDEX idx_notifications_user_occurred_at ON notifications (user_id, occurred_at DESC);
+CREATE INDEX idx_notifications_user_type_occurred_at ON notifications (user_id, type, occurred_at DESC);
+CREATE INDEX idx_notifications_user_is_read_occurred_at ON notifications (user_id, is_read, occurred_at DESC);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1138,25 +1138,44 @@ paths:
   /api/v1/notifications:
     get:
       tags: [Notification]
-      summary: 알림 목록 조회
+      summary: 알림 목록 조회 (폴링용)
       security:
         - bearerAuth: []
       parameters:
         - name: category
           in: query
+          description: 알림 카테고리 필터
           schema:
             type: string
-            enum: [ALL, WISHLIST, PARTICIPATION, PICKUP, REQUEST]
+            enum: [ALL, WISH, APPLY, PICKUP, REQUEST]
             default: ALL
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/Size'
+        - name: cursor
+          in: query
+          required: false
+          description: "다음 페이지 조회 커서. 형식: `{occurredAt}|{id}`"
+          schema:
+            type: string
+            example: "2026-05-22T09:00:00|101"
+        - name: limit
+          in: query
+          required: false
+          description: 조회 개수 (1~100, 기본 20)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
       responses:
         '200':
           description: 알림 목록
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponseNotificationPage'
+                $ref: '#/components/schemas/ApiResponseNotificationListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
   /api/v1/notifications/unread-count:
     get:
@@ -2832,88 +2851,69 @@ components:
         error: { nullable: true, example: null }
 
     # ── Notification ───────────────────────────────────────────
-    NotificationItem:
+    NotificationType:
+      type: string
+      enum: [PICKUP, WISH, APPLY, REQUEST]
+
+    NotificationDeeplinkType:
+      type: string
+      enum: [PICKUP_GUIDE, GROUPBUY_DETAIL, MY_APPLYING, REQUEST_STATUS]
+
+    NotificationSection:
+      type: string
+      enum: [TODAY, YESTERDAY, OLDER]
+
+    NotificationItemResponse:
       type: object
-      required: [id, category, type, title, body, targetType, targetId, isRead, readAt, actionType, dateGroup, createdAt]
+      required: [id, type, title, body, isRead, occurredAt, deeplinkType, section]
       properties:
         id:
           type: integer
           format: int64
-        category:
-          type: string
-          enum: [WISHLIST, PARTICIPATION, PICKUP, REQUEST]
         type:
-          type: string
-          enum:
-            - PICKUP_TODAY
-            - PICKUP_TOMORROW
-            - PICKUP_NOT_CONFIRMED
-            - WISHLIST_DEADLINE_D3
-            - WISHLIST_DEADLINE_D1
-            - WISHLIST_TARGET_ACHIEVED
-            - PARTICIPATION_CONFIRMED
-            - GROUP_BUY_ACHIEVED
-            - GROUP_BUY_FAILED
-            - REQUEST_OPENED
-            - REQUEST_REJECTED
-            - REQUEST_NEW_PARTICIPANT
-            - REQUEST_TARGET_ACHIEVED
-            - REQUEST_DEADLINE_D3
+          $ref: '#/components/schemas/NotificationType'
         title:
           type: string
         body:
           type: string
-        targetType:
+          description: 알림 본문 요약
+        isRead:
+          type: boolean
+        occurredAt:
           type: string
-          enum: [GROUP_BUY, GROUP_BUY_REQUEST, PARTICIPATION]
-          nullable: true
+          format: date-time
         targetId:
           type: integer
           format: int64
           nullable: true
-        isRead:
-          type: boolean
-        readAt:
-          type: string
-          format: date-time
-          nullable: true
-        actionType:
-          type: string
-          nullable: true
-          enum: [QR_CODE, PICKUP_GUIDE, GROUP_BUY_DETAIL, MY_PAGE_ACTIVE, MY_PAGE_REFUND, REQUEST_STATUS]
-          description: "인라인 액션 버튼 유형. null이면 버튼 미노출"
-        dateGroup:
-          type: string
-          enum: [TODAY, YESTERDAY, BEFORE]
-          description: "알림 날짜 그룹 (오늘/어제/이전)"
-        createdAt:
-          type: string
-          format: date-time
+        deeplinkType:
+          $ref: '#/components/schemas/NotificationDeeplinkType'
+        section:
+          $ref: '#/components/schemas/NotificationSection'
 
-    NotificationPage:
+    NotificationListResponse:
       type: object
-      required: [content, totalElements, totalPages, number, size]
+      required: [items, hasNext]
       properties:
-        content:
+        items:
           type: array
           items:
-            $ref: '#/components/schemas/NotificationItem'
-        totalElements:
-          type: integer
-        totalPages:
-          type: integer
-        number:
-          type: integer
-        size:
-          type: integer
+            $ref: '#/components/schemas/NotificationItemResponse'
+        nextCursor:
+          type: string
+          nullable: true
+          example: "2026-05-22T09:00:00|101"
+        hasNext:
+          type: boolean
+          example: true
 
-    ApiResponseNotificationPage:
+    ApiResponseNotificationListResponse:
       type: object
       required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
-          $ref: '#/components/schemas/NotificationPage'
+          $ref: '#/components/schemas/NotificationListResponse'
         error: { nullable: true, example: null }
 
     ApiResponseUnreadCount:

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -1,0 +1,199 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.dto.NotificationCategory
+import com.moongchijang.domain.notification.application.dto.NotificationCursor
+import com.moongchijang.domain.notification.domain.entity.NotificationType
+import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.support.NotificationFixture
+import com.moongchijang.support.UserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class NotificationQueryServiceTest {
+
+    @Mock
+    private lateinit var notificationRepository: NotificationRepository
+
+    private val service by lazy { NotificationQueryService(notificationRepository) }
+
+    @Test
+    fun `카테고리 ALL 조회 시 type 필터 없음`() {
+        val user = UserFixture.createEmailUser(id = 1L)
+        val occurredAt = LocalDateTime.now().minusHours(1).withNano(0)
+        val notifications = listOf(
+            NotificationFixture.createNotification(user = user, id = 11L, occurredAt = occurredAt)
+        )
+
+        `when`(
+            notificationRepository.findForList(
+                userId = 1L,
+                type = null,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(notifications)
+
+        val result = service.getNotifications(
+            userId = 1L,
+            category = NotificationCategory.ALL,
+            cursor = null,
+            limit = 20
+        )
+
+        verify(notificationRepository).findForList(
+            userId = 1L,
+            type = null,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 21)
+        )
+        assertThat(result.items).hasSize(1)
+        assertThat(result.items[0].id).isEqualTo(11L)
+    }
+
+    @Test
+    fun `카테고리 APPLY 조회 시 APPLY type 필터 적용`() {
+        `when`(
+            notificationRepository.findForList(
+                userId = 2L,
+                type = NotificationType.APPLY,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(emptyList())
+
+        service.getNotifications(
+            userId = 2L,
+            category = NotificationCategory.APPLY,
+            cursor = null,
+            limit = 20
+        )
+
+        verify(notificationRepository).findForList(
+            userId = 2L,
+            type = NotificationType.APPLY,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 21)
+        )
+    }
+
+    @Test
+    fun `커서 기반 조회 hasNext와 nextCursor 반환`() {
+        val user = UserFixture.createEmailUser(id = 3L)
+        val now = LocalDateTime.now().withNano(0)
+        val n1 = NotificationFixture.createNotification(user = user, id = 31L, occurredAt = now.minusMinutes(1))
+        val n2 = NotificationFixture.createNotification(user = user, id = 30L, occurredAt = now.minusMinutes(2))
+        val n3 = NotificationFixture.createNotification(user = user, id = 29L, occurredAt = now.minusMinutes(3))
+        val cursor = NotificationCursor(now, 100L).encode()
+
+        `when`(
+            notificationRepository.findForList(
+                userId = 3L,
+                type = null,
+                cursorOccurredAt = now,
+                cursorId = 100L,
+                pageable = PageRequest.of(0, 3)
+            )
+        ).thenReturn(listOf(n1, n2, n3))
+
+        val result = service.getNotifications(
+            userId = 3L,
+            category = NotificationCategory.ALL,
+            cursor = cursor,
+            limit = 2
+        )
+
+        assertThat(result.hasNext).isTrue()
+        assertThat(result.items).hasSize(2)
+        assertThat(result.nextCursor).isEqualTo(NotificationCursor(n2.occurredAt, n2.id).encode())
+    }
+
+    @Test
+    fun `section TODAY YESTERDAY OLDER 분류`() {
+        val user = UserFixture.createEmailUser(id = 4L)
+        val now = LocalDateTime.now().withNano(0)
+        val today = NotificationFixture.createNotification(user = user, id = 41L, occurredAt = now)
+        val yesterday = NotificationFixture.createNotification(user = user, id = 40L, occurredAt = now.minusDays(1))
+        val older = NotificationFixture.createNotification(user = user, id = 39L, occurredAt = now.minusDays(3))
+
+        `when`(
+            notificationRepository.findForList(
+                userId = 4L,
+                type = null,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(listOf(today, yesterday, older))
+
+        val result = service.getNotifications(
+            userId = 4L,
+            category = NotificationCategory.ALL,
+            cursor = null,
+            limit = 20
+        )
+
+        assertThat(result.items.map { it.section.name }).containsExactly("TODAY", "YESTERDAY", "OLDER")
+    }
+
+    @Test
+    fun `limit 범위 보정`() {
+        `when`(
+            notificationRepository.findForList(
+                userId = 5L,
+                type = null,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 2)
+            )
+        ).thenReturn(emptyList())
+        `when`(
+            notificationRepository.findForList(
+                userId = 5L,
+                type = null,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 101)
+            )
+        ).thenReturn(emptyList())
+
+        service.getNotifications(
+            userId = 5L,
+            category = NotificationCategory.ALL,
+            cursor = null,
+            limit = 0
+        )
+        service.getNotifications(
+            userId = 5L,
+            category = NotificationCategory.ALL,
+            cursor = null,
+            limit = 999
+        )
+
+        verify(notificationRepository).findForList(
+            userId = 5L,
+            type = null,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 2)
+        )
+        verify(notificationRepository).findForList(
+            userId = 5L,
+            type = null,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 101)
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/repository/NotificationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/repository/NotificationRepositoryIntegrationTest.kt
@@ -1,0 +1,132 @@
+package com.moongchijang.domain.notification.repository
+
+import com.moongchijang.domain.notification.domain.entity.Notification
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationType
+import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class NotificationRepositoryIntegrationTest {
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired
+    private lateinit var em: EntityManager
+
+    @Test
+    fun `최신순 정렬 occurredAt desc id desc`() {
+        val user = persistUser("repo-sort@test.com")
+        val sameTime = LocalDateTime.of(2026, 5, 22, 9, 0, 0)
+
+        val newer = persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = sameTime.plusMinutes(1))
+        val tieLowerId = persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = sameTime)
+        val tieHigherId = persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = sameTime)
+
+        flushAndClear()
+
+        val result = notificationRepository.findForList(
+            userId = user.id!!,
+            type = null,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 10)
+        )
+
+        assertThat(result.map { it.id }).containsExactly(newer.id, tieHigherId.id, tieLowerId.id)
+    }
+
+    @Test
+    fun `카테고리 type 필터 적용`() {
+        val user = persistUser("repo-filter@test.com")
+        persistNotification(user = user, type = NotificationType.APPLY, occurredAt = LocalDateTime.now().minusMinutes(1))
+        persistNotification(user = user, type = NotificationType.WISH, occurredAt = LocalDateTime.now().minusMinutes(2))
+
+        flushAndClear()
+
+        val result = notificationRepository.findForList(
+            userId = user.id!!,
+            type = NotificationType.APPLY,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 10)
+        )
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0].type).isEqualTo(NotificationType.APPLY)
+    }
+
+    @Test
+    fun `커서 이후 데이터 조회`() {
+        val user = persistUser("repo-cursor@test.com")
+        val base = LocalDateTime.of(2026, 5, 22, 9, 0, 0)
+
+        persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = base.plusMinutes(1))
+        val sameTimeLowId = persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = base)
+        val sameTimeHighId = persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = base)
+        val older = persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = base.minusMinutes(1))
+
+        flushAndClear()
+
+        val result = notificationRepository.findForList(
+            userId = user.id!!,
+            type = null,
+            cursorOccurredAt = base,
+            cursorId = sameTimeHighId.id,
+            pageable = PageRequest.of(0, 10)
+        )
+
+        assertThat(result.map { it.id }).containsExactly(sameTimeLowId.id, older.id)
+    }
+
+    private fun persistUser(email: String): User {
+        val user = User(
+            provider = AuthProvider.EMAIL,
+            email = email,
+            passwordHash = "pw",
+            nickname = "tester",
+            role = UserRole.BUYER,
+            signupCompleted = true
+        )
+        em.persist(user)
+        return user
+    }
+
+    private fun persistNotification(
+        user: User,
+        type: NotificationType,
+        occurredAt: LocalDateTime
+    ): Notification {
+        val notification = Notification(
+            user = user,
+            type = type,
+            title = "알림",
+            body = "본문",
+            isRead = false,
+            occurredAt = occurredAt,
+            targetId = 100L,
+            deeplinkType = NotificationDeeplinkType.PICKUP_GUIDE
+        )
+        em.persist(notification)
+        return notification
+    }
+
+    private fun flushAndClear() {
+        em.flush()
+        em.clear()
+    }
+}

--- a/src/test/kotlin/com/moongchijang/support/NotificationFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/NotificationFixture.kt
@@ -1,0 +1,34 @@
+package com.moongchijang.support
+
+import com.moongchijang.domain.notification.domain.entity.Notification
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationType
+import com.moongchijang.domain.user.domain.entity.User
+import java.time.LocalDateTime
+
+object NotificationFixture {
+
+    fun createNotification(
+        user: User,
+        id: Long = 0L,
+        type: NotificationType = NotificationType.PICKUP,
+        title: String = "알림 제목",
+        body: String = "알림 본문",
+        isRead: Boolean = false,
+        occurredAt: LocalDateTime = LocalDateTime.now(),
+        targetId: Long? = null,
+        deeplinkType: NotificationDeeplinkType = NotificationDeeplinkType.PICKUP_GUIDE,
+    ): Notification {
+        return Notification(
+            user = user,
+            type = type,
+            title = title,
+            body = body,
+            isRead = isRead,
+            occurredAt = occurredAt,
+            targetId = targetId,
+            deeplinkType = deeplinkType,
+            id = id,
+        )
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 알림 도메인 및 저장 구조를 추가했습니다.
  - `Notification` 엔티티 및 `NotificationType`, `NotificationDeeplinkType` enum을 추가했습니다.
  - Flyway 마이그레이션(`V17__create_notifications_table.sql`)으로 `notifications` 테이블을 생성했습니다.
  - 조회 성능을 위한 인덱스(`user_id+occurred_at`, `user_id+type+occurred_at`, `user_id+is_read+occurred_at`)를 반영했습니다.
- 사용자별 알림 목록 조회 API를 구현했습니다.
  - `GET /api/v1/notifications`
  - 카테고리 필터(`ALL`, `WISH`, `APPLY`, `PICKUP`, `REQUEST`)를 지원합니다.
  - 최신순 정렬(`occurredAt DESC, id DESC`)을 적용했습니다.
  - 폴링에 적합한 커서 페이지네이션(`cursor`, `nextCursor`, `hasNext`)을 적용했습니다.
  - 알림 항목별 `TODAY / YESTERDAY / OLDER` 섹션 분류 필드를 응답에 포함했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #144 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인