### PR TITLE
[MCJ-1494] FEAT: 알림 발송 트리거(즉시/스케줄) 구축 및 중복 방지, 재시도 체계 도입

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteNotificationTargetProjection.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteNotificationTargetProjection.kt
@@ -1,0 +1,6 @@
+package com.moongchijang.domain.favorite.domain.repository
+
+interface FavoriteNotificationTargetProjection {
+    val groupBuyId: Long
+    val userId: Long
+}

--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
@@ -45,4 +45,21 @@ interface FavoriteRepository : JpaRepository<Favorite, Long>, FavoriteRepository
     fun findUserIdsByGroupBuyIdExcludingParticipants(
         @Param("groupBuyId") groupBuyId: Long
     ): List<Long>
+
+    @Query(
+        """
+        SELECT f.groupBuy.id AS groupBuyId, f.user.id AS userId
+        FROM Favorite f
+        WHERE f.groupBuy.id IN :groupBuyIds
+          AND NOT EXISTS (
+              SELECT p.id
+              FROM Participation p
+              WHERE p.user.id = f.user.id
+                AND p.groupBuy.id = f.groupBuy.id
+          )
+        """
+    )
+    fun findNotificationTargetsByGroupBuyIdsExcludingParticipants(
+        @Param("groupBuyIds") groupBuyIds: Collection<Long>
+    ): List<FavoriteNotificationTargetProjection>
 }

--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
@@ -28,4 +28,21 @@ interface FavoriteRepository : JpaRepository<Favorite, Long>, FavoriteRepository
         @Param("now") now: LocalDateTime,
         @Param("deadlineTo") deadlineTo: LocalDateTime,
     ): Long
