### PR TITLE
[MCJ-1496] FEAT: 찜 목록 조회에 마감 제외(excludeClosed) 옵션 반영

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryService.kt
@@ -20,16 +20,17 @@ class WishlistQueryService(
     fun getWishlist(
         userId: Long,
         filter: WishFilterType,
+        excludeClosed: Boolean,
         sort: WishSortType,
         pageable: Pageable,
         now: LocalDateTime = LocalDateTime.now(),
     ): WishlistPageResponse {
         log.info(
-            "[WishlistQueryService] 찜 목록 조회 시작: userId={}, filter={}, sort={}, page={}, size={}",
-            userId, filter, sort, pageable.pageNumber, pageable.pageSize
+            "[WishlistQueryService] 찜 목록 조회 시작: userId={}, filter={}, excludeClosed={}, sort={}, page={}, size={}",
+            userId, filter, excludeClosed, sort, pageable.pageNumber, pageable.pageSize
         )
 
-        val page = favoriteRepository.findWishlistGroupBuys(userId, filter, sort, pageable, now)
+        val page = favoriteRepository.findWishlistGroupBuys(userId, filter, excludeClosed, sort, pageable, now)
         val urgentCount = favoriteRepository.countUrgentByUserId(
             userId = userId,
             now = now,

--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishFilterType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishFilterType.kt
@@ -4,5 +4,4 @@ enum class WishFilterType {
     ALL,
     CLOSING_SOON,
     OPEN,
-    CLOSED,
 }

--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryCustom.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryCustom.kt
@@ -16,6 +16,7 @@ interface FavoriteRepositoryCustom {
     fun findWishlistGroupBuys(
         userId: Long,
         filter: WishFilterType,
+        excludeClosed: Boolean,
         sort: WishSortType,
         pageable: Pageable,
         now: LocalDateTime,

--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryImpl.kt
@@ -25,11 +25,12 @@ class FavoriteRepositoryImpl(
     override fun findWishlistGroupBuys(
         userId: Long,
         filter: WishFilterType,
+        excludeClosed: Boolean,
         sort: WishSortType,
         pageable: Pageable,
         now: LocalDateTime,
     ): Page<GroupBuy> {
-        val where = buildWhere(userId, filter, now)
+        val where = buildWhere(userId, filter, excludeClosed, now)
         val orderSpecifiers = buildOrderSpecifiers(sort)
 
         val content = queryFactory
@@ -56,10 +57,15 @@ class FavoriteRepositoryImpl(
     private fun buildWhere(
         userId: Long,
         filter: WishFilterType,
+        excludeClosed: Boolean,
         now: LocalDateTime,
     ): BooleanBuilder {
         val builder = BooleanBuilder()
             .and(favorite.user.id.eq(userId))
+
+        if (excludeClosed) {
+            builder.and(groupBuy.status.eq(GroupBuyStatus.IN_PROGRESS).and(groupBuy.deadline.gt(now)))
+        }
 
         filterPredicate(filter, now)?.let { builder.and(it) }
         return builder
@@ -85,7 +91,6 @@ class FavoriteRepositoryImpl(
                 .and(groupBuy.deadline.gt(now))
                 .and(groupBuy.deadline.loe(now.plusDays(FavoriteRepositoryCustom.CLOSING_SOON_DAYS)))
             WishFilterType.OPEN -> groupBuy.status.eq(GroupBuyStatus.IN_PROGRESS).and(groupBuy.deadline.gt(now))
-            WishFilterType.CLOSED -> groupBuy.status.eq(GroupBuyStatus.CLOSED).or(groupBuy.deadline.loe(now))
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryImpl.kt
@@ -63,8 +63,8 @@ class FavoriteRepositoryImpl(
         val builder = BooleanBuilder()
             .and(favorite.user.id.eq(userId))
 
-        if (excludeClosed) {
-            builder.and(groupBuy.status.eq(GroupBuyStatus.IN_PROGRESS).and(groupBuy.deadline.gt(now)))
+        if (excludeClosed && filter == WishFilterType.ALL) {
+            builder.and(isOpen(now))
         }
 
         filterPredicate(filter, now)?.let { builder.and(it) }
@@ -87,10 +87,13 @@ class FavoriteRepositoryImpl(
     private fun filterPredicate(filter: WishFilterType, now: LocalDateTime): BooleanExpression? {
         return when (filter) {
             WishFilterType.ALL -> null
-            WishFilterType.CLOSING_SOON -> groupBuy.status.eq(GroupBuyStatus.IN_PROGRESS)
-                .and(groupBuy.deadline.gt(now))
+            WishFilterType.CLOSING_SOON -> isOpen(now)
                 .and(groupBuy.deadline.loe(now.plusDays(FavoriteRepositoryCustom.CLOSING_SOON_DAYS)))
-            WishFilterType.OPEN -> groupBuy.status.eq(GroupBuyStatus.IN_PROGRESS).and(groupBuy.deadline.gt(now))
+            WishFilterType.OPEN -> isOpen(now)
         }
     }
+
+    private fun isOpen(now: LocalDateTime): BooleanExpression =
+        groupBuy.status.eq(GroupBuyStatus.IN_PROGRESS)
+            .and(groupBuy.deadline.gt(now))
 }

--- a/src/main/kotlin/com/moongchijang/domain/favorite/presentation/WishlistController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/presentation/WishlistController.kt
@@ -48,18 +48,20 @@ class WishlistController(
     fun getWishlists(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @RequestParam(required = false, defaultValue = "ALL") filter: WishFilterType,
+        @RequestParam(required = false, defaultValue = "false") excludeClosed: Boolean,
         @RequestParam(required = false, defaultValue = "LATEST") sort: WishSortType,
         pageable: Pageable,
     ): ResponseEntity<ApiResponse<WishlistPageResponse>> {
         val userId = principal.id
         log.info(
-            "[WishlistController] 찜 목록 조회 요청 수신: userId={}, filter={}, sort={}, page={}, size={}",
-            userId, filter, sort, pageable.pageNumber, pageable.pageSize
+            "[WishlistController] 찜 목록 조회 요청 수신: userId={}, filter={}, excludeClosed={}, sort={}, page={}, size={}",
+            userId, filter, excludeClosed, sort, pageable.pageNumber, pageable.pageSize
         )
 
         val response = wishlistQueryService.getWishlist(
             userId = userId,
             filter = filter,
+            excludeClosed = excludeClosed,
             sort = sort,
             pageable = pageable,
         )

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -885,9 +885,15 @@ paths:
           in: query
           schema:
             type: string
-            enum: [ALL, CLOSING_SOON, OPEN, CLOSED]
+            enum: [ALL, CLOSING_SOON, OPEN]
             default: ALL
-          description: ALL=전체 / CLOSING_SOON=마감임박(D-3) / OPEN=모집중 / CLOSED=마감공구
+          description: ALL=전체 / CLOSING_SOON=마감임박(D-3) / OPEN=모집중
+        - name: excludeClosed
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: true면 마감 공고 제외, false면 마감 포함
         - name: sort
           in: query
           schema:

--- a/src/test/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryServiceTest.kt
@@ -43,6 +43,7 @@ class WishlistQueryServiceTest {
             favoriteRepository.findWishlistGroupBuys(
                 userId = userId,
                 filter = WishFilterType.ALL,
+                excludeClosed = false,
                 sort = WishSortType.LATEST,
                 pageable = pageable,
                 now = now,
@@ -53,12 +54,13 @@ class WishlistQueryServiceTest {
         val result = service.getWishlist(
             userId = userId,
             filter = WishFilterType.ALL,
+            excludeClosed = false,
             sort = WishSortType.LATEST,
             pageable = pageable,
             now = now,
         )
 
-        verify(favoriteRepository).findWishlistGroupBuys(userId, WishFilterType.ALL, WishSortType.LATEST, pageable, now)
+        verify(favoriteRepository).findWishlistGroupBuys(userId, WishFilterType.ALL, false, WishSortType.LATEST, pageable, now)
         verify(favoriteRepository).countUrgentByUserId(userId, now, now.plusHours(24))
         assertEquals(1, result.content.size)
         assertEquals(2, result.urgentCount)
@@ -84,6 +86,7 @@ class WishlistQueryServiceTest {
             favoriteRepository.findWishlistGroupBuys(
                 userId = userId,
                 filter = WishFilterType.CLOSING_SOON,
+                excludeClosed = false,
                 sort = WishSortType.DEADLINE,
                 pageable = pageable,
                 now = now,
@@ -91,7 +94,7 @@ class WishlistQueryServiceTest {
         ).thenReturn(PageImpl(listOf(item), pageable, 1))
         `when`(favoriteRepository.countUrgentByUserId(userId, now, now.plusHours(24))).thenReturn(0L)
 
-        val result = service.getWishlist(userId, WishFilterType.CLOSING_SOON, WishSortType.DEADLINE, pageable, now)
+        val result = service.getWishlist(userId, WishFilterType.CLOSING_SOON, false, WishSortType.DEADLINE, pageable, now)
         val card = result.content.first()
 
         assertEquals(202L, card.groupBuyId)
@@ -121,6 +124,7 @@ class WishlistQueryServiceTest {
             favoriteRepository.findWishlistGroupBuys(
                 userId = userId,
                 filter = WishFilterType.ALL,
+                excludeClosed = false,
                 sort = WishSortType.LATEST,
                 pageable = pageable,
                 now = now,
@@ -128,7 +132,7 @@ class WishlistQueryServiceTest {
         ).thenReturn(PageImpl(listOf(item), pageable, 1))
         `when`(favoriteRepository.countUrgentByUserId(userId, now, now.plusHours(24))).thenReturn(1L)
 
-        val result = service.getWishlist(userId, WishFilterType.ALL, WishSortType.LATEST, pageable, now)
+        val result = service.getWishlist(userId, WishFilterType.ALL, false, WishSortType.LATEST, pageable, now)
         val card = result.content.first()
 
         assertEquals(0, card.dDay)


### PR DESCRIPTION
## 📌 작업한 내용
- 찜 목록 조회 필터 정책 정리
  - `CLOSED` 필터 제거
  - `ALL`, `OPEN`, `CLOSING_SOON` 유지
- 찜 목록 조회 API에 `excludeClosed` 옵션 추가
  - `GET /api/v1/wishlists?excludeClosed=true|false`
  - `true`: 마감 공고 제외
  - `false`: 마감 공고 포함(기본값)
- Repository(Querydsl) 조회 조건 반영
  - `excludeClosed=true` 시 `IN_PROGRESS + deadline > now` 조건 적용
  - `CLOSING_SOON`은 진행중 + 미마감 + D-3 이내로 보강
- Service/Controller에 `excludeClosed` 파라미터 연동
- 관련 테스트 및 OpenAPI 스펙 업데이트

## 🔍 참고 사항
- 화면의 “마감 제외” 체크박스 동작을 서버 쿼리 파라미터로 반영했습니다.
- `urgentCount`는 기존 정책대로 전체 찜 기준(24시간 이내) 집계를 유지합니다.
 
## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #151 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인