### PR TITLE
[MCJ-1476] FEAT: 마이페이지 탭 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -12,4 +12,6 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
         statuses: Collection<GroupBuyRequestStatus>,
         desiredPickupDate: LocalDate
     ): List<GroupBuyRequest>
+
+    fun countByUserId(userId: Long): Long
 }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -1,0 +1,101 @@
+package com.moongchijang.domain.mypage.application
+
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.mypage.application.dto.MypageGroupBuyRequestResponse
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationResponse
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationStatusFilter
+import com.moongchijang.domain.mypage.application.dto.MypageRefundResponse
+import com.moongchijang.domain.mypage.application.dto.MypageSummaryResponse
+import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
+import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class MypageService(
+    private val participationRepository: ParticipationRepository,
+    private val groupBuyRequestRepository: GroupBuyRequestRepository,
+    private val paymentOrderRepository: PaymentOrderRepository
+) {
+
+    fun getSummary(userId: Long): MypageSummaryResponse =
+        MypageSummaryResponse(
+            activeCount = participationRepository.countByUserIdAndStatusInAndPickupStatusIn(
+                userId = userId,
+                statuses = ACTIVE_PARTICIPATION_STATUSES,
+                pickupStatuses = ACTIVE_PICKUP_STATUSES
+            ),
+            completedCount = participationRepository.countByUserIdAndStatusInAndPickupStatus(
+                userId = userId,
+                statuses = ACTIVE_PARTICIPATION_STATUSES,
+                pickupStatus = PickupStatus.PICKED_UP
+            ),
+            refundedCount = participationRepository.countByUserIdAndStatus(
+                userId = userId,
+                status = ParticipationStatus.REFUNDED
+            ),
+            requestCount = groupBuyRequestRepository.countByUserId(userId)
+        )
+
+    fun getRefunds(userId: Long): List<MypageRefundResponse> =
+        participationRepository
+            .findByUserIdAndStatusOrderByRefundedAtDescCreatedAtDesc(userId, ParticipationStatus.REFUNDED)
+            .map(MypageRefundResponse::from)
+
+    fun getParticipations(
+        userId: Long,
+        status: MypageParticipationStatusFilter
+    ): List<MypageParticipationResponse> =
+        when (status) {
+            MypageParticipationStatusFilter.ACTIVE -> getActiveParticipations(userId)
+            MypageParticipationStatusFilter.COMPLETED -> getCompletedParticipations(userId)
+            MypageParticipationStatusFilter.REFUNDED -> getRefundedParticipations(userId)
+        }
+
+    fun getActiveParticipations(userId: Long): List<MypageParticipationResponse> {
+        val cancellableGroupBuyIds = approvedPaymentGroupBuyIds(userId)
+        return participationRepository.findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
+                userId = userId,
+                statuses = ACTIVE_PARTICIPATION_STATUSES,
+                pickupStatuses = ACTIVE_PICKUP_STATUSES
+            )
+            .map { MypageParticipationResponse.from(it, cancellableGroupBuyIds) }
+    }
+
+    fun getCompletedParticipations(userId: Long): List<MypageParticipationResponse> =
+        participationRepository
+            .findByUserIdAndStatusInAndPickupStatusOrderByPickedUpAtDescCreatedAtDesc(
+                userId = userId,
+                statuses = ACTIVE_PARTICIPATION_STATUSES,
+                pickupStatus = PickupStatus.PICKED_UP
+            )
+            .map(MypageParticipationResponse::from)
+
+    fun getRefundedParticipations(userId: Long): List<MypageParticipationResponse> =
+        participationRepository
+            .findByUserIdAndStatusOrderByCreatedAtDesc(userId, ParticipationStatus.REFUNDED)
+            .map(MypageParticipationResponse::from)
+
+    fun getGroupBuyRequests(userId: Long): List<MypageGroupBuyRequestResponse> =
+        groupBuyRequestRepository
+            .findByUserIdOrderByCreatedAtDesc(userId)
+            .map(MypageGroupBuyRequestResponse::from)
+
+    private fun approvedPaymentGroupBuyIds(userId: Long): Set<Long> =
+        paymentOrderRepository.findGroupBuyIdsByUserIdAndStatus(userId, PaymentOrderStatus.APPROVED).toSet()
+
+    private companion object {
+        val ACTIVE_PARTICIPATION_STATUSES = listOf(
+            ParticipationStatus.PAID_WAITING_GOAL,
+            ParticipationStatus.CONFIRMED
+        )
+        val ACTIVE_PICKUP_STATUSES = listOf(
+            PickupStatus.NOT_READY,
+            PickupStatus.READY
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -57,13 +57,15 @@ class MypageService(
         }
 
     fun getActiveParticipations(userId: Long): List<MypageParticipationResponse> {
+        val participations = participationRepository.findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
+            userId = userId,
+            statuses = ACTIVE_PARTICIPATION_STATUSES,
+            pickupStatuses = ACTIVE_PICKUP_STATUSES
+        )
+        if (participations.isEmpty()) return emptyList()
+
         val cancellableGroupBuyIds = approvedPaymentGroupBuyIds(userId)
-        return participationRepository.findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
-                userId = userId,
-                statuses = ACTIVE_PARTICIPATION_STATUSES,
-                pickupStatuses = ACTIVE_PICKUP_STATUSES
-            )
-            .map { MypageParticipationResponse.from(it, cancellableGroupBuyIds) }
+        return participations.map { MypageParticipationResponse.from(it, cancellableGroupBuyIds) }
     }
 
     fun getCompletedParticipations(userId: Long): List<MypageParticipationResponse> =

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageParticipationStatusFilter.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageParticipationStatusFilter.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.mypage.application.dto
+
+enum class MypageParticipationStatusFilter {
+    ACTIVE,
+    COMPLETED,
+    REFUNDED
+}

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -99,7 +99,9 @@ data class MypageParticipationResponse(
                 paymentAmount = participation.totalAmount,
                 quantity = participation.quantity,
                 pickupStatus = participation.pickupStatus.name,
-                dDay = ChronoUnit.DAYS.between(LocalDate.now(), groupBuy.deadline.toLocalDate()).toInt(),
+                dDay = ChronoUnit.DAYS.between(LocalDate.now(), groupBuy.deadline.toLocalDate())
+                    .toInt()
+                    .coerceAtLeast(0),
                 canCancel = participation.status == ParticipationStatus.PAID_WAITING_GOAL &&
                     groupBuy.id in approvedPaymentGroupBuyIds,
                 canViewPickup = canViewPickupOrQr,
@@ -121,12 +123,10 @@ data class MypageParticipationResponse(
 
         private fun displayStatus(status: ParticipationStatus, pickupStatus: PickupStatus): String =
             when {
-                pickupStatus == PickupStatus.PICKED_UP -> "픽업 완료"
-                status == ParticipationStatus.PAID_WAITING_GOAL -> "참여중 / 달성 전"
-                status == ParticipationStatus.CONFIRMED -> "참여중 / 달성 완료"
-                status == ParticipationStatus.CANCELLED -> "취소"
-                status == ParticipationStatus.REFUNDED -> "환불 완료"
-                status == ParticipationStatus.PENDING -> "결제 대기"
+                pickupStatus == PickupStatus.PICKED_UP -> "PICKED_UP"
+                status == ParticipationStatus.PAID_WAITING_GOAL -> "PAID_WAITING_GOAL"
+                status == ParticipationStatus.CONFIRMED -> "CONFIRMED"
+                status == ParticipationStatus.REFUNDED -> "REFUNDED"
                 else -> status.name
             }
 

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -1,0 +1,162 @@
+package com.moongchijang.domain.mypage.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+
+data class MypageSummaryResponse(
+    val activeCount: Long,
+    val completedCount: Long,
+    val refundedCount: Long,
+    val requestCount: Long
+)
+
+data class MypageRefundResponse(
+    val participationId: Long,
+    val productName: String,
+    val refundStatus: String,
+    val storeName: String,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: LocalTime,
+    val pickupTimeEnd: LocalTime,
+    val paymentAmount: Int,
+    val quantity: Int,
+    val cancelReason: String?,
+    val cancelReasonDetail: String?,
+    val refundedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(participation: Participation): MypageRefundResponse {
+            val groupBuy = participation.groupBuy
+
+            return MypageRefundResponse(
+                participationId = participation.id,
+                productName = groupBuy.productName,
+                refundStatus = "COMPLETED",
+                storeName = groupBuy.store.name,
+                pickupDate = groupBuy.pickupDate,
+                pickupTimeStart = groupBuy.pickupTimeStart,
+                pickupTimeEnd = groupBuy.pickupTimeEnd,
+                paymentAmount = participation.totalAmount,
+                quantity = participation.quantity,
+                cancelReason = participation.cancelReason?.name,
+                cancelReasonDetail = participation.cancelReasonDetail,
+                refundedAt = participation.refundedAt
+            )
+        }
+    }
+}
+
+data class MypageParticipationResponse(
+    val participationId: Long,
+    val groupBuyId: Long,
+    val productName: String,
+    val participationStatus: String,
+    val achievementRate: Int,
+    val achievementStatus: String,
+    val displayStatus: String,
+    val storeName: String,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: LocalTime,
+    val pickupTimeEnd: LocalTime,
+    val pickupLocation: String,
+    val paymentAmount: Int,
+    val quantity: Int,
+    val pickupStatus: String,
+    val dDay: Int,
+    val canCancel: Boolean,
+    val canViewPickup: Boolean,
+    val canViewQr: Boolean,
+    val qrAvailability: String
+) {
+    companion object {
+        fun from(
+            participation: Participation,
+            approvedPaymentGroupBuyIds: Set<Long> = emptySet()
+        ): MypageParticipationResponse {
+            val groupBuy = participation.groupBuy
+            val canViewPickupOrQr = participation.status == ParticipationStatus.CONFIRMED &&
+                participation.pickupStatus in listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+
+            return MypageParticipationResponse(
+                participationId = participation.id,
+                groupBuyId = groupBuy.id,
+                productName = groupBuy.productName,
+                participationStatus = participation.status.name,
+                achievementRate = achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity),
+                achievementStatus = achievementStatus(participation.status),
+                displayStatus = displayStatus(participation.status, participation.pickupStatus),
+                storeName = groupBuy.store.name,
+                pickupDate = groupBuy.pickupDate,
+                pickupTimeStart = groupBuy.pickupTimeStart,
+                pickupTimeEnd = groupBuy.pickupTimeEnd,
+                pickupLocation = groupBuy.pickupLocation,
+                paymentAmount = participation.totalAmount,
+                quantity = participation.quantity,
+                pickupStatus = participation.pickupStatus.name,
+                dDay = ChronoUnit.DAYS.between(LocalDate.now(), groupBuy.deadline.toLocalDate()).toInt(),
+                canCancel = participation.status == ParticipationStatus.PAID_WAITING_GOAL &&
+                    groupBuy.id in approvedPaymentGroupBuyIds,
+                canViewPickup = canViewPickupOrQr,
+                canViewQr = canViewPickupOrQr,
+                qrAvailability = qrAvailability(participation)
+            )
+        }
+
+        private fun achievementRate(currentQuantity: Int, targetQuantity: Int): Int {
+            if (targetQuantity <= 0) return 0
+            return ((currentQuantity * 100) / targetQuantity).coerceIn(0, 100)
+        }
+
+        private fun achievementStatus(status: ParticipationStatus): String =
+            when (status) {
+                ParticipationStatus.CONFIRMED -> "ACHIEVED"
+                else -> "BEFORE_ACHIEVED"
+            }
+
+        private fun displayStatus(status: ParticipationStatus, pickupStatus: PickupStatus): String =
+            when {
+                pickupStatus == PickupStatus.PICKED_UP -> "픽업 완료"
+                status == ParticipationStatus.PAID_WAITING_GOAL -> "참여중 / 달성 전"
+                status == ParticipationStatus.CONFIRMED -> "참여중 / 달성 완료"
+                status == ParticipationStatus.CANCELLED -> "취소"
+                status == ParticipationStatus.REFUNDED -> "환불 완료"
+                status == ParticipationStatus.PENDING -> "결제 대기"
+                else -> status.name
+            }
+
+        private fun qrAvailability(participation: Participation): String =
+            when {
+                participation.pickupStatus == PickupStatus.PICKED_UP -> "PICKED_UP"
+                participation.status != ParticipationStatus.CONFIRMED -> "UNAVAILABLE"
+                LocalDate.now().isBefore(participation.groupBuy.pickupDate) -> "LOCKED"
+                else -> "AVAILABLE"
+            }
+    }
+}
+
+data class MypageGroupBuyRequestResponse(
+    val productName: String,
+    val status: String,
+    val storeName: String,
+    val desiredPickupDate: LocalDate,
+    val desiredQuantity: Int,
+    val requestId: Long
+) {
+    companion object {
+        fun from(request: GroupBuyRequest): MypageGroupBuyRequestResponse =
+            MypageGroupBuyRequestResponse(
+                productName = request.productName,
+                status = request.status.name,
+                storeName = request.storeName,
+                desiredPickupDate = request.desiredPickupDate,
+                desiredQuantity = request.desiredQuantity,
+                requestId = request.id
+            )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
@@ -1,0 +1,83 @@
+package com.moongchijang.domain.mypage.presentation
+
+import com.moongchijang.domain.mypage.application.MypageService
+import com.moongchijang.domain.mypage.application.dto.MypageGroupBuyRequestResponse
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationResponse
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationStatusFilter
+import com.moongchijang.domain.mypage.application.dto.MypageRefundResponse
+import com.moongchijang.domain.mypage.application.dto.MypageSummaryResponse
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1")
+@Tag(name = "MyPage", description = "마이페이지")
+class MypageController(
+    private val mypageService: MypageService
+) {
+
+    @GetMapping("/mypage/summary")
+    @Operation(summary = "마이페이지 탭별 건수 조회")
+    fun getSummary(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<MypageSummaryResponse>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
+
+    @GetMapping("/users/me/tabs/counts")
+    @Operation(summary = "내 탭별 건수 조회")
+    fun getUserTabCounts(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<MypageSummaryResponse>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
+
+    @GetMapping("/users/me/participations")
+    @Operation(summary = "내 참여 내역 상태별 조회")
+    fun getUserParticipations(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @RequestParam status: MypageParticipationStatusFilter
+    ): ResponseEntity<ApiResponse<List<MypageParticipationResponse>>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getParticipations(principal.id, status)))
+
+    @GetMapping("/users/me/group-buy-requests")
+    @Operation(summary = "내 공구 개설 요청 내역 조회")
+    fun getUserGroupBuyRequests(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
+
+    @GetMapping("/mypage/refunds")
+    @Operation(summary = "내 환불 내역 조회")
+    fun getRefunds(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<MypageRefundResponse>>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getRefunds(principal.id)))
+
+    @GetMapping("/mypage/participations/active")
+    @Operation(summary = "내 참여중 공구 내역 조회")
+    fun getActiveParticipations(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<MypageParticipationResponse>>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getActiveParticipations(principal.id)))
+
+    @GetMapping("/mypage/participations/completed")
+    @Operation(summary = "내 완료 공구 내역 조회")
+    fun getCompletedParticipations(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<MypageParticipationResponse>>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getCompletedParticipations(principal.id)))
+
+    @GetMapping("/mypage/group-buy-requests")
+    @Operation(summary = "내 공구 개설 요청 내역 조회")
+    fun getGroupBuyRequests(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> =
+        ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -6,6 +6,7 @@ import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -142,6 +143,46 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
         @Param("fromDate") fromDate: LocalDate,
     ): List<Participation>
+
+    @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
+    fun findByUserIdAndStatusOrderByRefundedAtDescCreatedAtDesc(
+        userId: Long,
+        status: ParticipationStatus
+    ): List<Participation>
+
+    @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
+    fun findByUserIdAndStatusOrderByCreatedAtDesc(
+        userId: Long,
+        status: ParticipationStatus
+    ): List<Participation>
+
+    @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
+    fun findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
+        userId: Long,
+        statuses: Collection<ParticipationStatus>,
+        pickupStatuses: Collection<PickupStatus>
+    ): List<Participation>
+
+    @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
+    fun findByUserIdAndStatusInAndPickupStatusOrderByPickedUpAtDescCreatedAtDesc(
+        userId: Long,
+        statuses: Collection<ParticipationStatus>,
+        pickupStatus: PickupStatus
+    ): List<Participation>
+
+    fun countByUserIdAndStatusInAndPickupStatusIn(
+        userId: Long,
+        statuses: Collection<ParticipationStatus>,
+        pickupStatuses: Collection<PickupStatus>
+    ): Long
+
+    fun countByUserIdAndStatusInAndPickupStatus(
+        userId: Long,
+        statuses: Collection<ParticipationStatus>,
+        pickupStatus: PickupStatus
+    ): Long
+
+    fun countByUserIdAndStatus(userId: Long, status: ParticipationStatus): Long
 
     fun existsByPickupToken(pickupToken: String): Boolean
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.payment.domain.repository
 
 import com.moongchijang.domain.payment.domain.entity.PaymentOrder
