### PR TITLE
[MCJ-1499] FIX: 찜 목록 조회 500 오류 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepositoryImpl.kt
@@ -36,7 +36,7 @@ class FavoriteRepositoryImpl(
         val content = queryFactory
             .select(groupBuy)
             .from(favorite)
-            .join(favorite.groupBuy, groupBuy).fetchJoin()
+            .join(favorite.groupBuy, groupBuy)
             .join(groupBuy.store, store).fetchJoin()
             .where(where)
             .orderBy(*orderSpecifiers.toTypedArray())

--- a/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
@@ -1,0 +1,117 @@
+package com.moongchijang.domain.favorite.repository
+
+import com.moongchijang.domain.favorite.application.dto.WishFilterType
+import com.moongchijang.domain.favorite.application.dto.WishSortType
+import com.moongchijang.domain.favorite.domain.entity.Favorite
+import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class FavoriteRepositoryImplIntegrationTest {
+
+    @Autowired
+    private lateinit var favoriteRepository: FavoriteRepository
+
+    @Autowired
+    private lateinit var em: EntityManager
+
+    @Test
+    fun `찜 목록 조회 시 groupBuy와 store를 함께 조회한다`() {
+        val user = persistUser("favorite-user@test.com")
+        val groupBuy = persistGroupBuy()
+        em.persist(Favorite(user = user, groupBuy = groupBuy))
+        flushAndClear()
+
+        val page = favoriteRepository.findWishlistGroupBuys(
+            userId = user.id!!,
+            filter = WishFilterType.ALL,
+            excludeClosed = false,
+            sort = WishSortType.LATEST,
+            pageable = PageRequest.of(0, 20),
+            now = LocalDateTime.of(2026, 5, 23, 10, 0),
+        )
+
+        assertThat(page.content).hasSize(1)
+        assertThat(page.content.first().store.name).isEqualTo("찜 테스트 매장")
+    }
+
+    private fun flushAndClear() {
+        em.flush()
+        em.clear()
+    }
+
+    private fun persistUser(email: String): User {
+        val user = User(
+            provider = AuthProvider.EMAIL,
+            email = email,
+            passwordHash = "pw",
+            nickname = "tester",
+            role = UserRole.BUYER,
+            signupCompleted = true,
+        )
+        em.persist(user)
+        return user
+    }
+
+    private fun persistGroupBuy(): GroupBuy {
+        val store = Store(
+            name = "찜 테스트 매장",
+            address = "서울 강남구",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG,
+        )
+        em.persist(store)
+
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "찜 테스트 매장",
+            storeAddress = "서울 강남구",
+            productName = "테스트 상품",
+            desiredQuantity = 50,
+            desiredPickupDate = LocalDate.now().plusDays(3),
+        )
+        em.persist(request)
+
+        val groupBuy = GroupBuy(
+            store = store,
+            groupBuyRequest = request,
+            thumbnailUrl = "https://example.com/test.jpg",
+            productName = "테스트 상품",
+            productDescription = "설명",
+            price = 10000,
+            targetQuantity = 50,
+            currentQuantity = 10,
+            maxQuantity = 100,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = LocalDateTime.of(2026, 5, 30, 21, 0),
+            pickupDate = LocalDate.of(2026, 6, 1),
+            pickupTimeStart = LocalTime.of(10, 0),
+            pickupTimeEnd = LocalTime.of(12, 0),
+            pickupLocation = "서울 강남구",
+            shareCount = 0,
+        )
+        em.persist(groupBuy)
+        return groupBuy
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
@@ -39,7 +39,7 @@ class FavoriteRepositoryImplIntegrationTest {
     @Test
     fun `찜 목록 조회 시 groupBuy와 store를 함께 조회한다`() {
         val user = persistUser("favorite-user@test.com")
-        val groupBuy = persistGroupBuy()
+        val groupBuy = persistGroupBuy(requestUserId = user.id!!)
         em.persist(Favorite(user = user, groupBuy = groupBuy))
         flushAndClear()
 
@@ -74,7 +74,7 @@ class FavoriteRepositoryImplIntegrationTest {
         return user
     }
 
-    private fun persistGroupBuy(): GroupBuy {
+    private fun persistGroupBuy(requestUserId: Long): GroupBuy {
         val store = Store(
             name = "찜 테스트 매장",
             address = "서울 강남구",
@@ -84,12 +84,12 @@ class FavoriteRepositoryImplIntegrationTest {
         em.persist(store)
 
         val request = GroupBuyRequest(
-            userId = 1L,
+            userId = requestUserId,
             storeName = "찜 테스트 매장",
             storeAddress = "서울 강남구",
             productName = "테스트 상품",
             desiredQuantity = 50,
-            desiredPickupDate = LocalDate.now().plusDays(3),
+            desiredPickupDate = LocalDate.of(2026, 5, 26),
         )
         em.persist(request)
 


### PR DESCRIPTION
## 📌 작업한 내용
- 찜 목록 조회 Querydsl 쿼리에서 `favorite.groupBuy` fetch join을 일반 join으로 수정
- 실제 응답 매핑에 필요한 `groupBuy.store` fetch join은 유지
- 찜 목록 조회 레포지토리 통합 테스트 추가

## 🔍 참고 사항
- `GET /api/v1/wishlists`에서 select 대상이 `GroupBuy`인데 `Favorite -> GroupBuy` 관계에 fetch join을 걸어 Hibernate 6 쿼리 해석 예외가 발생했습니다.
- 찜 추가/해제 API는 정상이고, 목록 조회 API만 500으로 재현됐습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #157

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

검증:
```bash
./gradlew test --tests 'com.moongchijang.domain.favorite.repository.FavoriteRepositoryImplIntegrationTest'\n```\n