### PR TITLE
[MCJ-1493] FEAT: 알림 읽음 처리 API 및 미읽음 집계 기능 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
@@ -1,0 +1,68 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.dto.NotificationUnreadCountResponse
+import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NotificationCommandService(
+    private val notificationRepository: NotificationRepository
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun markAsRead(userId: Long, notificationId: Long) {
+        log.info(
+            "[NotificationCommandService] 알림 단건 읽음 처리 시작: userId={}, notificationId={}",
+            userId,
+            notificationId
+        )
+
+        val notification = notificationRepository.findById(notificationId)
+            .orElseThrow { CustomException(ErrorCode.NOTIFICATION_NOT_FOUND) }
+
+        if (notification.user.id != userId) {
+            throw CustomException(ErrorCode.NOTIFICATION_FORBIDDEN)
+        }
+        notification.markAsRead()
+
+        log.info(
+            "[NotificationCommandService] 알림 단건 읽음 처리 완료: userId={}, notificationId={}, isRead={}",
+            userId,
+            notificationId,
+            notification.isRead
+        )
+    }
+
+    @Transactional
+    fun markAllAsRead(userId: Long): Int {
+        log.info("[NotificationCommandService] 알림 전체 읽음 처리 시작: userId={}", userId)
+
+        val updatedCount = notificationRepository.markAllAsReadByUserId(userId)
+
+        log.info(
+            "[NotificationCommandService] 알림 전체 읽음 처리 완료: userId={}, updatedCount={}",
+            userId,
+            updatedCount
+        )
+        return updatedCount
+    }
+
+    @Transactional(readOnly = true)
+    fun getUnreadCount(userId: Long): NotificationUnreadCountResponse {
+        log.info("[NotificationCommandService] 미읽음 알림 개수 조회 시작: userId={}", userId)
+
+        val count = notificationRepository.countUnreadByUserId(userId)
+
+        log.info(
+            "[NotificationCommandService] 미읽음 알림 개수 조회 완료: userId={}, count={}",
+            userId,
+            count
+        )
+        return NotificationUnreadCountResponse(count = count)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationUnreadCountResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationUnreadCountResponse.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.notification.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "미읽음 알림 개수 응답")
+data class NotificationUnreadCountResponse(
+
+    @field:Schema(description = "미읽음 알림 개수", example = "3")
+    val count: Long
+)

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
@@ -57,4 +57,10 @@ class Notification(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
-) : BaseEntity()
+) : BaseEntity() {
+    fun markAsRead() {
+        if (!isRead) {
+            isRead = true
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
-import java.util.Optional
 
 interface NotificationRepository : JpaRepository<Notification, Long> {
 
@@ -32,8 +31,6 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         @Param("cursorId") cursorId: Long?,
         pageable: Pageable
     ): List<Notification>
-
-    fun findByIdAndUserId(id: Long, userId: Long): Optional<Notification>
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
@@ -2,11 +2,13 @@ package com.moongchijang.domain.notification.domain.repository
 
 import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationType
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
+import java.util.Optional
 
 interface NotificationRepository : JpaRepository<Notification, Long> {
 
@@ -30,4 +32,27 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         @Param("cursorId") cursorId: Long?,
         pageable: Pageable
     ): List<Notification>
+
+    fun findByIdAndUserId(id: Long, userId: Long): Optional<Notification>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        UPDATE Notification n
+        SET n.isRead = true
+        WHERE n.user.id = :userId
+          AND n.isRead = false
+        """
+    )
+    fun markAllAsReadByUserId(@Param("userId") userId: Long): Int
+
+    @Query(
+        """
+        SELECT COUNT(n)
+        FROM Notification n
+        WHERE n.user.id = :userId
+          AND n.isRead = false
+        """
+    )
+    fun countUnreadByUserId(@Param("userId") userId: Long): Long
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/presentation/NotificationController.kt
@@ -1,8 +1,10 @@
 package com.moongchijang.domain.notification.presentation
 
+import com.moongchijang.domain.notification.application.NotificationCommandService
 import com.moongchijang.domain.notification.application.NotificationQueryService
 import com.moongchijang.domain.notification.application.dto.NotificationCategory
 import com.moongchijang.domain.notification.application.dto.NotificationListResponse
+import com.moongchijang.domain.notification.application.dto.NotificationUnreadCountResponse
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
@@ -17,15 +19,18 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/notifications")
-@Tag(name = "Notification", description = "알림 목록 조회")
+@Tag(name = "Notification", description = "알림 목록 조회 및 읽음 처리")
 class NotificationController(
-    private val notificationQueryService: NotificationQueryService
+    private val notificationQueryService: NotificationQueryService,
+    private val notificationCommandService: NotificationCommandService
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -74,6 +79,105 @@ class NotificationController(
             response.hasNext
         )
 
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "알림 단건 읽음 처리")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "알림 단건 읽음 처리 성공"),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "로그인 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (본인 알림 아님)",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "알림을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun markNotificationAsRead(
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+        @PathVariable notificationId: Long
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        log.info(
+            "[NotificationController] 알림 단건 읽음 처리 요청 수신: userId={}, notificationId={}",
+            userId,
+            notificationId
+        )
+
+        notificationCommandService.markAsRead(userId = userId, notificationId = notificationId)
+
+        log.info(
+            "[NotificationController] 알림 단건 읽음 처리 응답 완료: userId={}, notificationId={}",
+            userId,
+            notificationId
+        )
+        return ResponseEntity.ok(ApiResponse.success())
+    }
+
+    @PatchMapping("/read-all")
+    @Operation(summary = "알림 전체 읽음 처리")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "알림 전체 읽음 처리 성공"),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "로그인 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun markAllNotificationsAsRead(
+        @AuthenticationPrincipal principal: CustomUserPrincipal?
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        log.info("[NotificationController] 알림 전체 읽음 처리 요청 수신: userId={}", userId)
+
+        val updatedCount = notificationCommandService.markAllAsRead(userId = userId)
+
+        log.info(
+            "[NotificationController] 알림 전체 읽음 처리 응답 완료: userId={}, updatedCount={}",
+            userId,
+            updatedCount
+        )
+        return ResponseEntity.ok(ApiResponse.success())
+    }
+
+    @GetMapping("/unread-count")
+    @Operation(summary = "미읽음 알림 개수 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "미읽음 알림 개수 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "로그인 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getUnreadNotificationCount(
+        @AuthenticationPrincipal principal: CustomUserPrincipal?
+    ): ResponseEntity<ApiResponse<NotificationUnreadCountResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        log.info("[NotificationController] 미읽음 알림 개수 조회 요청 수신: userId={}", userId)
+
+        val response = notificationCommandService.getUnreadCount(userId = userId)
+
+        log.info(
+            "[NotificationController] 미읽음 알림 개수 조회 응답 완료: userId={}, count={}",
+            userId,
+            response.count
+        )
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 }

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -113,4 +113,8 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PARTICIPATION_NOT_FOUND(404_356, "참여 정보를 찾을 수 없습니다.", 404),
     PARTICIPATION_CANCEL_NOT_ALLOWED(409_357, "취소할 수 없는 참여 상태입니다.", 409),
     PARTICIPATION_CANCEL_REASON_DETAIL_REQUIRED(400_358, "기타 취소 사유를 입력해주세요.", 400),
+
+    // Notification(360~369)
+    NOTIFICATION_NOT_FOUND(404_360, "알림을 찾을 수 없습니다.", 404),
+    NOTIFICATION_FORBIDDEN(403_360, "본인 알림만 처리할 수 있습니다.", 403),
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1180,7 +1180,7 @@ paths:
   /api/v1/notifications/unread-count:
     get:
       tags: [Notification]
-      summary: 미읽음 알림 개수 조회 (탭바 배지용)
+      summary: 미읽음 알림 개수 조회
       security:
         - bearerAuth: []
       responses:
@@ -1189,7 +1189,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponseUnreadCount'
+                $ref: '#/components/schemas/ApiResponseNotificationUnreadCountResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
   /api/v1/notifications/read-all:
     patch:
@@ -1200,11 +1202,13 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessNoData'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
 
   /api/v1/notifications/{notificationId}/read:
     patch:
       tags: [Notification]
-      summary: 개별 알림 읽음 처리
+      summary: 알림 단건 읽음 처리
       security:
         - bearerAuth: []
       parameters:
@@ -1217,6 +1221,12 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessNoData'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   # ─────────────────────────────────────────────────────────────
   # MyPage
@@ -2916,7 +2926,7 @@ components:
           $ref: '#/components/schemas/NotificationListResponse'
         error: { nullable: true, example: null }
 
-    ApiResponseUnreadCount:
+    ApiResponseNotificationUnreadCountResponse:
       type: object
       required: [success, data, error]
       properties:
@@ -2925,7 +2935,7 @@ components:
           type: object
           required: [count]
           properties:
-            count: { type: integer }
+            count: { type: integer, format: int64, example: 3 }
         error: { nullable: true, example: null }
 
     # ── MyPage ─────────────────────────────────────────────────

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationCommandServiceTest.kt
@@ -1,0 +1,104 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.NotificationFixture
+import com.moongchijang.support.UserFixture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class NotificationCommandServiceTest {
+
+    @Mock
+    private lateinit var notificationRepository: NotificationRepository
+
+    private val service by lazy { NotificationCommandService(notificationRepository) }
+
+    @Test
+    fun `같은 알림을 반복 읽음 처리할 때 멱등 동작 보장`() {
+        val user = UserFixture.createEmailUser(id = 1L)
+        val unread = NotificationFixture.createNotification(
+            user = user,
+            id = 101L,
+            isRead = false,
+            occurredAt = LocalDateTime.now().minusMinutes(10)
+        )
+        val alreadyRead = NotificationFixture.createNotification(
+            user = user,
+            id = 102L,
+            isRead = true,
+            occurredAt = LocalDateTime.now().minusMinutes(5)
+        )
+
+        `when`(notificationRepository.findById(101L)).thenReturn(Optional.of(unread))
+        `when`(notificationRepository.findById(102L)).thenReturn(Optional.of(alreadyRead))
+
+        assertDoesNotThrow { service.markAsRead(userId = 1L, notificationId = 101L) }
+        assertDoesNotThrow { service.markAsRead(userId = 1L, notificationId = 102L) }
+
+        assertThat(unread.isRead).isTrue()
+        assertThat(alreadyRead.isRead).isTrue()
+    }
+
+    @Test
+    fun `다른 사용자 알림을 읽음 처리할 때 권한 예외 반환`() {
+        val owner = UserFixture.createEmailUser(id = 2L)
+        val notification = NotificationFixture.createNotification(
+            user = owner,
+            id = 201L,
+            occurredAt = LocalDateTime.now()
+        )
+        `when`(notificationRepository.findById(201L)).thenReturn(Optional.of(notification))
+
+        val exception = assertThrows(CustomException::class.java) {
+            service.markAsRead(userId = 999L, notificationId = 201L)
+        }
+
+        assertEquals(ErrorCode.NOTIFICATION_FORBIDDEN, exception.errorCode)
+    }
+
+    @Test
+    fun `존재하지 않는 알림을 읽음 처리할 때 대상 없음 예외 반환`() {
+        `when`(notificationRepository.findById(301L)).thenReturn(Optional.empty())
+
+        val exception = assertThrows(CustomException::class.java) {
+            service.markAsRead(userId = 3L, notificationId = 301L)
+        }
+
+        assertEquals(ErrorCode.NOTIFICATION_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
+    fun `전체 읽음 처리를 반복 호출할 때 멱등 동작 보장`() {
+        `when`(notificationRepository.markAllAsReadByUserId(4L)).thenReturn(5, 0)
+
+        val firstUpdated = service.markAllAsRead(4L)
+        val secondUpdated = service.markAllAsRead(4L)
+
+        assertEquals(5, firstUpdated)
+        assertEquals(0, secondUpdated)
+    }
+
+    @Test
+    fun `미읽음 개수를 조회할 때 count 반환`() {
+        `when`(notificationRepository.countUnreadByUserId(5L)).thenReturn(7L)
+
+        val response = service.getUnreadCount(5L)
+
+        assertEquals(7L, response.count)
+        verify(notificationRepository, never()).markAllAsReadByUserId(5L)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.data.domain.PageRequest
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 @ExtendWith(MockitoExtension::class)
 class NotificationQueryServiceTest {
@@ -122,10 +123,22 @@ class NotificationQueryServiceTest {
     @Test
     fun `알림 목록을 조회할 때 TODAY YESTERDAY OLDER 섹션 분류 반환`() {
         val user = UserFixture.createEmailUser(id = 4L)
-        val now = LocalDateTime.now().withNano(0)
-        val today = NotificationFixture.createNotification(user = user, id = 41L, occurredAt = now)
-        val yesterday = NotificationFixture.createNotification(user = user, id = 40L, occurredAt = now.minusDays(1))
-        val older = NotificationFixture.createNotification(user = user, id = 39L, occurredAt = now.minusDays(3))
+        val kstToday = LocalDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDate()
+        val today = NotificationFixture.createNotification(
+            user = user,
+            id = 41L,
+            occurredAt = kstToday.atTime(10, 0)
+        )
+        val yesterday = NotificationFixture.createNotification(
+            user = user,
+            id = 40L,
+            occurredAt = kstToday.minusDays(1).atTime(10, 0)
+        )
+        val older = NotificationFixture.createNotification(
+            user = user,
+            id = 39L,
+            occurredAt = kstToday.minusDays(3).atTime(10, 0)
+        )
 
         `when`(
             notificationRepository.findForList(

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -25,7 +25,7 @@ class NotificationQueryServiceTest {
     private val service by lazy { NotificationQueryService(notificationRepository) }
 
     @Test
-    fun `카테고리 ALL 조회 시 type 필터 없음`() {
+    fun `카테고리 ALL로 조회할 때 type 필터 없는 목록 반환`() {
         val user = UserFixture.createEmailUser(id = 1L)
         val occurredAt = LocalDateTime.now().minusHours(1).withNano(0)
         val notifications = listOf(
@@ -61,7 +61,7 @@ class NotificationQueryServiceTest {
     }
 
     @Test
-    fun `카테고리 APPLY 조회 시 APPLY type 필터 적용`() {
+    fun `카테고리 APPLY로 조회할 때 APPLY type 필터 적용 검증`() {
         `when`(
             notificationRepository.findForList(
                 userId = 2L,
@@ -89,7 +89,7 @@ class NotificationQueryServiceTest {
     }
 
     @Test
-    fun `커서 기반 조회 hasNext와 nextCursor 반환`() {
+    fun `커서 기반으로 조회할 때 hasNext와 nextCursor 반환`() {
         val user = UserFixture.createEmailUser(id = 3L)
         val now = LocalDateTime.now().withNano(0)
         val n1 = NotificationFixture.createNotification(user = user, id = 31L, occurredAt = now.minusMinutes(1))
@@ -120,7 +120,7 @@ class NotificationQueryServiceTest {
     }
 
     @Test
-    fun `section TODAY YESTERDAY OLDER 분류`() {
+    fun `알림 목록을 조회할 때 TODAY YESTERDAY OLDER 섹션 분류 반환`() {
         val user = UserFixture.createEmailUser(id = 4L)
         val now = LocalDateTime.now().withNano(0)
         val today = NotificationFixture.createNotification(user = user, id = 41L, occurredAt = now)
@@ -148,7 +148,7 @@ class NotificationQueryServiceTest {
     }
 
     @Test
-    fun `limit 범위 보정`() {
+    fun `limit 범위를 벗어나 조회할 때 최소 최대 보정 적용`() {
         `when`(
             notificationRepository.findForList(
                 userId = 5L,

--- a/src/test/kotlin/com/moongchijang/domain/notification/repository/NotificationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/repository/NotificationRepositoryIntegrationTest.kt
@@ -29,7 +29,7 @@ class NotificationRepositoryIntegrationTest {
     private lateinit var em: EntityManager
 
     @Test
-    fun `최신순 정렬 occurredAt desc id desc`() {
+    fun `알림 목록을 조회할 때 최신순 정렬 반환`() {
         val user = persistUser("repo-sort@test.com")
         val sameTime = LocalDateTime.of(2026, 5, 22, 9, 0, 0)
 
@@ -51,7 +51,7 @@ class NotificationRepositoryIntegrationTest {
     }
 
     @Test
-    fun `카테고리 type 필터 적용`() {
+    fun `카테고리 필터로 조회할 때 해당 type 알림만 반환`() {
         val user = persistUser("repo-filter@test.com")
         persistNotification(user = user, type = NotificationType.APPLY, occurredAt = LocalDateTime.now().minusMinutes(1))
         persistNotification(user = user, type = NotificationType.WISH, occurredAt = LocalDateTime.now().minusMinutes(2))
@@ -71,7 +71,7 @@ class NotificationRepositoryIntegrationTest {
     }
 
     @Test
-    fun `커서 이후 데이터 조회`() {
+    fun `커서 기반 조회를 할 때 커서 이후 데이터 반환`() {
         val user = persistUser("repo-cursor@test.com")
         val base = LocalDateTime.of(2026, 5, 22, 9, 0, 0)
 
@@ -93,6 +93,55 @@ class NotificationRepositoryIntegrationTest {
         assertThat(result.map { it.id }).containsExactly(sameTimeLowId.id, older.id)
     }
 
+    @Test
+    fun `미읽음 개수를 조회할 때 isRead false 알림 개수 반환`() {
+        val user = persistUser("repo-unread-count@test.com")
+        persistReadMixNotifications(user)
+
+        flushAndClear()
+
+        val unreadCount = notificationRepository.countUnreadByUserId(user.id!!)
+
+        assertThat(unreadCount).isEqualTo(2L)
+    }
+
+    @Test
+    fun `전체 읽음 처리를 할 때 미읽음 알림 일괄 업데이트`() {
+        val user = persistUser("repo-read-all@test.com")
+        persistReadMixNotifications(user)
+
+        flushAndClear()
+
+        val updatedCount = notificationRepository.markAllAsReadByUserId(user.id!!)
+        flushAndClear()
+        val unreadAfterUpdate = notificationRepository.countUnreadByUserId(user.id!!)
+
+        assertThat(updatedCount).isEqualTo(2)
+        assertThat(unreadAfterUpdate).isEqualTo(0L)
+    }
+
+    @Test
+    fun `대량 미읽음에 전체 읽음 처리를 할 때 모두 읽음 상태로 변경`() {
+        val user = persistUser("repo-read-all-bulk@test.com")
+        repeat(BULK_NOTIFICATION_COUNT) { index ->
+            persistNotification(
+                user = user,
+                type = NotificationType.PICKUP,
+                occurredAt = LocalDateTime.now().minusSeconds(index.toLong()),
+                isRead = false
+            )
+        }
+
+        flushAndClear()
+
+        val updatedCount = notificationRepository.markAllAsReadByUserId(user.id!!)
+        flushAndClear()
+        val unreadAfterUpdate = notificationRepository.countUnreadByUserId(user.id!!)
+
+        assertThat(updatedCount).isEqualTo(BULK_NOTIFICATION_COUNT)
+        assertThat(unreadAfterUpdate).isZero()
+    }
+
     private fun persistUser(email: String): User {
         val user = User(
             provider = AuthProvider.EMAIL,
@@ -109,14 +158,15 @@ class NotificationRepositoryIntegrationTest {
     private fun persistNotification(
         user: User,
         type: NotificationType,
-        occurredAt: LocalDateTime
+        occurredAt: LocalDateTime,
+        isRead: Boolean = false
     ): Notification {
         val notification = Notification(
             user = user,
             type = type,
             title = "알림",
             body = "본문",
-            isRead = false,
+            isRead = isRead,
             occurredAt = occurredAt,
             targetId = 100L,
             deeplinkType = NotificationDeeplinkType.PICKUP_GUIDE
@@ -125,8 +175,18 @@ class NotificationRepositoryIntegrationTest {
         return notification
     }
 
+    private fun persistReadMixNotifications(user: User) {
+        persistNotification(user = user, type = NotificationType.PICKUP, occurredAt = LocalDateTime.now(), isRead = false)
+        persistNotification(user = user, type = NotificationType.WISH, occurredAt = LocalDateTime.now().minusMinutes(1), isRead = false)
+        persistNotification(user = user, type = NotificationType.APPLY, occurredAt = LocalDateTime.now().minusMinutes(2), isRead = true)
+    }
+
     private fun flushAndClear() {
         em.flush()
         em.clear()
+    }
+
+    companion object {
+        private const val BULK_NOTIFICATION_COUNT = 300
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 알림 읽음 처리 기능을 구현했습니다.
  - `PATCH /api/v1/notifications/{notificationId}/read` 단건 읽음 처리 API를 추가했습니다.
  - `PATCH /api/v1/notifications/read-all` 전체 읽음 처리 API를 추가했습니다.
  - `GET /api/v1/notifications/unread-count` 미읽음 개수 조회 API를 추가했습니다.
- 읽음 처리 서비스 로직을 추가했습니다.
  - 단건 읽음은 엔티티 기반(`Notification.markAsRead()`)으로 처리했습니다.
  - 전체 읽음은 벌크 업데이트 쿼리로 처리했습니다.
  - 미읽음 개수 집계 응답 DTO(`NotificationUnreadCountResponse`)를 추가했습니다.
- 리포지토리 쿼리를 확장했습니다.
  - 사용자 기준 전체 읽음 처리 쿼리
  - 사용자 기준 미읽음 개수 조회 쿼리
- 테스트를 추가/보강했습니다.
  - 서비스 테스트: 단건 멱등성, 권한 검증, 대상 없음 예외, 전체 읽음 멱등성, 미읽음 개수 반환
  - 리포지토리 통합 테스트: 미읽음 count, 전체 읽음 업데이트, 대량(300건) 일괄 읽음 처리

## 🔍 참고 사항
- 단건 읽음 처리는 엔티티 메서드 호출 방식으로 구현했고, 전체 읽음 처리는 벌크 쿼리로 분리해 성능/멱등성을 확보했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #145 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인