+
+    @Query(
+        """
+        SELECT DISTINCT f.user.id
+        FROM Favorite f
+        WHERE f.groupBuy.id = :groupBuyId
+          AND NOT EXISTS (
+              SELECT p.id
+              FROM Participation p
+              WHERE p.user.id = f.user.id
+                AND p.groupBuy.id = :groupBuyId
+          )
+        """
+    )
+    fun findUserIdsByGroupBuyIdExcludingParticipants(
+        @Param("groupBuyId") groupBuyId: Long
+    ): List<Long>
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -8,6 +8,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
 import com.moongchijang.domain.groupbuy.domain.entity.NotificationStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoAlimtalkClient
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
@@ -34,6 +35,7 @@ class GroupBuyOpenRequestService(
     private val groupBuyRepository: GroupBuyRepository,
     private val userRepository: UserRepository,
     private val aligoAlimtalkClient: AligoAlimtalkClient,
+    private val notificationEventPublisher: NotificationEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -70,10 +72,18 @@ class GroupBuyOpenRequestService(
     }
 
     fun notifyOpened(groupBuy: GroupBuy): GroupBuyOpenNotificationResult {
-        return notifyOpened(
+        val result = notifyOpened(
             regions = notificationRegionCodes(groupBuy.store),
             productName = groupBuy.productName,
         )
+        if (result.targetUserIds.isNotEmpty()) {
+            notificationEventPublisher.publishRequestOpened(
+                targetGroupBuyId = groupBuy.id,
+                requesterUserIds = result.targetUserIds,
+                occurredAt = java.time.LocalDateTime.now()
+            )
+        }
+        return result
     }
 
     fun notifyOpened(region: String, productName: String): GroupBuyOpenNotificationResult {
@@ -97,6 +107,7 @@ class GroupBuyOpenRequestService(
         val usersById = userRepository.findByIdInAndDeletedAtIsNull(requestsByUserId.keys)
             .associateBy { it.id }
 
+        val targetUserIds = requestsByUserId.keys.toList()
         var sentCount = 0
         var failedCount = 0
 
@@ -123,6 +134,7 @@ class GroupBuyOpenRequestService(
             targetCount = requestsByUserId.size,
             sentCount = sentCount,
             failedCount = failedCount,
+            targetUserIds = targetUserIds
         )
     }
 
@@ -377,4 +389,5 @@ data class GroupBuyOpenNotificationResult(
     val targetCount: Int,
     val sentCount: Int,
     val failedCount: Int,
+    val targetUserIds: List<Long> = emptyList(),
 )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
@@ -1,0 +1,51 @@
+package com.moongchijang.domain.groupbuy.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class GroupBuyRequestStatusCommandService(
+    private val groupBuyRequestRepository: GroupBuyRequestRepository,
+    private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository,
+    private val notificationEventPublisher: NotificationEventPublisher,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun rejectRequest(
+        requestId: Long,
+        reason: String?,
+        changedAt: LocalDateTime = LocalDateTime.now()
+    ) {
+        val request = groupBuyRequestRepository.findById(requestId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
+
+        request.markRejected(reason)
+        groupBuyRequestStatusHistoryRepository.save(
+            GroupBuyRequestStatusHistory(
+                groupBuyRequestId = request.id,
+                status = GroupBuyRequestStatus.REJECTED,
+                changedAt = changedAt
+            )
+        )
+
+        notificationEventPublisher.publishRequestRejected(
+            requestId = request.id,
+            requesterUserId = request.userId,
+            occurredAt = changedAt
+        )
+        log.info(
+            "[GroupBuyRequestStatusCommandService] 요청공구 거절 처리 및 알림 트리거 발행: requestId={}, requesterUserId={}",
+            requestId, request.userId
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
@@ -1,8 +1,12 @@
 package com.moongchijang.domain.groupbuy.application
 
+import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.slf4j.LoggerFactory
@@ -15,6 +19,8 @@ import java.time.LocalDateTime
 @Service
 class GroupBuyStatusTransitionService(
     private val groupBuyRepository: GroupBuyRepository,
+    private val participationRepository: ParticipationRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher,
     private val transactionManager: PlatformTransactionManager,
     @Value("\${groupbuy.status-transition.batch-size:500}")
     private val batchSize: Int
@@ -75,6 +81,7 @@ class GroupBuyStatusTransitionService(
             when (groupBuy.status) {
                 GroupBuyStatus.IN_PROGRESS -> {
                     groupBuy.transitionToFailedByDeadline(now)
+                    publishApplyGroupBuyFailedEvent(groupBuy.id, now)
                     inProgressToFailed++
                 }
                 GroupBuyStatus.ACHIEVED -> {
@@ -96,6 +103,21 @@ class GroupBuyStatusTransitionService(
         TransactionTemplate(transactionManager).apply {
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
         }
+
+    private fun publishApplyGroupBuyFailedEvent(groupBuyId: Long, occurredAt: LocalDateTime) {
+        val participantUserIds = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuyId)
+        if (participantUserIds.isEmpty()) return
+
+        applicationEventPublisher.publishEvent(
+            NotificationImmediateTriggerEvent(
+                triggerType = NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE,
+                targetId = groupBuyId,
+                userIds = participantUserIds,
+                scheduleKey = "groupbuy-failed:$groupBuyId",
+                occurredAt = occurredAt
+            )
+        )
+    }
 
     private data class BatchTransitionResult(
         val total: Int,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
@@ -1,12 +1,10 @@
 package com.moongchijang.domain.groupbuy.application
 
-import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
-import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.slf4j.LoggerFactory
@@ -20,7 +18,7 @@ import java.time.LocalDateTime
 class GroupBuyStatusTransitionService(
     private val groupBuyRepository: GroupBuyRepository,
     private val participationRepository: ParticipationRepository,
-    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val notificationEventPublisher: NotificationEventPublisher,
     private val transactionManager: PlatformTransactionManager,
     @Value("\${groupbuy.status-transition.batch-size:500}")
     private val batchSize: Int
@@ -108,14 +106,10 @@ class GroupBuyStatusTransitionService(
         val participantUserIds = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuyId)
         if (participantUserIds.isEmpty()) return
 
-        applicationEventPublisher.publishEvent(
-            NotificationImmediateTriggerEvent(
-                triggerType = NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE,
-                targetId = groupBuyId,
-                userIds = participantUserIds,
-                scheduleKey = "groupbuy-failed:$groupBuyId",
-                occurredAt = occurredAt
-            )
+        notificationEventPublisher.publishApplyGroupBuyFailed(
+            groupBuyId = groupBuyId,
+            participantUserIds = participantUserIds,
+            occurredAt = occurredAt
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequest.kt
@@ -63,4 +63,9 @@ class GroupBuyRequest(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 
-) : BaseEntity()
+) : BaseEntity() {
+    fun markRejected(reason: String?) {
+        status = GroupBuyRequestStatus.REJECTED
+        rejectionReason = reason?.ifBlank { null }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -21,6 +21,12 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
         pageable: Pageable
     ): List<GroupBuy>
 
+    fun findByStatusInAndDeadlineBetween(
+        statuses: Collection<GroupBuyStatus>,
+        deadlineFrom: LocalDateTime,
+        deadlineTo: LocalDateTime
+    ): List<GroupBuy>
+
     @EntityGraph(attributePaths = ["store"])
     fun findWithStoreById(id: Long): Optional<GroupBuy>
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -1,8 +1,15 @@
 package com.moongchijang.domain.groupbuy.domain.repository
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
 
 interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
     fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<GroupBuyRequest>
+
+    fun findByStatusInAndDesiredPickupDate(
+        statuses: Collection<GroupBuyRequestStatus>,
+        desiredPickupDate: LocalDate
+    ): List<GroupBuyRequest>
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
@@ -1,0 +1,88 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class NotificationEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher
+) {
+
+    fun publishApplyPaymentSuccess(
+        groupBuyId: Long,
+        orderId: String,
+        userId: Long,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+            targetId = groupBuyId,
+            userIds = listOf(userId),
+            scheduleKey = "payment-success:$orderId",
+            occurredAt = occurredAt
+        )
+    }
+
+    fun publishApplyGroupBuyAchieved(
+        groupBuyId: Long,
+        participantUserIds: List<Long>,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.APPLY_GROUPBUY_ACHIEVED_IMMEDIATE,
+            targetId = groupBuyId,
+            userIds = participantUserIds,
+            scheduleKey = "groupbuy-achieved:$groupBuyId",
+            occurredAt = occurredAt
+        )
+    }
+
+    fun publishWishTargetAchieved(
+        groupBuyId: Long,
+        userIds: List<Long>,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE,
+            targetId = groupBuyId,
+            userIds = userIds,
+            scheduleKey = "wish-target-achieved:$groupBuyId",
+            occurredAt = occurredAt
+        )
+    }
+
+    fun publishApplyGroupBuyFailed(
+        groupBuyId: Long,
+        participantUserIds: List<Long>,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE,
+            targetId = groupBuyId,
+            userIds = participantUserIds,
+            scheduleKey = "groupbuy-failed:$groupBuyId",
+            occurredAt = occurredAt
+        )
+    }
+
+    private fun publish(
+        triggerType: NotificationTriggerType,
+        targetId: Long,
+        userIds: List<Long>,
+        scheduleKey: String,
+        occurredAt: LocalDateTime
+    ) {
+        applicationEventPublisher.publishEvent(
+            NotificationImmediateTriggerEvent(
+                triggerType = triggerType,
+                targetId = targetId,
+                userIds = userIds,
+                scheduleKey = scheduleKey,
+                occurredAt = occurredAt
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
@@ -111,6 +111,35 @@ class NotificationEventPublisher(
         )
     }
 
+    fun publishPickupCompleted(
+        groupBuyId: Long,
+        userId: Long,
+        participationId: Long,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.PICKUP_COMPLETED_IMMEDIATE,
+            targetId = groupBuyId,
+            userIds = listOf(userId),
+            scheduleKey = "pickup-completed:$groupBuyId:$participationId",
+            occurredAt = occurredAt
+        )
+    }
+
+    fun publishRequestRejected(
+        requestId: Long,
+        requesterUserId: Long,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
+            targetId = requestId,
+            userIds = listOf(requesterUserId),
+            scheduleKey = "request-rejected:$requestId",
+            occurredAt = occurredAt
+        )
+    }
+
     fun publishScheduledTrigger(
         triggerType: NotificationTriggerType,
         targetId: Long,

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
@@ -68,6 +68,22 @@ class NotificationEventPublisher(
         )
     }
 
+    fun publishScheduledTrigger(
+        triggerType: NotificationTriggerType,
+        targetId: Long,
+        userIds: List<Long>,
+        scheduleKey: String,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = triggerType,
+            targetId = targetId,
+            userIds = userIds,
+            scheduleKey = scheduleKey,
+            occurredAt = occurredAt
+        )
+    }
+
     private fun publish(
         triggerType: NotificationTriggerType,
         targetId: Long,

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
@@ -68,6 +68,49 @@ class NotificationEventPublisher(
         )
     }
 
+    fun publishRequestOpened(
+        targetGroupBuyId: Long,
+        requesterUserIds: List<Long>,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.REQUEST_OPENED_IMMEDIATE,
+            targetId = targetGroupBuyId,
+            userIds = requesterUserIds,
+            scheduleKey = "request-opened:$targetGroupBuyId",
+            occurredAt = occurredAt
+        )
+    }
+
+    fun publishRequestNewParticipant(
+        targetGroupBuyId: Long,
+        requesterUserId: Long,
+        participationId: Long,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.REQUEST_NEW_PARTICIPANT_IMMEDIATE,
+            targetId = targetGroupBuyId,
+            userIds = listOf(requesterUserId),
+            scheduleKey = "request-new-participant:$targetGroupBuyId:$participationId",
+            occurredAt = occurredAt
+        )
+    }
+
+    fun publishRequestTargetAchieved(
+        targetGroupBuyId: Long,
+        requesterUserId: Long,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.REQUEST_TARGET_ACHIEVED_IMMEDIATE,
+            targetId = targetGroupBuyId,
+            userIds = listOf(requesterUserId),
+            scheduleKey = "request-target-achieved:$targetGroupBuyId",
+            occurredAt = occurredAt
+        )
+    }
+
     fun publishScheduledTrigger(
         triggerType: NotificationTriggerType,
         targetId: Long,

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -88,57 +88,45 @@ class NotificationImmediateDispatchService(
     }
 
     private fun toNotificationMeta(triggerType: NotificationTriggerType): NotificationMeta {
+        val notificationType = toNotificationType(triggerType)
+        return NotificationMeta(
+            type = notificationType,
+            // TODO: 상세 템플릿/문구는 정해진 이후 수정 예정
+            title = "알림",
+            body = "새 알림이 도착했습니다.",
+            deeplinkType = defaultDeeplinkType(notificationType)
+        )
+    }
+
+    private fun toNotificationType(triggerType: NotificationTriggerType): NotificationType {
         return when (triggerType) {
-            NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE -> NotificationMeta(
-                type = NotificationType.WISH,
-                title = "찜한 공구가 달성됐어요",
-                body = "공구가 목표 인원을 달성했습니다.",
-                deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL
-            )
-            NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE -> NotificationMeta(
-                type = NotificationType.APPLY,
-                title = "공구 참여가 완료됐어요",
-                body = "결제가 성공적으로 완료되었습니다.",
-                deeplinkType = NotificationDeeplinkType.MY_APPLYING
-            )
-            NotificationTriggerType.APPLY_GROUPBUY_ACHIEVED_IMMEDIATE -> NotificationMeta(
-                type = NotificationType.APPLY,
-                title = "참여한 공구가 달성됐어요",
-                body = "공구가 성공적으로 달성되었습니다.",
-                deeplinkType = NotificationDeeplinkType.MY_APPLYING
-            )
-            NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE -> NotificationMeta(
-                type = NotificationType.APPLY,
-                title = "참여한 공구가 미달성 마감됐어요",
-                body = "미달성으로 마감되어 환불이 진행될 예정입니다.",
-                deeplinkType = NotificationDeeplinkType.MY_APPLYING
-            )
             NotificationTriggerType.PICKUP_COMPLETED_IMMEDIATE,
             NotificationTriggerType.PICKUP_SAME_DAY_MORNING,
             NotificationTriggerType.PICKUP_DAY_BEFORE_MORNING,
-            NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF -> NotificationMeta(
-                type = NotificationType.PICKUP,
-                title = "픽업 알림",
-                body = "픽업 상태를 확인해주세요.",
-                deeplinkType = NotificationDeeplinkType.PICKUP_GUIDE
-            )
+            NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF -> NotificationType.PICKUP
+
             NotificationTriggerType.WISH_DEADLINE_MINUS_3_DAYS,
-            NotificationTriggerType.WISH_DEADLINE_MINUS_1_DAY -> NotificationMeta(
-                type = NotificationType.WISH,
-                title = "찜한 공구 알림",
-                body = "찜한 공구의 마감일이 다가오고 있어요.",
-                deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL
-            )
+            NotificationTriggerType.WISH_DEADLINE_MINUS_1_DAY,
+            NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE -> NotificationType.WISH
+
+            NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+            NotificationTriggerType.APPLY_GROUPBUY_ACHIEVED_IMMEDIATE,
+            NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE -> NotificationType.APPLY
+
             NotificationTriggerType.REQUEST_OPENED_IMMEDIATE,
             NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
             NotificationTriggerType.REQUEST_NEW_PARTICIPANT_IMMEDIATE,
             NotificationTriggerType.REQUEST_TARGET_ACHIEVED_IMMEDIATE,
-            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> NotificationMeta(
-                type = NotificationType.REQUEST,
-                title = "요청 공구 알림",
-                body = "요청 공구 상태를 확인해주세요.",
-                deeplinkType = NotificationDeeplinkType.REQUEST_STATUS
-            )
+            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> NotificationType.REQUEST
+        }
+    }
+
+    private fun defaultDeeplinkType(notificationType: NotificationType): NotificationDeeplinkType {
+        return when (notificationType) {
+            NotificationType.PICKUP -> NotificationDeeplinkType.PICKUP_GUIDE
+            NotificationType.WISH -> NotificationDeeplinkType.GROUPBUY_DETAIL
+            NotificationType.APPLY -> NotificationDeeplinkType.MY_APPLYING
+            NotificationType.REQUEST -> NotificationDeeplinkType.REQUEST_STATUS
         }
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -1,0 +1,151 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import com.moongchijang.domain.notification.domain.entity.Notification
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.notification.domain.entity.NotificationType
+import com.moongchijang.domain.notification.domain.repository.NotificationDispatchHistoryRepository
+import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class NotificationImmediateDispatchService(
+    private val notificationRepository: NotificationRepository,
+    private val notificationDispatchHistoryRepository: NotificationDispatchHistoryRepository,
+    private val userRepository: UserRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun dispatch(event: NotificationImmediateTriggerEvent) {
+        val dedupedUserIds = event.userIds.distinct()
+        if (dedupedUserIds.isEmpty()) {
+            return
+        }
+
+        dedupedUserIds.forEach { userId ->
+            val exists = notificationDispatchHistoryRepository.findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
+                userId = userId,
+                triggerType = event.triggerType,
+                targetId = event.targetId,
+                scheduleKey = event.scheduleKey
+            ).isPresent
+            if (exists) {
+                log.info(
+                    "[NotificationImmediateDispatchService] 즉시 발송 중복 스킵: userId={}, triggerType={}, targetId={}, scheduleKey={}",
+                    userId, event.triggerType, event.targetId, event.scheduleKey
+                )
+                return@forEach
+            }
+
+            val history = notificationDispatchHistoryRepository.save(
+                NotificationDispatchHistory(
+                    userId = userId,
+                    triggerType = event.triggerType,
+                    targetId = event.targetId,
+                    scheduleKey = event.scheduleKey,
+                    status = NotificationDispatchStatus.PENDING
+                )
+            )
+
+            try {
+                val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                if (user == null) {
+                    history.markFailed(errorMessage = "USER_NOT_FOUND", nextRetryAt = null)
+                    return@forEach
+                }
+
+                val meta = toNotificationMeta(event.triggerType)
+                notificationRepository.save(
+                    Notification(
+                        user = user,
+                        type = meta.type,
+                        title = meta.title,
+                        body = meta.body,
+                        occurredAt = event.occurredAt,
+                        targetId = event.targetId,
+                        deeplinkType = meta.deeplinkType
+                    )
+                )
+                history.markSuccess(event.occurredAt)
+            } catch (e: Exception) {
+                history.markFailed(
+                    errorMessage = e.message ?: "UNKNOWN_ERROR",
+                    nextRetryAt = null
+                )
+                log.error(
+                    "[NotificationImmediateDispatchService] 즉시 발송 실패: userId={}, triggerType={}, targetId={}, scheduleKey={}",
+                    userId, event.triggerType, event.targetId, event.scheduleKey, e
+                )
+            }
+        }
+    }
+
+    private fun toNotificationMeta(triggerType: NotificationTriggerType): NotificationMeta {
+        return when (triggerType) {
+            NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE -> NotificationMeta(
+                type = NotificationType.WISH,
+                title = "찜한 공구가 달성됐어요",
+                body = "공구가 목표 인원을 달성했습니다.",
+                deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL
+            )
+            NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE -> NotificationMeta(
+                type = NotificationType.APPLY,
+                title = "공구 참여가 완료됐어요",
+                body = "결제가 성공적으로 완료되었습니다.",
+                deeplinkType = NotificationDeeplinkType.MY_APPLYING
+            )
+            NotificationTriggerType.APPLY_GROUPBUY_ACHIEVED_IMMEDIATE -> NotificationMeta(
+                type = NotificationType.APPLY,
+                title = "참여한 공구가 달성됐어요",
+                body = "공구가 성공적으로 달성되었습니다.",
+                deeplinkType = NotificationDeeplinkType.MY_APPLYING
+            )
+            NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE -> NotificationMeta(
+                type = NotificationType.APPLY,
+                title = "참여한 공구가 미달성 마감됐어요",
+                body = "미달성으로 마감되어 환불이 진행될 예정입니다.",
+                deeplinkType = NotificationDeeplinkType.MY_APPLYING
+            )
+            NotificationTriggerType.PICKUP_COMPLETED_IMMEDIATE,
+            NotificationTriggerType.PICKUP_SAME_DAY_MORNING,
+            NotificationTriggerType.PICKUP_DAY_BEFORE_MORNING,
+            NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF -> NotificationMeta(
+                type = NotificationType.PICKUP,
+                title = "픽업 알림",
+                body = "픽업 상태를 확인해주세요.",
+                deeplinkType = NotificationDeeplinkType.PICKUP_GUIDE
+            )
+            NotificationTriggerType.WISH_DEADLINE_MINUS_3_DAYS,
+            NotificationTriggerType.WISH_DEADLINE_MINUS_1_DAY -> NotificationMeta(
+                type = NotificationType.WISH,
+                title = "찜한 공구 알림",
+                body = "찜한 공구의 마감일이 다가오고 있어요.",
+                deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL
+            )
+            NotificationTriggerType.REQUEST_OPENED_IMMEDIATE,
+            NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
+            NotificationTriggerType.REQUEST_NEW_PARTICIPANT_IMMEDIATE,
+            NotificationTriggerType.REQUEST_TARGET_ACHIEVED_IMMEDIATE,
+            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> NotificationMeta(
+                type = NotificationType.REQUEST,
+                title = "요청 공구 알림",
+                body = "요청 공구 상태를 확인해주세요.",
+                deeplinkType = NotificationDeeplinkType.REQUEST_STATUS
+            )
+        }
+    }
+
+    private data class NotificationMeta(
+        val type: NotificationType,
+        val title: String,
+        val body: String,
+        val deeplinkType: NotificationDeeplinkType,
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -72,11 +72,10 @@ class NotificationImmediateDispatchService(
         }
 
         targets.forEach { history ->
-            val targetId = history.targetId ?: return@forEach
             dispatchSingle(
                 event = NotificationImmediateTriggerEvent(
                     triggerType = history.triggerType,
-                    targetId = targetId,
+                    targetId = history.targetId,
                     userIds = listOf(history.userId),
                     scheduleKey = history.scheduleKey,
                     occurredAt = now

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Service
 class NotificationImmediateDispatchService(
@@ -22,6 +23,7 @@ class NotificationImmediateDispatchService(
     private val userRepository: UserRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
+    private val zoneId: ZoneId = ZoneId.of("Asia/Seoul")
 
     @Transactional
     fun dispatch(event: NotificationImmediateTriggerEvent) {
@@ -136,7 +138,7 @@ class NotificationImmediateDispatchService(
     )
 
     private fun calculateNextRetryAt(retryCount: Int): LocalDateTime? {
-        val now = LocalDateTime.now()
+        val now = LocalDateTime.now(zoneId)
         return when {
             retryCount <= 1 -> now.plusMinutes(1)
             retryCount == 2 -> now.plusMinutes(5)

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -13,6 +13,7 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class NotificationImmediateDispatchService(
@@ -30,16 +31,16 @@ class NotificationImmediateDispatchService(
         }
 
         dedupedUserIds.forEach { userId ->
-            val exists = notificationDispatchHistoryRepository.findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
+            val existingHistory = notificationDispatchHistoryRepository.findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
                 userId = userId,
                 triggerType = event.triggerType,
                 targetId = event.targetId,
                 scheduleKey = event.scheduleKey
-            ).isPresent
-            if (exists) {
+            ).orElse(null)
+            if (existingHistory != null) {
                 log.info(
-                    "[NotificationImmediateDispatchService] 즉시 발송 중복 스킵: userId={}, triggerType={}, targetId={}, scheduleKey={}",
-                    userId, event.triggerType, event.targetId, event.scheduleKey
+                    "[NotificationImmediateDispatchService] 즉시 발송 중복 스킵: userId={}, triggerType={}, targetId={}, scheduleKey={}, retryCount={}",
+                    userId, event.triggerType, event.targetId, event.scheduleKey, existingHistory.retryCount
                 )
                 return@forEach
             }
@@ -54,36 +55,33 @@ class NotificationImmediateDispatchService(
                 )
             )
 
-            try {
-                val user = userRepository.findByIdAndDeletedAtIsNull(userId)
-                if (user == null) {
-                    history.markFailed(errorMessage = "USER_NOT_FOUND", nextRetryAt = null)
-                    return@forEach
-                }
+            dispatchSingle(event, userId, history)
+        }
+    }
 
-                val meta = toNotificationMeta(event.triggerType)
-                notificationRepository.save(
-                    Notification(
-                        user = user,
-                        type = meta.type,
-                        title = meta.title,
-                        body = meta.body,
-                        occurredAt = event.occurredAt,
-                        targetId = event.targetId,
-                        deeplinkType = meta.deeplinkType
-                    )
-                )
-                history.markSuccess(event.occurredAt)
-            } catch (e: Exception) {
-                history.markFailed(
-                    errorMessage = e.message ?: "UNKNOWN_ERROR",
-                    nextRetryAt = null
-                )
-                log.error(
-                    "[NotificationImmediateDispatchService] 즉시 발송 실패: userId={}, triggerType={}, targetId={}, scheduleKey={}",
-                    userId, event.triggerType, event.targetId, event.scheduleKey, e
-                )
-            }
+    @Transactional
+    fun retryFailedDispatches(now: LocalDateTime) {
+        val targets = notificationDispatchHistoryRepository.findByStatusInAndNextRetryAtLessThanEqual(
+            statuses = listOf(NotificationDispatchStatus.FAILED),
+            nextRetryAt = now
+        )
+        if (targets.isEmpty()) {
+            return
+        }
+
+        targets.forEach { history ->
+            val targetId = history.targetId ?: return@forEach
+            dispatchSingle(
+                event = NotificationImmediateTriggerEvent(
+                    triggerType = history.triggerType,
+                    targetId = targetId,
+                    userIds = listOf(history.userId),
+                    scheduleKey = history.scheduleKey,
+                    occurredAt = now
+                ),
+                userId = history.userId,
+                history = history
+            )
         }
     }
 
@@ -136,4 +134,62 @@ class NotificationImmediateDispatchService(
         val body: String,
         val deeplinkType: NotificationDeeplinkType,
     )
+
+    private fun calculateNextRetryAt(retryCount: Int): LocalDateTime? {
+        val now = LocalDateTime.now()
+        return when {
+            retryCount <= 1 -> now.plusMinutes(1)
+            retryCount == 2 -> now.plusMinutes(5)
+            retryCount == 3 -> now.plusMinutes(30)
+            else -> null
+        }
+    }
+
+    private fun dispatchSingle(
+        event: NotificationImmediateTriggerEvent,
+        userId: Long,
+        history: NotificationDispatchHistory
+    ) {
+        try {
+            val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            if (user == null) {
+                history.markFailed(
+                    errorMessage = "USER_NOT_FOUND",
+                    nextRetryAt = calculateNextRetryAt(history.retryCount)
+                )
+                log.warn(
+                    "[NotificationImmediateDispatchService] 즉시 발송 실패(USER_NOT_FOUND): userId={}, triggerType={}, targetId={}, scheduleKey={}, retryCount={}, nextRetryAt={}",
+                    userId, event.triggerType, event.targetId, event.scheduleKey, history.retryCount, history.nextRetryAt
+                )
+                return
+            }
+
+            val meta = toNotificationMeta(event.triggerType)
+            notificationRepository.save(
+                Notification(
+                    user = user,
+                    type = meta.type,
+                    title = meta.title,
+                    body = meta.body,
+                    occurredAt = event.occurredAt,
+                    targetId = event.targetId,
+                    deeplinkType = meta.deeplinkType
+                )
+            )
+            history.markSuccess(event.occurredAt)
+            log.info(
+                "[NotificationImmediateDispatchService] 즉시 발송 성공: userId={}, triggerType={}, targetId={}, scheduleKey={}, retryCount={}",
+                userId, event.triggerType, event.targetId, event.scheduleKey, history.retryCount
+            )
+        } catch (e: Exception) {
+            history.markFailed(
+                errorMessage = e.message ?: "UNKNOWN_ERROR",
+                nextRetryAt = calculateNextRetryAt(history.retryCount)
+            )
+            log.error(
+                "[NotificationImmediateDispatchService] 즉시 발송 실패: userId={}, triggerType={}, targetId={}, scheduleKey={}, retryCount={}, nextRetryAt={}",
+                userId, event.triggerType, event.targetId, event.scheduleKey, history.retryCount, history.nextRetryAt, e
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateTriggerEventListener.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateTriggerEventListener.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationImmediateTriggerEventListener(
+    private val notificationImmediateDispatchService: NotificationImmediateDispatchService
+) {
+
+    @EventListener
+    fun on(event: NotificationImmediateTriggerEvent) {
+        notificationImmediateDispatchService.dispatch(event)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateTriggerEventListener.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateTriggerEventListener.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
 import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 
 @Component
@@ -9,6 +10,7 @@ class NotificationImmediateTriggerEventListener(
     private val notificationImmediateDispatchService: NotificationImmediateDispatchService
 ) {
 
+    @Async("notificationEventExecutor")
     @EventListener
     fun on(event: NotificationImmediateTriggerEvent) {
         notificationImmediateDispatchService.dispatch(event)

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -94,34 +94,30 @@ class NotificationTriggerScheduler(
     }
 
     fun triggerPickupIncompleteAfterCutoffNotificationAt(now: LocalDateTime) {
+        val pickupCutoffBaseAt = now.minusMinutes(30)
         val candidates = participationRepository.findForPickupCutoffCheck(
-            pickupDateFrom = now.toLocalDate().minusDays(1),
-            pickupDateTo = now.toLocalDate(),
+            pickupCutoffBaseAt = pickupCutoffBaseAt,
             participationStatuses = listOf(ParticipationStatus.CONFIRMED),
             pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
         )
 
-        var triggered = 0
         candidates.forEach { participation ->
             val cutoffAt = LocalDateTime.of(
                 participation.groupBuy.pickupDate,
                 participation.groupBuy.pickupTimeEnd
             ).plusMinutes(30)
-            if (now >= cutoffAt) {
-                notificationEventPublisher.publishScheduledTrigger(
-                    triggerType = NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF,
-                    targetId = participation.groupBuy.id,
-                    userIds = listOf(participation.user.id!!),
-                    scheduleKey = "pickup-cutoff:${participation.id}:${cutoffAt}",
-                    occurredAt = now
-                )
-                triggered += 1
-            }
+            notificationEventPublisher.publishScheduledTrigger(
+                triggerType = NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF,
+                targetId = participation.groupBuy.id,
+                userIds = listOf(participation.user.id!!),
+                scheduleKey = "pickup-cutoff:${participation.id}:${cutoffAt}",
+                occurredAt = now
+            )
         }
 
         log.info(
             "[NotificationTriggerScheduler] 픽업 미완료 컷오프 알림 트리거 완료: candidateCount={}, triggered={}",
-            candidates.size, triggered
+            candidates.size, candidates.size
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -171,8 +171,20 @@ class NotificationTriggerScheduler(
             deadlineTo = windowTo
         )
 
+        val groupBuyIds = groupBuys.map { it.id }
+        if (groupBuyIds.isEmpty()) {
+            log.info(
+                "[NotificationTriggerScheduler] 찜 마감 리마인드 알림 트리거 완료: triggerType={}, windowFrom={}, windowTo={}, groupBuyCount={}",
+                offset.triggerType, windowFrom, windowTo, groupBuys.size
+            )
+            return
+        }
+        val targetsByGroupBuyId = favoriteRepository
+            .findNotificationTargetsByGroupBuyIdsExcludingParticipants(groupBuyIds)
+            .groupBy(keySelector = { it.groupBuyId }, valueTransform = { it.userId })
+
         groupBuys.forEach { groupBuy ->
-            val userIds = favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(groupBuy.id)
+            val userIds = targetsByGroupBuyId[groupBuy.id].orEmpty().distinct()
             if (userIds.isEmpty()) return@forEach
 
             notificationEventPublisher.publishScheduledTrigger(

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -20,6 +20,7 @@ import java.time.ZoneId
 @Component
 class NotificationTriggerScheduler(
     private val notificationEventPublisher: NotificationEventPublisher,
+    private val notificationImmediateDispatchService: NotificationImmediateDispatchService,
     private val participationRepository: ParticipationRepository,
     private val groupBuyRepository: GroupBuyRepository,
     private val favoriteRepository: FavoriteRepository,
@@ -122,6 +123,13 @@ class NotificationTriggerScheduler(
             "[NotificationTriggerScheduler] 픽업 미완료 컷오프 알림 트리거 완료: candidateCount={}, triggered={}",
             candidates.size, triggered
         )
+    }
+
+    @Scheduled(cron = "0 */5 * * * *", zone = KST_ZONE_ID)
+    fun retryFailedImmediateDispatches() {
+        val now = nowKst()
+        notificationImmediateDispatchService.retryFailedDispatches(now)
+        log.info("[NotificationTriggerScheduler] 즉시 발송 실패 재처리 실행: now={}", now)
     }
 
     private fun dispatchPickupReminder(

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -29,7 +29,10 @@ class NotificationTriggerScheduler(
 
     @Scheduled(cron = "0 0 7 * * *", zone = KST_ZONE_ID)
     fun triggerPickupMorningNotifications() {
-        val now = nowKst()
+        triggerPickupMorningNotificationsAt(nowKst())
+    }
+
+    fun triggerPickupMorningNotificationsAt(now: LocalDateTime) {
         val today = now.toLocalDate()
         val tomorrow = today.plusDays(1)
 
@@ -49,14 +52,20 @@ class NotificationTriggerScheduler(
 
     @Scheduled(cron = "0 */10 * * * *", zone = KST_ZONE_ID)
     fun triggerWishlistDeadlineNotifications() {
-        val now = nowKst()
+        triggerWishlistDeadlineNotificationsAt(nowKst())
+    }
+
+    fun triggerWishlistDeadlineNotificationsAt(now: LocalDateTime) {
         dispatchWishlistDeadlineReminder(now, ReminderOffset.DAYS_3)
         dispatchWishlistDeadlineReminder(now, ReminderOffset.DAYS_1)
     }
 
     @Scheduled(cron = "0 0 7 * * *", zone = KST_ZONE_ID)
     fun triggerRequestDeadlineMinus3DaysNotification() {
-        val now = nowKst()
+        triggerRequestDeadlineMinus3DaysNotificationAt(nowKst())
+    }
+
+    fun triggerRequestDeadlineMinus3DaysNotificationAt(now: LocalDateTime) {
         val targetDate = now.toLocalDate().plusDays(3)
         val requests = groupBuyRequestRepository.findByStatusInAndDesiredPickupDate(
             statuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT),
@@ -80,7 +89,10 @@ class NotificationTriggerScheduler(
 
     @Scheduled(cron = "0 */10 * * * *", zone = KST_ZONE_ID)
     fun triggerPickupIncompleteAfterCutoffNotification() {
-        val now = nowKst()
+        triggerPickupIncompleteAfterCutoffNotificationAt(nowKst())
+    }
+
+    fun triggerPickupIncompleteAfterCutoffNotificationAt(now: LocalDateTime) {
         val candidates = participationRepository.findForPickupCutoffCheck(
             pickupDateFrom = now.toLocalDate().minusDays(1),
             pickupDateTo = now.toLocalDate(),

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -1,0 +1,188 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+
+@Component
+class NotificationTriggerScheduler(
+    private val notificationEventPublisher: NotificationEventPublisher,
+    private val participationRepository: ParticipationRepository,
+    private val groupBuyRepository: GroupBuyRepository,
+    private val favoriteRepository: FavoriteRepository,
+    private val groupBuyRequestRepository: GroupBuyRequestRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = "0 0 7 * * *", zone = KST_ZONE_ID)
+    fun triggerPickupMorningNotifications() {
+        val now = nowKst()
+        val today = now.toLocalDate()
+        val tomorrow = today.plusDays(1)
+
+        dispatchPickupReminder(
+            pickupDate = today,
+            triggerType = NotificationTriggerType.PICKUP_SAME_DAY_MORNING,
+            scheduleKeyPrefix = "pickup-same-day-morning",
+            occurredAt = now
+        )
+        dispatchPickupReminder(
+            pickupDate = tomorrow,
+            triggerType = NotificationTriggerType.PICKUP_DAY_BEFORE_MORNING,
+            scheduleKeyPrefix = "pickup-day-before-morning",
+            occurredAt = now
+        )
+    }
+
+    @Scheduled(cron = "0 */10 * * * *", zone = KST_ZONE_ID)
+    fun triggerWishlistDeadlineNotifications() {
+        val now = nowKst()
+        dispatchWishlistDeadlineReminder(now, ReminderOffset.DAYS_3)
+        dispatchWishlistDeadlineReminder(now, ReminderOffset.DAYS_1)
+    }
+
+    @Scheduled(cron = "0 0 7 * * *", zone = KST_ZONE_ID)
+    fun triggerRequestDeadlineMinus3DaysNotification() {
+        val now = nowKst()
+        val targetDate = now.toLocalDate().plusDays(3)
+        val requests = groupBuyRequestRepository.findByStatusInAndDesiredPickupDate(
+            statuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT),
+            desiredPickupDate = targetDate
+        )
+
+        requests.forEach { request ->
+            notificationEventPublisher.publishScheduledTrigger(
+                triggerType = NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS,
+                targetId = request.id,
+                userIds = listOf(request.userId),
+                scheduleKey = "request-deadline-d3:${request.id}:$targetDate",
+                occurredAt = now
+            )
+        }
+        log.info(
+            "[NotificationTriggerScheduler] 요청공구 D-3 알림 트리거 완료: targetDate={}, requestCount={}",
+            targetDate, requests.size
+        )
+    }
+
+    @Scheduled(cron = "0 */10 * * * *", zone = KST_ZONE_ID)
+    fun triggerPickupIncompleteAfterCutoffNotification() {
+        val now = nowKst()
+        val candidates = participationRepository.findForPickupCutoffCheck(
+            pickupDateFrom = now.toLocalDate().minusDays(1),
+            pickupDateTo = now.toLocalDate(),
+            participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+            pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+        )
+
+        var triggered = 0
+        candidates.forEach { participation ->
+            val cutoffAt = LocalDateTime.of(
+                participation.groupBuy.pickupDate,
+                participation.groupBuy.pickupTimeEnd
+            ).plusMinutes(30)
+            if (now >= cutoffAt) {
+                notificationEventPublisher.publishScheduledTrigger(
+                    triggerType = NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF,
+                    targetId = participation.groupBuy.id,
+                    userIds = listOf(participation.user.id!!),
+                    scheduleKey = "pickup-cutoff:${participation.id}:${cutoffAt}",
+                    occurredAt = now
+                )
+                triggered += 1
+            }
+        }
+
+        log.info(
+            "[NotificationTriggerScheduler] 픽업 미완료 컷오프 알림 트리거 완료: candidateCount={}, triggered={}",
+            candidates.size, triggered
+        )
+    }
+
+    private fun dispatchPickupReminder(
+        pickupDate: LocalDate,
+        triggerType: NotificationTriggerType,
+        scheduleKeyPrefix: String,
+        occurredAt: LocalDateTime
+    ) {
+        val participations = participationRepository.findForPickupReminderByPickupDate(
+            pickupDate = pickupDate,
+            participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+            pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+        )
+
+        participations.groupBy { it.groupBuy.id }.forEach { (groupBuyId, items) ->
+            val userIds = items.mapNotNull { it.user.id }.distinct()
+            if (userIds.isEmpty()) return@forEach
+            notificationEventPublisher.publishScheduledTrigger(
+                triggerType = triggerType,
+                targetId = groupBuyId,
+                userIds = userIds,
+                scheduleKey = "$scheduleKeyPrefix:$groupBuyId:$pickupDate",
+                occurredAt = occurredAt
+            )
+        }
+        log.info(
+            "[NotificationTriggerScheduler] 픽업 리마인드 알림 트리거 완료: triggerType={}, pickupDate={}, participationCount={}",
+            triggerType, pickupDate, participations.size
+        )
+    }
+
+    private fun dispatchWishlistDeadlineReminder(now: LocalDateTime, offset: ReminderOffset) {
+        val windowFrom = now.plusHours(offset.hours)
+        val windowTo = windowFrom.plusMinutes(WINDOW_MINUTES.toLong())
+
+        val groupBuys = groupBuyRepository.findByStatusInAndDeadlineBetween(
+            statuses = listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED),
+            deadlineFrom = windowFrom,
+            deadlineTo = windowTo
+        )
+
+        groupBuys.forEach { groupBuy ->
+            val userIds = favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(groupBuy.id)
+            if (userIds.isEmpty()) return@forEach
+
+            notificationEventPublisher.publishScheduledTrigger(
+                triggerType = offset.triggerType,
+                targetId = groupBuy.id,
+                userIds = userIds,
+                scheduleKey = "${offset.scheduleKeyPrefix}:${groupBuy.id}:${groupBuy.deadline}",
+                occurredAt = now
+            )
+        }
+
+        log.info(
+            "[NotificationTriggerScheduler] 찜 마감 리마인드 알림 트리거 완료: triggerType={}, windowFrom={}, windowTo={}, groupBuyCount={}",
+            offset.triggerType, windowFrom, windowTo, groupBuys.size
+        )
+    }
+
+    private fun nowKst(): LocalDateTime = LocalDateTime.now(ZoneId.of(KST_ZONE_ID))
+
+    private enum class ReminderOffset(
+        val hours: Long,
+        val triggerType: NotificationTriggerType,
+        val scheduleKeyPrefix: String
+    ) {
+        DAYS_3(72, NotificationTriggerType.WISH_DEADLINE_MINUS_3_DAYS, "wish-deadline-d3"),
+        DAYS_1(24, NotificationTriggerType.WISH_DEADLINE_MINUS_1_DAY, "wish-deadline-d1"),
+    }
+
+    companion object {
+        private const val KST_ZONE_ID = "Asia/Seoul"
+        private const val WINDOW_MINUTES = 10
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/event/NotificationImmediateTriggerEvent.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/event/NotificationImmediateTriggerEvent.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.domain.notification.application.event
+
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import java.time.LocalDateTime
+
+data class NotificationImmediateTriggerEvent(
+    val triggerType: NotificationTriggerType,
+    val targetId: Long,
+    val userIds: List<Long>,
+    val scheduleKey: String,
+    val occurredAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchDedupKey.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchDedupKey.kt
@@ -3,14 +3,14 @@ package com.moongchijang.domain.notification.domain.entity
 data class NotificationDispatchDedupKey(
     val userId: Long,
     val triggerType: NotificationTriggerType,
-    val targetId: Long?,
+    val targetId: Long,
     val scheduleKey: String
 ) {
     companion object {
         fun of(
             userId: Long,
             triggerType: NotificationTriggerType,
-            targetId: Long?,
+            targetId: Long,
             scheduleKey: String
         ): NotificationDispatchDedupKey {
             return NotificationDispatchDedupKey(

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchDedupKey.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchDedupKey.kt
@@ -1,0 +1,24 @@
+package com.moongchijang.domain.notification.domain.entity
+
+data class NotificationDispatchDedupKey(
+    val userId: Long,
+    val triggerType: NotificationTriggerType,
+    val targetId: Long?,
+    val scheduleKey: String
+) {
+    companion object {
+        fun of(
+            userId: Long,
+            triggerType: NotificationTriggerType,
+            targetId: Long?,
+            scheduleKey: String
+        ): NotificationDispatchDedupKey {
+            return NotificationDispatchDedupKey(
+                userId = userId,
+                triggerType = triggerType,
+                targetId = targetId,
+                scheduleKey = scheduleKey
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchHistory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchHistory.kt
@@ -1,0 +1,86 @@
+package com.moongchijang.domain.notification.domain.entity
+
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "notification_dispatch_histories",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_notification_dispatch_dedup",
+            columnNames = ["user_id", "trigger_type", "target_id", "schedule_key"]
+        )
+    ],
+    indexes = [
+        Index(
+            name = "idx_notification_dispatch_status_next_retry_at",
+            columnList = "status,next_retry_at"
+        ),
+        Index(
+            name = "idx_notification_dispatch_user_trigger_processed_at",
+            columnList = "user_id,trigger_type,processed_at"
+        )
+    ]
+)
+class NotificationDispatchHistory(
+
+    @Column(name = "user_id", nullable = false)
+    var userId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trigger_type", nullable = false, length = 60)
+    var triggerType: NotificationTriggerType,
+
+    @Column(name = "target_id")
+    var targetId: Long? = null,
+
+    @Column(name = "schedule_key", nullable = false, length = 100)
+    var scheduleKey: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: NotificationDispatchStatus = NotificationDispatchStatus.PENDING,
+
+    @Column(name = "retry_count", nullable = false)
+    var retryCount: Int = 0,
+
+    @Column(name = "next_retry_at")
+    var nextRetryAt: LocalDateTime? = null,
+
+    @Column(name = "processed_at")
+    var processedAt: LocalDateTime? = null,
+
+    @Column(name = "last_error", length = 1000)
+    var lastError: String? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity() {
+    fun markSuccess(processedAt: LocalDateTime = LocalDateTime.now()): NotificationDispatchHistory {
+        status = NotificationDispatchStatus.SUCCESS
+        this.processedAt = processedAt
+        nextRetryAt = null
+        lastError = null
+        return this
+    }
+
+    fun markFailed(errorMessage: String, nextRetryAt: LocalDateTime?): NotificationDispatchHistory {
+        status = NotificationDispatchStatus.FAILED
+        retryCount += 1
+        lastError = errorMessage
+        this.nextRetryAt = nextRetryAt
+        return this
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchHistory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchHistory.kt
@@ -42,8 +42,8 @@ class NotificationDispatchHistory(
     @Column(name = "trigger_type", nullable = false, length = 60)
     var triggerType: NotificationTriggerType,
 
-    @Column(name = "target_id")
-    var targetId: Long? = null,
+    @Column(name = "target_id", nullable = false)
+    var targetId: Long,
 
     @Column(name = "schedule_key", nullable = false, length = 100)
     var scheduleKey: String,

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchStatus.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.notification.domain.entity
+
+enum class NotificationDispatchStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationTriggerType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationTriggerType.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.notification.domain.entity
+
+enum class NotificationTriggerType {
+    PICKUP_SAME_DAY_MORNING,              // ①
+    PICKUP_DAY_BEFORE_MORNING,            // ②
+    PICKUP_COMPLETED_IMMEDIATE,           // ③-1
+    PICKUP_NOT_COMPLETED_AFTER_CUTOFF,    // ③-2
+    WISH_DEADLINE_MINUS_3_DAYS,           // ④
+    WISH_DEADLINE_MINUS_1_DAY,            // ⑤
+    WISH_TARGET_ACHIEVED_IMMEDIATE,       // ⑥
+    APPLY_PAYMENT_SUCCESS_IMMEDIATE,      // ⑦
+    APPLY_GROUPBUY_ACHIEVED_IMMEDIATE,    // ⑧
+    APPLY_GROUPBUY_FAILED_IMMEDIATE,      // ⑨
+    REQUEST_OPENED_IMMEDIATE,             // ⑩
+    REQUEST_REJECTED_IMMEDIATE,           // ⑪
+    REQUEST_NEW_PARTICIPANT_IMMEDIATE,    // ⑫
+    REQUEST_TARGET_ACHIEVED_IMMEDIATE,    // ⑬
+    REQUEST_DEADLINE_MINUS_3_DAYS         // ⑭
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationDispatchHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationDispatchHistoryRepository.kt
@@ -1,0 +1,23 @@
+package com.moongchijang.domain.notification.domain.repository
+
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+import java.util.Optional
+
+interface NotificationDispatchHistoryRepository : JpaRepository<NotificationDispatchHistory, Long> {
+
+    fun findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
+        userId: Long,
+        triggerType: NotificationTriggerType,
+        targetId: Long?,
+        scheduleKey: String
+    ): Optional<NotificationDispatchHistory>
+
+    fun findByStatusInAndNextRetryAtLessThanEqual(
+        statuses: Collection<NotificationDispatchStatus>,
+        nextRetryAt: LocalDateTime
+    ): List<NotificationDispatchHistory>
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationDispatchHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationDispatchHistoryRepository.kt
@@ -12,7 +12,7 @@ interface NotificationDispatchHistoryRepository : JpaRepository<NotificationDisp
     fun findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
         userId: Long,
         triggerType: NotificationTriggerType,
-        targetId: Long?,
+        targetId: Long,
         scheduleKey: String
     ): Optional<NotificationDispatchHistory>
 

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandService.kt
@@ -1,0 +1,42 @@
+package com.moongchijang.domain.participation.application
+
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class ParticipationPickupCommandService(
+    private val participationRepository: ParticipationRepository,
+    private val userRepository: UserRepository,
+    private val notificationEventPublisher: NotificationEventPublisher,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun completePickup(participationId: Long, processedByUserId: Long, pickedUpAt: LocalDateTime = LocalDateTime.now()) {
+        val participation = participationRepository.findByIdForUpdate(participationId)
+            .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+        val processor = userRepository.findByIdAndDeletedAtIsNull(processedByUserId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        participation.markPickedUp(processedBy = processor, pickedUpAt = pickedUpAt)
+        val userId = participation.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        notificationEventPublisher.publishPickupCompleted(
+            groupBuyId = participation.groupBuy.id,
+            userId = userId,
+            participationId = participation.id,
+            occurredAt = pickedUpAt
+        )
+        log.info(
+            "[ParticipationPickupCommandService] 픽업 완료 처리 및 알림 트리거 발행: participationId={}, userId={}, processedByUserId={}",
+            participationId, userId, processedByUserId
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
@@ -88,4 +88,13 @@ class Participation(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
-) : BaseEntity()
+) : BaseEntity() {
+    fun markPickedUp(
+        processedBy: User,
+        pickedUpAt: LocalDateTime = LocalDateTime.now()
+    ) {
+        pickupProcessedBy = processedBy
+        pickupStatus = PickupStatus.PICKED_UP
+        this.pickedUpAt = pickedUpAt
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDate
 import java.util.Optional
 
 interface ParticipationRepository : JpaRepository<Participation, Long> {
@@ -26,6 +27,39 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         """
     )
     fun findDistinctUserIdsByGroupBuyId(@Param("groupBuyId") groupBuyId: Long): List<Long>
+
+    @Query(
+        """
+        SELECT p
+        FROM Participation p
+        JOIN FETCH p.groupBuy gb
+        WHERE gb.pickupDate = :pickupDate
+          AND p.status IN :participationStatuses
+          AND p.pickupStatus IN :pickupStatuses
+        """
+    )
+    fun findForPickupReminderByPickupDate(
+        @Param("pickupDate") pickupDate: LocalDate,
+        @Param("participationStatuses") participationStatuses: Collection<ParticipationStatus>,
+        @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
+    ): List<Participation>
+
+    @Query(
+        """
+        SELECT p
+        FROM Participation p
+        JOIN FETCH p.groupBuy gb
+        WHERE gb.pickupDate BETWEEN :pickupDateFrom AND :pickupDateTo
+          AND p.status IN :participationStatuses
+          AND p.pickupStatus IN :pickupStatuses
+        """
+    )
+    fun findForPickupCutoffCheck(
+        @Param("pickupDateFrom") pickupDateFrom: LocalDate,
+        @Param("pickupDateTo") pickupDateTo: LocalDate,
+        @Param("participationStatuses") participationStatuses: Collection<ParticipationStatus>,
+        @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
+    ): List<Participation>
 
     @Query(
         value = """

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.Optional
 
 interface ParticipationRepository : JpaRepository<Participation, Long> {
@@ -49,14 +50,13 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         SELECT p
         FROM Participation p
         JOIN FETCH p.groupBuy gb
-        WHERE gb.pickupDate BETWEEN :pickupDateFrom AND :pickupDateTo
+        WHERE function('timestamp', gb.pickupDate, gb.pickupTimeEnd) <= :pickupCutoffBaseAt
           AND p.status IN :participationStatuses
           AND p.pickupStatus IN :pickupStatuses
         """
     )
     fun findForPickupCutoffCheck(
-        @Param("pickupDateFrom") pickupDateFrom: LocalDate,
-        @Param("pickupDateTo") pickupDateTo: LocalDate,
+        @Param("pickupCutoffBaseAt") pickupCutoffBaseAt: LocalDateTime,
         @Param("participationStatuses") participationStatuses: Collection<ParticipationStatus>,
         @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
     ): List<Participation>

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -19,6 +19,15 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     fun findByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Participation?
 
     @Query(
+        """
+        SELECT DISTINCT p.user.id
+        FROM Participation p
+        WHERE p.groupBuy.id = :groupBuyId
+        """
+    )
+    fun findDistinctUserIdsByGroupBuyId(@Param("groupBuyId") groupBuyId: Long): List<Long>
+
+    @Query(
         value = """
             select p
             from Participation p

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -344,7 +344,10 @@ class PaymentService(
         if (groupBuy.status == GroupBuyStatus.ACHIEVED) {
             publishApplyGroupBuyAchievedEvent(groupBuy.id, approvedAt)
             publishWishTargetAchievedEvent(groupBuy.id, approvedAt)
+            publishRequestTargetAchievedEvent(groupBuy, approvedAt)
         }
+
+        publishRequestNewParticipantEvent(groupBuy, participation, approvedAt)
 
         return PaymentApprovalResult.Success(
             ConfirmPaymentResponse(
@@ -387,6 +390,32 @@ class PaymentService(
         notificationEventPublisher.publishWishTargetAchieved(
             groupBuyId = groupBuyId,
             userIds = favoriteUserIds,
+            occurredAt = occurredAt
+        )
+    }
+
+    private fun publishRequestNewParticipantEvent(
+        groupBuy: GroupBuy,
+        participation: Participation,
+        occurredAt: LocalDateTime
+    ) {
+        val requesterUserId = groupBuy.groupBuyRequest.userId
+        val participantUserId = participation.user.id ?: return
+        if (requesterUserId == participantUserId) return
+
+        notificationEventPublisher.publishRequestNewParticipant(
+            targetGroupBuyId = groupBuy.id,
+            requesterUserId = requesterUserId,
+            participationId = participation.id,
+            occurredAt = occurredAt
+        )
+    }
+
+    private fun publishRequestTargetAchievedEvent(groupBuy: GroupBuy, occurredAt: LocalDateTime) {
+        val requesterUserId = groupBuy.groupBuyRequest.userId
+        notificationEventPublisher.publishRequestTargetAchieved(
+            targetGroupBuyId = groupBuy.id,
+            requesterUserId = requesterUserId,
             occurredAt = occurredAt
         )
     }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -5,6 +5,9 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
+import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -29,6 +32,7 @@ import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
@@ -42,12 +46,14 @@ class PaymentService(
     private val groupBuyRepository: GroupBuyRepository,
     private val userRepository: UserRepository,
     private val participationRepository: ParticipationRepository,
+    private val favoriteRepository: FavoriteRepository,
     private val paymentOrderRepository: PaymentOrderRepository,
     private val paymentRepository: PaymentRepository,
     private val portOnePaymentPort: PortOnePaymentPort,
     private val portOneProperties: PortOneProperties,
     private val transactionManager: PlatformTransactionManager,
     private val redisLockUtil: RedisLockUtil,
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -335,6 +341,13 @@ class PaymentService(
             )
         )
 
+        publishApplyPaymentSuccessEvent(order, approvedAt)
+
+        if (groupBuy.status == GroupBuyStatus.ACHIEVED) {
+            publishApplyGroupBuyAchievedEvent(groupBuy.id, approvedAt)
+            publishWishTargetAchievedEvent(groupBuy.id, approvedAt)
+        }
+
         return PaymentApprovalResult.Success(
             ConfirmPaymentResponse(
                 paymentId = paymentResult.paymentId,
@@ -344,6 +357,49 @@ class PaymentService(
                 amount = paymentResult.totalAmount,
                 method = paymentResult.method,
                 approvedAt = approvedAt,
+            )
+        )
+    }
+
+    private fun publishApplyPaymentSuccessEvent(order: PaymentOrder, occurredAt: LocalDateTime) {
+        val userId = order.user.id ?: return
+        applicationEventPublisher.publishEvent(
+            NotificationImmediateTriggerEvent(
+                triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+                targetId = order.groupBuy.id,
+                userIds = listOf(userId),
+                scheduleKey = "payment-success:${order.orderId}",
+                occurredAt = occurredAt
+            )
+        )
+    }
+
+    private fun publishApplyGroupBuyAchievedEvent(groupBuyId: Long, occurredAt: LocalDateTime) {
+        val participantUserIds = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuyId)
+        if (participantUserIds.isEmpty()) return
+
+        applicationEventPublisher.publishEvent(
+            NotificationImmediateTriggerEvent(
+                triggerType = NotificationTriggerType.APPLY_GROUPBUY_ACHIEVED_IMMEDIATE,
+                targetId = groupBuyId,
+                userIds = participantUserIds,
+                scheduleKey = "groupbuy-achieved:$groupBuyId",
+                occurredAt = occurredAt
+            )
+        )
+    }
+
+    private fun publishWishTargetAchievedEvent(groupBuyId: Long, occurredAt: LocalDateTime) {
+        val favoriteUserIds = favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(groupBuyId)
+        if (favoriteUserIds.isEmpty()) return
+
+        applicationEventPublisher.publishEvent(
+            NotificationImmediateTriggerEvent(
+                triggerType = NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE,
+                targetId = groupBuyId,
+                userIds = favoriteUserIds,
+                scheduleKey = "wish-target-achieved:$groupBuyId",
+                occurredAt = occurredAt
             )
         )
     }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -6,8 +6,7 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
-import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
-import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -32,7 +31,6 @@ import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
@@ -53,7 +51,7 @@ class PaymentService(
     private val portOneProperties: PortOneProperties,
     private val transactionManager: PlatformTransactionManager,
     private val redisLockUtil: RedisLockUtil,
-    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val notificationEventPublisher: NotificationEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -363,14 +361,11 @@ class PaymentService(
 
     private fun publishApplyPaymentSuccessEvent(order: PaymentOrder, occurredAt: LocalDateTime) {
         val userId = order.user.id ?: return
-        applicationEventPublisher.publishEvent(
-            NotificationImmediateTriggerEvent(
-                triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
-                targetId = order.groupBuy.id,
-                userIds = listOf(userId),
-                scheduleKey = "payment-success:${order.orderId}",
-                occurredAt = occurredAt
-            )
+        notificationEventPublisher.publishApplyPaymentSuccess(
+            groupBuyId = order.groupBuy.id,
+            orderId = order.orderId,
+            userId = userId,
+            occurredAt = occurredAt
         )
     }
 
@@ -378,14 +373,10 @@ class PaymentService(
         val participantUserIds = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuyId)
         if (participantUserIds.isEmpty()) return
 
-        applicationEventPublisher.publishEvent(
-            NotificationImmediateTriggerEvent(
-                triggerType = NotificationTriggerType.APPLY_GROUPBUY_ACHIEVED_IMMEDIATE,
-                targetId = groupBuyId,
-                userIds = participantUserIds,
-                scheduleKey = "groupbuy-achieved:$groupBuyId",
-                occurredAt = occurredAt
-            )
+        notificationEventPublisher.publishApplyGroupBuyAchieved(
+            groupBuyId = groupBuyId,
+            participantUserIds = participantUserIds,
+            occurredAt = occurredAt
         )
     }
 
@@ -393,14 +384,10 @@ class PaymentService(
         val favoriteUserIds = favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(groupBuyId)
         if (favoriteUserIds.isEmpty()) return
 
-        applicationEventPublisher.publishEvent(
-            NotificationImmediateTriggerEvent(
-                triggerType = NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE,
-                targetId = groupBuyId,
-                userIds = favoriteUserIds,
-                scheduleKey = "wish-target-achieved:$groupBuyId",
-                occurredAt = occurredAt
-            )
+        notificationEventPublisher.publishWishTargetAchieved(
+            groupBuyId = groupBuyId,
+            userIds = favoriteUserIds,
+            occurredAt = occurredAt
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/global/config/NotificationAsyncConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/NotificationAsyncConfig.kt
@@ -1,0 +1,21 @@
+package com.moongchijang.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+class NotificationAsyncConfig {
+
+    @Bean(name = ["notificationEventExecutor"])
+    fun notificationEventExecutor(): Executor {
+        return ThreadPoolTaskExecutor().apply {
+            corePoolSize = 4
+            maxPoolSize = 8
+            queueCapacity = 500
+            setThreadNamePrefix("notification-event-")
+            initialize()
+        }
+    }
+}

--- a/src/main/resources/db/migration/V18__create_notification_dispatch_histories_table.sql
+++ b/src/main/resources/db/migration/V18__create_notification_dispatch_histories_table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE notification_dispatch_histories (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    trigger_type VARCHAR(60) NOT NULL,
+    target_id BIGINT NULL,
+    schedule_key VARCHAR(100) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    retry_count INT NOT NULL DEFAULT 0,
+    next_retry_at DATETIME NULL,
+    processed_at DATETIME NULL,
+    last_error VARCHAR(1000) NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_notification_dispatch_dedup UNIQUE (user_id, trigger_type, target_id, schedule_key)
+);
+
+CREATE INDEX idx_notification_dispatch_status_next_retry_at
+    ON notification_dispatch_histories (status, next_retry_at);
+
+CREATE INDEX idx_notification_dispatch_user_trigger_processed_at
+    ON notification_dispatch_histories (user_id, trigger_type, processed_at);

--- a/src/main/resources/db/migration/V18__create_notification_dispatch_histories_table.sql
+++ b/src/main/resources/db/migration/V18__create_notification_dispatch_histories_table.sql
@@ -2,7 +2,7 @@ CREATE TABLE notification_dispatch_histories (
     id BIGINT NOT NULL AUTO_INCREMENT,
     user_id BIGINT NOT NULL,
     trigger_type VARCHAR(60) NOT NULL,
-    target_id BIGINT NULL,
+    target_id BIGINT NOT NULL,
     schedule_key VARCHAR(100) NOT NULL,
     status VARCHAR(20) NOT NULL,
     retry_count INT NOT NULL DEFAULT 0,

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandServiceTest.kt
@@ -1,0 +1,57 @@
+package com.moongchijang.domain.groupbuy.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.support.GroupBuyFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class GroupBuyRequestStatusCommandServiceTest {
+
+    @Mock
+    private lateinit var groupBuyRequestRepository: GroupBuyRequestRepository
+
+    @Mock
+    private lateinit var groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository
+
+    @Mock
+    private lateinit var notificationEventPublisher: NotificationEventPublisher
+
+    private val service by lazy {
+        GroupBuyRequestStatusCommandService(
+            groupBuyRequestRepository = groupBuyRequestRepository,
+            groupBuyRequestStatusHistoryRepository = groupBuyRequestStatusHistoryRepository,
+            notificationEventPublisher = notificationEventPublisher
+        )
+    }
+
+    @Test
+    fun `요청공구를 거절할 때 거절 상태 반영과 즉시 알림 이벤트 발행`() {
+        val now = LocalDateTime.of(2026, 5, 23, 15, 0)
+        val request = GroupBuyFixture.createGroupBuyRequest(userId = 7L).apply { id = 301L }
+
+        `when`(groupBuyRequestRepository.findById(301L)).thenReturn(Optional.of(request))
+        `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenAnswer { it.arguments[0] }
+
+        service.rejectRequest(requestId = 301L, reason = "품절", changedAt = now)
+
+        assertEquals(GroupBuyRequestStatus.REJECTED, request.status)
+        assertEquals("품절", request.rejectionReason)
+        verify(notificationEventPublisher).publishRequestRejected(
+            requestId = 301L,
+            requesterUserId = 7L,
+            occurredAt = now
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -10,6 +10,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.entity.NotificationStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyOpenRequestRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoAlimtalkClient
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
@@ -60,6 +61,9 @@ class GroupBuyOpenRequestServiceTest {
 
     @Mock
     private lateinit var aligoAlimtalkClient: AligoAlimtalkClient
+
+    @Mock
+    private lateinit var notificationEventPublisher: NotificationEventPublisher
 
     @InjectMocks
     private lateinit var service: GroupBuyOpenRequestService

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
@@ -3,6 +3,8 @@ package com.moongchijang.domain.groupbuy.service
 import com.moongchijang.domain.groupbuy.application.GroupBuyStatusTransitionService
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -31,12 +33,24 @@ class GroupBuyStatusTransitionServiceTest {
     @Mock
     private lateinit var transactionStatus: TransactionStatus
 
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var notificationEventPublisher: NotificationEventPublisher
+
     private lateinit var service: GroupBuyStatusTransitionService
 
     @BeforeEach
     fun setUp() {
         `when`(transactionManager.getTransaction(any())).thenReturn(transactionStatus)
-        service = GroupBuyStatusTransitionService(groupBuyRepository, transactionManager, 500)
+        service = GroupBuyStatusTransitionService(
+            groupBuyRepository,
+            participationRepository,
+            notificationEventPublisher,
+            transactionManager,
+            500
+        )
     }
 
     @Test
@@ -127,7 +141,13 @@ class GroupBuyStatusTransitionServiceTest {
     @Test
     fun `자동 전이 실행 시 batch size 기준 반복 처리`() {
         val now = LocalDateTime.now()
-        val batchService = GroupBuyStatusTransitionService(groupBuyRepository, transactionManager, 2)
+        val batchService = GroupBuyStatusTransitionService(
+            groupBuyRepository,
+            participationRepository,
+            notificationEventPublisher,
+            transactionManager,
+            2
+        )
         val pageable = PageRequest.of(0, 2, Sort.by(Sort.Order.asc("deadline"), Sort.Order.asc("id")))
         val first = GroupBuyFixture.createGroupBuy(id = 11L, status = GroupBuyStatus.IN_PROGRESS, deadline = now.minusMinutes(1))
         val second = GroupBuyFixture.createGroupBuy(id = 12L, status = GroupBuyStatus.ACHIEVED, deadline = now.minusMinutes(1))

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
@@ -124,6 +124,35 @@ class NotificationImmediateDispatchServiceTest {
         verify(notificationRepository).save(any())
     }
 
+    @Test
+    fun `실패 이력 재시도 시 대상 건 재발송 처리`() {
+        val now = LocalDateTime.of(2026, 5, 23, 9, 0)
+        val failedHistory = NotificationDispatchHistory(
+            userId = 9L,
+            triggerType = NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE,
+            targetId = 901L,
+            scheduleKey = "groupbuy-failed:901",
+            status = NotificationDispatchStatus.FAILED,
+            retryCount = 1,
+            nextRetryAt = now.minusMinutes(1)
+        )
+        val user = UserFixture.createEmailUser(id = 9L)
+
+        `when`(
+            notificationDispatchHistoryRepository.findByStatusInAndNextRetryAtLessThanEqual(
+                statuses = listOf(NotificationDispatchStatus.FAILED),
+                nextRetryAt = now
+            )
+        ).thenReturn(listOf(failedHistory))
+        `when`(userRepository.findByIdAndDeletedAtIsNull(9L)).thenReturn(user)
+        `when`(notificationRepository.save(any())).thenAnswer { it.arguments[0] }
+
+        service.retryFailedDispatches(now)
+
+        assertEquals(NotificationDispatchStatus.SUCCESS, failedHistory.status)
+        verify(notificationRepository).save(any())
+    }
+
     private fun mockHistory(userId: Long, scheduleKey: String): NotificationDispatchHistory {
         return NotificationDispatchHistory(
             userId = userId,

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
@@ -1,0 +1,135 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.notification.domain.repository.NotificationDispatchHistoryRepository
+import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class NotificationImmediateDispatchServiceTest {
+
+    @Mock
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Mock
+    private lateinit var notificationDispatchHistoryRepository: NotificationDispatchHistoryRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    private val service by lazy {
+        NotificationImmediateDispatchService(
+            notificationRepository = notificationRepository,
+            notificationDispatchHistoryRepository = notificationDispatchHistoryRepository,
+            userRepository = userRepository
+        )
+    }
+
+    @Test
+    fun `같은 중복키 이력이 존재할 때 즉시 발송 스킵`() {
+        val event = NotificationImmediateTriggerEvent(
+            triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+            targetId = 101L,
+            userIds = listOf(1L),
+            scheduleKey = "payment-success:o-1",
+            occurredAt = LocalDateTime.now()
+        )
+        `when`(
+            notificationDispatchHistoryRepository.findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
+                userId = 1L,
+                triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+                targetId = 101L,
+                scheduleKey = "payment-success:o-1"
+            )
+        ).thenReturn(Optional.of(mockHistory(userId = 1L, scheduleKey = "payment-success:o-1")))
+
+        service.dispatch(event)
+
+        verify(notificationRepository, never()).save(any())
+    }
+
+    @Test
+    fun `사용자가 존재하지 않을 때 실패 이력 상태 저장`() {
+        val event = NotificationImmediateTriggerEvent(
+            triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+            targetId = 102L,
+            userIds = listOf(2L),
+            scheduleKey = "payment-success:o-2",
+            occurredAt = LocalDateTime.now()
+        )
+        val pending = mockHistory(userId = 2L, scheduleKey = "payment-success:o-2")
+
+        `when`(
+            notificationDispatchHistoryRepository.findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
+                userId = 2L,
+                triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+                targetId = 102L,
+                scheduleKey = "payment-success:o-2"
+            )
+        ).thenReturn(Optional.empty())
+        `when`(notificationDispatchHistoryRepository.save(any(NotificationDispatchHistory::class.java))).thenReturn(pending)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(null)
+
+        service.dispatch(event)
+
+        assertEquals(NotificationDispatchStatus.FAILED, pending.status)
+        verify(notificationRepository, never()).save(any())
+    }
+
+    @Test
+    fun `사용자와 이력이 유효할 때 알림 저장`() {
+        val now = LocalDateTime.now()
+        val event = NotificationImmediateTriggerEvent(
+            triggerType = NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE,
+            targetId = 103L,
+            userIds = listOf(3L),
+            scheduleKey = "wish-target-achieved:103",
+            occurredAt = now
+        )
+        val pending = mockHistory(userId = 3L, scheduleKey = "wish-target-achieved:103")
+        val user = UserFixture.createEmailUser(id = 3L)
+
+        `when`(
+            notificationDispatchHistoryRepository.findByUserIdAndTriggerTypeAndTargetIdAndScheduleKey(
+                userId = 3L,
+                triggerType = NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE,
+                targetId = 103L,
+                scheduleKey = "wish-target-achieved:103"
+            )
+        ).thenReturn(Optional.empty())
+        `when`(notificationDispatchHistoryRepository.save(any(NotificationDispatchHistory::class.java))).thenReturn(pending)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(3L)).thenReturn(user)
+        `when`(notificationRepository.save(any())).thenAnswer { it.arguments[0] }
+
+        service.dispatch(event)
+
+        assertEquals(NotificationDispatchStatus.SUCCESS, pending.status)
+        verify(notificationRepository).save(any())
+    }
+
+    private fun mockHistory(userId: Long, scheduleKey: String): NotificationDispatchHistory {
+        return NotificationDispatchHistory(
+            userId = userId,
+            triggerType = NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE,
+            targetId = 1L,
+            scheduleKey = scheduleKey
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
@@ -29,6 +29,9 @@ class NotificationTriggerSchedulerTest {
     private lateinit var notificationEventPublisher: NotificationEventPublisher
 
     @Mock
+    private lateinit var notificationImmediateDispatchService: NotificationImmediateDispatchService
+
+    @Mock
     private lateinit var participationRepository: ParticipationRepository
 
     @Mock
@@ -43,6 +46,7 @@ class NotificationTriggerSchedulerTest {
     private val scheduler by lazy {
         NotificationTriggerScheduler(
             notificationEventPublisher = notificationEventPublisher,
+            notificationImmediateDispatchService = notificationImmediateDispatchService,
             participationRepository = participationRepository,
             groupBuyRepository = groupBuyRepository,
             favoriteRepository = favoriteRepository,

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
@@ -229,8 +229,7 @@ class NotificationTriggerSchedulerTest {
 
         `when`(
             participationRepository.findForPickupCutoffCheck(
-                now.toLocalDate().minusDays(1),
-                now.toLocalDate(),
+                now.minusMinutes(30),
                 listOf(ParticipationStatus.CONFIRMED),
                 listOf(PickupStatus.NOT_READY, PickupStatus.READY)
             )

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
@@ -1,0 +1,236 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.ParticipationFixture
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@ExtendWith(MockitoExtension::class)
+class NotificationTriggerSchedulerTest {
+
+    @Mock
+    private lateinit var notificationEventPublisher: NotificationEventPublisher
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var favoriteRepository: FavoriteRepository
+
+    @Mock
+    private lateinit var groupBuyRequestRepository: GroupBuyRequestRepository
+
+    private val scheduler by lazy {
+        NotificationTriggerScheduler(
+            notificationEventPublisher = notificationEventPublisher,
+            participationRepository = participationRepository,
+            groupBuyRepository = groupBuyRepository,
+            favoriteRepository = favoriteRepository,
+            groupBuyRequestRepository = groupBuyRequestRepository
+        )
+    }
+
+    @Test
+    fun `오전 스케줄러를 실행할 때 픽업 당일 전일 알림 발행`() {
+        val now = LocalDateTime.of(2026, 5, 23, 7, 0)
+        val todayParticipation = ParticipationFixture.createParticipation(
+            participationId = 1L,
+            groupBuyId = 11L,
+            quantity = 1,
+            totalAmount = 1000,
+            currentQuantity = 10,
+            targetQuantity = 20,
+            deadline = now.plusDays(1),
+            pickupDate = now.toLocalDate(),
+            pickupTimeStart = LocalTime.of(12, 0),
+            createdAt = now.minusDays(1),
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatus = PickupStatus.NOT_READY
+        )
+        val tomorrowParticipation = ParticipationFixture.createParticipation(
+            participationId = 2L,
+            groupBuyId = 12L,
+            quantity = 1,
+            totalAmount = 1000,
+            currentQuantity = 10,
+            targetQuantity = 20,
+            deadline = now.plusDays(2),
+            pickupDate = now.toLocalDate().plusDays(1),
+            pickupTimeStart = LocalTime.of(12, 0),
+            createdAt = now.minusDays(1),
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatus = PickupStatus.NOT_READY
+        )
+
+        `when`(
+            participationRepository.findForPickupReminderByPickupDate(
+                now.toLocalDate(),
+                listOf(ParticipationStatus.CONFIRMED),
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+            )
+        ).thenReturn(listOf(todayParticipation))
+        `when`(
+            participationRepository.findForPickupReminderByPickupDate(
+                now.toLocalDate().plusDays(1),
+                listOf(ParticipationStatus.CONFIRMED),
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+            )
+        ).thenReturn(listOf(tomorrowParticipation))
+
+        scheduler.triggerPickupMorningNotificationsAt(now)
+
+        verify(notificationEventPublisher).publishScheduledTrigger(
+            NotificationTriggerType.PICKUP_SAME_DAY_MORNING,
+            11L,
+            listOf(1L),
+            "pickup-same-day-morning:11:${now.toLocalDate()}",
+            now
+        )
+        verify(notificationEventPublisher).publishScheduledTrigger(
+            NotificationTriggerType.PICKUP_DAY_BEFORE_MORNING,
+            12L,
+            listOf(1L),
+            "pickup-day-before-morning:12:${now.toLocalDate().plusDays(1)}",
+            now
+        )
+    }
+
+    @Test
+    fun `찜 마감 리마인드 스케줄러를 실행할 때 D3 D1 알림 발행`() {
+        val now = LocalDateTime.of(2026, 5, 23, 10, 0)
+        val d3GroupBuy = GroupBuyFixture.createGroupBuy(
+            id = 21L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = now.plusHours(72).plusMinutes(1)
+        )
+        val d1GroupBuy = GroupBuyFixture.createGroupBuy(
+            id = 22L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = now.plusHours(24).plusMinutes(1)
+        )
+
+        `when`(
+            groupBuyRepository.findByStatusInAndDeadlineBetween(
+                listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED),
+                now.plusHours(72),
+                now.plusHours(72).plusMinutes(10)
+            )
+        ).thenReturn(listOf(d3GroupBuy))
+        `when`(
+            groupBuyRepository.findByStatusInAndDeadlineBetween(
+                listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED),
+                now.plusHours(24),
+                now.plusHours(24).plusMinutes(10)
+            )
+        ).thenReturn(listOf(d1GroupBuy))
+        `when`(favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(21L)).thenReturn(listOf(100L))
+        `when`(favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(22L)).thenReturn(listOf(200L))
+
+        scheduler.triggerWishlistDeadlineNotificationsAt(now)
+
+        verify(notificationEventPublisher).publishScheduledTrigger(
+            NotificationTriggerType.WISH_DEADLINE_MINUS_3_DAYS,
+            21L,
+            listOf(100L),
+            "wish-deadline-d3:21:${d3GroupBuy.deadline}",
+            now
+        )
+        verify(notificationEventPublisher).publishScheduledTrigger(
+            NotificationTriggerType.WISH_DEADLINE_MINUS_1_DAY,
+            22L,
+            listOf(200L),
+            "wish-deadline-d1:22:${d1GroupBuy.deadline}",
+            now
+        )
+    }
+
+    @Test
+    fun `요청공구 D3 스케줄러를 실행할 때 요청자 대상 알림 발행`() {
+        val now = LocalDateTime.of(2026, 5, 23, 7, 0)
+        val request = GroupBuyRequest(
+            userId = 7L,
+            storeName = "테스트 매장",
+            storeAddress = "서울",
+            productName = "소금빵",
+            desiredQuantity = 10,
+            desiredPickupDate = now.toLocalDate().plusDays(3)
+        ).apply { id = 31L }
+
+        `when`(
+            groupBuyRequestRepository.findByStatusInAndDesiredPickupDate(
+                listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT),
+                now.toLocalDate().plusDays(3)
+            )
+        ).thenReturn(listOf(request))
+
+        scheduler.triggerRequestDeadlineMinus3DaysNotificationAt(now)
+
+        verify(notificationEventPublisher).publishScheduledTrigger(
+            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS,
+            31L,
+            listOf(7L),
+            "request-deadline-d3:31:${now.toLocalDate().plusDays(3)}",
+            now
+        )
+    }
+
+    @Test
+    fun `픽업 미완료 컷오프 스케줄러를 실행할 때 마감 후 30분 지난 참여 알림 발행`() {
+        val now = LocalDateTime.of(2026, 5, 23, 10, 0)
+        val participation = ParticipationFixture.createParticipation(
+            participationId = 41L,
+            groupBuyId = 41L,
+            quantity = 1,
+            totalAmount = 1000,
+            currentQuantity = 10,
+            targetQuantity = 20,
+            deadline = now.minusDays(1),
+            pickupDate = now.toLocalDate().minusDays(1),
+            pickupTimeStart = LocalTime.of(8, 0),
+            createdAt = now.minusDays(2),
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatus = PickupStatus.READY
+        ).apply {
+            groupBuy.pickupTimeEnd = LocalTime.of(9, 0)
+        }
+
+        `when`(
+            participationRepository.findForPickupCutoffCheck(
+                now.toLocalDate().minusDays(1),
+                now.toLocalDate(),
+                listOf(ParticipationStatus.CONFIRMED),
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+            )
+        ).thenReturn(listOf(participation))
+
+        scheduler.triggerPickupIncompleteAfterCutoffNotificationAt(now)
+
+        verify(notificationEventPublisher).publishScheduledTrigger(
+            NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF,
+            41L,
+            listOf(1L),
+            "pickup-cutoff:41:${LocalDateTime.of(now.toLocalDate().minusDays(1), LocalTime.of(9, 0)).plusMinutes(30)}",
+            now
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.notification.application
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.favorite.domain.repository.FavoriteNotificationTargetProjection
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
@@ -147,8 +148,16 @@ class NotificationTriggerSchedulerTest {
                 now.plusHours(24).plusMinutes(10)
             )
         ).thenReturn(listOf(d1GroupBuy))
-        `when`(favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(21L)).thenReturn(listOf(100L))
-        `when`(favoriteRepository.findUserIdsByGroupBuyIdExcludingParticipants(22L)).thenReturn(listOf(200L))
+        `when`(
+            favoriteRepository.findNotificationTargetsByGroupBuyIdsExcludingParticipants(listOf(21L))
+        ).thenReturn(
+            listOf(notificationTarget(groupBuyId = 21L, userId = 100L))
+        )
+        `when`(
+            favoriteRepository.findNotificationTargetsByGroupBuyIdsExcludingParticipants(listOf(22L))
+        ).thenReturn(
+            listOf(notificationTarget(groupBuyId = 22L, userId = 200L))
+        )
 
         scheduler.triggerWishlistDeadlineNotificationsAt(now)
 
@@ -236,5 +245,12 @@ class NotificationTriggerSchedulerTest {
             "pickup-cutoff:41:${LocalDateTime.of(now.toLocalDate().minusDays(1), LocalTime.of(9, 0)).plusMinutes(30)}",
             now
         )
+    }
+}
+
+private fun notificationTarget(groupBuyId: Long, userId: Long): FavoriteNotificationTargetProjection {
+    return object : FavoriteNotificationTargetProjection {
+        override val groupBuyId: Long = groupBuyId
+        override val userId: Long = userId
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandServiceTest.kt
@@ -1,0 +1,68 @@
+package com.moongchijang.domain.participation.application
+
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.support.ParticipationFixture
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class ParticipationPickupCommandServiceTest {
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var notificationEventPublisher: NotificationEventPublisher
+
+    private val service by lazy {
+        ParticipationPickupCommandService(
+            participationRepository = participationRepository,
+            userRepository = userRepository,
+            notificationEventPublisher = notificationEventPublisher
+        )
+    }
+
+    @Test
+    fun `픽업 완료를 처리할 때 픽업 완료 즉시 알림 이벤트 발행`() {
+        val now = LocalDateTime.of(2026, 5, 23, 12, 0)
+        val participation = ParticipationFixture.createParticipation(
+            participationId = 101L,
+            groupBuyId = 201L,
+            quantity = 1,
+            totalAmount = 1000,
+            currentQuantity = 10,
+            targetQuantity = 20,
+            deadline = now.plusDays(1),
+            pickupDate = LocalDate.of(2026, 5, 23),
+            pickupTimeStart = LocalTime.of(10, 0),
+            createdAt = now.minusDays(1)
+        )
+        val processor = UserFixture.createEmailUser(id = 999L)
+
+        `when`(participationRepository.findByIdForUpdate(101L)).thenReturn(Optional.of(participation))
+        `when`(userRepository.findByIdAndDeletedAtIsNull(999L)).thenReturn(processor)
+
+        service.completePickup(participationId = 101L, processedByUserId = 999L, pickedUpAt = now)
+
+        verify(notificationEventPublisher).publishPickupCompleted(
+            groupBuyId = 201L,
+            userId = 1L,
+            participationId = 101L,
+            occurredAt = now
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -5,6 +5,8 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -64,6 +66,9 @@ class PaymentServiceTest {
     private lateinit var participationRepository: ParticipationRepository
 
     @Mock
+    private lateinit var favoriteRepository: FavoriteRepository
+
+    @Mock
     private lateinit var paymentOrderRepository: PaymentOrderRepository
 
     @Mock
@@ -81,6 +86,9 @@ class PaymentServiceTest {
     @Mock
     private lateinit var redisLockUtil: RedisLockUtil
 
+    @Mock
+    private lateinit var notificationEventPublisher: NotificationEventPublisher
+
     private val portOneProperties = PortOneProperties(
         storeId = "store-test",
         channelKey = "channel-test",
@@ -92,12 +100,14 @@ class PaymentServiceTest {
             groupBuyRepository = groupBuyRepository,
             userRepository = userRepository,
             participationRepository = participationRepository,
+            favoriteRepository = favoriteRepository,
             paymentOrderRepository = paymentOrderRepository,
             paymentRepository = paymentRepository,
             portOnePaymentPort = portOnePaymentPort,
             portOneProperties = portOneProperties,
             transactionManager = transactionManager,
             redisLockUtil = redisLockUtil,
+            notificationEventPublisher = notificationEventPublisher,
         )
     }
 


### PR DESCRIPTION
## 📌 작업한 내용
### 1) 알림 발송 트리거 아키텍처 구축
- 요구 조건 `①~⑭`를 기준으로 알림 발송을 **즉시 트리거**와 **스케줄 트리거**로 분리 구현했습니다.
- 즉시 트리거는 도메인 이벤트 기반으로 처리하고, 스케줄 트리거는 배치 스케줄러에서 처리하도록 구성했습니다.
- 발행 코드 일관성을 위해 `NotificationEventPublisher` 래퍼를 도입해 이벤트 발행 지점을 표준화했습니다.

### 2) 즉시 발송 트리거 구현 (도메인 이벤트 기반)
- 결제/공구 상태/요청공구 상태 변경 시점에 즉시 알림 트리거를 발행하도록 연결했습니다.
- 주요 연결 포인트:
  - 결제 성공, 공구 달성, 공구 미달성
  - 찜 대상 공구 목표 달성
  - 요청공구 개설 완료, 거절, 신규 참여자, 목표 달성
  - 픽업 완료 처리 시점
- `NotificationImmediateTriggerEventListener` → `NotificationImmediateDispatchService`로 이어지는 처리 파이프라인을 구성했습니다.

### 3) 스케줄 발송 트리거 구현 (KST 기준)
- 타임존은 `Asia/Seoul(KST)`로 고정했습니다.
- 배치 주기:
  - 오전 7시: 픽업 당일/전일, 요청공구 D-3
  - 10분 주기: 찜 D-3(72h), 찜 D-1(24h), 픽업 마감+30분 미완료
  - 5분 주기: 실패 건 재시도 스캔/재처리
- 시간 조건 기반 발송에서 동일 윈도우 재실행 시 중복 발송이 나지 않도록 dedup 키와 연계했습니다.

### 4) 중복 발송 방지/이력 관리
- `notification_dispatch_histories` 테이블을 추가해 발송 이력을 영속 관리합니다.
- 중복 방지 키: `userId + triggerType + targetId + scheduleKey`
- UNIQUE 제약으로 멱등성을 보장하고, 상태(`PENDING/SUCCESS/FAILED`) 및 재시도 메타데이터를 함께 관리합니다.
- 운영 관측을 위한 인덱스와 조회 경로를 함께 반영했습니다.

### 5) 재시도/실패 처리 고도화
- 실패 시 backoff(1분 → 5분 → 30분) 기반 `nextRetryAt`를 계산해 재시도합니다.
- 재시도 시에는 신규 건 생성이 아니라 기존 실패 이력을 재활용해 일관성 있게 처리합니다.
- 성공/실패/중복 스킵 로그에 핵심 식별자(userId, triggerType, targetId, scheduleKey, retryCount)를 포함했습니다.

### 6) 요구사항 ①~⑭ 매핑
| 번호 | 요구사항 | 트리거 유형 | 처리 방식 | 구현 포인트 |
|---|---|---|---|---|
| ① | 픽업 당일 오전 발송 | `PICKUP_SAME_DAY_MORNING` | 스케줄(07:00) | 픽업일=오늘 대상 |
| ② | 픽업 전날 오전 발송 | `PICKUP_DAY_BEFORE_MORNING` | 스케줄(07:00) | 픽업일=내일 대상 |
| ③-1 | 픽업 완료 확인(픽업 완료 시점) | `PICKUP_COMPLETED_IMMEDIATE` | 즉시 이벤트 | 픽업 완료 커맨드 시 발행 |
| ③-2 | 픽업 완료 확인(마감+30분 미완료) | `PICKUP_NOT_COMPLETED_AFTER_CUTOFF` | 스케줄(10분) | cutoff 지난 미완료 대상 |
| ④ | 찜한 공구 마감 D-3 | `WISH_DEADLINE_MINUS_3_DAYS` | 스케줄(10분) | 마감 72시간 윈도우 |
| ⑤ | 찜한 공구 마감 D-1 | `WISH_DEADLINE_MINUS_1_DAY` | 스케줄(10분) | 마감 24시간 윈도우 |
| ⑥ | 찜한 공구 목표 인원 달성 | `WISH_TARGET_ACHIEVED_IMMEDIATE` | 즉시 이벤트 | 결제 후 달성 판정 시 |
| ⑦ | 공구 참여 완료(결제 성공) | `APPLY_PAYMENT_SUCCESS_IMMEDIATE` | 즉시 이벤트 | 결제 성공 시 |
| ⑧ | 달성 확정(공구 성공) | `APPLY_GROUPBUY_ACHIEVED_IMMEDIATE` | 즉시 이벤트 | 상태 전이 성공 시 |
| ⑨ | 미달성 마감(환불 예정) | `APPLY_GROUPBUY_FAILED_IMMEDIATE` | 즉시 이벤트 | 상태 전이 실패 시 |
| ⑩ | 요청한 공구 개설 완료 | `REQUEST_OPENED_IMMEDIATE` | 즉시 이벤트 | open request notify 성공 시 |
| ⑪ | 요청한 공구 개설 불가 | `REQUEST_REJECTED_IMMEDIATE` | 즉시 이벤트 | 요청 거절 커맨드 시 |
| ⑫ | 요청공구 신규 참여자 신청 | `REQUEST_NEW_PARTICIPANT_IMMEDIATE` | 즉시 이벤트 | 신규 참여 시 |
| ⑬ | 요청공구 목표 인원 달성 | `REQUEST_TARGET_ACHIEVED_IMMEDIATE` | 즉시 이벤트 | 목표 달성 시 |
| ⑭ | 요청공구 마감 D-3 | `REQUEST_DEADLINE_MINUS_3_DAYS` | 스케줄(07:00) | desiredPickupDate 기준 D-3 |

## 🔍 참고 사항

### 모니터링 포인트
- 스케줄러 실행 건수/대상 건수/발행 건수(07:00, 10분, 5분 재시도)
- 디스패치 결과별 로그(성공/실패/중복 스킵)
- `notification_dispatch_histories` 상태별 적체량(`FAILED` 누적, `nextRetryAt` 경과 건수)
- 트리거 타입별 실패율 급증 여부
- 스케줄러 heartbeat 미실행 감지

### 멱등성/안정성
- dedup UNIQUE 키를 통해 동일 트리거의 중복 생성/중복 발송을 방지합니다.
- 재시도는 기존 실패 건을 재활용해 데이터 정합성을 유지합니다.

### 스코프 구분
- 이번 PR은 **“트리거/발송 파이프라인”** 중심입니다.

### 설계 고민 및 선택 근거
1. 즉시 발송 vs 스케줄 발송 분리
- 고민: 모든 조건을 이벤트 기반으로만 처리할지, 시간 조건을 스케줄러로 분리할지 고민했습니다.
- 선택: 상태 변화에 반응하는 항목은 이벤트 기반, 시간 윈도우 기반 항목은 스케줄러로 분리했습니다.
- 이유: 책임 분리가 명확해지고, 장애 분석/재처리 경로를 단순화할 수 있기 때문입니다.

2. 중복 방지 위치
- 고민: 애플리케이션 레벨 중복 체크만으로 갈지, DB 제약까지 둘지 고민했습니다.
- 선택: 애플리케이션 체크 + DB UNIQUE 제약을 함께 적용했습니다.
- 이유: 다중 인스턴스/동시 실행 환경에서 최종 정합성은 DB 제약이 가장 안정적이기 때문입니다.

3. 이벤트 발행 코드 일관성
- 고민: 각 도메인 서비스에서 이벤트를 직접 생성할지, 래퍼를 둘지 고민했습니다.
- 선택: `NotificationEventPublisher` 래퍼를 도입했습니다.
- 이유: 발행 포맷/공통 메타데이터 관리가 일관되고, 이후 트리거 추가 시 변경 비용이 낮아집니다.

4. 재시도 전략
- 고민: 즉시 무한 재시도 vs 백오프 기반 제한 재시도 중 선택이 필요했습니다.
- 선택: 백오프(1분→5분→30분) + 스케줄러 재처리로 구성했습니다.
- 이유: 장애 전파를 줄이고, 일시 장애 회복 가능성을 높이면서 운영자가 상태를 관측하기 쉽습니다. 

### 리뷰 반영 및 개선 사항

1. 타임존 일관성 보강
- 리뷰 포인트: 재시도 스케줄 계산에서 `LocalDateTime.now()` 사용으로 시스템 타임존 의존 가능성
- 반영: `NotificationImmediateDispatchService`의 재시도 시각 계산을 `Asia/Seoul` 기준으로 고정
- 효과: 스케줄러(KST)와 재시도 로직의 시간 기준 일치, 환경별 시간 오차 리스크 제거

2. 멱등성 제약 강화 (`target_id` nullable 이슈)
- 리뷰 포인트: dedup 유니크 키에 포함된 `target_id`가 NULL 허용이면 DB에서 중복 허용 가능
- 반영:
  - `notification_dispatch_histories.target_id`를 `NOT NULL`로 변경
  - 엔티티/리포지토리 타입을 `Long?` → `Long`으로 정리
  - 재시도 로직의 nullable 분기 제거
- 효과: DB 레벨 멱등성 보장 강화, 중복 발송 가능성 축소

3. 찜 마감 스케줄러 N+1 제거
- 리뷰 포인트: 그룹바이 루프 내부에서 사용자 조회 쿼리 반복 호출(N+1)
- 반영:
  - `FavoriteRepository`에 `groupBuyIds` 배치 조회 메서드 추가
  - `(groupBuyId, userId)` projection 조회 후 메모리 groupBy 처리
- 효과: 쿼리 수 감소, 대상 건수 증가 시 DB 부하 완화

4. 픽업 컷오프 후보 필터 DB 이관
- 리뷰 포인트: 후보 전체 조회 후 애플리케이션에서 `now >= cutoffAt` 필터링
- 반영:
  - `ParticipationRepository.findForPickupCutoffCheck`에서 cutoff 기준을 쿼리 조건으로 반영
  - 스케줄러는 조회된 대상만 발행하도록 단순화
- 효과: 메모리 사용량 감소, 대량 데이터 처리 시 성능/안정성 개선

5. 즉시 알림 이벤트 비동기 처리
- 리뷰 포인트: 동기 이벤트 리스너가 메인 도메인 플로우(결제/상태전이) 응답 지연 유발 가능
- 반영:
  - `NotificationImmediateTriggerEventListener`에 `@Async` 적용
  - `notificationEventExecutor`(전용 ThreadPoolTaskExecutor) 구성
- 효과: 핵심 비즈니스 응답 경로와 알림 발송 경로 분리, 체감 응답성 개선

### 테스트/검증
- 각 개선 포인트 반영 후 관련 테스트를 재실행하여 회귀 없음 확인
- 스케줄러/디스패치/연관 서비스 테스트 및 컴파일 검증 완료

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #146 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인