+import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
 import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
@@ -15,4 +16,17 @@ interface PaymentOrderRepository : JpaRepository<PaymentOrder, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select po from PaymentOrder po where po.orderId = :orderId")
     fun findByOrderIdForUpdate(@Param("orderId") orderId: String): PaymentOrder?
+
+    @Query(
+        """
+        select po.groupBuy.id
+        from PaymentOrder po
+        where po.user.id = :userId
+          and po.status = :status
+        """
+    )
+    fun findGroupBuyIdsByUserIdAndStatus(
+        @Param("userId") userId: Long,
+        @Param("status") status: PaymentOrderStatus,
+    ): List<Long>
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3144,7 +3144,7 @@ components:
               achievementStatus:
                 type: string
                 enum: [BEFORE_ACHIEVED, ACHIEVED]
-              displayStatus: { type: string, example: "참여중 / 달성 완료" }
+              displayStatus: { type: string, example: CONFIRMED }
               storeName: { type: string }
               pickupDate: { type: string, format: date }
               pickupTimeStart: { type: string, format: time }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1262,26 +1262,24 @@ paths:
   /api/v1/users/me/participations:
     get:
       tags: [MyPage]
-      summary: 참여 목록 조회 (참여중 · 완료 · 환불 탭)
+      summary: 내 참여 내역 상태별 조회
       security:
         - bearerAuth: []
       parameters:
         - name: status
           in: query
