### PR TITLE
[MCJ-1473] feat: 공구 요청 상태 전이 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -14,6 +14,8 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusH
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -115,12 +117,12 @@ class GroupBuyRequestService(
                 groupBuyRequest.openedGroupBuyId = null
             }
             GroupBuyRequestStatus.OPENED -> {
-                openedGroupBuyForNotification = openedGroupBuyId?.let {
-                    groupBuyRepository.findWithStoreById(it)
-                        .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
-                }
+                val openedId = openedGroupBuyId
+                    ?: throw CustomException(ErrorCode.GROUPBUY_REQUEST_OPENED_GROUP_BUY_REQUIRED)
+                openedGroupBuyForNotification = groupBuyRepository.findWithStoreById(openedId)
+                    .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
                 groupBuyRequest.rejectionReason = null
-                groupBuyRequest.openedGroupBuyId = openedGroupBuyId
+                groupBuyRequest.openedGroupBuyId = openedId
             }
             GroupBuyRequestStatus.IN_CONTACT -> {
                 groupBuyRequest.rejectionReason = null
@@ -135,10 +137,11 @@ class GroupBuyRequestService(
         groupBuyRequestStatusHistoryRepository.save(
             GroupBuyRequestStatusHistory(
                 groupBuyRequestId = groupBuyRequest.id,
-                status = request.targetStatus
+                status = request.targetStatus,
+                changedAt = LocalDateTime.now()
             )
         )
-        openedGroupBuyForNotification?.let { groupBuyOpenRequestService.notifyOpened(it) }
+        openedGroupBuyForNotification?.let { notifyOpenedAfterCommit(it) }
 
         val history = groupBuyRequestStatusHistoryRepository
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
@@ -161,5 +164,20 @@ class GroupBuyRequestService(
         if (!isAllowed) {
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION)
         }
+    }
+
+    private fun notifyOpenedAfterCommit(groupBuy: GroupBuy) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            groupBuyOpenRequestService.notifyOpened(groupBuy)
+            return
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    groupBuyOpenRequestService.notifyOpened(groupBuy)
+                }
+            }
+        )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -3,9 +3,11 @@ package com.moongchijang.domain.groupbuy.application
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestCreateRequest
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestIdResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestResponse
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestStatusUpdateRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.global.exception.CustomException
@@ -19,7 +21,8 @@ import java.time.LocalDateTime
 @Transactional
 class GroupBuyRequestService(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
-    private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository
+    private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository,
+    private val groupBuyRepository: GroupBuyRepository
 ) {
 
     fun create(userId: Long, request: GroupBuyRequestCreateRequest): GroupBuyRequestIdResponse {
@@ -89,5 +92,69 @@ class GroupBuyRequestService(
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
 
         return GroupBuyRequestResponse.from(request, history)
+    }
+
+    fun updateStatus(requestId: Long, request: GroupBuyRequestStatusUpdateRequest): GroupBuyRequestResponse {
+        val groupBuyRequest = groupBuyRequestRepository.findById(requestId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
+
+        validateTransition(groupBuyRequest.status, request.targetStatus)
+
+        val rejectionReason = request.rejectionReason?.trim()
+        val openedGroupBuyId = request.openedGroupBuyId
+
+        when (request.targetStatus) {
+            GroupBuyRequestStatus.REJECTED -> {
+                if (rejectionReason.isNullOrBlank()) {
+                    throw CustomException(ErrorCode.GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED)
+                }
+                groupBuyRequest.rejectionReason = rejectionReason
+                groupBuyRequest.openedGroupBuyId = null
+            }
+            GroupBuyRequestStatus.OPENED -> {
+                if (openedGroupBuyId != null && !groupBuyRepository.existsById(openedGroupBuyId)) {
+                    throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
+                }
+                groupBuyRequest.rejectionReason = null
+                groupBuyRequest.openedGroupBuyId = openedGroupBuyId
+            }
+            GroupBuyRequestStatus.IN_CONTACT -> {
+                groupBuyRequest.rejectionReason = null
+                groupBuyRequest.openedGroupBuyId = null
+            }
+            GroupBuyRequestStatus.IN_REVIEW -> {
+                throw CustomException(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION)
+            }
+        }
+
+        groupBuyRequest.status = request.targetStatus
+        groupBuyRequestStatusHistoryRepository.save(
+            GroupBuyRequestStatusHistory(
+                groupBuyRequestId = groupBuyRequest.id,
+                status = request.targetStatus
+            )
+        )
+
+        val history = groupBuyRequestStatusHistoryRepository
+            .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
+
+        return GroupBuyRequestResponse.from(groupBuyRequest, history)
+    }
+
+    private fun validateTransition(
+        currentStatus: GroupBuyRequestStatus,
+        targetStatus: GroupBuyRequestStatus
+    ) {
+        val isAllowed = when (currentStatus) {
+            GroupBuyRequestStatus.IN_REVIEW -> targetStatus == GroupBuyRequestStatus.IN_CONTACT
+            GroupBuyRequestStatus.IN_CONTACT ->
+                targetStatus == GroupBuyRequestStatus.OPENED || targetStatus == GroupBuyRequestStatus.REJECTED
+            GroupBuyRequestStatus.OPENED,
+            GroupBuyRequestStatus.REJECTED -> false
+        }
+
+        if (!isAllowed) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION)
+        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestCreateReq
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestIdResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestStatusUpdateRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
@@ -22,7 +23,8 @@ import java.time.LocalDateTime
 class GroupBuyRequestService(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
     private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository,
-    private val groupBuyRepository: GroupBuyRepository
+    private val groupBuyRepository: GroupBuyRepository,
+    private val groupBuyOpenRequestService: GroupBuyOpenRequestService,
 ) {
 
     fun create(userId: Long, request: GroupBuyRequestCreateRequest): GroupBuyRequestIdResponse {
@@ -102,6 +104,7 @@ class GroupBuyRequestService(
 
         val rejectionReason = request.rejectionReason?.trim()
         val openedGroupBuyId = request.openedGroupBuyId
+        var openedGroupBuyForNotification: GroupBuy? = null
 
         when (request.targetStatus) {
             GroupBuyRequestStatus.REJECTED -> {
@@ -112,8 +115,9 @@ class GroupBuyRequestService(
                 groupBuyRequest.openedGroupBuyId = null
             }
             GroupBuyRequestStatus.OPENED -> {
-                if (openedGroupBuyId != null && !groupBuyRepository.existsById(openedGroupBuyId)) {
-                    throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
+                openedGroupBuyForNotification = openedGroupBuyId?.let {
+                    groupBuyRepository.findWithStoreById(it)
+                        .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
                 }
                 groupBuyRequest.rejectionReason = null
                 groupBuyRequest.openedGroupBuyId = openedGroupBuyId
@@ -134,6 +138,7 @@ class GroupBuyRequestService(
                 status = request.targetStatus
             )
         )
+        openedGroupBuyForNotification?.let { groupBuyOpenRequestService.notifyOpened(it) }
 
         val history = groupBuyRequestStatusHistoryRepository
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestStatusUpdateRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestStatusUpdateRequest.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+data class GroupBuyRequestStatusUpdateRequest(
+
+    @field:NotNull(message = "변경할 상태는 필수입니다")
+    val targetStatus: GroupBuyRequestStatus,
+
+    @field:Size(max = 500, message = "거절 사유는 500자 이하이어야 합니다")
+    val rejectionReason: String? = null,
+
+    val openedGroupBuyId: Long? = null
+)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
@@ -1,0 +1,32 @@
+package com.moongchijang.domain.groupbuy.presentation
+
+import com.moongchijang.domain.groupbuy.application.GroupBuyRequestService
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestResponse
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestStatusUpdateRequest
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/group-buy-requests")
+@Tag(name = "GroupBuyRequestAdmin", description = "공구 개설 요청 관리")
+class GroupBuyRequestAdminController(
+    private val groupBuyRequestService: GroupBuyRequestService
+) {
+
+    @PatchMapping("/{requestId}/status")
+    @Operation(summary = "공구 개설 요청 상태 변경")
+    fun updateStatus(
+        @PathVariable requestId: Long,
+        @Valid @RequestBody request: GroupBuyRequestStatusUpdateRequest
+    ): ResponseEntity<ApiResponse<GroupBuyRequestResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.updateStatus(requestId, request)))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -31,6 +31,8 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_REQUEST_NOT_FOUND(404_010, "공구 요청을 찾을 수 없습니다.", 404),
     GROUPBUY_REQUEST_FORBIDDEN(403_010, "본인의 공구 요청만 조회할 수 있습니다.", 403),
     GROUPBUY_REQUEST_INVALID_DATE(400_010, "희망 픽업 날짜는 오늘 이후여야 합니다.", 400),
+    GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION(400_011, "허용되지 않는 공구 요청 상태 전이입니다.", 400),
+    GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED(400_012, "거절 상태로 변경할 때는 거절 사유가 필요합니다.", 400),
 
     // GroupBuyOpenRequest
     DUPLICATE_OPEN_REQUEST(409_010, "이미 알림 신청한 공구입니다.", 409),

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -33,6 +33,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_REQUEST_INVALID_DATE(400_010, "희망 픽업 날짜는 오늘 이후여야 합니다.", 400),
     GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION(400_011, "허용되지 않는 공구 요청 상태 전이입니다.", 400),
     GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED(400_012, "거절 상태로 변경할 때는 거절 사유가 필요합니다.", 400),
+    GROUPBUY_REQUEST_OPENED_GROUP_BUY_REQUIRED(400_013, "개설 완료 상태로 변경할 때는 개설된 공구 ID가 필요합니다.", 400),
 
     // GroupBuyOpenRequest
     DUPLICATE_OPEN_REQUEST(409_010, "이미 알림 신청한 공구입니다.", 409),

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
                     "/api/v1/group-buys/progress",
                     "/api/v1/group-buys/*/progress",
                 ).permitAll()
+                it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
 
                 it.anyRequest().authenticated()
             }
@@ -71,7 +72,7 @@ class SecurityConfig(
             "https://www.moongchijang.com",
             "https://api.moongchijang.com"
         )
-        configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        configuration.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
         configuration.allowedHeaders = listOf("Authorization", "Content-Type", "Accept")
         configuration.allowCredentials = true
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -102,7 +102,11 @@ paths:
         - bearerAuth: []
       responses:
         '200':
-          $ref: '#/components/responses/SuccessNoData'
+          description: 상태 변경 결과
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseGroupBuyRequestDetail'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -2546,7 +2550,7 @@ components:
 
     GroupBuyRequestDetail:
       type: object
-      required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, rejectionReason, createdAt]
+      required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, rejectionReason, openedGroupBuyId, statusHistory, createdAt]
       properties:
         requestId: { type: integer, format: int64 }
         storeName: { type: string }
@@ -2562,11 +2566,24 @@ components:
         additionalNote: { type: string, nullable: true }
         status:
           type: string
-          enum: [SUBMITTED, IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
+          enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
           description: |
-            SUBMITTED=요청 접수 / IN_REVIEW=검토 중 / IN_CONTACT=매장 컨택 중 /
+            IN_REVIEW=검토 중 / IN_CONTACT=매장 컨택 중 /
             OPENED=공구 개설 완료 / REJECTED=개설 불가
+        contactPhone: { type: string, nullable: true }
+        contactInstagram: { type: string, nullable: true }
         rejectionReason: { type: string, nullable: true, description: status=REJECTED 시 노출 }
+        openedGroupBuyId: { type: integer, format: int64, nullable: true, description: status=OPENED 시 개설된 공구 id }
+        statusHistory:
+          type: array
+          items:
+            type: object
+            required: [status, changedAt]
+            properties:
+              status:
+                type: string
+                enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
+              changedAt: { type: string, format: date-time }
         createdAt: { type: string, format: date-time }
 
     ApiResponseGroupBuyRequestList:
@@ -3220,24 +3237,21 @@ components:
 
     AdminRequestStatusUpdate:
       type: object
-      required: [status]
+      required: [targetStatus]
       properties:
-        status:
+        targetStatus:
           type: string
           enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
-        contactPhone:
-          type: string
-          pattern: '^\d{3}-\d{3,4}-\d{4}$'
-          nullable: true
-        contactInstagram:
-          type: string
-          pattern: '^@.+'
-          nullable: true
         rejectionReason:
           type: string
-          maxLength: 100
+          maxLength: 500
           nullable: true
-          description: status=REJECTED 시 필수
+          description: targetStatus=REJECTED 시 필수
+        openedGroupBuyId:
+          type: integer
+          format: int64
+          nullable: true
+          description: targetStatus=OPENED 시 실제 개설된 공구 id. 전달 시 존재 검증 후 개설 알림 발송에 사용
 
     ApiResponseAdminGroupBuyList:
       type: object

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -102,11 +102,7 @@ paths:
         - bearerAuth: []
       responses:
         '200':
-          description: 상태 변경 결과
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseGroupBuyRequestDetail'
+          $ref: '#/components/responses/SuccessNoData'
         '401':
           $ref: '#/components/responses/Unauthorized'
 
@@ -1480,7 +1476,11 @@ paths:
               $ref: '#/components/schemas/AdminRequestStatusUpdate'
       responses:
         '200':
-          $ref: '#/components/responses/SuccessNoData'
+          description: 상태 변경 결과
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseGroupBuyRequestDetail'
         '400':
           $ref: '#/components/responses/BadRequest'
 
@@ -3251,7 +3251,7 @@ components:
           type: integer
           format: int64
           nullable: true
-          description: targetStatus=OPENED 시 실제 개설된 공구 id. 전달 시 존재 검증 후 개설 알림 발송에 사용
+          description: targetStatus=OPENED 시 필수. 실제 개설된 공구 id이며 존재 검증 후 개설 알림 발송에 사용
 
     ApiResponseAdminGroupBuyList:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -1,10 +1,11 @@
 package com.moongchijang.domain.groupbuy.service
 
 import com.moongchijang.domain.groupbuy.application.GroupBuyRequestService
-import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestCreateRequest
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestStatusUpdateRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.global.exception.CustomException
@@ -30,6 +31,9 @@ class GroupBuyRequestServiceTest {
 
     @Mock
     private lateinit var groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
 
     @InjectMocks
     private lateinit var service: GroupBuyRequestService
@@ -289,6 +293,176 @@ class GroupBuyRequestServiceTest {
 
         val ex = assertThrows<CustomException> { service.getDetail(1L, requestId) }
         assertEquals(ErrorCode.GROUPBUY_REQUEST_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `IN_REVIEW 요청을 IN_CONTACT로 변경하면 상태와 히스토리를 저장한다`() {
+        val requestId = 10L
+        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+            desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5)).apply { id = requestId }
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
+        `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
+            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT)
+        )
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+            .thenReturn(listOf(
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_REVIEW),
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT)
+            ))
+
+        val result = service.updateStatus(
+            requestId,
+            GroupBuyRequestStatusUpdateRequest(targetStatus = GroupBuyRequestStatus.IN_CONTACT)
+        )
+
+        assertEquals(GroupBuyRequestStatus.IN_CONTACT, groupBuyRequest.status)
+        assertEquals(GroupBuyRequestStatus.IN_CONTACT.name, result.status)
+        assertEquals(2, result.statusHistory.size)
+        val captor = argumentCaptor<GroupBuyRequestStatusHistory>()
+        verify(groupBuyRequestStatusHistoryRepository).save(captor.capture())
+        assertEquals(requestId, captor.value.groupBuyRequestId)
+        assertEquals(GroupBuyRequestStatus.IN_CONTACT, captor.value.status)
+    }
+
+    @Test
+    fun `IN_CONTACT 요청을 REJECTED로 변경할 때 거절 사유를 저장한다`() {
+        val requestId = 11L
+        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+            desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
+            status = GroupBuyRequestStatus.IN_CONTACT).apply {
+            id = requestId
+            openedGroupBuyId = 99L
+        }
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
+        `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
+            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.REJECTED)
+        )
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+            .thenReturn(listOf(
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_REVIEW),
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT),
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.REJECTED)
+            ))
+
+        val result = service.updateStatus(
+            requestId,
+            GroupBuyRequestStatusUpdateRequest(
+                targetStatus = GroupBuyRequestStatus.REJECTED,
+                rejectionReason = "  공급 불가  "
+            )
+        )
+
+        assertEquals(GroupBuyRequestStatus.REJECTED, groupBuyRequest.status)
+        assertEquals("공급 불가", groupBuyRequest.rejectionReason)
+        assertNull(groupBuyRequest.openedGroupBuyId)
+        assertEquals("공급 불가", result.rejectionReason)
+    }
+
+    @Test
+    fun `REJECTED 변경 시 거절 사유가 없으면 GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED 예외`() {
+        val requestId = 12L
+        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+            desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
+            status = GroupBuyRequestStatus.IN_CONTACT).apply { id = requestId }
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
+
+        val ex = assertThrows<CustomException> {
+            service.updateStatus(
+                requestId,
+                GroupBuyRequestStatusUpdateRequest(
+                    targetStatus = GroupBuyRequestStatus.REJECTED,
+                    rejectionReason = " "
+                )
+            )
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED, ex.errorCode)
+        verify(groupBuyRequestStatusHistoryRepository, never()).save(any())
+    }
+
+    @Test
+    fun `IN_CONTACT 요청을 OPENED로 변경할 때 공구 id가 있으면 존재 검증 후 저장한다`() {
+        val requestId = 13L
+        val openedGroupBuyId = 100L
+        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+            desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
+            status = GroupBuyRequestStatus.IN_CONTACT).apply {
+            id = requestId
+            rejectionReason = "이전 사유"
+        }
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
+        `when`(groupBuyRepository.existsById(openedGroupBuyId)).thenReturn(true)
+        `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
+            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.OPENED)
+        )
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+            .thenReturn(listOf(
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_REVIEW),
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT),
+                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.OPENED)
+            ))
+
+        val result = service.updateStatus(
+            requestId,
+            GroupBuyRequestStatusUpdateRequest(
+                targetStatus = GroupBuyRequestStatus.OPENED,
+                openedGroupBuyId = openedGroupBuyId
+            )
+        )
+
+        assertEquals(GroupBuyRequestStatus.OPENED, groupBuyRequest.status)
+        assertNull(groupBuyRequest.rejectionReason)
+        assertEquals(openedGroupBuyId, groupBuyRequest.openedGroupBuyId)
+        assertEquals(openedGroupBuyId, result.openedGroupBuyId)
+        verify(groupBuyRepository).existsById(openedGroupBuyId)
+    }
+
+    @Test
+    fun `OPENED 변경 시 공구 id가 존재하지 않으면 GROUPBUY_NOT_FOUND 예외`() {
+        val requestId = 14L
+        val openedGroupBuyId = 100L
+        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+            desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
+            status = GroupBuyRequestStatus.IN_CONTACT).apply { id = requestId }
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
+        `when`(groupBuyRepository.existsById(openedGroupBuyId)).thenReturn(false)
+
+        val ex = assertThrows<CustomException> {
+            service.updateStatus(
+                requestId,
+                GroupBuyRequestStatusUpdateRequest(
+                    targetStatus = GroupBuyRequestStatus.OPENED,
+                    openedGroupBuyId = openedGroupBuyId
+                )
+            )
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
+        verify(groupBuyRequestStatusHistoryRepository, never()).save(any())
+    }
+
+    @Test
+    fun `허용되지 않는 상태 전이는 GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION 예외`() {
+        val requestId = 15L
+        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+            desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5)).apply { id = requestId }
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
+
+        val ex = assertThrows<CustomException> {
+            service.updateStatus(
+                requestId,
+                GroupBuyRequestStatusUpdateRequest(targetStatus = GroupBuyRequestStatus.OPENED)
+            )
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION, ex.errorCode)
+        verify(groupBuyRequestStatusHistoryRepository, never()).save(any())
     }
 
     private inline fun <reified T> argumentCaptor() = org.mockito.ArgumentCaptor.forClass(T::class.java)

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -329,6 +329,7 @@ class GroupBuyRequestServiceTest {
         verify(groupBuyRequestStatusHistoryRepository).save(captor.capture())
         assertEquals(requestId, captor.value.groupBuyRequestId)
         assertEquals(GroupBuyRequestStatus.IN_CONTACT, captor.value.status)
+        assertNotNull(captor.value.changedAt)
     }
 
     @Test
@@ -434,8 +435,29 @@ class GroupBuyRequestServiceTest {
     }
 
     @Test
-    fun `OPENED 변경 시 공구 id가 존재하지 않으면 GROUPBUY_NOT_FOUND 예외`() {
+    fun `OPENED 변경 시 공구 id가 없으면 GROUPBUY_REQUEST_OPENED_GROUP_BUY_REQUIRED 예외`() {
         val requestId = 14L
+        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+            desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
+            status = GroupBuyRequestStatus.IN_CONTACT).apply { id = requestId }
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
+
+        val ex = assertThrows<CustomException> {
+            service.updateStatus(
+                requestId,
+                GroupBuyRequestStatusUpdateRequest(targetStatus = GroupBuyRequestStatus.OPENED)
+            )
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_REQUEST_OPENED_GROUP_BUY_REQUIRED, ex.errorCode)
+        verifyNoInteractions(groupBuyRepository, groupBuyOpenRequestService)
+        verify(groupBuyRequestStatusHistoryRepository, never()).save(any())
+    }
+
+    @Test
+    fun `OPENED 변경 시 공구 id가 존재하지 않으면 GROUPBUY_NOT_FOUND 예외`() {
+        val requestId = 15L
         val openedGroupBuyId = 100L
         val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
@@ -461,7 +483,7 @@ class GroupBuyRequestServiceTest {
 
     @Test
     fun `허용되지 않는 상태 전이는 GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION 예외`() {
-        val requestId = 15L
+        val requestId = 16L
         val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5)).apply { id = requestId }
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -1,8 +1,10 @@
 package com.moongchijang.domain.groupbuy.service
 
 import com.moongchijang.domain.groupbuy.application.GroupBuyRequestService
+import com.moongchijang.domain.groupbuy.application.GroupBuyOpenRequestService
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestStatusUpdateRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
@@ -10,6 +12,7 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestReposit
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
 import com.moongchijang.support.GroupBuyRequestFixture
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -34,6 +37,9 @@ class GroupBuyRequestServiceTest {
 
     @Mock
     private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var groupBuyOpenRequestService: GroupBuyOpenRequestService
 
     @InjectMocks
     private lateinit var service: GroupBuyRequestService
@@ -393,9 +399,14 @@ class GroupBuyRequestServiceTest {
             id = requestId
             rejectionReason = "이전 사유"
         }
+        val openedGroupBuy = GroupBuyFixture.createGroupBuy(
+            id = openedGroupBuyId,
+            status = GroupBuyStatus.IN_PROGRESS,
+            productName = "튀김소보로"
+        )
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
-        `when`(groupBuyRepository.existsById(openedGroupBuyId)).thenReturn(true)
+        `when`(groupBuyRepository.findWithStoreById(openedGroupBuyId)).thenReturn(Optional.of(openedGroupBuy))
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
             GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.OPENED)
         )
@@ -418,7 +429,8 @@ class GroupBuyRequestServiceTest {
         assertNull(groupBuyRequest.rejectionReason)
         assertEquals(openedGroupBuyId, groupBuyRequest.openedGroupBuyId)
         assertEquals(openedGroupBuyId, result.openedGroupBuyId)
-        verify(groupBuyRepository).existsById(openedGroupBuyId)
+        verify(groupBuyRepository).findWithStoreById(openedGroupBuyId)
+        verify(groupBuyOpenRequestService).notifyOpened(openedGroupBuy)
     }
 
     @Test
@@ -430,7 +442,7 @@ class GroupBuyRequestServiceTest {
             status = GroupBuyRequestStatus.IN_CONTACT).apply { id = requestId }
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
-        `when`(groupBuyRepository.existsById(openedGroupBuyId)).thenReturn(false)
+        `when`(groupBuyRepository.findWithStoreById(openedGroupBuyId)).thenReturn(Optional.empty())
 
         val ex = assertThrows<CustomException> {
             service.updateStatus(
@@ -444,6 +456,7 @@ class GroupBuyRequestServiceTest {
 
         assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
         verify(groupBuyRequestStatusHistoryRepository, never()).save(any())
+        verifyNoInteractions(groupBuyOpenRequestService)
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업한 내용
- 관리자/운영자용 공구 요청 상태 변경 API를 추가했습니다.
- 허용 상태 전이를 `IN_REVIEW -> IN_CONTACT -> OPENED/REJECTED`로 제한했습니다.
- `REJECTED` 전이 시 거절 사유 필수 검증과 저장을 추가했습니다.
- `OPENED` 전이 시 `openedGroupBuyId` 존재 검증과 저장을 추가했습니다.
- 상태 변경 히스토리 저장을 보장했습니다.
- `OPENED` 전이 후 실제 공구 개설 알림 트리거를 연결했습니다.
- 관리자 PATCH API 호출을 위해 CORS 허용 메서드에 `PATCH`를 추가했습니다.
- OpenAPI 명세를 실제 요청/응답 DTO에 맞게 갱신했습니다.

## 🔍 참고 사항
- 상태 변경 API 경로: `PATCH /api/v1/admin/group-buy-requests/{requestId}/status`
- 요청 필드: `targetStatus`, `rejectionReason`, `openedGroupBuyId`
- `openedGroupBuyId`가 전달된 `OPENED` 전이에서만 공구 개설 알림을 발송합니다.

## 🖼️ 스크린샷


## 🔗 관련 이슈
- #111
- MCJ-1473

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
