### PR TITLE
[MCJ-1505] FIX: 환불 내역 환불대기 상태 응답 지원

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -43,7 +43,11 @@ class MypageService(
 
     fun getRefunds(userId: Long): List<MypageRefundResponse> =
         participationRepository
-            .findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(userId, REFUND_PARTICIPATION_STATUSES)
+            .findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
+                userId = userId,
+                statuses = REFUND_PARTICIPATION_STATUSES,
+                refundPendingStatus = ParticipationStatus.REFUND_PENDING
+            )
             .map(MypageRefundResponse::from)
 
     fun getParticipations(

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -34,16 +34,16 @@ class MypageService(
                 statuses = ACTIVE_PARTICIPATION_STATUSES,
                 pickupStatus = PickupStatus.PICKED_UP
             ),
-            refundedCount = participationRepository.countByUserIdAndStatus(
+            refundedCount = participationRepository.countByUserIdAndStatusIn(
                 userId = userId,
-                status = ParticipationStatus.REFUNDED
+                statuses = REFUND_PARTICIPATION_STATUSES
             ),
             requestCount = groupBuyRequestRepository.countByUserId(userId)
         )
 
     fun getRefunds(userId: Long): List<MypageRefundResponse> =
         participationRepository
-            .findByUserIdAndStatusOrderByRefundedAtDescCreatedAtDesc(userId, ParticipationStatus.REFUNDED)
+            .findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(userId, REFUND_PARTICIPATION_STATUSES)
             .map(MypageRefundResponse::from)
 
     fun getParticipations(
@@ -79,7 +79,7 @@ class MypageService(
 
     fun getRefundedParticipations(userId: Long): List<MypageParticipationResponse> =
         participationRepository
-            .findByUserIdAndStatusOrderByCreatedAtDesc(userId, ParticipationStatus.REFUNDED)
+            .findByUserIdAndStatusInOrderByCreatedAtDesc(userId, REFUND_PARTICIPATION_STATUSES)
             .map(MypageParticipationResponse::from)
 
     fun getGroupBuyRequests(userId: Long): List<MypageGroupBuyRequestResponse> =
@@ -98,6 +98,10 @@ class MypageService(
         val ACTIVE_PICKUP_STATUSES = listOf(
             PickupStatus.NOT_READY,
             PickupStatus.READY
+        )
+        val REFUND_PARTICIPATION_STATUSES = listOf(
+            ParticipationStatus.REFUND_PENDING,
+            ParticipationStatus.REFUNDED
         )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -37,7 +37,7 @@ data class MypageRefundResponse(
             return MypageRefundResponse(
                 participationId = participation.id,
                 productName = groupBuy.productName,
-                refundStatus = "COMPLETED",
+                refundStatus = refundStatus(participation),
                 storeName = groupBuy.store.name,
                 pickupDate = groupBuy.pickupDate,
                 pickupTimeStart = groupBuy.pickupTimeStart,
@@ -49,6 +49,12 @@ data class MypageRefundResponse(
                 refundedAt = participation.refundedAt
             )
         }
+
+        private fun refundStatus(participation: Participation): String =
+            when (participation.status) {
+                ParticipationStatus.REFUND_PENDING -> "PENDING"
+                else -> "COMPLETED"
+            }
     }
 }
 
@@ -126,6 +132,7 @@ data class MypageParticipationResponse(
                 pickupStatus == PickupStatus.PICKED_UP -> "PICKED_UP"
                 status == ParticipationStatus.PAID_WAITING_GOAL -> "PAID_WAITING_GOAL"
                 status == ParticipationStatus.CONFIRMED -> "CONFIRMED"
+                status == ParticipationStatus.REFUND_PENDING -> "REFUND_PENDING"
                 status == ParticipationStatus.REFUNDED -> "REFUNDED"
                 else -> status.name
             }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -53,7 +53,8 @@ data class MypageRefundResponse(
         private fun refundStatus(participation: Participation): String =
             when (participation.status) {
                 ParticipationStatus.REFUND_PENDING -> "PENDING"
-                else -> "COMPLETED"
+                ParticipationStatus.REFUNDED -> "COMPLETED"
+                else -> throw IllegalArgumentException("Unsupported refund participation status: ${participation.status}")
             }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/ParticipationStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/ParticipationStatus.kt
@@ -5,5 +5,6 @@ enum class ParticipationStatus {
     PAID_WAITING_GOAL,
     CONFIRMED,
     CANCELLED,
+    REFUND_PENDING,
     REFUNDED
 }

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -157,6 +157,18 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     ): List<Participation>
 
     @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
+    fun findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
+        userId: Long,
+        statuses: Collection<ParticipationStatus>
+    ): List<Participation>
+
+    @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
+    fun findByUserIdAndStatusInOrderByCreatedAtDesc(
+        userId: Long,
+        statuses: Collection<ParticipationStatus>
+    ): List<Participation>
+
+    @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
     fun findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
         userId: Long,
         statuses: Collection<ParticipationStatus>,
@@ -183,6 +195,8 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     ): Long
 
     fun countByUserIdAndStatus(userId: Long, status: ParticipationStatus): Long
+
+    fun countByUserIdAndStatusIn(userId: Long, statuses: Collection<ParticipationStatus>): Long
 
     fun existsByPickupToken(pickupToken: String): Boolean
 

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -156,10 +156,24 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         status: ParticipationStatus
     ): List<Participation>
 