+          required: true
           schema:
             type: string
             enum: [ACTIVE, COMPLETED, REFUNDED]
-            default: ACTIVE
           description: ACTIVE=참여중 / COMPLETED=완료 / REFUNDED=환불내역
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/Size'
       responses:
         '200':
-          description: 참여 목록
+          description: 상태별 참여 목록
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponseParticipationPage'
+                $ref: '#/components/schemas/ApiResponseMypageParticipationList'
 
   /api/v1/users/me/participations/in-progress:
     get:
@@ -1326,7 +1324,7 @@ paths:
   /api/v1/users/me/group-buy-requests:
     get:
       tags: [MyPage]
-      summary: 내 공구 요청 목록 조회 (개설 요청 내역 탭)
+      summary: 내 공구 개설 요청 내역 조회
       security:
         - bearerAuth: []
       responses:
@@ -1335,7 +1333,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponseGroupBuyRequestList'
+                $ref: '#/components/schemas/ApiResponseMypageGroupBuyRequestList'
 
   /api/v1/users/me/tabs/counts:
     get:
@@ -1351,6 +1349,77 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseTabCounts'
+
+  /api/v1/mypage/summary:
+    get:
+      tags: [MyPage]
+      summary: 마이페이지 탭별 건수 조회
+      description: 참여중 · 완료 · 환불내역 · 개설요청 건수를 반환한다.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 탭별 건수
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseTabCounts'
+
+  /api/v1/mypage/participations/active:
+    get:
+      tags: [MyPage]
+      summary: 내 참여중 공구 내역 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 참여중 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseMypageParticipationList'
+
+  /api/v1/mypage/participations/completed:
+    get:
+      tags: [MyPage]
+      summary: 내 완료 공구 내역 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 완료 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseMypageParticipationList'
+
+  /api/v1/mypage/refunds:
+    get:
+      tags: [MyPage]
+      summary: 내 환불 내역 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 환불 내역 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseRefundList'
+
+  /api/v1/mypage/group-buy-requests:
+    get:
+      tags: [MyPage]
+      summary: 내 공구 개설 요청 내역 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 개설 요청 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseMypageGroupBuyRequestList'
 
   # ─────────────────────────────────────────────────────────────
   # Owner
