### PR TITLE
[MCJ-1495] FEAT: 알림 템플릿, 딥링크 스키마 표준화 및 필수 정보 렌더링 적용

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
@@ -111,21 +111,6 @@ class NotificationEventPublisher(
         )
     }
 
-    fun publishPickupCompleted(
-        groupBuyId: Long,
-        userId: Long,
-        participationId: Long,
-        occurredAt: LocalDateTime
-    ) {
-        publish(
-            triggerType = NotificationTriggerType.PICKUP_COMPLETED_IMMEDIATE,
-            targetId = groupBuyId,
-            userIds = listOf(userId),
-            scheduleKey = "pickup-completed:$groupBuyId:$participationId",
-            occurredAt = occurredAt
-        )
-    }
-
     fun publishRequestRejected(
         requestId: Long,
         requesterUserId: Long,

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -14,6 +14,8 @@ import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.notification.domain.repository.NotificationDispatchHistoryRepository
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
 import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -147,47 +149,43 @@ class NotificationImmediateDispatchService(
     )
 
     private fun resolveTemplateVariables(triggerType: NotificationTriggerType, targetId: Long): Map<String, String> {
-        val variables = mutableMapOf(
-            "상품명" to "공구 상품",
-            "픽업시간범위" to "00:00 ~ 00:00",
-            "픽업일자" to "0000-00-00",
-            "매장명" to "매장",
-            "매장주소" to "매장 주소",
-            "마감시각" to "00:00",
-            "목표참여개수" to "0",
-            "현재참여개수" to "0",
-            "환불예상시각" to "0000-00-00 00:00",
-        )
+        val variables = mutableMapOf<String, String>()
 
-        val groupBuy = when (triggerType) {
+        when (triggerType) {
             NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
-            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> null
+            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> {
+                val groupBuyRequest = groupBuyRequestRepository.findById(targetId)
+                    .orElseThrow {
+                        CustomException(
+                            ErrorCode.NOTIFICATION_NOT_FOUND,
+                            "알림 템플릿 대상 요청공구를 찾을 수 없습니다. targetId=$targetId, triggerType=$triggerType"
+                        )
+                    }
 
-            else -> groupBuyRepository.findWithStoreById(targetId)?.orElse(null)
-        }
-        val groupBuyRequest = when (triggerType) {
-            NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
-            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> groupBuyRequestRepository.findById(targetId)?.orElse(null)
+                variables["상품명"] = groupBuyRequest.productName
+                variables["목표참여개수"] = groupBuyRequest.desiredQuantity.toString()
+            }
 
-            else -> null
-        }
+            else -> {
+                val groupBuy = groupBuyRepository.findWithStoreById(targetId)
+                    .orElseThrow {
+                        CustomException(
+                            ErrorCode.NOTIFICATION_NOT_FOUND,
+                            "알림 템플릿 대상 공구를 찾을 수 없습니다. targetId=$targetId, triggerType=$triggerType"
+                        )
+                    }
 
-        if (groupBuy != null) {
-            variables["상품명"] = groupBuy.productName
-            variables["픽업시간범위"] =
-                "${groupBuy.pickupTimeStart.format(TIME_FORMATTER)} ~ ${groupBuy.pickupTimeEnd.format(TIME_FORMATTER)}"
-            variables["픽업일자"] = groupBuy.pickupDate.format(DATE_FORMATTER)
-            variables["매장명"] = groupBuy.store.name
-            variables["매장주소"] = groupBuy.store.address
-            variables["마감시각"] = groupBuy.deadline.format(TIME_FORMATTER)
-            variables["목표참여개수"] = groupBuy.targetQuantity.toString()
-            variables["현재참여개수"] = groupBuy.currentQuantity.toString()
-            variables["환불예상시각"] = estimateRefundDateTime(groupBuy.deadline).format(DATETIME_FORMATTER)
-        }
-
-        if (groupBuyRequest != null) {
-            variables["상품명"] = groupBuyRequest.productName
-            variables["목표참여개수"] = groupBuyRequest.desiredQuantity.toString()
+                variables["상품명"] = groupBuy.productName
+                variables["픽업시간범위"] =
+                    "${groupBuy.pickupTimeStart.format(TIME_FORMATTER)} ~ ${groupBuy.pickupTimeEnd.format(TIME_FORMATTER)}"
+                variables["픽업일자"] = groupBuy.pickupDate.format(DATE_FORMATTER)
+                variables["매장명"] = groupBuy.store.name
+                variables["매장주소"] = groupBuy.store.address
+                variables["마감시각"] = groupBuy.deadline.format(TIME_FORMATTER)
+                variables["목표참여개수"] = groupBuy.targetQuantity.toString()
+                variables["현재참여개수"] = groupBuy.currentQuantity.toString()
+                variables["환불예상시각"] = estimateRefundDateTime(groupBuy.deadline).format(DATETIME_FORMATTER)
+            }
         }
 
         return variables

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -108,7 +108,7 @@ class NotificationImmediateDispatchService(
         val notificationType = toNotificationType(triggerType)
         val template = notificationTemplateRegistry.getTemplateByTriggerType(triggerType)
         val rendered = notificationTemplateRenderer.render(
-            templateType = template.type,
+            template = template,
             variables = resolveTemplateVariables(triggerType, targetId)
         )
         return NotificationMeta(

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -99,7 +99,6 @@ class NotificationImmediateDispatchService(
 
     private fun toNotificationType(triggerType: NotificationTriggerType): NotificationType {
         return when (triggerType) {
-            NotificationTriggerType.PICKUP_COMPLETED_IMMEDIATE,
             NotificationTriggerType.PICKUP_SAME_DAY_MORNING,
             NotificationTriggerType.PICKUP_DAY_BEFORE_MORNING,
             NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF -> NotificationType.PICKUP

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.DayOfWeek
 
 @Service
 class NotificationImmediateDispatchService(
@@ -33,6 +34,8 @@ class NotificationImmediateDispatchService(
 ) {
     companion object {
         private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+        private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        private val DATETIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
     }
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -147,21 +150,24 @@ class NotificationImmediateDispatchService(
         val variables = mutableMapOf(
             "상품명" to "공구 상품",
             "픽업시간범위" to "00:00 ~ 00:00",
+            "픽업일자" to "0000-00-00",
             "매장명" to "매장",
+            "매장주소" to "매장 주소",
             "마감시각" to "00:00",
             "목표참여개수" to "0",
             "현재참여개수" to "0",
+            "환불예상시각" to "0000-00-00 00:00",
         )
 
         val groupBuy = when (triggerType) {
             NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
             NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> null
 
-            else -> groupBuyRepository.findWithStoreById(targetId).orElse(null)
+            else -> groupBuyRepository.findWithStoreById(targetId)?.orElse(null)
         }
         val groupBuyRequest = when (triggerType) {
             NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
-            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> groupBuyRequestRepository.findById(targetId).orElse(null)
+            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> groupBuyRequestRepository.findById(targetId)?.orElse(null)
 
             else -> null
         }
@@ -170,10 +176,13 @@ class NotificationImmediateDispatchService(
             variables["상품명"] = groupBuy.productName
             variables["픽업시간범위"] =
                 "${groupBuy.pickupTimeStart.format(TIME_FORMATTER)} ~ ${groupBuy.pickupTimeEnd.format(TIME_FORMATTER)}"
+            variables["픽업일자"] = groupBuy.pickupDate.format(DATE_FORMATTER)
             variables["매장명"] = groupBuy.store.name
+            variables["매장주소"] = groupBuy.store.address
             variables["마감시각"] = groupBuy.deadline.format(TIME_FORMATTER)
             variables["목표참여개수"] = groupBuy.targetQuantity.toString()
             variables["현재참여개수"] = groupBuy.currentQuantity.toString()
+            variables["환불예상시각"] = estimateRefundDateTime(groupBuy.deadline).format(DATETIME_FORMATTER)
         }
 
         if (groupBuyRequest != null) {
@@ -182,6 +191,18 @@ class NotificationImmediateDispatchService(
         }
 
         return variables
+    }
+
+    private fun estimateRefundDateTime(baseDateTime: LocalDateTime): LocalDateTime {
+        var cursor = baseDateTime
+        var addedBusinessDays = 0
+        while (addedBusinessDays < 3) {
+            cursor = cursor.plusDays(1)
+            if (cursor.dayOfWeek != DayOfWeek.SATURDAY && cursor.dayOfWeek != DayOfWeek.SUNDAY) {
+                addedBusinessDays += 1
+            }
+        }
+        return cursor.withHour(10).withMinute(0).withSecond(0).withNano(0)
     }
 
     private fun calculateNextRetryAt(retryCount: Int): LocalDateTime? {

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -1,6 +1,10 @@
 package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import com.moongchijang.domain.notification.application.template.NotificationTemplateRegistry
+import com.moongchijang.domain.notification.application.template.NotificationTemplateRenderer
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
@@ -15,13 +19,22 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 @Service
 class NotificationImmediateDispatchService(
     private val notificationRepository: NotificationRepository,
     private val notificationDispatchHistoryRepository: NotificationDispatchHistoryRepository,
     private val userRepository: UserRepository,
+    private val groupBuyRepository: GroupBuyRepository,
+    private val groupBuyRequestRepository: GroupBuyRequestRepository,
+    private val notificationTemplateRegistry: NotificationTemplateRegistry,
+    private val notificationTemplateRenderer: NotificationTemplateRenderer,
 ) {
+    companion object {
+        private val TIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+    }
+
     private val log = LoggerFactory.getLogger(javaClass)
     private val zoneId: ZoneId = ZoneId.of("Asia/Seoul")
 
@@ -86,14 +99,18 @@ class NotificationImmediateDispatchService(
         }
     }
 
-    private fun toNotificationMeta(triggerType: NotificationTriggerType): NotificationMeta {
+    private fun toNotificationMeta(triggerType: NotificationTriggerType, targetId: Long): NotificationMeta {
         val notificationType = toNotificationType(triggerType)
+        val template = notificationTemplateRegistry.getTemplateByTriggerType(triggerType)
+        val rendered = notificationTemplateRenderer.render(
+            templateType = template.type,
+            variables = resolveTemplateVariables(triggerType, targetId)
+        )
         return NotificationMeta(
             type = notificationType,
-            // TODO: 상세 템플릿/문구는 정해진 이후 수정 예정
-            title = "알림",
-            body = "새 알림이 도착했습니다.",
-            deeplinkType = defaultDeeplinkType(notificationType)
+            title = rendered.title,
+            body = rendered.body,
+            deeplinkType = rendered.deeplinkType
         )
     }
 
@@ -119,21 +136,53 @@ class NotificationImmediateDispatchService(
         }
     }
 
-    private fun defaultDeeplinkType(notificationType: NotificationType): NotificationDeeplinkType {
-        return when (notificationType) {
-            NotificationType.PICKUP -> NotificationDeeplinkType.PICKUP_GUIDE
-            NotificationType.WISH -> NotificationDeeplinkType.GROUPBUY_DETAIL
-            NotificationType.APPLY -> NotificationDeeplinkType.MY_APPLYING
-            NotificationType.REQUEST -> NotificationDeeplinkType.REQUEST_STATUS
-        }
-    }
-
     private data class NotificationMeta(
         val type: NotificationType,
         val title: String,
         val body: String,
         val deeplinkType: NotificationDeeplinkType,
     )
+
+    private fun resolveTemplateVariables(triggerType: NotificationTriggerType, targetId: Long): Map<String, String> {
+        val variables = mutableMapOf(
+            "상품명" to "공구 상품",
+            "픽업시간범위" to "00:00 ~ 00:00",
+            "매장명" to "매장",
+            "마감시각" to "00:00",
+            "목표참여개수" to "0",
+            "현재참여개수" to "0",
+        )
+
+        val groupBuy = when (triggerType) {
+            NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
+            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> null
+
+            else -> groupBuyRepository.findWithStoreById(targetId).orElse(null)
+        }
+        val groupBuyRequest = when (triggerType) {
+            NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
+            NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> groupBuyRequestRepository.findById(targetId).orElse(null)
+
+            else -> null
+        }
+
+        if (groupBuy != null) {
+            variables["상품명"] = groupBuy.productName
+            variables["픽업시간범위"] =
+                "${groupBuy.pickupTimeStart.format(TIME_FORMATTER)} ~ ${groupBuy.pickupTimeEnd.format(TIME_FORMATTER)}"
+            variables["매장명"] = groupBuy.store.name
+            variables["마감시각"] = groupBuy.deadline.format(TIME_FORMATTER)
+            variables["목표참여개수"] = groupBuy.targetQuantity.toString()
+            variables["현재참여개수"] = groupBuy.currentQuantity.toString()
+        }
+
+        if (groupBuyRequest != null) {
+            variables["상품명"] = groupBuyRequest.productName
+            variables["목표참여개수"] = groupBuyRequest.desiredQuantity.toString()
+        }
+
+        return variables
+    }
 
     private fun calculateNextRetryAt(retryCount: Int): LocalDateTime? {
         val now = LocalDateTime.now(zoneId)
@@ -164,7 +213,7 @@ class NotificationImmediateDispatchService(
                 return
             }
 
-            val meta = toNotificationMeta(event.triggerType)
+            val meta = toNotificationMeta(event.triggerType, event.targetId)
             notificationRepository.save(
                 Notification(
                     user = user,

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/deeplink/NotificationDeeplinkSchema.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/deeplink/NotificationDeeplinkSchema.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.notification.application.deeplink
+
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+
+object NotificationDeeplinkSchema {
+
+    fun toParams(deeplinkType: NotificationDeeplinkType, targetId: Long?): Map<String, String> {
+        if (targetId == null) {
+            return emptyMap()
+        }
+
+        return when (deeplinkType) {
+            NotificationDeeplinkType.PICKUP_GUIDE -> mapOf("groupBuyId" to targetId.toString())
+            NotificationDeeplinkType.GROUPBUY_DETAIL -> mapOf("groupBuyId" to targetId.toString())
+            NotificationDeeplinkType.MY_APPLYING -> mapOf("groupBuyId" to targetId.toString())
+            NotificationDeeplinkType.REQUEST_STATUS -> mapOf("targetId" to targetId.toString())
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.notification.application.dto
 
+import com.moongchijang.domain.notification.application.deeplink.NotificationDeeplinkSchema
 import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
@@ -34,6 +35,12 @@ data class NotificationItemResponse(
     @field:Schema(description = "딥링크 타입", example = "PICKUP_GUIDE")
     val deeplinkType: NotificationDeeplinkType,
 
+    @field:Schema(
+        description = "딥링크 파라미터. PICKUP_GUIDE/GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 targetId를 사용합니다.",
+        example = "{\"groupBuyId\":\"2001\"}"
+    )
+    val deeplinkParams: Map<String, String>,
+
     @field:Schema(description = "기간 구분", example = "TODAY")
     val section: NotificationSection
 ) {
@@ -48,6 +55,7 @@ data class NotificationItemResponse(
                 occurredAt = notification.occurredAt,
                 targetId = notification.targetId,
                 deeplinkType = notification.deeplinkType,
+                deeplinkParams = NotificationDeeplinkSchema.toParams(notification.deeplinkType, notification.targetId),
                 section = resolveSection(notification.occurredAt.toLocalDate(), today)
             )
         }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplate.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplate.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.notification.application.template
+
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+
+data class NotificationTemplate(
+    val type: NotificationTemplateType,
+    val titleTemplate: String,
+    val bodyTemplate: String,
+    val deeplinkType: NotificationDeeplinkType,
+)

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
@@ -72,13 +72,13 @@ class NotificationTemplateRegistry {
         NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED to NotificationTemplate(
             type = NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED,
             titleTemplate = "공구 성공! 픽업 일정 확인하세요.",
-            bodyTemplate = "{상품명} 공구가 달성됐어요.\n마이페이지에서 픽업 정보를 확인해주세요!",
+            bodyTemplate = "{상품명} 공구가 달성됐어요.\n픽업: {픽업일자} {픽업시간범위}\n매장: {매장명}\n주소: {매장주소}",
             deeplinkType = NotificationDeeplinkType.MY_APPLYING,
         ),
         NotificationTemplateType.APPLY_GROUPBUY_FAILED to NotificationTemplate(
             type = NotificationTemplateType.APPLY_GROUPBUY_FAILED,
             titleTemplate = "아쉽게도 공구가 미달성됐어요.",
-            bodyTemplate = "{상품명} 공구가 목표 수량에 미달해 마감됐어요.\n결제 금액은 3~5 영업일 내 환불될 예정이에요.",
+            bodyTemplate = "{상품명} 공구가 목표 수량에 미달해 마감됐어요.\n결제 금액은 {환불예상시각} 환불될 예정이에요.",
             deeplinkType = NotificationDeeplinkType.MY_APPLYING,
         ),
         NotificationTemplateType.REQUEST_OPENED to NotificationTemplate(

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
@@ -1,0 +1,125 @@
+package com.moongchijang.domain.notification.application.template
+
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationTemplateRegistry {
+
+    private val triggerTypeToTemplateType: Map<NotificationTriggerType, NotificationTemplateType> = mapOf(
+        NotificationTriggerType.PICKUP_SAME_DAY_MORNING to NotificationTemplateType.PICKUP_SAME_DAY_REMINDER,
+        NotificationTriggerType.PICKUP_DAY_BEFORE_MORNING to NotificationTemplateType.PICKUP_DAY_BEFORE_REMINDER,
+        NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF to NotificationTemplateType.PICKUP_INCOMPLETE_AFTER_CUTOFF,
+        NotificationTriggerType.WISH_DEADLINE_MINUS_3_DAYS to NotificationTemplateType.WISH_DEADLINE_MINUS_3_DAYS,
+        NotificationTriggerType.WISH_DEADLINE_MINUS_1_DAY to NotificationTemplateType.WISH_DEADLINE_MINUS_1_DAY,
+        NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE to NotificationTemplateType.WISH_TARGET_ACHIEVED,
+        NotificationTriggerType.APPLY_PAYMENT_SUCCESS_IMMEDIATE to NotificationTemplateType.APPLY_PAYMENT_SUCCESS,
+        NotificationTriggerType.APPLY_GROUPBUY_ACHIEVED_IMMEDIATE to NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED,
+        NotificationTriggerType.APPLY_GROUPBUY_FAILED_IMMEDIATE to NotificationTemplateType.APPLY_GROUPBUY_FAILED,
+        NotificationTriggerType.REQUEST_OPENED_IMMEDIATE to NotificationTemplateType.REQUEST_OPENED,
+        NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE to NotificationTemplateType.REQUEST_REJECTED,
+        NotificationTriggerType.REQUEST_NEW_PARTICIPANT_IMMEDIATE to NotificationTemplateType.REQUEST_NEW_PARTICIPANT,
+        NotificationTriggerType.REQUEST_TARGET_ACHIEVED_IMMEDIATE to NotificationTemplateType.REQUEST_TARGET_ACHIEVED,
+        NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS to NotificationTemplateType.REQUEST_DEADLINE_MINUS_3_DAYS,
+    )
+
+    private val templates: Map<NotificationTemplateType, NotificationTemplate> = mapOf(
+        NotificationTemplateType.PICKUP_SAME_DAY_REMINDER to NotificationTemplate(
+            type = NotificationTemplateType.PICKUP_SAME_DAY_REMINDER,
+            titleTemplate = "오늘 픽업일이에요! 시간 확인하세요.",
+            bodyTemplate = "{상품명} 픽업시간은 오늘 {픽업시간범위}, {매장명}(이)에요.",
+            deeplinkType = NotificationDeeplinkType.PICKUP_GUIDE,
+        ),
+        NotificationTemplateType.PICKUP_DAY_BEFORE_REMINDER to NotificationTemplate(
+            type = NotificationTemplateType.PICKUP_DAY_BEFORE_REMINDER,
+            titleTemplate = "내일 픽업일이에요. 잊지마세요!",
+            bodyTemplate = "{상품명} 픽업이\n내일 {픽업시간범위}로 예정됐어요.",
+            deeplinkType = NotificationDeeplinkType.PICKUP_GUIDE,
+        ),
+        NotificationTemplateType.PICKUP_INCOMPLETE_AFTER_CUTOFF to NotificationTemplate(
+            type = NotificationTemplateType.PICKUP_INCOMPLETE_AFTER_CUTOFF,
+            titleTemplate = "픽업완료 확인이 필요해요.",
+            bodyTemplate = "{상품명} 픽업이 완료됐나요?\n사장님께 QR 확인 후 완료 처리해 주세요.",
+            deeplinkType = NotificationDeeplinkType.PICKUP_GUIDE,
+        ),
+        NotificationTemplateType.WISH_DEADLINE_MINUS_3_DAYS to NotificationTemplate(
+            type = NotificationTemplateType.WISH_DEADLINE_MINUS_3_DAYS,
+            titleTemplate = "찜한 공구 마감 3일 전이에요.",
+            bodyTemplate = "{상품명} 신청 마감까지 3일 남았어요.",
+            deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL,
+        ),
+        NotificationTemplateType.WISH_DEADLINE_MINUS_1_DAY to NotificationTemplate(
+            type = NotificationTemplateType.WISH_DEADLINE_MINUS_1_DAY,
+            titleTemplate = "찜한 공구 마감이 내일이에요.",
+            bodyTemplate = "{상품명} 신청 마감이 내일 {마감시각}까지예요.\n아직 신청 안 하셨나요?",
+            deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL,
+        ),
+        NotificationTemplateType.WISH_TARGET_ACHIEVED to NotificationTemplate(
+            type = NotificationTemplateType.WISH_TARGET_ACHIEVED,
+            titleTemplate = "찜한 공구 목표 인원 달성!",
+            bodyTemplate = "{상품명}(이)가 목표 인원 {목표참여개수}명을 달성했어요.\n지금 참여하면 무조건 픽업 가능!",
+            deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL,
+        ),
+        NotificationTemplateType.APPLY_PAYMENT_SUCCESS to NotificationTemplate(
+            type = NotificationTemplateType.APPLY_PAYMENT_SUCCESS,
+            titleTemplate = "공구 참여 완료! 결제됐어요.",
+            bodyTemplate = "{상품명} 참여가 완료됐어요.\n달성되면 바로 알려드릴게요!",
+            deeplinkType = NotificationDeeplinkType.MY_APPLYING,
+        ),
+        NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED to NotificationTemplate(
+            type = NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED,
+            titleTemplate = "공구 성공! 픽업 일정 확인하세요.",
+            bodyTemplate = "{상품명} 공구가 달성됐어요.\n마이페이지에서 픽업 정보를 확인해주세요!",
+            deeplinkType = NotificationDeeplinkType.MY_APPLYING,
+        ),
+        NotificationTemplateType.APPLY_GROUPBUY_FAILED to NotificationTemplate(
+            type = NotificationTemplateType.APPLY_GROUPBUY_FAILED,
+            titleTemplate = "아쉽게도 공구가 미달성됐어요.",
+            bodyTemplate = "{상품명} 공구가 목표 수량에 미달해 마감됐어요.\n결제 금액은 3~5 영업일 내 환불될 예정이에요.",
+            deeplinkType = NotificationDeeplinkType.MY_APPLYING,
+        ),
+        NotificationTemplateType.REQUEST_OPENED to NotificationTemplate(
+            type = NotificationTemplateType.REQUEST_OPENED,
+            titleTemplate = "[요청공구] 축하해요! 공구 개설 성공!",
+            bodyTemplate = "요청하신 {상품명} 공구가 개설됐어요.\n지금 바로 참여해 달성률을 높여주세요!",
+            deeplinkType = NotificationDeeplinkType.REQUEST_STATUS,
+        ),
+        NotificationTemplateType.REQUEST_REJECTED to NotificationTemplate(
+            type = NotificationTemplateType.REQUEST_REJECTED,
+            titleTemplate = "[요청공구] 공구 개설 실패..",
+            bodyTemplate = "요청하신 {상품명} 공구가 개설 실패했어요.\n다른 공구 상품을 둘러볼까요?",
+            deeplinkType = NotificationDeeplinkType.REQUEST_STATUS,
+        ),
+        NotificationTemplateType.REQUEST_NEW_PARTICIPANT to NotificationTemplate(
+            type = NotificationTemplateType.REQUEST_NEW_PARTICIPANT,
+            titleTemplate = "[요청공구] 새 참여자가 신청했어요.",
+            bodyTemplate = "{상품명}에 새 신청이 들어왔어요.\n현재 {현재참여개수}/{목표참여개수}개 참여 중이에요.",
+            deeplinkType = NotificationDeeplinkType.REQUEST_STATUS,
+        ),
+        NotificationTemplateType.REQUEST_TARGET_ACHIEVED to NotificationTemplate(
+            type = NotificationTemplateType.REQUEST_TARGET_ACHIEVED,
+            titleTemplate = "[요청공구] 축하해요! 공구 달성 성공!",
+            bodyTemplate = "주최하신 {상품명}(이)가 목표 {목표참여개수}개을 달성했어요.\n픽업 일정을 확정해 주세요.",
+            deeplinkType = NotificationDeeplinkType.REQUEST_STATUS,
+        ),
+        NotificationTemplateType.REQUEST_DEADLINE_MINUS_3_DAYS to NotificationTemplate(
+            type = NotificationTemplateType.REQUEST_DEADLINE_MINUS_3_DAYS,
+            titleTemplate = "[요청공구] 공구 마감이 3일 남았어요.",
+            bodyTemplate = "주최하신 {상품명} 신청 마감까지 3일 남았어요.\n현재 {현재참여개수}/{목표참여개수}개 달성중",
+            deeplinkType = NotificationDeeplinkType.REQUEST_STATUS,
+        ),
+    )
+
+    fun getTemplateByTriggerType(triggerType: NotificationTriggerType): NotificationTemplate {
+        val templateType = triggerTypeToTemplateType[triggerType]
+            ?: throw IllegalArgumentException("지원하지 않는 알림 트리거입니다: $triggerType")
+        return templates[templateType]
+            ?: throw IllegalArgumentException("등록되지 않은 알림 템플릿입니다: $templateType")
+    }
+
+    fun getTemplateByType(templateType: NotificationTemplateType): NotificationTemplate {
+        return templates[templateType]
+            ?: throw IllegalArgumentException("등록되지 않은 알림 템플릿입니다: $templateType")
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
@@ -2,6 +2,8 @@ package com.moongchijang.domain.notification.application.template
 
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.springframework.stereotype.Component
 
 @Component
@@ -113,13 +115,22 @@ class NotificationTemplateRegistry {
 
     fun getTemplateByTriggerType(triggerType: NotificationTriggerType): NotificationTemplate {
         val templateType = triggerTypeToTemplateType[triggerType]
-            ?: throw IllegalArgumentException("지원하지 않는 알림 트리거입니다: $triggerType")
+            ?: throw CustomException(
+                ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND,
+                "notification template trigger mapping not found: triggerType=$triggerType"
+            )
         return templates[templateType]
-            ?: throw IllegalArgumentException("등록되지 않은 알림 템플릿입니다: $templateType")
+            ?: throw CustomException(
+                ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND,
+                "notification template not registered: templateType=$templateType"
+            )
     }
 
     fun getTemplateByType(templateType: NotificationTemplateType): NotificationTemplate {
         return templates[templateType]
-            ?: throw IllegalArgumentException("등록되지 않은 알림 템플릿입니다: $templateType")
+            ?: throw CustomException(
+                ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND,
+                "notification template not registered: templateType=$templateType"
+            )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
@@ -117,12 +117,12 @@ class NotificationTemplateRegistry {
         val templateType = triggerTypeToTemplateType[triggerType]
             ?: throw CustomException(
                 ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND,
-                "notification template trigger mapping not found: triggerType=$triggerType"
+                "알림 템플릿 트리거 매핑을 찾을 수 없습니다. triggerType=$triggerType"
             )
         return templates[templateType]
             ?: throw CustomException(
                 ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND,
-                "notification template not registered: templateType=$templateType"
+                "알림 템플릿이 등록되지 않았습니다. templateType=$templateType"
             )
     }
 
@@ -130,7 +130,7 @@ class NotificationTemplateRegistry {
         return templates[templateType]
             ?: throw CustomException(
                 ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND,
-                "notification template not registered: templateType=$templateType"
+                "알림 템플릿이 등록되지 않았습니다. templateType=$templateType"
             )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderResult.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderResult.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.notification.application.template
+
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+
+data class NotificationTemplateRenderResult(
+    val title: String,
+    val body: String,
+    val deeplinkType: NotificationDeeplinkType,
+)

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
@@ -1,5 +1,7 @@
 package com.moongchijang.domain.notification.application.template
 
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.springframework.stereotype.Component
 
 @Component
@@ -19,7 +21,10 @@ class NotificationTemplateRenderer(
         val placeholders = PLACEHOLDER_PATTERN.findAll(templateText).map { it.groupValues[1] }.toSet()
         val missing = placeholders.filterNot { variables[it]?.isNotBlank() == true }
         if (missing.isNotEmpty()) {
-            throw IllegalArgumentException("알림 템플릿 변수 누락: ${missing.joinToString(",")}")
+            throw CustomException(
+                ErrorCode.NOTIFICATION_TEMPLATE_VARIABLE_MISSING,
+                "missing notification template variables: ${missing.joinToString(",")}"
+            )
         }
 
         var rendered = templateText

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
@@ -23,7 +23,7 @@ class NotificationTemplateRenderer(
         if (missing.isNotEmpty()) {
             throw CustomException(
                 ErrorCode.NOTIFICATION_TEMPLATE_VARIABLE_MISSING,
-                "missing notification template variables: ${missing.joinToString(",")}"
+                "알림 템플릿 변수 값이 누락되었습니다. missing=${missing.joinToString(",")}"
             )
         }
 

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
@@ -5,11 +5,8 @@ import com.moongchijang.global.exception.ErrorCode
 import org.springframework.stereotype.Component
 
 @Component
-class NotificationTemplateRenderer(
-    private val notificationTemplateRegistry: NotificationTemplateRegistry,
-) {
-    fun render(templateType: NotificationTemplateType, variables: Map<String, String>): NotificationTemplateRenderResult {
-        val template = notificationTemplateRegistry.getTemplateByType(templateType)
+class NotificationTemplateRenderer {
+    fun render(template: NotificationTemplate, variables: Map<String, String>): NotificationTemplateRenderResult {
         return NotificationTemplateRenderResult(
             title = renderText(template.titleTemplate, variables),
             body = renderText(template.bodyTemplate, variables),

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRenderer.kt
@@ -1,0 +1,35 @@
+package com.moongchijang.domain.notification.application.template
+
+import org.springframework.stereotype.Component
+
+@Component
+class NotificationTemplateRenderer(
+    private val notificationTemplateRegistry: NotificationTemplateRegistry,
+) {
+    fun render(templateType: NotificationTemplateType, variables: Map<String, String>): NotificationTemplateRenderResult {
+        val template = notificationTemplateRegistry.getTemplateByType(templateType)
+        return NotificationTemplateRenderResult(
+            title = renderText(template.titleTemplate, variables),
+            body = renderText(template.bodyTemplate, variables),
+            deeplinkType = template.deeplinkType,
+        )
+    }
+
+    private fun renderText(templateText: String, variables: Map<String, String>): String {
+        val placeholders = PLACEHOLDER_PATTERN.findAll(templateText).map { it.groupValues[1] }.toSet()
+        val missing = placeholders.filterNot { variables[it]?.isNotBlank() == true }
+        if (missing.isNotEmpty()) {
+            throw IllegalArgumentException("알림 템플릿 변수 누락: ${missing.joinToString(",")}")
+        }
+
+        var rendered = templateText
+        placeholders.forEach { placeholder ->
+            rendered = rendered.replace("{$placeholder}", variables.getValue(placeholder))
+        }
+        return rendered
+    }
+
+    companion object {
+        private val PLACEHOLDER_PATTERN = Regex("\\{([^{}]+)}")
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateType.kt
@@ -1,0 +1,18 @@
+package com.moongchijang.domain.notification.application.template
+
+enum class NotificationTemplateType {
+    PICKUP_SAME_DAY_REMINDER,                 // ①
+    PICKUP_DAY_BEFORE_REMINDER,               // ②
+    PICKUP_INCOMPLETE_AFTER_CUTOFF,           // ③
+    WISH_DEADLINE_MINUS_3_DAYS,               // ④
+    WISH_DEADLINE_MINUS_1_DAY,                // ⑤
+    WISH_TARGET_ACHIEVED,                     // ⑥
+    APPLY_PAYMENT_SUCCESS,                    // ⑦
+    APPLY_GROUPBUY_ACHIEVED,                  // ⑧
+    APPLY_GROUPBUY_FAILED,                    // ⑨
+    REQUEST_OPENED,                           // ⑩
+    REQUEST_REJECTED,                         // ⑪
+    REQUEST_NEW_PARTICIPANT,                  // ⑫
+    REQUEST_TARGET_ACHIEVED,                  // ⑬
+    REQUEST_DEADLINE_MINUS_3_DAYS             // ⑭
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationTriggerType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationTriggerType.kt
@@ -3,8 +3,7 @@ package com.moongchijang.domain.notification.domain.entity
 enum class NotificationTriggerType {
     PICKUP_SAME_DAY_MORNING,              // ①
     PICKUP_DAY_BEFORE_MORNING,            // ②
-    PICKUP_COMPLETED_IMMEDIATE,           // ③-1
-    PICKUP_NOT_COMPLETED_AFTER_CUTOFF,    // ③-2
+    PICKUP_NOT_COMPLETED_AFTER_CUTOFF,    // ③
     WISH_DEADLINE_MINUS_3_DAYS,           // ④
     WISH_DEADLINE_MINUS_1_DAY,            // ⑤
     WISH_TARGET_ACHIEVED_IMMEDIATE,       // ⑥

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandService.kt
@@ -1,6 +1,5 @@
 package com.moongchijang.domain.participation.application
 
-import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
@@ -14,7 +13,6 @@ import java.time.LocalDateTime
 class ParticipationPickupCommandService(
     private val participationRepository: ParticipationRepository,
     private val userRepository: UserRepository,
-    private val notificationEventPublisher: NotificationEventPublisher,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -26,17 +24,9 @@ class ParticipationPickupCommandService(
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
         participation.markPickedUp(processedBy = processor, pickedUpAt = pickedUpAt)
-        val userId = participation.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
-
-        notificationEventPublisher.publishPickupCompleted(
-            groupBuyId = participation.groupBuy.id,
-            userId = userId,
-            participationId = participation.id,
-            occurredAt = pickedUpAt
-        )
         log.info(
-            "[ParticipationPickupCommandService] 픽업 완료 처리 및 알림 트리거 발행: participationId={}, userId={}, processedByUserId={}",
-            participationId, userId, processedByUserId
+            "[ParticipationPickupCommandService] 픽업 완료 처리: participationId={}, processedByUserId={}",
+            participationId, processedByUserId
         )
     }
 }

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -126,4 +126,6 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     // Notification(360~369)
     NOTIFICATION_NOT_FOUND(404_360, "알림을 찾을 수 없습니다.", 404),
     NOTIFICATION_FORBIDDEN(403_360, "본인 알림만 처리할 수 있습니다.", 403),
+    NOTIFICATION_TEMPLATE_NOT_FOUND(404_361, "알림 템플릿을 찾을 수 없습니다.", 404),
+    NOTIFICATION_TEMPLATE_VARIABLE_MISSING(400_361, "알림 템플릿 변수 값이 누락되었습니다.", 400),
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3055,7 +3055,7 @@ components:
 
     NotificationItemResponse:
       type: object
-      required: [id, type, title, body, isRead, occurredAt, deeplinkType, section]
+      required: [id, type, title, body, isRead, occurredAt, deeplinkType, deeplinkParams, section]
       properties:
         id:
           type: integer
@@ -3078,6 +3078,13 @@ components:
           nullable: true
         deeplinkType:
           $ref: '#/components/schemas/NotificationDeeplinkType'
+        deeplinkParams:
+          type: object
+          description: 딥링크 파라미터. PICKUP_GUIDE/GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 targetId를 사용합니다.
+          additionalProperties:
+            type: string
+          example:
+            groupBuyId: "2001"
         section:
           $ref: '#/components/schemas/NotificationSection'
 

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationDeeplinkSchemaTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationDeeplinkSchemaTest.kt
@@ -1,0 +1,40 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.deeplink.NotificationDeeplinkSchema
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class NotificationDeeplinkSchemaTest {
+
+    @Test
+    fun `PICKUP_GUIDE 딥링크 파라미터는 groupBuyId 반환`() {
+        val params = NotificationDeeplinkSchema.toParams(NotificationDeeplinkType.PICKUP_GUIDE, 11L)
+        assertEquals("11", params["groupBuyId"])
+    }
+
+    @Test
+    fun `GROUPBUY_DETAIL 딥링크 파라미터는 groupBuyId 반환`() {
+        val params = NotificationDeeplinkSchema.toParams(NotificationDeeplinkType.GROUPBUY_DETAIL, 12L)
+        assertEquals("12", params["groupBuyId"])
+    }
+
+    @Test
+    fun `MY_APPLYING 딥링크 파라미터는 groupBuyId 반환`() {
+        val params = NotificationDeeplinkSchema.toParams(NotificationDeeplinkType.MY_APPLYING, 13L)
+        assertEquals("13", params["groupBuyId"])
+    }
+
+    @Test
+    fun `REQUEST_STATUS 딥링크 파라미터는 targetId 반환`() {
+        val params = NotificationDeeplinkSchema.toParams(NotificationDeeplinkType.REQUEST_STATUS, 14L)
+        assertEquals("14", params["targetId"])
+    }
+
+    @Test
+    fun `targetId가 null이면 빈 파라미터 반환`() {
+        val params = NotificationDeeplinkSchema.toParams(NotificationDeeplinkType.REQUEST_STATUS, null)
+        assertTrue(params.isEmpty())
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
@@ -1,6 +1,10 @@
 package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.application.event.NotificationImmediateTriggerEvent
+import com.moongchijang.domain.notification.application.template.NotificationTemplateRegistry
+import com.moongchijang.domain.notification.application.template.NotificationTemplateRenderer
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
@@ -34,11 +38,24 @@ class NotificationImmediateDispatchServiceTest {
     @Mock
     private lateinit var userRepository: UserRepository
 
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var groupBuyRequestRepository: GroupBuyRequestRepository
+
+    private val notificationTemplateRegistry = NotificationTemplateRegistry()
+    private val notificationTemplateRenderer = NotificationTemplateRenderer(notificationTemplateRegistry)
+
     private val service by lazy {
         NotificationImmediateDispatchService(
             notificationRepository = notificationRepository,
             notificationDispatchHistoryRepository = notificationDispatchHistoryRepository,
-            userRepository = userRepository
+            userRepository = userRepository,
+            groupBuyRepository = groupBuyRepository,
+            groupBuyRequestRepository = groupBuyRequestRepository,
+            notificationTemplateRegistry = notificationTemplateRegistry,
+            notificationTemplateRenderer = notificationTemplateRenderer
         )
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
@@ -8,9 +8,11 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestReposit
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.notification.domain.repository.NotificationDispatchHistoryRepository
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
 import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.support.GroupBuyFixture
 import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -133,6 +135,7 @@ class NotificationImmediateDispatchServiceTest {
         ).thenReturn(Optional.empty())
         `when`(notificationDispatchHistoryRepository.save(any(NotificationDispatchHistory::class.java))).thenReturn(pending)
         `when`(userRepository.findByIdAndDeletedAtIsNull(3L)).thenReturn(user)
+        `when`(groupBuyRepository.findWithStoreById(103L)).thenReturn(Optional.of(mockGroupBuy(103L)))
         `when`(notificationRepository.save(any())).thenAnswer { it.arguments[0] }
 
         service.dispatch(event)
@@ -162,6 +165,7 @@ class NotificationImmediateDispatchServiceTest {
             )
         ).thenReturn(listOf(failedHistory))
         `when`(userRepository.findByIdAndDeletedAtIsNull(9L)).thenReturn(user)
+        `when`(groupBuyRepository.findWithStoreById(901L)).thenReturn(Optional.of(mockGroupBuy(901L)))
         `when`(notificationRepository.save(any())).thenAnswer { it.arguments[0] }
 
         service.retryFailedDispatches(now)
@@ -178,4 +182,6 @@ class NotificationImmediateDispatchServiceTest {
             scheduleKey = scheduleKey
         )
     }
+
+    private fun mockGroupBuy(id: Long) = GroupBuyFixture.createGroupBuy(id = id, status = GroupBuyStatus.IN_PROGRESS)
 }

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
@@ -47,7 +47,7 @@ class NotificationImmediateDispatchServiceTest {
     private lateinit var groupBuyRequestRepository: GroupBuyRequestRepository
 
     private val notificationTemplateRegistry = NotificationTemplateRegistry()
-    private val notificationTemplateRenderer = NotificationTemplateRenderer(notificationTemplateRegistry)
+    private val notificationTemplateRenderer = NotificationTemplateRenderer()
 
     private val service by lazy {
         NotificationImmediateDispatchService(

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRegistryTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRegistryTest.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.template.NotificationTemplateRegistry
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class NotificationTemplateRegistryTest {
+
+    private val registry = NotificationTemplateRegistry()
+
+    @Test
+    fun `모든 알림 트리거 타입은 템플릿 매핑 존재`() {
+        NotificationTriggerType.entries.forEach { triggerType ->
+            val template = registry.getTemplateByTriggerType(triggerType)
+            assertNotNull(template)
+        }
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
@@ -4,6 +4,8 @@ import com.moongchijang.domain.notification.application.template.NotificationTem
 import com.moongchijang.domain.notification.application.template.NotificationTemplateRegistry
 import com.moongchijang.domain.notification.application.template.NotificationTemplateType
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -31,7 +33,7 @@ class NotificationTemplateRendererTest {
 
     @Test
     fun `필수 템플릿 변수가 누락될 때 예외 발생`() {
-        val exception = assertThrows<IllegalArgumentException> {
+        val exception = assertThrows<CustomException> {
             renderer.render(
                 templateType = NotificationTemplateType.REQUEST_NEW_PARTICIPANT,
                 variables = mapOf(
@@ -41,6 +43,7 @@ class NotificationTemplateRendererTest {
             )
         }
 
-        assertTrue(exception.message!!.contains("목표참여개수"))
+        assertEquals(ErrorCode.NOTIFICATION_TEMPLATE_VARIABLE_MISSING, exception.errorCode)
+        assertTrue(exception.detail!!.contains("목표참여개수"))
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.assertThrows
 class NotificationTemplateRendererTest {
 
     private val registry = NotificationTemplateRegistry()
-    private val renderer = NotificationTemplateRenderer(registry)
+    private val renderer = NotificationTemplateRenderer()
 
     @Test
     fun `픽업 전일 템플릿 렌더링 시 줄바꿈 포함 본문 반환`() {
         val rendered = renderer.render(
-            templateType = NotificationTemplateType.PICKUP_DAY_BEFORE_REMINDER,
+            template = registry.getTemplateByType(NotificationTemplateType.PICKUP_DAY_BEFORE_REMINDER),
             variables = mapOf(
                 "상품명" to "소금빵",
                 "픽업시간범위" to "10:00 ~ 12:00"
@@ -35,7 +35,7 @@ class NotificationTemplateRendererTest {
     fun `필수 템플릿 변수가 누락될 때 예외 발생`() {
         val exception = assertThrows<CustomException> {
             renderer.render(
-                templateType = NotificationTemplateType.REQUEST_NEW_PARTICIPANT,
+                template = registry.getTemplateByType(NotificationTemplateType.REQUEST_NEW_PARTICIPANT),
                 variables = mapOf(
                     "상품명" to "소금빵",
                     "현재참여개수" to "3"
@@ -50,7 +50,7 @@ class NotificationTemplateRendererTest {
     @Test
     fun `달성 템플릿 렌더링 시 픽업 정보 포함 본문 반환`() {
         val rendered = renderer.render(
-            templateType = NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED,
+            template = registry.getTemplateByType(NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED),
             variables = mapOf(
                 "상품명" to "소금빵",
                 "픽업일자" to "2026-05-30",
@@ -68,7 +68,7 @@ class NotificationTemplateRendererTest {
     @Test
     fun `미달성 템플릿 렌더링 시 환불 예상 시각 포함 본문 반환`() {
         val rendered = renderer.render(
-            templateType = NotificationTemplateType.APPLY_GROUPBUY_FAILED,
+            template = registry.getTemplateByType(NotificationTemplateType.APPLY_GROUPBUY_FAILED),
             variables = mapOf(
                 "상품명" to "소금빵",
                 "환불예상시각" to "2026-05-28 10:00"

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
@@ -1,0 +1,46 @@
+package com.moongchijang.domain.notification.application
+
+import com.moongchijang.domain.notification.application.template.NotificationTemplateRenderer
+import com.moongchijang.domain.notification.application.template.NotificationTemplateRegistry
+import com.moongchijang.domain.notification.application.template.NotificationTemplateType
+import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class NotificationTemplateRendererTest {
+
+    private val registry = NotificationTemplateRegistry()
+    private val renderer = NotificationTemplateRenderer(registry)
+
+    @Test
+    fun `픽업 전일 템플릿 렌더링 시 줄바꿈 포함 본문 반환`() {
+        val rendered = renderer.render(
+            templateType = NotificationTemplateType.PICKUP_DAY_BEFORE_REMINDER,
+            variables = mapOf(
+                "상품명" to "소금빵",
+                "픽업시간범위" to "10:00 ~ 12:00"
+            )
+        )
+
+        assertEquals("내일 픽업일이에요. 잊지마세요!", rendered.title)
+        assertEquals("소금빵 픽업이\n내일 10:00 ~ 12:00로 예정됐어요.", rendered.body)
+        assertEquals(NotificationDeeplinkType.PICKUP_GUIDE, rendered.deeplinkType)
+    }
+
+    @Test
+    fun `필수 템플릿 변수가 누락될 때 예외 발생`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            renderer.render(
+                templateType = NotificationTemplateType.REQUEST_NEW_PARTICIPANT,
+                variables = mapOf(
+                    "상품명" to "소금빵",
+                    "현재참여개수" to "3"
+                )
+            )
+        }
+
+        assertTrue(exception.message!!.contains("목표참여개수"))
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
@@ -46,4 +46,35 @@ class NotificationTemplateRendererTest {
         assertEquals(ErrorCode.NOTIFICATION_TEMPLATE_VARIABLE_MISSING, exception.errorCode)
         assertTrue(exception.detail!!.contains("목표참여개수"))
     }
+
+    @Test
+    fun `달성 템플릿 렌더링 시 픽업 정보 포함 본문 반환`() {
+        val rendered = renderer.render(
+            templateType = NotificationTemplateType.APPLY_GROUPBUY_ACHIEVED,
+            variables = mapOf(
+                "상품명" to "소금빵",
+                "픽업일자" to "2026-05-30",
+                "픽업시간범위" to "09:00 ~ 12:00",
+                "매장명" to "성수베이커리",
+                "매장주소" to "서울 성동구 성수이로 1"
+            )
+        )
+
+        assertTrue(rendered.body.contains("픽업: 2026-05-30 09:00 ~ 12:00"))
+        assertTrue(rendered.body.contains("매장: 성수베이커리"))
+        assertTrue(rendered.body.contains("주소: 서울 성동구 성수이로 1"))
+    }
+
+    @Test
+    fun `미달성 템플릿 렌더링 시 환불 예상 시각 포함 본문 반환`() {
+        val rendered = renderer.render(
+            templateType = NotificationTemplateType.APPLY_GROUPBUY_FAILED,
+            variables = mapOf(
+                "상품명" to "소금빵",
+                "환불예상시각" to "2026-05-28 10:00"
+            )
+        )
+
+        assertTrue(rendered.body.contains("2026-05-28 10:00"))
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandServiceTest.kt
@@ -1,14 +1,14 @@
 package com.moongchijang.domain.participation.application
 
-import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.support.ParticipationFixture
 import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.LocalDate
@@ -25,19 +25,15 @@ class ParticipationPickupCommandServiceTest {
     @Mock
     private lateinit var userRepository: UserRepository
 
-    @Mock
-    private lateinit var notificationEventPublisher: NotificationEventPublisher
-
     private val service by lazy {
         ParticipationPickupCommandService(
             participationRepository = participationRepository,
-            userRepository = userRepository,
-            notificationEventPublisher = notificationEventPublisher
+            userRepository = userRepository
         )
     }
 
     @Test
-    fun `픽업 완료를 처리할 때 픽업 완료 즉시 알림 이벤트 발행`() {
+    fun `픽업 완료를 처리할 때 픽업 상태 변경`() {
         val now = LocalDateTime.of(2026, 5, 23, 12, 0)
         val participation = ParticipationFixture.createParticipation(
             participationId = 101L,
@@ -58,11 +54,8 @@ class ParticipationPickupCommandServiceTest {
 
         service.completePickup(participationId = 101L, processedByUserId = 999L, pickedUpAt = now)
 
-        verify(notificationEventPublisher).publishPickupCompleted(
-            groupBuyId = 201L,
-            userId = 1L,
-            participationId = 101L,
-            occurredAt = now
-        )
+        assertEquals(PickupStatus.PICKED_UP, participation.pickupStatus)
+        assertEquals(now, participation.pickedUpAt)
+        assertEquals(999L, participation.pickupProcessedBy?.id)
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용

### 1) 알림 조건 정정 및 트리거 스코프 정리
- 픽업 관련 요구사항을 재확인하여 `③`을 **“픽업 마감 +30분 이후 미완료 안내” 단일 조건**으로 정리했습니다.
- 기존 `PICKUP_COMPLETED_IMMEDIATE(③-1)` 경로를 제거하고, 픽업 완료 커맨드는 상태 변경 책임만 유지하도록 정리했습니다.
- 요청공구 신규 참여(⑫)는 **“내 요청공구에 다른 사용자가 참여했을 때”** 조건으로 해석되도록 기존 로직을 유지/검증했습니다.

### 2) 알림 템플릿 레이어 신설 (1~14 유형)
- 알림 문구를 한 곳에서 관리할 수 있도록 템플릿 구조를 도입했습니다.
- 추가 구성:
  - `NotificationTemplateType` (요구사항 1~14 대응 타입)
  - `NotificationTemplate` (title/body/deeplinkType)
  - `NotificationTemplateRegistry` (triggerType → templateType 매핑 + 템플릿 등록)
  - `NotificationTemplateRenderer` (placeholder 치환 + 누락값 검증)
- 기획에서 의도한 줄바꿈은 본문 템플릿에 `\n`으로 그대로 반영했습니다.

### 3) 즉시 알림 디스패치에 템플릿 렌더링 실제 연결
- 기존 하드코딩 문구(`알림`, `새 알림이 도착했습니다.`)를 제거했습니다.
- `NotificationImmediateDispatchService`에서
  - `triggerType`에 해당하는 템플릿을 선택하고,
  - `targetId` 기반 도메인 데이터(공구/요청공구)를 조회해 변수 맵을 만들고,
  - 렌더 결과(title/body/deeplinkType)로 실제 `Notification`을 생성하도록 변경했습니다.

### 4) 필수 포함 정보 규칙 반영
- 달성 알림(8): 본문에 픽업 정보 필수 포함
  - `픽업일자`, `픽업시간범위`, `매장명`, `매장주소`
- 미달성 알림(9): 본문에 환불 예상 시각 포함
  - `환불예상시각` 변수 적용
  - 영업일 기준 계산 로직(주말 제외) 추가
- 픽업 리마인드(1,2): 상품명/픽업 시간 범위 등 필수 값 기반으로 렌더링되도록 정리

### 5) 딥링크 정책 표준화
- `NotificationDeeplinkSchema`를 도입해 딥링크 파라미터 키를 고정했습니다.
  - `PICKUP_GUIDE`, `GROUPBUY_DETAIL`, `MY_APPLYING` → `groupBuyId`
  - `REQUEST_STATUS` → `targetId`
- 응답 DTO(`NotificationItemResponse`)에 `deeplinkParams` 필드를 추가해 클라이언트가 타입별 이동 파라미터를 명확히 받을 수 있도록 했습니다.

---

## 🔍 참고 사항

### 설계 고민 및 선택 근거
1. 템플릿 중앙화 vs 분산 하드코딩
- 선택: 중앙 템플릿 레이어(`Registry + Renderer`) 도입
- 이유: 문구 변경/정책 확장 시 영향 범위를 최소화하고 테스트 가능성을 높이기 위함

2. 필수 정보 주입 시점
- 선택: 디스패치 직전 도메인 조회 기반 변수 생성
- 이유: 발송 시점의 최신 데이터(공구 상태/수량/매장 정보)를 반영하기 위함

3. 딥링크 정책
- 선택: `NotificationDeeplinkSchema`로 키를 고정
- 이유: 클라이언트 분기 로직 단순화, 타입별 파라미터 계약 안정화

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #147 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인