-    @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])
+    @Query(
+        """
+        select p
+        from Participation p
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.user.id = :userId
+          and p.status in :statuses
+        order by
+          case when p.status = :refundPendingStatus then 0 else 1 end,
+          p.refundedAt desc,
+          p.createdAt desc
+        """
+    )
     fun findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
-        userId: Long,
-        statuses: Collection<ParticipationStatus>
+        @Param("userId") userId: Long,
+        @Param("statuses") statuses: Collection<ParticipationStatus>,
+        @Param("refundPendingStatus") refundPendingStatus: ParticipationStatus = ParticipationStatus.REFUND_PENDING
     ): List<Participation>
 
     @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -671,6 +671,7 @@ class PaymentService(
             ParticipationStatus.PAID_WAITING_GOAL -> "참여중 / 달성 전"
             ParticipationStatus.CONFIRMED -> "참여중 / 달성 완료"
             ParticipationStatus.CANCELLED -> "취소"
+            ParticipationStatus.REFUND_PENDING -> "환불 대기"
             ParticipationStatus.REFUNDED -> "환불 완료"
             ParticipationStatus.PENDING -> "결제 대기"
         }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3174,7 +3174,7 @@ components:
               productName: { type: string }
               participationStatus:
                 type: string
-                enum: [PENDING, PAID_WAITING_GOAL, CONFIRMED, CANCELLED, REFUNDED]
+                enum: [PENDING, PAID_WAITING_GOAL, CONFIRMED, CANCELLED, REFUND_PENDING, REFUNDED]
               achievementRate:
                 type: integer
                 minimum: 0
@@ -3185,7 +3185,7 @@ components:
                 enum: [BEFORE_ACHIEVED, ACHIEVED]
               displayStatus:
                 type: string
-                enum: [PICKED_UP, PAID_WAITING_GOAL, CONFIRMED, REFUNDED, PENDING, CANCELLED]
+                enum: [PICKED_UP, PAID_WAITING_GOAL, CONFIRMED, REFUND_PENDING, REFUNDED, PENDING, CANCELLED]
                 description: 픽업/참여 상태 조합 기반 화면 표시 상태
               storeName: { type: string }
               pickupDate: { type: string, format: date }

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -99,7 +99,8 @@ class MypageServiceTest {
         `when`(
             participationRepository.findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
                 userId,
-                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                ParticipationStatus.REFUND_PENDING
             )
         ).thenReturn(listOf(pending, completed))
 

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -62,7 +62,12 @@ class MypageServiceTest {
                 PickupStatus.PICKED_UP
             )
         ).thenReturn(3L)
-        `when`(participationRepository.countByUserIdAndStatus(userId, ParticipationStatus.REFUNDED))
+        `when`(
+            participationRepository.countByUserIdAndStatusIn(
+                userId,
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+            )
+        )
             .thenReturn(1L)
         `when`(groupBuyRequestRepository.countByUserId(userId)).thenReturn(4L)
 
@@ -75,9 +80,16 @@ class MypageServiceTest {
     }
 
     @Test