@@ -2835,8 +2904,14 @@ components:
                 description: PENDING=환불대기 / COMPLETED=환불완료
               cancelReason:
                 type: string
-                enum: [NOT_ACHIEVED, EARLY_EXIT, PAYMENT_ERROR, OTHER]
+                enum: [TIME_UNAVAILABLE, NO_LONGER_WANTED, PREFER_DIRECT_VISIT, BOUGHT_ELSEWHERE, OTHER]
+                nullable: true
                 description: 취소 사유
+              cancelReasonDetail:
+                type: string
+                nullable: true
+                description: 취소 상세 사유
+              refundedAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 
     # ── Pickup & QR ────────────────────────────────────────────
@@ -3044,6 +3119,76 @@ components:
         error: { nullable: true, example: null }
 
     # ── MyPage ─────────────────────────────────────────────────
+    ApiResponseMypageParticipationList:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: array
+          items:
+            type: object
+            required: [participationId, groupBuyId, productName, participationStatus, achievementRate, achievementStatus, displayStatus, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, paymentAmount, quantity, pickupStatus, dDay, canCancel, canViewPickup, canViewQr, qrAvailability]
+            properties:
+              participationId: { type: integer, format: int64 }
+              groupBuyId: { type: integer, format: int64 }
+              productName: { type: string }
+              participationStatus:
+                type: string
+                enum: [PENDING, PAID_WAITING_GOAL, CONFIRMED, CANCELLED, REFUNDED]
+              achievementRate:
+                type: integer
+                minimum: 0
+                maximum: 100
+                description: 현재 수량 기준 달성률
+              achievementStatus:
+                type: string
+                enum: [BEFORE_ACHIEVED, ACHIEVED]
+              displayStatus: { type: string, example: "참여중 / 달성 완료" }
+              storeName: { type: string }
+              pickupDate: { type: string, format: date }
+              pickupTimeStart: { type: string, format: time }
+              pickupTimeEnd: { type: string, format: time }
+              pickupLocation: { type: string }
+              paymentAmount: { type: integer }
+              quantity: { type: integer }
+              pickupStatus:
+                type: string
+                enum: [NOT_READY, READY, PICKED_UP, NO_SHOW]
+              dDay:
+                type: integer
+                description: 공구 마감일까지 남은 일수
+              canCancel:
+                type: boolean
+                description: PAID_WAITING_GOAL 참여이고 APPROVED 결제 주문이 있으면 true
+              canViewPickup: { type: boolean, description: "참여 확정 후 픽업 미완료이면 /api/v1/participations/{participationId}/pickup 호출 가능" }
+              canViewQr: { type: boolean, description: "참여 확정 후 픽업 미완료이면 /api/v1/participations/{participationId}/qr 호출 가능. 픽업일 전에는 QR API가 LOCKED를 반환" }
+              qrAvailability:
+                type: string
+                enum: [UNAVAILABLE, LOCKED, AVAILABLE, PICKED_UP]
+        error: { nullable: true, example: null }
+
+    ApiResponseMypageGroupBuyRequestList:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: array
+          items:
+            type: object
+            required: [productName, status, storeName, desiredPickupDate, desiredQuantity, requestId]
+            properties:
+              productName: { type: string }
+              status:
+                type: string
+                enum: [SUBMITTED, IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
+              storeName: { type: string }
+              desiredPickupDate: { type: string, format: date }
+              desiredQuantity: { type: integer }
+              requestId: { type: integer, format: int64 }
+        error: { nullable: true, example: null }
+
     ApiResponseParticipationPage:
       type: object
       required: [success, data, error]

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -22,13 +22,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.time.temporal.ChronoUnit
 
 @ExtendWith(MockitoExtension::class)
 class MypageServiceTest {
@@ -137,7 +137,7 @@ class MypageServiceTest {
         assertEquals(ParticipationStatus.PAID_WAITING_GOAL.name, result[0].participationStatus)
         assertEquals(60, result[0].achievementRate)
         assertEquals("BEFORE_ACHIEVED", result[0].achievementStatus)
-        assertEquals("참여중 / 달성 전", result[0].displayStatus)
+        assertEquals("PAID_WAITING_GOAL", result[0].displayStatus)
         assertEquals("문치 베이커리", result[0].storeName)
         assertEquals(LocalDate.of(2026, 5, 25), result[0].pickupDate)
         assertEquals(LocalTime.of(13, 0), result[0].pickupTimeStart)
@@ -146,14 +146,31 @@ class MypageServiceTest {
         assertEquals(24_000, result[0].paymentAmount)
         assertEquals(2, result[0].quantity)
         assertEquals(PickupStatus.NOT_READY.name, result[0].pickupStatus)
-        assertEquals(
-            ChronoUnit.DAYS.between(LocalDate.now(), participation.groupBuy.deadline.toLocalDate()).toInt(),
-            result[0].dDay
-        )
+        assertEquals(1, result[0].dDay)
         assertEquals(true, result[0].canCancel)
         assertEquals(false, result[0].canViewPickup)
         assertEquals(false, result[0].canViewQr)
         assertEquals("UNAVAILABLE", result[0].qrAvailability)
+    }
+
+    @Test
+    fun `active participations가 비어 있으면 결제 주문을 조회하지 않는다`() {
+        val userId = 1L
+        `when`(
+            participationRepository.findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
+                userId,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED),
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+            )
+        ).thenReturn(emptyList())
+
+        val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.ACTIVE)
+
+        assertEquals(emptyList<Any>(), result)
+        verify(paymentOrderRepository, never()).findGroupBuyIdsByUserIdAndStatus(
+            userId,
+            PaymentOrderStatus.APPROVED
+        )
     }
 
     @Test
