### PR TITLE
[MCJ-1475] FEAT: 픽업 안내 및 QR API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -22,6 +22,18 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     @Query(
         """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.id = :participationId
+        """
+    )
+    fun findPickupDetailById(@Param("participationId") participationId: Long): Participation?
+
+    @Query(
+        """
         SELECT DISTINCT p.user.id
         FROM Participation p
         WHERE p.groupBuy.id = :groupBuyId
@@ -109,6 +121,42 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
         pageable: Pageable
     ): Page<Participation>
+
+    @Query(
+        """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.user.id = :userId
+          and p.status = :status
+          and p.pickupStatus in :pickupStatuses
+          and gb.pickupDate >= :fromDate
+        order by gb.pickupDate asc, gb.pickupTimeStart asc, p.id asc
+        """
+    )
+    fun findNearestPickupQrCandidates(
+        @Param("userId") userId: Long,
+        @Param("status") status: ParticipationStatus,
+        @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
+        @Param("fromDate") fromDate: LocalDate,
+    ): List<Participation>
+
+    fun existsByPickupToken(pickupToken: String): Boolean
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.pickupToken = :pickupToken
+        """
+    )
+    fun findByPickupTokenForUpdate(@Param("pickupToken") pickupToken: String): Participation?
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Participation p join fetch p.groupBuy where p.id = :id")

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -39,7 +39,6 @@ class PickupService(
             storeName = store.name,
             storeAddress = store.address,
             storePhone = store.phoneNumber,
-            storePhoneNumber = store.phoneNumber,
             latitude = store.latitude,
             longitude = store.longitude,
             transitInfo = null,
@@ -129,10 +128,9 @@ class PickupService(
         }
 
         val processedBy = userRepository.findByIdAndDeletedAtIsNull(processedByUserId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
         val pickedUpAt = LocalDateTime.now()
-        participation.pickupStatus = PickupStatus.PICKED_UP
-        participation.pickedUpAt = pickedUpAt
-        participation.pickupProcessedBy = processedBy
+        participation.markPickedUp(processedBy, pickedUpAt)
 
         return PickupVerifyResponse(
             participationId = participation.id,

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -1,0 +1,187 @@
+package com.moongchijang.domain.pickup.application
+
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.pickup.application.dto.NearestPickupQrReason
+import com.moongchijang.domain.pickup.application.dto.NearestPickupQrResponse
+import com.moongchijang.domain.pickup.application.dto.PickupAvailabilityStatus
+import com.moongchijang.domain.pickup.application.dto.PickupGuideResponse
+import com.moongchijang.domain.pickup.application.dto.PickupQrResponse
+import com.moongchijang.domain.pickup.application.dto.PickupVerifyResponse
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+@Service
+class PickupService(
+    private val participationRepository: ParticipationRepository,
+    private val userRepository: UserRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getPickupGuide(participationId: Long, userId: Long): PickupGuideResponse {
+        val participation = findOwnedParticipation(participationId, userId)
+        val groupBuy = participation.groupBuy
+        val store = groupBuy.store
+
+        return PickupGuideResponse(
+            participationId = participation.id,
+            availabilityStatus = participation.availabilityStatus(),
+            pickupStatus = participation.pickupStatus,
+            storeName = store.name,
+            storeAddress = store.address,
+            storePhone = store.phoneNumber,
+            storePhoneNumber = store.phoneNumber,
+            latitude = store.latitude,
+            longitude = store.longitude,
+            transitInfo = null,
+            productName = groupBuy.productName,
+            quantity = participation.quantity,
+            pickupDate = groupBuy.pickupDate,
+            pickupTimeStart = groupBuy.pickupTimeStart,
+            pickupTimeEnd = groupBuy.pickupTimeEnd,
+            pickupLocation = groupBuy.pickupLocation,
+            remainingMinutes = participation.remainingPickupMinutes(),
+            pickedUpAt = participation.pickedUpAt,
+        )
+    }
+
+    @Transactional
+    fun getPickupQr(participationId: Long, userId: Long): PickupQrResponse {
+        val participation = findOwnedParticipation(participationId, userId)
+        return buildPickupQrResponse(participation)
+    }
+
+    @Transactional
+    fun getNearestPickupQr(userId: Long): NearestPickupQrResponse {
+        val today = LocalDate.now()
+        val candidates = participationRepository.findNearestPickupQrCandidates(
+            userId = userId,
+            status = ParticipationStatus.CONFIRMED,
+            pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+            fromDate = today,
+        )
+
+        if (candidates.isEmpty()) {
+            return NearestPickupQrResponse(
+                hasCandidate = false,
+                hasMultipleToday = false,
+                reason = NearestPickupQrReason.NO_AVAILABLE_PICKUP,
+                item = null,
+            )
+        }
+
+        val todayCandidates = candidates.filter { it.groupBuy.pickupDate == today }
+        val selected = todayCandidates.firstOrNull() ?: candidates.first()
+
+        return NearestPickupQrResponse(
+            hasCandidate = true,
+            hasMultipleToday = todayCandidates.size > 1,
+            reason = if (todayCandidates.isEmpty()) NearestPickupQrReason.ONLY_FUTURE_PICKUP else null,
+            item = buildPickupQrResponse(selected),
+        )
+    }
+
+    private fun buildPickupQrResponse(participation: Participation): PickupQrResponse {
+        val isActive = participation.isPickupActive()
+        if (isActive && participation.pickupStatus == PickupStatus.NOT_READY) {
+            participation.pickupStatus = PickupStatus.READY
+        }
+        if (isActive && participation.pickupStatus == PickupStatus.READY && participation.pickupToken == null) {
+            participation.pickupToken = generateUniquePickupToken()
+        }
+
+        return PickupQrResponse(
+            participationId = participation.id,
+            availabilityStatus = participation.availabilityStatus(),
+            pickupStatus = participation.pickupStatus,
+            userName = participation.user.nickname,
+            productName = participation.groupBuy.productName,
+            quantity = participation.quantity,
+            storeName = participation.groupBuy.store.name,
+            pickupLocation = participation.groupBuy.pickupLocation,
+            qrCode = participation.pickupToken.takeIf { isActive && participation.pickupStatus == PickupStatus.READY },
+            pickupDate = participation.groupBuy.pickupDate,
+            pickupTimeStart = participation.groupBuy.pickupTimeStart,
+            pickupTimeEnd = participation.groupBuy.pickupTimeEnd,
+            pickedUpAt = participation.pickedUpAt,
+        )
+    }
+
+    @Transactional
+    fun verifyPickup(qrCode: String, processedByUserId: Long): PickupVerifyResponse {
+        val participation = participationRepository.findByPickupTokenForUpdate(qrCode)
+            ?: throw CustomException(ErrorCode.PICKUP_QR_NOT_FOUND)
+
+        if (!participation.isPickupActive()) {
+            throw CustomException(ErrorCode.PICKUP_LOCKED)
+        }
+        if (participation.pickupStatus == PickupStatus.PICKED_UP) {
+            throw CustomException(ErrorCode.PICKUP_ALREADY_USED)
+        }
+
+        val processedBy = userRepository.findByIdAndDeletedAtIsNull(processedByUserId)
+        val pickedUpAt = LocalDateTime.now()
+        participation.pickupStatus = PickupStatus.PICKED_UP
+        participation.pickedUpAt = pickedUpAt
+        participation.pickupProcessedBy = processedBy
+
+        return PickupVerifyResponse(
+            participationId = participation.id,
+            pickupStatus = participation.pickupStatus,
+            pickedUpAt = pickedUpAt,
+            pickupProcessedByUserId = processedBy?.id,
+        )
+    }
+
+    private fun findOwnedParticipation(participationId: Long, userId: Long): Participation {
+        val participation = participationRepository.findPickupDetailById(participationId)
+            ?: throw CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
+
+        if (participation.user.id != userId) {
+            throw CustomException(ErrorCode.PICKUP_PARTICIPATION_FORBIDDEN)
+        }
+        return participation
+    }
+
+    private fun Participation.isPickupActive(): Boolean =
+        !LocalDate.now().isBefore(groupBuy.pickupDate)
+
+    private fun Participation.availabilityStatus(): PickupAvailabilityStatus =
+        when {
+            pickupStatus == PickupStatus.PICKED_UP -> PickupAvailabilityStatus.PICKED_UP
+            isPickupActive() -> PickupAvailabilityStatus.AVAILABLE
+            else -> PickupAvailabilityStatus.LOCKED
+        }
+
+    private fun Participation.remainingPickupMinutes(): Long? {
+        val today = LocalDate.now()
+        if (groupBuy.pickupDate != today) return null
+
+        val now = LocalDateTime.now()
+        val pickupEndAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeEnd)
+        return ChronoUnit.MINUTES.between(now, pickupEndAt).coerceAtLeast(0)
+    }
+
+    private fun generateUniquePickupToken(): String {
+        repeat(TOKEN_GENERATION_ATTEMPTS) {
+            val token = UUID.randomUUID().toString()
+            if (!participationRepository.existsByPickupToken(token)) {
+                return token
+            }
+        }
+        throw CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
+    }
+
+    companion object {
+        private const val TOKEN_GENERATION_ATTEMPTS = 5
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
@@ -18,7 +18,6 @@ data class PickupGuideResponse(
     val storeName: String,
     val storeAddress: String,
     val storePhone: String?,
-    val storePhoneNumber: String?,
     val latitude: Double?,
     val longitude: Double?,
     val transitInfo: String?,

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
@@ -1,0 +1,68 @@
+package com.moongchijang.domain.pickup.application.dto
+
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+enum class PickupAvailabilityStatus {
+    LOCKED,
+    AVAILABLE,
+    PICKED_UP
+}
+
+data class PickupGuideResponse(
+    val participationId: Long,
+    val availabilityStatus: PickupAvailabilityStatus,
+    val pickupStatus: PickupStatus,
+    val storeName: String,
+    val storeAddress: String,
+    val storePhone: String?,
+    val storePhoneNumber: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+    val transitInfo: String?,
+    val productName: String,
+    val quantity: Int,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: LocalTime,
+    val pickupTimeEnd: LocalTime,
+    val pickupLocation: String,
+    val remainingMinutes: Long?,
+    val pickedUpAt: LocalDateTime?,
+)
+
+data class PickupQrResponse(
+    val participationId: Long,
+    val availabilityStatus: PickupAvailabilityStatus,
+    val pickupStatus: PickupStatus,
+    val userName: String?,
+    val productName: String,
+    val quantity: Int,
+    val storeName: String,
+    val pickupLocation: String,
+    val qrCode: String?,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: LocalTime,
+    val pickupTimeEnd: LocalTime,
+    val pickedUpAt: LocalDateTime?,
+)
+
+enum class NearestPickupQrReason {
+    NO_AVAILABLE_PICKUP,
+    ONLY_FUTURE_PICKUP
+}
+
+data class NearestPickupQrResponse(
+    val hasCandidate: Boolean,
+    val hasMultipleToday: Boolean,
+    val reason: NearestPickupQrReason?,
+    val item: PickupQrResponse?,
+)
+
+data class PickupVerifyResponse(
+    val participationId: Long,
+    val pickupStatus: PickupStatus,
+    val pickedUpAt: LocalDateTime,
+    val pickupProcessedByUserId: Long?,
+)

--- a/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
@@ -5,13 +5,11 @@ import com.moongchijang.domain.pickup.application.dto.NearestPickupQrResponse
 import com.moongchijang.domain.pickup.application.dto.PickupGuideResponse
 import com.moongchijang.domain.pickup.application.dto.PickupQrResponse
 import com.moongchijang.domain.pickup.application.dto.PickupVerifyResponse
-import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import org.springframework.http.ResponseEntity
-import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -61,14 +59,6 @@ class PickupController(
     }
 
     private fun CustomUserPrincipal?.requirePickupVerifierUserId(): Long {
-        val authenticated = this ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        if (authenticated.role !in PICKUP_VERIFIER_ROLES) {
-            throw AccessDeniedException("Pickup verification requires ADMIN or SELLER role")
-        }
-        return authenticated.id
-    }
-
-    companion object {
-        private val PICKUP_VERIFIER_ROLES = setOf(UserRole.ADMIN, UserRole.SELLER)
+        return this?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
@@ -1,0 +1,74 @@
+package com.moongchijang.domain.pickup.presentation
+
+import com.moongchijang.domain.pickup.application.PickupService
+import com.moongchijang.domain.pickup.application.dto.NearestPickupQrResponse
+import com.moongchijang.domain.pickup.application.dto.PickupGuideResponse
+import com.moongchijang.domain.pickup.application.dto.PickupQrResponse
+import com.moongchijang.domain.pickup.application.dto.PickupVerifyResponse
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+class PickupController(
+    private val pickupService: PickupService,
+) {
+
+    @GetMapping("/participations/{participationId}/pickup")
+    fun getPickupGuide(
+        @PathVariable participationId: Long,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+    ): ResponseEntity<ApiResponse<PickupGuideResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        return ResponseEntity.ok(ApiResponse.success(pickupService.getPickupGuide(participationId, userId)))
+    }
+
+    @GetMapping("/participations/{participationId}/qr")
+    fun getPickupQr(
+        @PathVariable participationId: Long,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+    ): ResponseEntity<ApiResponse<PickupQrResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        return ResponseEntity.ok(ApiResponse.success(pickupService.getPickupQr(participationId, userId)))
+    }
+
+    @GetMapping("/pickups/me/nearest-qr")
+    fun getNearestPickupQr(
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+    ): ResponseEntity<ApiResponse<NearestPickupQrResponse>> {
+        val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        return ResponseEntity.ok(ApiResponse.success(pickupService.getNearestPickupQr(userId)))
+    }
+
+    @PostMapping("/pickups/{qrCode}/verify")
+    fun verifyPickup(
+        @PathVariable qrCode: String,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
+    ): ResponseEntity<ApiResponse<PickupVerifyResponse>> {
+        val userId = principal.requirePickupVerifierUserId()
+        return ResponseEntity.ok(ApiResponse.success(pickupService.verifyPickup(qrCode, userId)))
+    }
+
+    private fun CustomUserPrincipal?.requirePickupVerifierUserId(): Long {
+        val authenticated = this ?: throw CustomException(ErrorCode.INVALID_LOGIN)
+        if (authenticated.role !in PICKUP_VERIFIER_ROLES) {
+            throw AccessDeniedException("Pickup verification requires ADMIN or SELLER role")
+        }
+        return authenticated.id
+    }
+
+    companion object {
+        private val PICKUP_VERIFIER_ROLES = setOf(UserRole.ADMIN, UserRole.SELLER)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -117,6 +117,12 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PARTICIPATION_CANCEL_NOT_ALLOWED(409_357, "취소할 수 없는 참여 상태입니다.", 409),
     PARTICIPATION_CANCEL_REASON_DETAIL_REQUIRED(400_358, "기타 취소 사유를 입력해주세요.", 400),
 
+    // Pickup(400~449)
+    PICKUP_PARTICIPATION_FORBIDDEN(403_400, "본인의 참여 정보만 조회할 수 있습니다.", 403),
+    PICKUP_LOCKED(400_400, "픽업일 00시 이후 이용할 수 있습니다.", 400),
+    PICKUP_QR_NOT_FOUND(404_401, "픽업 QR을 찾을 수 없습니다.", 404),
+    PICKUP_ALREADY_USED(409_400, "이미 사용된 픽업 QR입니다.", 409),
+
     // Notification(360~369)
     NOTIFICATION_NOT_FOUND(404_360, "알림을 찾을 수 없습니다.", 404),
     NOTIFICATION_FORBIDDEN(403_360, "본인 알림만 처리할 수 있습니다.", 403),

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -50,6 +50,10 @@ class SecurityConfig(
                     "/api/v1/group-buys/progress",
                     "/api/v1/group-buys/*/progress",
                 ).permitAll()
+                it.requestMatchers(
+                    HttpMethod.POST,
+                    "/api/v1/pickups/*/verify",
+                ).hasAnyRole("ADMIN", "SELLER")
                 it.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
 
                 it.anyRequest().authenticated()

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2856,7 +2856,6 @@ components:
             storeName: { type: string }
             storeAddress: { type: string }
             storePhone: { type: string, nullable: true }
-            storePhoneNumber: { type: string, nullable: true }
             latitude: { type: number, format: double, nullable: true }
             longitude: { type: number, format: double, nullable: true }
             transitInfo: { type: string, nullable: true, description: "대중교통 안내. 현재 저장 원천이 없으면 null" }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1112,11 +1112,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponseQrCode'
 
+  /api/v1/pickups/me/nearest-qr:
+    get:
+      tags: [Pickup]
+      summary: 피드용 가장 가까운 픽업 QR 조회
+      description: |
+        피드 진입 시 사용자의 가장 가까운 픽업 QR 후보를 조회한다.
+        당일 픽업 예정 건이 있으면 픽업 시작 시간이 가장 빠른 건을 반환하고,
+        당일 건이 여러 개면 hasMultipleToday=true로 내려준다.
+        당일 픽업 건이 없고 향후 픽업 예정 건만 있으면 LOCKED 상태와 qrCode=null로 반환한다.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 가장 가까운 픽업 QR 후보
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseNearestPickupQr'
+
   /api/v1/pickups/{qrCode}/verify:
     post:
       tags: [Pickup]
       summary: QR 코드 스캔 검증 및 수령 처리
-      description: 소비자 QR을 매장(사장님)이 스캔하면 대기 → 완료로 자동 전환된다.
+      description: ADMIN 또는 SELLER 권한 사용자가 소비자 QR을 스캔하면 대기 → 완료로 자동 전환된다.
       security:
         - bearerAuth: []
       parameters:
@@ -2825,21 +2844,30 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [participationId, storeName, storePhone, storeAddress, latitude, longitude, transitInfo, pickupDate, pickupTimeStart, pickupTimeEnd, productName, quantity, remainingMinutes]
+          required: [participationId, availabilityStatus, pickupStatus, storeName, storeAddress, productName, quantity, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation]
           properties:
             participationId: { type: integer, format: int64 }
+            availabilityStatus:
+              type: string
+              enum: [LOCKED, AVAILABLE, PICKED_UP]
+            pickupStatus:
+              type: string
+              enum: [NOT_READY, READY, PICKED_UP, NO_SHOW]
             storeName: { type: string }
-            storePhone: { type: string }
             storeAddress: { type: string }
+            storePhone: { type: string, nullable: true }
+            storePhoneNumber: { type: string, nullable: true }
             latitude: { type: number, format: double, nullable: true }
             longitude: { type: number, format: double, nullable: true }
-            transitInfo: { type: string, nullable: true, description: "대중교통 안내 텍스트. 예) 2호선 성수역 3번 출구에서 도보 5분" }
+            transitInfo: { type: string, nullable: true, description: "대중교통 안내. 현재 저장 원천이 없으면 null" }
+            productName: { type: string }
+            quantity: { type: integer }
             pickupDate: { type: string, format: date }
             pickupTimeStart: { type: string, format: time }
             pickupTimeEnd: { type: string, format: time }
-            productName: { type: string }
-            quantity: { type: integer }
-            remainingMinutes: { type: integer, nullable: true, description: 픽업 종료까지 남은 분 (당일만) }
+            pickupLocation: { type: string }
+            remainingMinutes: { type: integer, format: int64, nullable: true, description: "당일 픽업 종료까지 남은 분. 당일이 아니면 null" }
+            pickedUpAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 
     ApiResponseQrCode:
@@ -2849,17 +2877,73 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [qrCode, nickname, productName, quantity, isUsed, storeName, pickupDate, pickupTimeStart, pickupTimeEnd]
+          required: [participationId, availabilityStatus, pickupStatus, productName, quantity, storeName, pickupLocation, pickupDate, pickupTimeStart, pickupTimeEnd]
           properties:
-            qrCode: { type: string, format: uuid }
-            nickname: { type: string }
+            participationId: { type: integer, format: int64 }
+            availabilityStatus:
+              type: string
+              enum: [LOCKED, AVAILABLE, PICKED_UP]
+            pickupStatus:
+              type: string
+              enum: [NOT_READY, READY, PICKED_UP, NO_SHOW]
+            userName: { type: string, nullable: true, description: "참여자 닉네임" }
             productName: { type: string }
-            quantity: { type: integer }
-            isUsed: { type: boolean }
+            quantity: { type: integer, format: int32 }
             storeName: { type: string }
+            pickupLocation: { type: string }
+            qrCode: { type: string, format: uuid, nullable: true }
             pickupDate: { type: string, format: date }
             pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
             pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
+            pickedUpAt: { type: string, format: date-time, nullable: true }
+        error: { nullable: true, example: null }
+
+    ApiResponseNearestPickupQr:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [hasCandidate, hasMultipleToday, item]
+          properties:
+            hasCandidate:
+              type: boolean
+              description: 표시 가능한 픽업 후보가 있으면 true
+              example: true
+            hasMultipleToday:
+              type: boolean
+              description: 당일 픽업 예정 건이 2개 이상이면 true
+              example: false
+            reason:
+              type: string
+              nullable: true
+              enum: [NO_AVAILABLE_PICKUP, ONLY_FUTURE_PICKUP]
+              description: 후보가 없거나 QR이 잠긴 사유
+              example: null
+            item:
+              type: object
+              nullable: true
+              required: [participationId, availabilityStatus, pickupStatus, productName, quantity, storeName, pickupLocation, pickupDate, pickupTimeStart, pickupTimeEnd]
+              properties:
+                participationId: { type: integer, format: int64 }
+                availabilityStatus:
+                  type: string
+                  enum: [LOCKED, AVAILABLE, PICKED_UP]
+                  description: 당일 00시 이후 QR 사용 가능 시 AVAILABLE
+                pickupStatus:
+                  type: string
+                  enum: [NOT_READY, READY, PICKED_UP, NO_SHOW]
+                userName: { type: string, nullable: true, description: "참여자 닉네임" }
+                productName: { type: string }
+                quantity: { type: integer, format: int32 }
+                storeName: { type: string }
+                pickupLocation: { type: string }
+                qrCode: { type: string, format: uuid, nullable: true, description: "LOCKED 상태에서는 null" }
+                pickupDate: { type: string, format: date }
+                pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
+                pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
+                pickedUpAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 
     ApiResponsePickupVerify:
@@ -2869,18 +2953,14 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [participationId, userName, productName, quantity, pickupDate, pickupTimeStart, pickupTimeEnd, pickupStatus]
+          required: [participationId, pickupStatus, pickedUpAt]
           properties:
             participationId: { type: integer, format: int64 }
-            userName: { type: string }
-            productName: { type: string }
-            quantity: { type: integer }
-            pickupDate: { type: string, format: date }
-            pickupTimeStart: { type: string, format: time }
-            pickupTimeEnd: { type: string, format: time }
             pickupStatus:
               type: string
-              enum: [WAITING, COMPLETED]
+              enum: [NOT_READY, READY, PICKED_UP, NO_SHOW]
+            pickedUpAt: { type: string, format: date-time }
+            pickupProcessedByUserId: { type: integer, format: int64, nullable: true }
         error: { nullable: true, example: null }
 
     # ── Notification ───────────────────────────────────────────

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -1,0 +1,353 @@
+package com.moongchijang.domain.pickup.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.pickup.application.dto.NearestPickupQrReason
+import com.moongchijang.domain.pickup.application.dto.PickupAvailabilityStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@ExtendWith(MockitoExtension::class)
+class PickupServiceTest {
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    private val service: PickupService by lazy {
+        PickupService(
+            participationRepository = participationRepository,
+            userRepository = userRepository,
+        )
+    }
+
+    @Test
+    fun `픽업 안내는 소비자 본인 참여의 매장 상품 픽업 정보를 반환한다`() {
+        val participation = createParticipation(pickupDate = LocalDate.now().plusDays(1))
+        `when`(participationRepository.findPickupDetailById(99L)).thenReturn(participation)
+
+        val result = service.getPickupGuide(99L, 1L)
+
+        assertEquals(99L, result.participationId)
+        assertEquals(PickupAvailabilityStatus.LOCKED, result.availabilityStatus)
+        assertEquals(PickupStatus.NOT_READY, result.pickupStatus)
+        assertEquals("뭉치장 베이커리", result.storeName)
+        assertEquals("서울 성동구 성수동", result.storeAddress)
+        assertEquals("02-1234-5678", result.storePhone)
+        assertEquals("02-1234-5678", result.storePhoneNumber)
+        assertEquals(37.54, result.latitude)
+        assertEquals(127.05, result.longitude)
+        assertNull(result.transitInfo)
+        assertEquals("두쫀쿠", result.productName)
+        assertEquals(2, result.quantity)
+        assertEquals(participation.groupBuy.pickupDate, result.pickupDate)
+        assertEquals(LocalTime.of(14, 0), result.pickupTimeStart)
+        assertEquals(LocalTime.of(18, 0), result.pickupTimeEnd)
+        assertEquals("매장 카운터", result.pickupLocation)
+        assertNull(result.remainingMinutes)
+    }
+
+    @Test
+    fun `픽업 안내는 매장 좌표가 없어도 주소와 null 좌표를 반환한다`() {
+        val participation = createParticipation(
+            pickupDate = LocalDate.now().plusDays(1),
+            store = createStore(latitude = null, longitude = null),
+        )
+        `when`(participationRepository.findPickupDetailById(99L)).thenReturn(participation)
+
+        val result = service.getPickupGuide(99L, 1L)
+
+        assertEquals("서울 성동구 성수동", result.storeAddress)
+        assertNull(result.latitude)
+        assertNull(result.longitude)
+    }
+
+    @Test
+    fun `본인 참여가 아니면 픽업 안내 조회를 거부한다`() {
+        val participation = createParticipation(user = UserFixture.createKakaoUser(id = 2L))
+        `when`(participationRepository.findPickupDetailById(99L)).thenReturn(participation)
+
+        val ex = assertThrows<CustomException> {
+            service.getPickupGuide(99L, 1L)
+        }
+
+        assertEquals(ErrorCode.PICKUP_PARTICIPATION_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `픽업일 전 QR 조회는 잠금 상태와 null QR을 반환한다`() {
+        val participation = createParticipation(pickupDate = LocalDate.now().plusDays(1))
+        `when`(participationRepository.findPickupDetailById(99L)).thenReturn(participation)
+
+        val result = service.getPickupQr(99L, 1L)
+
+        assertEquals(PickupAvailabilityStatus.LOCKED, result.availabilityStatus)
+        assertEquals(PickupStatus.NOT_READY, result.pickupStatus)
+        assertEquals("테스트유저", result.userName)
+        assertEquals("두쫀쿠", result.productName)
+        assertEquals(2, result.quantity)
+        assertEquals("뭉치장 베이커리", result.storeName)
+        assertEquals("매장 카운터", result.pickupLocation)
+        assertEquals(participation.groupBuy.pickupDate, result.pickupDate)
+        assertEquals(LocalTime.of(14, 0), result.pickupTimeStart)
+        assertEquals(LocalTime.of(18, 0), result.pickupTimeEnd)
+        assertNull(result.qrCode)
+        assertNull(participation.pickupToken)
+    }
+
+    @Test
+    fun `픽업일 00시 이후 QR 토큰이 없으면 지연 생성하고 READY로 전환한다`() {
+        val participation = createParticipation(pickupDate = LocalDate.now())
+        `when`(participationRepository.findPickupDetailById(99L)).thenReturn(participation)
+        `when`(participationRepository.existsByPickupToken(anyString())).thenReturn(false)
+
+        val result = service.getPickupQr(99L, 1L)
+
+        assertEquals(PickupAvailabilityStatus.AVAILABLE, result.availabilityStatus)
+        assertEquals(PickupStatus.READY, result.pickupStatus)
+        assertNotNull(result.qrCode)
+        assertEquals(result.qrCode, participation.pickupToken)
+    }
+
+    @Test
+    fun `이미 픽업 완료된 참여는 QR 토큰을 노출하지 않는다`() {
+        val participation = createParticipation(
+            pickupDate = LocalDate.now(),
+            pickupStatus = PickupStatus.PICKED_UP,
+            pickupToken = "used-token",
+            pickedUpAt = LocalDateTime.now().minusHours(1),
+        )
+        `when`(participationRepository.findPickupDetailById(99L)).thenReturn(participation)
+
+        val result = service.getPickupQr(99L, 1L)
+
+        assertEquals(PickupAvailabilityStatus.PICKED_UP, result.availabilityStatus)
+        assertEquals(PickupStatus.PICKED_UP, result.pickupStatus)
+        assertNull(result.qrCode)
+    }
+
+    @Test
+    fun `가장 가까운 QR은 당일 픽업 중 가장 이른 참여를 반환하고 다건 여부를 표시한다`() {
+        val laterToday = createParticipation(id = 101L, pickupDate = LocalDate.now(), pickupTimeStart = LocalTime.of(16, 0))
+        val earliestToday = createParticipation(id = 102L, pickupDate = LocalDate.now(), pickupTimeStart = LocalTime.of(10, 0))
+        val future = createParticipation(id = 103L, pickupDate = LocalDate.now().plusDays(1), pickupTimeStart = LocalTime.of(9, 0))
+        `when`(
+            participationRepository.findNearestPickupQrCandidates(
+                userId = 1L,
+                status = ParticipationStatus.CONFIRMED,
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                fromDate = LocalDate.now(),
+            )
+        ).thenReturn(listOf(earliestToday, laterToday, future))
+        `when`(participationRepository.existsByPickupToken(anyString())).thenReturn(false)
+
+        val result = service.getNearestPickupQr(1L)
+
+        assertEquals(true, result.hasCandidate)
+        assertEquals(true, result.hasMultipleToday)
+        assertNull(result.reason)
+        assertEquals(102L, result.item?.participationId)
+        assertEquals(PickupAvailabilityStatus.AVAILABLE, result.item?.availabilityStatus)
+        assertNotNull(result.item?.qrCode)
+        assertEquals(PickupStatus.READY, earliestToday.pickupStatus)
+    }
+
+    @Test
+    fun `당일 픽업이 없고 미래 픽업만 있으면 잠금 상태 후보를 반환한다`() {
+        val future = createParticipation(id = 103L, pickupDate = LocalDate.now().plusDays(1))
+        `when`(
+            participationRepository.findNearestPickupQrCandidates(
+                userId = 1L,
+                status = ParticipationStatus.CONFIRMED,
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                fromDate = LocalDate.now(),
+            )
+        ).thenReturn(listOf(future))
+
+        val result = service.getNearestPickupQr(1L)
+
+        assertEquals(true, result.hasCandidate)
+        assertEquals(false, result.hasMultipleToday)
+        assertEquals(NearestPickupQrReason.ONLY_FUTURE_PICKUP, result.reason)
+        assertEquals(103L, result.item?.participationId)
+        assertEquals(PickupAvailabilityStatus.LOCKED, result.item?.availabilityStatus)
+        assertNull(result.item?.qrCode)
+    }
+
+    @Test
+    fun `가장 가까운 QR 후보가 없으면 빈 상태를 반환한다`() {
+        `when`(
+            participationRepository.findNearestPickupQrCandidates(
+                userId = 1L,
+                status = ParticipationStatus.CONFIRMED,
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                fromDate = LocalDate.now(),
+            )
+        ).thenReturn(emptyList())
+
+        val result = service.getNearestPickupQr(1L)
+
+        assertEquals(false, result.hasCandidate)
+        assertEquals(false, result.hasMultipleToday)
+        assertEquals(NearestPickupQrReason.NO_AVAILABLE_PICKUP, result.reason)
+        assertNull(result.item)
+    }
+
+    @Test
+    fun `픽업일 전 QR 검증은 실패한다`() {
+        val participation = createParticipation(
+            pickupDate = LocalDate.now().plusDays(1),
+            pickupStatus = PickupStatus.READY,
+            pickupToken = "qr-token",
+        )
+        `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
+
+        val ex = assertThrows<CustomException> {
+            service.verifyPickup("qr-token", 7L)
+        }
+
+        assertEquals(ErrorCode.PICKUP_LOCKED, ex.errorCode)
+        verify(userRepository, never()).findByIdAndDeletedAtIsNull(7L)
+    }
+
+    @Test
+    fun `QR 검증 성공은 픽업 완료 처리하고 처리자를 저장한다`() {
+        val processor = UserFixture.createKakaoUser(id = 7L)
+        val participation = createParticipation(
+            pickupDate = LocalDate.now(),
+            pickupStatus = PickupStatus.READY,
+            pickupToken = "qr-token",
+        )
+        `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(processor)
+
+        val result = service.verifyPickup("qr-token", 7L)
+
+        assertEquals(PickupStatus.PICKED_UP, result.pickupStatus)
+        assertNotNull(result.pickedUpAt)
+        assertEquals(7L, result.pickupProcessedByUserId)
+        assertEquals(PickupStatus.PICKED_UP, participation.pickupStatus)
+        assertNotNull(participation.pickedUpAt)
+        assertEquals(processor, participation.pickupProcessedBy)
+    }
+
+    @Test
+    fun `이미 사용된 QR은 재사용을 거부한다`() {
+        val participation = createParticipation(
+            pickupDate = LocalDate.now(),
+            pickupStatus = PickupStatus.PICKED_UP,
+            pickupToken = "qr-token",
+            pickedUpAt = LocalDateTime.now().minusMinutes(10),
+        )
+        `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
+
+        val ex = assertThrows<CustomException> {
+            service.verifyPickup("qr-token", 7L)
+        }
+
+        assertEquals(ErrorCode.PICKUP_ALREADY_USED, ex.errorCode)
+        verify(userRepository, never()).findByIdAndDeletedAtIsNull(7L)
+    }
+
+    private fun createParticipation(
+        id: Long = 99L,
+        user: User = UserFixture.createKakaoUser(id = 1L),
+        pickupDate: LocalDate = LocalDate.now(),
+        pickupTimeStart: LocalTime = LocalTime.of(14, 0),
+        pickupStatus: PickupStatus = PickupStatus.NOT_READY,
+        pickupToken: String? = null,
+        pickedUpAt: LocalDateTime? = null,
+        store: Store = createStore(),
+    ): Participation =
+        Participation(
+            user = user,
+            groupBuy = createGroupBuy(
+                pickupDate = pickupDate,
+                pickupTimeStart = pickupTimeStart,
+                store = store,
+            ),
+            quantity = 2,
+            productAmount = 12_000,
+            feeAmount = 0,
+            totalAmount = 12_000,
+            status = ParticipationStatus.CONFIRMED,
+            pickupStatus = pickupStatus,
+            pickupToken = pickupToken,
+            pickedUpAt = pickedUpAt,
+        ).apply { this.id = id }
+
+    private fun createGroupBuy(
+        pickupDate: LocalDate,
+        pickupTimeStart: LocalTime = LocalTime.of(14, 0),
+        store: Store = createStore(),
+    ): GroupBuy =
+        GroupBuy(
+            store = store,
+            groupBuyRequest = createGroupBuyRequest(pickupDate),
+            thumbnailUrl = "https://example.com/image.jpg",
+            productName = "두쫀쿠",
+            productDescription = "설명",
+            price = 6000,
+            targetQuantity = 50,
+            currentQuantity = 50,
+            maxQuantity = 100,
+            status = GroupBuyStatus.ACHIEVED,
+            deadline = LocalDateTime.now().minusDays(1),
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart,
+            pickupTimeEnd = LocalTime.of(18, 0),
+            pickupLocation = "매장 카운터",
+        ).apply { id = 10L }
+
+    private fun createStore(
+        latitude: Double? = 37.54,
+        longitude: Double? = 127.05,
+    ): Store =
+        Store(
+            name = "뭉치장 베이커리",
+            address = "서울 성동구 성수동",
+            phoneNumber = "02-1234-5678",
+            latitude = latitude,
+            longitude = longitude,
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN,
+        ).apply { id = 20L }
+
+    private fun createGroupBuyRequest(pickupDate: LocalDate): GroupBuyRequest =
+        GroupBuyRequest(
+            userId = 1L,
+            storeName = "뭉치장 베이커리",
+            storeAddress = "서울 성동구 성수동",
+            productName = "두쫀쿠",
+            desiredQuantity = 50,
+            desiredPickupDate = pickupDate,
+        ).apply { id = 30L }
+}

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -62,7 +62,6 @@ class PickupServiceTest {
         assertEquals("뭉치장 베이커리", result.storeName)
         assertEquals("서울 성동구 성수동", result.storeAddress)
         assertEquals("02-1234-5678", result.storePhone)
-        assertEquals("02-1234-5678", result.storePhoneNumber)
         assertEquals(37.54, result.latitude)
         assertEquals(127.05, result.longitude)
         assertNull(result.transitInfo)
@@ -236,6 +235,23 @@ class PickupServiceTest {
 
         assertEquals(ErrorCode.PICKUP_LOCKED, ex.errorCode)
         verify(userRepository, never()).findByIdAndDeletedAtIsNull(7L)
+    }
+
+    @Test
+    fun `QR 검증 처리자를 찾을 수 없으면 실패한다`() {
+        val participation = createParticipation(
+            pickupDate = LocalDate.now(),
+            pickupStatus = PickupStatus.READY,
+            pickupToken = "qr-token",
+        )
+        `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(null)
+
+        val ex = assertThrows<CustomException> {
+            service.verifyPickup("qr-token", 7L)
+        }
+
+        assertEquals(ErrorCode.USER_NOT_FOUND, ex.errorCode)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/pickup/presentation/PickupControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/presentation/PickupControllerTest.kt
@@ -8,12 +8,9 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.security.principal.CustomUserPrincipal
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import org.springframework.security.access.AccessDeniedException
 import java.time.LocalDateTime
 
 class PickupControllerTest {
@@ -67,15 +64,6 @@ class PickupControllerTest {
 
         assertEquals(response, result.body?.data)
         verify(pickupService).verifyPickup("qr-token", 8L)
-    }
-
-    @Test
-    fun `BUYER는 QR 검증을 호출할 수 없다`() {
-        assertThrows<AccessDeniedException> {
-            controller.verifyPickup("qr-token", principal(UserRole.BUYER, id = 1L))
-        }
-
-        verify(pickupService, never()).verifyPickup("qr-token", 1L)
     }
 
     private fun principal(role: UserRole, id: Long): CustomUserPrincipal =

--- a/src/test/kotlin/com/moongchijang/domain/pickup/presentation/PickupControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/presentation/PickupControllerTest.kt
@@ -1,0 +1,87 @@
+package com.moongchijang.domain.pickup.presentation
+
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.pickup.application.PickupService
+import com.moongchijang.domain.pickup.application.dto.NearestPickupQrResponse
+import com.moongchijang.domain.pickup.application.dto.PickupVerifyResponse
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.security.principal.CustomUserPrincipal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.security.access.AccessDeniedException
+import java.time.LocalDateTime
+
+class PickupControllerTest {
+
+    private val pickupService: PickupService = mock(PickupService::class.java)
+    private val controller = PickupController(pickupService)
+
+    @Test
+    fun `인증 사용자는 가장 가까운 QR 후보를 조회할 수 있다`() {
+        val response = NearestPickupQrResponse(
+            hasCandidate = false,
+            hasMultipleToday = false,
+            reason = null,
+            item = null,
+        )
+        `when`(pickupService.getNearestPickupQr(1L)).thenReturn(response)
+
+        val result = controller.getNearestPickupQr(principal(UserRole.BUYER, id = 1L))
+
+        assertEquals(response, result.body?.data)
+        verify(pickupService).getNearestPickupQr(1L)
+    }
+
+    @Test
+    fun `SELLER는 QR 검증을 호출할 수 있다`() {
+        val response = PickupVerifyResponse(
+            participationId = 99L,
+            pickupStatus = PickupStatus.PICKED_UP,
+            pickedUpAt = LocalDateTime.now(),
+            pickupProcessedByUserId = 7L,
+        )
+        `when`(pickupService.verifyPickup("qr-token", 7L)).thenReturn(response)
+
+        val result = controller.verifyPickup("qr-token", principal(UserRole.SELLER, id = 7L))
+
+        assertEquals(response, result.body?.data)
+        verify(pickupService).verifyPickup("qr-token", 7L)
+    }
+
+    @Test
+    fun `ADMIN은 QR 검증을 호출할 수 있다`() {
+        val response = PickupVerifyResponse(
+            participationId = 99L,
+            pickupStatus = PickupStatus.PICKED_UP,
+            pickedUpAt = LocalDateTime.now(),
+            pickupProcessedByUserId = 8L,
+        )
+        `when`(pickupService.verifyPickup("qr-token", 8L)).thenReturn(response)
+
+        val result = controller.verifyPickup("qr-token", principal(UserRole.ADMIN, id = 8L))
+
+        assertEquals(response, result.body?.data)
+        verify(pickupService).verifyPickup("qr-token", 8L)
+    }
+
+    @Test
+    fun `BUYER는 QR 검증을 호출할 수 없다`() {
+        assertThrows<AccessDeniedException> {
+            controller.verifyPickup("qr-token", principal(UserRole.BUYER, id = 1L))
+        }
+
+        verify(pickupService, never()).verifyPickup("qr-token", 1L)
+    }
+
+    private fun principal(role: UserRole, id: Long): CustomUserPrincipal =
+        CustomUserPrincipal(
+            id = id,
+            email = "$id@example.com",
+            role = role,
+        )
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 픽업 안내 조회 API를 추가했습니다.
- 참여별 QR 조회 API를 추가하고 픽업일 전에는 LOCKED 상태와 null QR을 반환하도록 했습니다.
- 피드 진입용 가장 가까운 픽업 QR 조회 API를 추가했습니다.
- QR 토큰은 픽업일 00시 이후 최초 조회 시 생성하고, 사용 완료 후 재사용을 막도록 했습니다.
- SELLER/ADMIN만 QR 검증 API를 호출할 수 있도록 권한을 보완했습니다.
- OpenAPI 명세를 실제 구현 DTO와 프론트 연동 경로 기준으로 갱신했습니다.

## 🔍 참고 사항
- 추가 API
  - `GET /api/v1/participations/{participationId}/pickup`
  - `GET /api/v1/participations/{participationId}/qr`
  - `GET /api/v1/pickups/me/nearest-qr`
  - `POST /api/v1/pickups/{qrCode}/verify`
- 픽업 안내 좌표는 `groupBuy.store.latitude/longitude`를 사용하며, 좌표가 없으면 200 응답에서 null로 내려갑니다.
- `transitInfo`는 현재 저장 원천이 없어 null로 내려갑니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
Closes #114
- MCJ-1475

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