-    fun `refunds는 REFUNDED 참여만 환불 내역 DTO로 변환한다`() {
+    fun `refunds는 환불대기와 환불완료 참여를 환불 내역 DTO로 변환한다`() {
         val userId = 1L
-        val participation = createParticipation().apply {
+        val pending = createParticipation().apply {
+            id = 9L
+            status = ParticipationStatus.REFUND_PENDING
+            cancelReason = ParticipationCancelReason.TIME_UNAVAILABLE
+            cancelReasonDetail = "마감 전 직접 취소"
+            refundedAt = null
+        }
+        val completed = createParticipation().apply {
             id = 10L
             status = ParticipationStatus.REFUNDED
             cancelReason = ParticipationCancelReason.TIME_UNAVAILABLE
@@ -85,18 +97,18 @@ class MypageServiceTest {
             refundedAt = LocalDateTime.of(2026, 5, 20, 10, 0)
         }
         `when`(
-            participationRepository.findByUserIdAndStatusOrderByRefundedAtDescCreatedAtDesc(
+            participationRepository.findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
                 userId,
-                ParticipationStatus.REFUNDED
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
             )
-        ).thenReturn(listOf(participation))
+        ).thenReturn(listOf(pending, completed))
 
         val result = mypageService.getRefunds(userId)
 
-        assertEquals(1, result.size)
-        assertEquals(10L, result[0].participationId)
+        assertEquals(2, result.size)
+        assertEquals(9L, result[0].participationId)
         assertEquals("초코 케이크", result[0].productName)
-        assertEquals("COMPLETED", result[0].refundStatus)
+        assertEquals("PENDING", result[0].refundStatus)
         assertEquals("문치 베이커리", result[0].storeName)
         assertEquals(LocalDate.of(2026, 5, 25), result[0].pickupDate)
         assertEquals(LocalTime.of(13, 0), result[0].pickupTimeStart)
@@ -105,6 +117,10 @@ class MypageServiceTest {
         assertEquals(2, result[0].quantity)
         assertEquals(ParticipationCancelReason.TIME_UNAVAILABLE.name, result[0].cancelReason)
         assertEquals("마감 전 직접 취소", result[0].cancelReasonDetail)
+        assertEquals(null, result[0].refundedAt)
+        assertEquals(10L, result[1].participationId)
+        assertEquals("COMPLETED", result[1].refundStatus)
+        assertEquals(LocalDateTime.of(2026, 5, 20, 10, 0), result[1].refundedAt)
     }
 
     @Test
@@ -215,22 +231,26 @@ class MypageServiceTest {
     }
 
     @Test
-    fun `refunded participations는 REFUNDED 상태 목록 DTO를 반환한다`() {
+    fun `refunded participations는 환불대기와 환불완료 상태 목록 DTO를 반환한다`() {
         val userId = 1L
         val participation = createParticipation().apply {
             id = 13L
             groupBuy.id = 103L
-            status = ParticipationStatus.REFUNDED
+            status = ParticipationStatus.REFUND_PENDING
         }
         `when`(
-            participationRepository.findByUserIdAndStatusOrderByCreatedAtDesc(userId, ParticipationStatus.REFUNDED)
+            participationRepository.findByUserIdAndStatusInOrderByCreatedAtDesc(
+                userId,
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+            )
         ).thenReturn(listOf(participation))
 
         val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.REFUNDED)
 
         assertEquals(1, result.size)
         assertEquals(13L, result[0].participationId)
-        assertEquals(ParticipationStatus.REFUNDED.name, result[0].participationStatus)
+        assertEquals(ParticipationStatus.REFUND_PENDING.name, result[0].participationStatus)
+        assertEquals("REFUND_PENDING", result[0].displayStatus)
         assertEquals(false, result[0].canCancel)
     }
 


### PR DESCRIPTION
## 📌 작업한 내용
- `ParticipationStatus.REFUND_PENDING` 상태를 추가했습니다.
- 마이페이지 환불 내역 조회와 환불 탭 조회가 `REFUND_PENDING`, `REFUNDED` 상태를 함께 반환하도록 수정했습니다.
- `MypageRefundResponse.refundStatus`가 `PENDING` 또는 `COMPLETED`로 계산되도록 하드코딩을 제거했습니다.
- 환불대기 표시 상태 분기와 관련 테스트를 추가했습니다.
- `src/main/resources/static/openapi.yaml`에 마이페이지 참여 응답 enum을 갱신했습니다.

## 🔍 참고 사항
- 실제 환불대기 건을 생성/처리하는 자동 환불 흐름은 후속 이슈 #164에서 구현합니다.
- 기존 OpenAPI의 `refundStatus: PENDING | COMPLETED` 계약을 실제 응답에서 표현할 수 있게 하는 보정을 구현했습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #167

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