@@ -183,7 +200,7 @@ class MypageServiceTest {
         assertEquals(ParticipationStatus.CONFIRMED.name, result[0].participationStatus)
         assertEquals(0, result[0].achievementRate)
         assertEquals("ACHIEVED", result[0].achievementStatus)
-        assertEquals("픽업 완료", result[0].displayStatus)
+        assertEquals("PICKED_UP", result[0].displayStatus)
         assertEquals("문치 베이커리", result[0].storeName)
         assertEquals(LocalDate.of(2026, 5, 25), result[0].pickupDate)
         assertEquals(LocalTime.of(13, 0), result[0].pickupTimeStart)
@@ -273,7 +290,7 @@ class MypageServiceTest {
             targetQuantity = 10,
             maxQuantity = 20,
             status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.IN_PROGRESS,
-            deadline = LocalDateTime.of(2026, 5, 24, 23, 59),
+            deadline = LocalDate.now().plusDays(1).atTime(23, 59),
             pickupDate = LocalDate.of(2026, 5, 25),
             pickupTimeStart = LocalTime.of(13, 0),
             pickupTimeEnd = LocalTime.of(15, 0),

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -1,0 +1,294 @@
+package com.moongchijang.domain.mypage.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationStatusFilter
+import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
+import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.ChronoUnit
+
+@ExtendWith(MockitoExtension::class)
+class MypageServiceTest {
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var groupBuyRequestRepository: GroupBuyRequestRepository
+
+    @Mock
+    private lateinit var paymentOrderRepository: PaymentOrderRepository
+
+    @InjectMocks
+    private lateinit var mypageService: MypageService
+
+    @Test
+    fun `summary는 참여중 완료 환불 개설요청 count를 반환한다`() {
+        val userId = 1L
+        `when`(
+            participationRepository.countByUserIdAndStatusInAndPickupStatusIn(
+                userId,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED),
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+            )
+        ).thenReturn(2L)
+        `when`(
+            participationRepository.countByUserIdAndStatusInAndPickupStatus(
+                userId,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED),
+                PickupStatus.PICKED_UP
+            )
+        ).thenReturn(3L)
+        `when`(participationRepository.countByUserIdAndStatus(userId, ParticipationStatus.REFUNDED))
+            .thenReturn(1L)
+        `when`(groupBuyRequestRepository.countByUserId(userId)).thenReturn(4L)
+
+        val result = mypageService.getSummary(userId)
+
+        assertEquals(2L, result.activeCount)
+        assertEquals(3L, result.completedCount)
+        assertEquals(1L, result.refundedCount)
+        assertEquals(4L, result.requestCount)
+    }
+
+    @Test
+    fun `refunds는 REFUNDED 참여만 환불 내역 DTO로 변환한다`() {
+        val userId = 1L
+        val participation = createParticipation().apply {
+            id = 10L
+            status = ParticipationStatus.REFUNDED
+            cancelReason = ParticipationCancelReason.TIME_UNAVAILABLE
+            cancelReasonDetail = "마감 전 직접 취소"
+            refundedAt = LocalDateTime.of(2026, 5, 20, 10, 0)
+        }
+        `when`(
+            participationRepository.findByUserIdAndStatusOrderByRefundedAtDescCreatedAtDesc(
+                userId,
+                ParticipationStatus.REFUNDED
+            )
+        ).thenReturn(listOf(participation))
+
+        val result = mypageService.getRefunds(userId)
+
+        assertEquals(1, result.size)
+        assertEquals(10L, result[0].participationId)
+        assertEquals("초코 케이크", result[0].productName)
+        assertEquals("COMPLETED", result[0].refundStatus)
+        assertEquals("문치 베이커리", result[0].storeName)
+        assertEquals(LocalDate.of(2026, 5, 25), result[0].pickupDate)
+        assertEquals(LocalTime.of(13, 0), result[0].pickupTimeStart)
+        assertEquals(LocalTime.of(15, 0), result[0].pickupTimeEnd)
+        assertEquals(24_000, result[0].paymentAmount)
+        assertEquals(2, result[0].quantity)
+        assertEquals(ParticipationCancelReason.TIME_UNAVAILABLE.name, result[0].cancelReason)
+        assertEquals("마감 전 직접 취소", result[0].cancelReasonDetail)
+    }
+
+    @Test
+    fun `active participations는 summary와 같은 참여중 조건으로 DTO를 반환한다`() {
+        val userId = 1L
+        val participation = createParticipation().apply {
+            id = 11L
+            groupBuy.id = 101L
+            groupBuy.currentQuantity = 6
+            status = ParticipationStatus.PAID_WAITING_GOAL
+            pickupStatus = PickupStatus.NOT_READY
+        }
+        `when`(
+            participationRepository.findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
+                userId,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED),
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+            )
+        ).thenReturn(listOf(participation))
+        `when`(
+            paymentOrderRepository.findGroupBuyIdsByUserIdAndStatus(userId, PaymentOrderStatus.APPROVED)
+        ).thenReturn(listOf(101L))
+
+        val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.ACTIVE)
+
+        assertEquals(1, result.size)
+        assertEquals(11L, result[0].participationId)
+        assertEquals(101L, result[0].groupBuyId)
+        assertEquals("초코 케이크", result[0].productName)
+        assertEquals(ParticipationStatus.PAID_WAITING_GOAL.name, result[0].participationStatus)
+        assertEquals(60, result[0].achievementRate)
+        assertEquals("BEFORE_ACHIEVED", result[0].achievementStatus)
+        assertEquals("참여중 / 달성 전", result[0].displayStatus)
+        assertEquals("문치 베이커리", result[0].storeName)
+        assertEquals(LocalDate.of(2026, 5, 25), result[0].pickupDate)
+        assertEquals(LocalTime.of(13, 0), result[0].pickupTimeStart)
+        assertEquals(LocalTime.of(15, 0), result[0].pickupTimeEnd)
+        assertEquals("문치 베이커리", result[0].pickupLocation)
+        assertEquals(24_000, result[0].paymentAmount)
+        assertEquals(2, result[0].quantity)
+        assertEquals(PickupStatus.NOT_READY.name, result[0].pickupStatus)
+        assertEquals(
+            ChronoUnit.DAYS.between(LocalDate.now(), participation.groupBuy.deadline.toLocalDate()).toInt(),
+            result[0].dDay
+        )
+        assertEquals(true, result[0].canCancel)
+        assertEquals(false, result[0].canViewPickup)
+        assertEquals(false, result[0].canViewQr)
+        assertEquals("UNAVAILABLE", result[0].qrAvailability)
+    }
+
+    @Test
+    fun `completed participations는 summary와 같은 픽업완료 조건으로 DTO를 반환한다`() {
+        val userId = 1L
+        val participation = createParticipation().apply {
+            id = 12L
+            groupBuy.id = 102L
+            status = ParticipationStatus.CONFIRMED
+            pickupStatus = PickupStatus.PICKED_UP
+            pickedUpAt = LocalDateTime.of(2026, 5, 25, 14, 0)
+        }
+        `when`(
+            participationRepository.findByUserIdAndStatusInAndPickupStatusOrderByPickedUpAtDescCreatedAtDesc(
+                userId,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED),
+                PickupStatus.PICKED_UP
+            )
+        ).thenReturn(listOf(participation))
+
+        val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.COMPLETED)
+
+        assertEquals(1, result.size)
+        assertEquals(12L, result[0].participationId)
+        assertEquals(102L, result[0].groupBuyId)
+        assertEquals("초코 케이크", result[0].productName)
+        assertEquals(ParticipationStatus.CONFIRMED.name, result[0].participationStatus)
+        assertEquals(0, result[0].achievementRate)
+        assertEquals("ACHIEVED", result[0].achievementStatus)
+        assertEquals("픽업 완료", result[0].displayStatus)
+        assertEquals("문치 베이커리", result[0].storeName)
+        assertEquals(LocalDate.of(2026, 5, 25), result[0].pickupDate)
+        assertEquals(LocalTime.of(13, 0), result[0].pickupTimeStart)
+        assertEquals(LocalTime.of(15, 0), result[0].pickupTimeEnd)
+        assertEquals(24_000, result[0].paymentAmount)
+        assertEquals(2, result[0].quantity)
+        assertEquals(PickupStatus.PICKED_UP.name, result[0].pickupStatus)
+        assertEquals(false, result[0].canCancel)
+        assertEquals(false, result[0].canViewPickup)
+        assertEquals(false, result[0].canViewQr)
+        assertEquals("PICKED_UP", result[0].qrAvailability)
+    }
+
+    @Test
+    fun `refunded participations는 REFUNDED 상태 목록 DTO를 반환한다`() {
+        val userId = 1L
+        val participation = createParticipation().apply {
+            id = 13L
+            groupBuy.id = 103L
+            status = ParticipationStatus.REFUNDED
+        }
+        `when`(
+            participationRepository.findByUserIdAndStatusOrderByCreatedAtDesc(userId, ParticipationStatus.REFUNDED)
+        ).thenReturn(listOf(participation))
+
+        val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.REFUNDED)
+
+        assertEquals(1, result.size)
+        assertEquals(13L, result[0].participationId)
+        assertEquals(ParticipationStatus.REFUNDED.name, result[0].participationStatus)
+        assertEquals(false, result[0].canCancel)
+    }
+
+    @Test
+    fun `group-buy-requests는 내 개설 요청 내역 DTO로 변환한다`() {
+        val userId = 1L
+        val request = GroupBuyRequest(
+            userId = userId,
+            storeName = "문치 베이커리",
+            productName = "소금빵",
+            desiredQuantity = 5,
+            desiredPickupDate = LocalDate.of(2026, 5, 27),
+            status = GroupBuyRequestStatus.IN_CONTACT
+        ).apply { id = 20L }
+        `when`(groupBuyRequestRepository.findByUserIdOrderByCreatedAtDesc(userId)).thenReturn(listOf(request))
+
+        val result = mypageService.getGroupBuyRequests(userId)
+
+        assertEquals(1, result.size)
+        assertEquals(20L, result[0].requestId)
+        assertEquals("소금빵", result[0].productName)
+        assertEquals(GroupBuyRequestStatus.IN_CONTACT.name, result[0].status)
+        assertEquals("문치 베이커리", result[0].storeName)
+        assertEquals(LocalDate.of(2026, 5, 27), result[0].desiredPickupDate)
+        assertEquals(5, result[0].desiredQuantity)
+
+        verify(groupBuyRequestRepository).findByUserIdOrderByCreatedAtDesc(userId)
+    }
+
+    private fun createParticipation(): Participation {
+        val user = User(
+            provider = AuthProvider.EMAIL,
+            email = "user@example.com",
+            passwordHash = "password",
+            nickname = "문치",
+            role = UserRole.BUYER
+        ).apply { id = 1L }
+        val store = Store(
+            name = "문치 베이커리",
+            address = "서울시 성동구",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
+        )
+        val groupBuyRequest = GroupBuyRequest(
+            userId = 2L,
+            storeName = store.name,
+            productName = "초코 케이크",
+            desiredQuantity = 10,
+            desiredPickupDate = LocalDate.of(2026, 5, 25)
+        )
+        val groupBuy = com.moongchijang.domain.groupbuy.domain.entity.GroupBuy(
+            store = store,
+            groupBuyRequest = groupBuyRequest,
+            productName = "초코 케이크",
+            productDescription = "진한 초코 케이크",
+            price = 12_000,
+            targetQuantity = 10,
+            maxQuantity = 20,
+            status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.IN_PROGRESS,
+            deadline = LocalDateTime.of(2026, 5, 24, 23, 59),
+            pickupDate = LocalDate.of(2026, 5, 25),
+            pickupTimeStart = LocalTime.of(13, 0),
+            pickupTimeEnd = LocalTime.of(15, 0),
+            pickupLocation = "문치 베이커리"
+        )
+
+        return Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 2,
+            productAmount = 24_000,
+            feeAmount = 0,
+            totalAmount = 24_000,
+            status = ParticipationStatus.REFUNDED,
+            pickupStatus = PickupStatus.NOT_READY
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/mypage/presentation/MypageControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/presentation/MypageControllerTest.kt
@@ -1,0 +1,74 @@
+package com.moongchijang.domain.mypage.presentation
+
+import com.moongchijang.domain.mypage.application.MypageService
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationStatusFilter
+import com.moongchijang.domain.mypage.application.dto.MypageSummaryResponse
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.security.principal.CustomUserPrincipal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class MypageControllerTest {
+
+    private val mypageService: MypageService = mock(MypageService::class.java)
+    private val controller = MypageController(mypageService)
+
+    @Test
+    fun `users me participations는 ACTIVE 상태 필터를 서비스로 전달한다`() {
+        `when`(mypageService.getParticipations(1L, MypageParticipationStatusFilter.ACTIVE)).thenReturn(emptyList())
+
+        val result = controller.getUserParticipations(principal(), MypageParticipationStatusFilter.ACTIVE)
+
+        assertEquals(emptyList<Any>(), result.body?.data)
+        verify(mypageService).getParticipations(1L, MypageParticipationStatusFilter.ACTIVE)
+    }
+
+    @Test
+    fun `users me participations는 COMPLETED 상태 필터를 서비스로 전달한다`() {
+        `when`(mypageService.getParticipations(1L, MypageParticipationStatusFilter.COMPLETED)).thenReturn(emptyList())
+
+        controller.getUserParticipations(principal(), MypageParticipationStatusFilter.COMPLETED)
+
+        verify(mypageService).getParticipations(1L, MypageParticipationStatusFilter.COMPLETED)
+    }
+
+    @Test
+    fun `users me participations는 REFUNDED 상태 필터를 서비스로 전달한다`() {
+        `when`(mypageService.getParticipations(1L, MypageParticipationStatusFilter.REFUNDED)).thenReturn(emptyList())
+
+        controller.getUserParticipations(principal(), MypageParticipationStatusFilter.REFUNDED)
+
+        verify(mypageService).getParticipations(1L, MypageParticipationStatusFilter.REFUNDED)
+    }
+
+    @Test
+    fun `users me tabs counts는 summary를 반환한다`() {
+        val summary = MypageSummaryResponse(activeCount = 1, completedCount = 2, refundedCount = 3, requestCount = 4)
+        `when`(mypageService.getSummary(1L)).thenReturn(summary)
+
+        val result = controller.getUserTabCounts(principal())
+
+        assertEquals(summary, result.body?.data)
+        verify(mypageService).getSummary(1L)
+    }
+
+    @Test
+    fun `users me group buy requests는 내 개설 요청 목록을 반환한다`() {
+        `when`(mypageService.getGroupBuyRequests(1L)).thenReturn(emptyList())
+
+        val result = controller.getUserGroupBuyRequests(principal())
+
+        assertEquals(emptyList<Any>(), result.body?.data)
+        verify(mypageService).getGroupBuyRequests(1L)
+    }
+
+    private fun principal(): CustomUserPrincipal =
+        CustomUserPrincipal(
+            id = 1L,
+            email = "user@example.com",
+            role = UserRole.BUYER,
+        )
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 마이페이지 탭 count API를 구현했습니다.
- `ACTIVE`, `COMPLETED`, `REFUNDED` 상태 필터 기반 내 참여 내역 API를 추가했습니다.
- 내 공구 개설 요청 내역 API를 추가했습니다.
- 환불 내역 조회와 기존 `/api/v1/mypage/...` alias를 유지했습니다.
- 참여 카드 응답에 `achievementRate`, `dDay`, `canCancel`, `canViewPickup`, `canViewQr`, `qrAvailability`를 포함했습니다.
- 조회 쿼리에 `EntityGraph`/fetch join을 적용해 카드 조회 N+1을 방지했습니다.
- OpenAPI 명세를 실제 구현 경로와 DTO 기준으로 갱신했습니다.

## 🔍 참고 사항
- 프론트 기준 주요 API
  - `GET /api/v1/users/me/participations?status=ACTIVE|COMPLETED|REFUNDED`
  - `GET /api/v1/users/me/group-buy-requests`
  - `GET /api/v1/users/me/tabs/counts`
- 기존 페이지네이션 API는 유지했습니다.
  - `GET /api/v1/users/me/participations/in-progress`
  - `GET /api/v1/users/me/participations/pickup-waiting`
- 상태 매핑
  - `ACTIVE`: `PAID_WAITING_GOAL`, `CONFIRMED` + `NOT_READY`, `READY`
  - `COMPLETED`: `PAID_WAITING_GOAL`, `CONFIRMED` + `PICKED_UP`
  - `REFUNDED`: `REFUNDED`

## 🖼️ 스크린샷

## 🔗 관련 이슈
Closes #115
- MCJ-1476

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
