### PR TITLE
[MCJ-1504] FIX: QR 픽업 응답 필드 보강

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
@@ -154,7 +155,7 @@ class PickupService(
     }
 
     private fun Participation.isPickupActive(): Boolean =
-        !LocalDate.now().isBefore(groupBuy.pickupDate)
+        !todayKst().isBefore(groupBuy.pickupDate)
 
     private fun Participation.availabilityStatus(): PickupAvailabilityStatus =
         when {
@@ -164,21 +165,24 @@ class PickupService(
         }
 
     private fun Participation.remainingPickupMinutes(): Long? {
-        val today = LocalDate.now()
+        val today = todayKst()
         if (groupBuy.pickupDate != today) return null
 
-        val now = LocalDateTime.now()
+        val now = nowKst()
         val pickupEndAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeEnd)
         return ChronoUnit.MINUTES.between(now, pickupEndAt).coerceAtLeast(0)
     }
 
     private fun Participation.pickupDDay(): Int =
-        ChronoUnit.DAYS.between(LocalDate.now(), groupBuy.pickupDate)
+        ChronoUnit.DAYS.between(todayKst(), groupBuy.pickupDate)
             .toInt()
-            .coerceAtLeast(0)
 
     private fun Participation.reservationNumber(): String =
         "MCJ-P%06d".format(id)
+
+    private fun todayKst(): LocalDate = LocalDate.now(KST_ZONE)
+
+    private fun nowKst(): LocalDateTime = LocalDateTime.now(KST_ZONE)
 
     private fun generateUniquePickupToken(): String {
         repeat(TOKEN_GENERATION_ATTEMPTS) {
@@ -192,5 +196,6 @@ class PickupService(
 
     companion object {
         private const val TOKEN_GENERATION_ATTEMPTS = 5
+        private val KST_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -100,17 +100,20 @@ class PickupService(
 
         return PickupQrResponse(
             participationId = participation.id,
+            reservationNumber = participation.reservationNumber(),
             availabilityStatus = participation.availabilityStatus(),
             pickupStatus = participation.pickupStatus,
             userName = participation.user.nickname,
             productName = participation.groupBuy.productName,
             quantity = participation.quantity,
             storeName = participation.groupBuy.store.name,
+            storeAddress = participation.groupBuy.store.address,
             pickupLocation = participation.groupBuy.pickupLocation,
             qrCode = participation.pickupToken.takeIf { isActive && participation.pickupStatus == PickupStatus.READY },
             pickupDate = participation.groupBuy.pickupDate,
             pickupTimeStart = participation.groupBuy.pickupTimeStart,
             pickupTimeEnd = participation.groupBuy.pickupTimeEnd,
+            dDay = participation.pickupDDay(),
             pickedUpAt = participation.pickedUpAt,
         )
     }
@@ -168,6 +171,14 @@ class PickupService(
         val pickupEndAt = LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeEnd)
         return ChronoUnit.MINUTES.between(now, pickupEndAt).coerceAtLeast(0)
     }
+
+    private fun Participation.pickupDDay(): Int =
+        ChronoUnit.DAYS.between(LocalDate.now(), groupBuy.pickupDate)
+            .toInt()
+            .coerceAtLeast(0)
+
+    private fun Participation.reservationNumber(): String =
+        "MCJ-P%06d".format(id)
 
     private fun generateUniquePickupToken(): String {
         repeat(TOKEN_GENERATION_ATTEMPTS) {

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
@@ -33,17 +33,20 @@ data class PickupGuideResponse(
 
 data class PickupQrResponse(
     val participationId: Long,
+    val reservationNumber: String,
     val availabilityStatus: PickupAvailabilityStatus,
     val pickupStatus: PickupStatus,
     val userName: String?,
     val productName: String,
     val quantity: Int,
     val storeName: String,
+    val storeAddress: String,
     val pickupLocation: String,
     val qrCode: String?,
     val pickupDate: LocalDate,
     val pickupTimeStart: LocalTime,
     val pickupTimeEnd: LocalTime,
+    val dDay: Int,
     val pickedUpAt: LocalDateTime?,
 )
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3006,7 +3006,7 @@ components:
             pickupDate: { type: string, format: date }
             pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
             pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
-            dDay: { type: integer, format: int32, description: "픽업일까지 남은 날짜. 당일이면 0" }
+            dDay: { type: integer, format: int32, description: "KST 기준 픽업일까지 남은 날짜. 당일이면 0, 지난 픽업일이면 음수" }
             pickedUpAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 
@@ -3057,7 +3057,7 @@ components:
                 pickupDate: { type: string, format: date }
                 pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
                 pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
-                dDay: { type: integer, format: int32, description: "픽업일까지 남은 날짜. 당일이면 0" }
+                dDay: { type: integer, format: int32, description: "KST 기준 픽업일까지 남은 날짜. 당일이면 0, 지난 픽업일이면 음수" }
                 pickedUpAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2986,9 +2986,10 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [participationId, availabilityStatus, pickupStatus, productName, quantity, storeName, pickupLocation, pickupDate, pickupTimeStart, pickupTimeEnd]
+          required: [participationId, reservationNumber, availabilityStatus, pickupStatus, productName, quantity, storeName, storeAddress, pickupLocation, pickupDate, pickupTimeStart, pickupTimeEnd, dDay]
           properties:
             participationId: { type: integer, format: int64 }
+            reservationNumber: { type: string, description: "예약 번호. 참여 id 기반 표시값. 예) MCJ-P000123" }
             availabilityStatus:
               type: string
               enum: [LOCKED, AVAILABLE, PICKED_UP]
@@ -2999,11 +3000,13 @@ components:
             productName: { type: string }
             quantity: { type: integer, format: int32 }
             storeName: { type: string }
+            storeAddress: { type: string }
             pickupLocation: { type: string }
             qrCode: { type: string, format: uuid, nullable: true }
             pickupDate: { type: string, format: date }
             pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
             pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
+            dDay: { type: integer, format: int32, description: "픽업일까지 남은 날짜. 당일이면 0" }
             pickedUpAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 
@@ -3033,9 +3036,10 @@ components:
             item:
               type: object
               nullable: true
-              required: [participationId, availabilityStatus, pickupStatus, productName, quantity, storeName, pickupLocation, pickupDate, pickupTimeStart, pickupTimeEnd]
+              required: [participationId, reservationNumber, availabilityStatus, pickupStatus, productName, quantity, storeName, storeAddress, pickupLocation, pickupDate, pickupTimeStart, pickupTimeEnd, dDay]
               properties:
                 participationId: { type: integer, format: int64 }
+                reservationNumber: { type: string, description: "예약 번호. 참여 id 기반 표시값. 예) MCJ-P000123" }
                 availabilityStatus:
                   type: string
                   enum: [LOCKED, AVAILABLE, PICKED_UP]
@@ -3047,11 +3051,13 @@ components:
                 productName: { type: string }
                 quantity: { type: integer, format: int32 }
                 storeName: { type: string }
+                storeAddress: { type: string }
                 pickupLocation: { type: string }
                 qrCode: { type: string, format: uuid, nullable: true, description: "LOCKED 상태에서는 null" }
                 pickupDate: { type: string, format: date }
                 pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
                 pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
+                dDay: { type: integer, format: int32, description: "픽업일까지 남은 날짜. 당일이면 0" }
                 pickedUpAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -110,14 +110,17 @@ class PickupServiceTest {
 
         assertEquals(PickupAvailabilityStatus.LOCKED, result.availabilityStatus)
         assertEquals(PickupStatus.NOT_READY, result.pickupStatus)
+        assertEquals("MCJ-P000099", result.reservationNumber)
         assertEquals("테스트유저", result.userName)
         assertEquals("두쫀쿠", result.productName)
         assertEquals(2, result.quantity)
         assertEquals("뭉치장 베이커리", result.storeName)
+        assertEquals("서울 성동구 성수동", result.storeAddress)
         assertEquals("매장 카운터", result.pickupLocation)
         assertEquals(participation.groupBuy.pickupDate, result.pickupDate)
         assertEquals(LocalTime.of(14, 0), result.pickupTimeStart)
         assertEquals(LocalTime.of(18, 0), result.pickupTimeEnd)
+        assertEquals(1, result.dDay)
         assertNull(result.qrCode)
         assertNull(participation.pickupToken)
     }
@@ -132,6 +135,7 @@ class PickupServiceTest {
 
         assertEquals(PickupAvailabilityStatus.AVAILABLE, result.availabilityStatus)
         assertEquals(PickupStatus.READY, result.pickupStatus)
+        assertEquals(0, result.dDay)
         assertNotNull(result.qrCode)
         assertEquals(result.qrCode, participation.pickupToken)
     }
@@ -174,7 +178,10 @@ class PickupServiceTest {
         assertEquals(true, result.hasMultipleToday)
         assertNull(result.reason)
         assertEquals(102L, result.item?.participationId)
+        assertEquals("MCJ-P000102", result.item?.reservationNumber)
         assertEquals(PickupAvailabilityStatus.AVAILABLE, result.item?.availabilityStatus)
+        assertEquals(0, result.item?.dDay)
+        assertEquals("서울 성동구 성수동", result.item?.storeAddress)
         assertNotNull(result.item?.qrCode)
         assertEquals(PickupStatus.READY, earliestToday.pickupStatus)
     }
@@ -198,6 +205,7 @@ class PickupServiceTest {
         assertEquals(NearestPickupQrReason.ONLY_FUTURE_PICKUP, result.reason)
         assertEquals(103L, result.item?.participationId)
         assertEquals(PickupAvailabilityStatus.LOCKED, result.item?.availabilityStatus)
+        assertEquals(1, result.item?.dDay)
         assertNull(result.item?.qrCode)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -210,6 +210,21 @@ class PickupServiceTest {
     }
 
     @Test
+    fun `픽업일이 지난 QR 조회는 음수 D-day를 반환한다`() {
+        val participation = createParticipation(
+            pickupDate = LocalDate.now().minusDays(1),
+            pickupStatus = PickupStatus.PICKED_UP,
+            pickedUpAt = LocalDateTime.now().minusHours(1),
+        )
+        `when`(participationRepository.findPickupDetailById(99L)).thenReturn(participation)
+
+        val result = service.getPickupQr(99L, 1L)
+
+        assertEquals(PickupAvailabilityStatus.PICKED_UP, result.availabilityStatus)
+        assertEquals(-1, result.dDay)
+    }
+
+    @Test
     fun `가장 가까운 QR 후보가 없으면 빈 상태를 반환한다`() {
         `when`(
             participationRepository.findNearestPickupQrCandidates(


### PR DESCRIPTION
## 📌 작업한 내용
- QR 픽업 응답 DTO에 `reservationNumber`, `storeAddress`, `dDay` 필드를 추가했습니다.
- `/api/v1/participations/{participationId}/qr`와 `/api/v1/pickups/me/nearest-qr` 응답 item에 신규 필드를 매핑했습니다.
- QR 응답 필드 검증 테스트를 추가했습니다.
- `src/main/resources/static/openapi.yaml`에 QR 응답 신규 필드와 required 항목을 반영했습니다.

## 🔍 참고 사항
- 예약 번호는 별도 DB 컬럼을 추가하지 않고 참여 id 기반 표시값(`MCJ-P000123`)으로 생성합니다.
- 픽업일 전 LOCKED, 픽업일 당일 이후 최초 조회 시 QR 지연 발급 동작은 유지했습니다.

## 🖼️ 스크린샷


## 🔗 관련 이슈
- Closes #166

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
