### PR TITLE
[MCJ-1502] FEAT: 환불대기 건 자동 환불 처리 흐름 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.groupbuy.application
 
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
@@ -79,6 +80,7 @@ class GroupBuyStatusTransitionService(
             when (groupBuy.status) {
                 GroupBuyStatus.IN_PROGRESS -> {
                     groupBuy.transitionToFailedByDeadline(now)
+                    markParticipationsRefundPending(groupBuy.id, now)
                     publishApplyGroupBuyFailedEvent(groupBuy.id, now)
                     inProgressToFailed++
                 }
@@ -111,6 +113,17 @@ class GroupBuyStatusTransitionService(
             participantUserIds = participantUserIds,
             occurredAt = occurredAt
         )
+    }
+
+    private fun markParticipationsRefundPending(groupBuyId: Long, cancelledAt: LocalDateTime) {
+        val participations = participationRepository.findByGroupBuyIdAndStatusIn(
+            groupBuyId = groupBuyId,
+            statuses = listOf(ParticipationStatus.PAID_WAITING_GOAL)
+        )
+        participations.forEach { participation ->
+            participation.status = ParticipationStatus.REFUND_PENDING
+            participation.cancelledAt = cancelledAt
+        }
     }
 
     private data class BatchTransitionResult(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
@@ -116,14 +116,12 @@ class GroupBuyStatusTransitionService(
     }
 
     private fun markParticipationsRefundPending(groupBuyId: Long, cancelledAt: LocalDateTime) {
-        val participations = participationRepository.findByGroupBuyIdAndStatusIn(
+        participationRepository.updateStatusByGroupBuyIdAndStatus(
             groupBuyId = groupBuyId,
-            statuses = listOf(ParticipationStatus.PAID_WAITING_GOAL)
+            oldStatus = ParticipationStatus.PAID_WAITING_GOAL,
+            newStatus = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = cancelledAt
         )
-        participations.forEach { participation ->
-            participation.status = ParticipationStatus.REFUND_PENDING
-            participation.cancelledAt = cancelledAt
-        }
     }
 
     private data class BatchTransitionResult(

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
@@ -42,10 +43,22 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     )
     fun findDistinctUserIdsByGroupBuyId(@Param("groupBuyId") groupBuyId: Long): List<Long>
 
-    fun findByGroupBuyIdAndStatusIn(
-        groupBuyId: Long,
-        statuses: Collection<ParticipationStatus>
-    ): List<Participation>
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        update Participation p
+        set p.status = :newStatus,
+            p.cancelledAt = :cancelledAt
+        where p.groupBuy.id = :groupBuyId
+          and p.status = :oldStatus
+        """
+    )
+    fun updateStatusByGroupBuyIdAndStatus(
+        @Param("groupBuyId") groupBuyId: Long,
+        @Param("oldStatus") oldStatus: ParticipationStatus,
+        @Param("newStatus") newStatus: ParticipationStatus,
+        @Param("cancelledAt") cancelledAt: LocalDateTime
+    ): Int
 
     @Query(
         """

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -42,6 +42,11 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     )
     fun findDistinctUserIdsByGroupBuyId(@Param("groupBuyId") groupBuyId: Long): List<Long>
 
+    fun findByGroupBuyIdAndStatusIn(
+        groupBuyId: Long,
+        statuses: Collection<ParticipationStatus>
+    ): List<Participation>
+
     @Query(
         """
         SELECT p
@@ -180,6 +185,12 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     fun findByUserIdAndStatusInOrderByCreatedAtDesc(
         userId: Long,
         statuses: Collection<ParticipationStatus>
+    ): List<Participation>
+
+    @EntityGraph(attributePaths = ["user", "groupBuy", "groupBuy.store"])
+    fun findByStatusOrderByCancelledAtAscCreatedAtAsc(
+        status: ParticipationStatus,
+        pageable: Pageable
     ): List<Participation>
 
     @EntityGraph(attributePaths = ["groupBuy", "groupBuy.store"])

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -31,6 +31,8 @@ import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
@@ -254,6 +256,37 @@ class PaymentService(
                 )
             } ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
         }
+    }
+
+    fun processPendingRefunds(batchSize: Int = PENDING_REFUND_BATCH_SIZE): PendingRefundProcessingResult {
+        val pageable = PageRequest.of(
+            0,
+            batchSize.coerceAtLeast(1),
+            Sort.by(Sort.Order.asc("cancelledAt"), Sort.Order.asc("createdAt"), Sort.Order.asc("id"))
+        )
+        val participations = transactionTemplate().execute {
+            participationRepository.findByStatusOrderByCancelledAtAscCreatedAtAsc(
+                status = ParticipationStatus.REFUND_PENDING,
+                pageable = pageable
+            )
+        } ?: emptyList()
+
+        var successCount = 0
+        var failedCount = 0
+        participations.forEach { participation ->
+            val success = processPendingRefund(participation.id)
+            if (success) {
+                successCount++
+            } else {
+                failedCount++
+            }
+        }
+
+        return PendingRefundProcessingResult(
+            targetCount = participations.size,
+            successCount = successCount,
+            failedCount = failedCount
+        )
     }
 
     private fun approvePayment(
@@ -576,6 +609,80 @@ class PaymentService(
         )
     }
 
+    private fun processPendingRefund(participationId: Long): Boolean {
+        val target = transactionTemplate().execute {
+            findPendingRefundTarget(participationId)
+        } ?: return false
+
+        val paymentResult = try {
+            portOnePaymentPort.cancelPayment(target.pgPaymentId, PENDING_REFUND_CANCEL_REASON)
+        } catch (e: CustomException) {
+            log.warn(
+                "[PaymentService] 환불대기 PG 취소 실패: participationId={}, orderId={}, errorCode={}",
+                target.participationId,
+                target.orderId,
+                e.errorCode
+            )
+            return false
+        }
+        if (paymentResult.status != PORTONE_STATUS_CANCELLED) {
+            log.warn(
+                "[PaymentService] 환불대기 PG 취소 미완료 상태: participationId={}, orderId={}, portOneStatus={}",
+                target.participationId,
+                target.orderId,
+                paymentResult.status
+            )
+            return false
+        }
+
+        return transactionTemplate().execute {
+            applyPendingRefundCompletion(
+                target = target,
+                refundedAt = paymentResult.cancelledAt ?: LocalDateTime.now()
+            )
+            true
+        } ?: false
+    }
+
+    private fun findPendingRefundTarget(participationId: Long): PendingRefundTarget? {
+        val participation = participationRepository.findByIdForUpdate(participationId)
+            .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+        if (participation.status != ParticipationStatus.REFUND_PENDING) {
+            return null
+        }
+
+        val userId = participation.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        val order = paymentOrderRepository.findByUserIdAndGroupBuyIdForUpdate(userId, participation.groupBuy.id)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+        validateApprovedPaymentOrder(order)
+        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+
+        return PendingRefundTarget(
+            participationId = participation.id,
+            orderId = order.orderId,
+            pgPaymentId = payment.pgPaymentId,
+        )
+    }
+
+    private fun applyPendingRefundCompletion(target: PendingRefundTarget, refundedAt: LocalDateTime) {
+        val participation = participationRepository.findByIdForUpdate(target.participationId)
+            .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+        if (participation.status != ParticipationStatus.REFUND_PENDING) {
+            return
+        }
+
+        val order = paymentOrderRepository.findByOrderIdForUpdate(target.orderId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+        val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
+            ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+
+        order.cancel(refundedAt)
+        payment.cancel(refundedAt)
+        participation.status = ParticipationStatus.REFUNDED
+        participation.refundedAt = refundedAt
+    }
+
     private fun validateParticipationOwner(participation: Participation, userId: Long) {
         if (participation.user.id != userId) {
             throw CustomException(ErrorCode.FORBIDDEN)
@@ -721,12 +828,26 @@ class PaymentService(
         val pgPaymentId: String,
     )
 
+    private data class PendingRefundTarget(
+        val participationId: Long,
+        val orderId: String,
+        val pgPaymentId: String,
+    )
+
     companion object {
         private const val LOCK_WAIT_MS = 500L
         private const val LOCK_LEASE_MS = 10_000L
+        private const val PENDING_REFUND_BATCH_SIZE = 100
+        private const val PENDING_REFUND_CANCEL_REASON = "MINIMUM_QUANTITY_NOT_MET"
         private const val PORTONE_STATUS_PAID = "PAID"
         private const val PORTONE_STATUS_FAILED = "FAILED"
         private const val PORTONE_STATUS_CANCELLED = "CANCELLED"
         private const val PORTONE_STATUS_PARTIAL_CANCELLED = "PARTIAL_CANCELLED"
     }
 }
+
+data class PendingRefundProcessingResult(
+    val targetCount: Int,
+    val successCount: Int,
+    val failedCount: Int,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -274,10 +274,15 @@ class PaymentService(
         var successCount = 0
         var failedCount = 0
         participations.forEach { participation ->
-            val success = processPendingRefund(participation.id)
-            if (success) {
-                successCount++
-            } else {
+            try {
+                val success = processPendingRefund(participation.id)
+                if (success) {
+                    successCount++
+                } else {
+                    failedCount++
+                }
+            } catch (e: Exception) {
+                log.error("[PaymentService] 환불대기 처리 중 예외 발생: participationId={}", participation.id, e)
                 failedCount++
             }
         }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PendingRefundScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PendingRefundScheduler.kt
@@ -1,0 +1,39 @@
+package com.moongchijang.domain.payment.application
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Component
+class PendingRefundScheduler(
+    private val paymentService: PaymentService,
+    @Value("\${payment.pending-refund.batch-size:100}")
+    private val batchSize: Int,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val running = AtomicBoolean(false)
+
+    @Scheduled(fixedDelayString = "\${payment.pending-refund.fixed-delay-ms:60000}")
+    fun processPendingRefunds() {
+        if (!running.compareAndSet(false, true)) {
+            log.warn("[PendingRefundScheduler] 이전 실행이 아직 진행 중이어서 이번 실행을 건너뜁니다.")
+            return
+        }
+
+        try {
+            val result = paymentService.processPendingRefunds(batchSize)
+            if (result.targetCount > 0) {
+                log.info(
+                    "[PendingRefundScheduler] 환불대기 처리 완료: targetCount={}, successCount={}, failedCount={}",
+                    result.targetCount,
+                    result.successCount,
+                    result.failedCount
+                )
+            }
+        } finally {
+            running.set(false)
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PendingRefundScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PendingRefundScheduler.kt
@@ -1,25 +1,36 @@
 package com.moongchijang.domain.payment.application
 
+import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.util.concurrent.atomic.AtomicBoolean
 
 @Component
 class PendingRefundScheduler(
     private val paymentService: PaymentService,
+    private val redisLockUtil: RedisLockUtil,
     @Value("\${payment.pending-refund.batch-size:100}")
     private val batchSize: Int,
+    @Value("\${payment.pending-refund.lock.wait-ms:100}")
+    private val lockWaitMs: Long,
+    @Value("\${payment.pending-refund.lock.lease-ms:55000}")
+    private val lockLeaseMs: Long,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-    private val running = AtomicBoolean(false)
 
     @Scheduled(fixedDelayString = "\${payment.pending-refund.fixed-delay-ms:60000}")
     fun processPendingRefunds() {
-        if (!running.compareAndSet(false, true)) {
-            log.warn("[PendingRefundScheduler] 이전 실행이 아직 진행 중이어서 이번 실행을 건너뜁니다.")
-            return
+        val token = try {
+            redisLockUtil.tryLockOrThrow(PENDING_REFUND_LOCK_KEY, waitMs = lockWaitMs, leaseMs = lockLeaseMs)
+        } catch (e: CustomException) {
+            if (e.errorCode == ErrorCode.GROUPBUY_LOCK_ACQUISITION_FAILED) {
+                log.warn("[PendingRefundScheduler] 다른 인스턴스에서 실행 중이어서 이번 실행을 건너뜁니다.")
+                return
+            }
+            throw e
         }
 
         try {
@@ -33,7 +44,14 @@ class PendingRefundScheduler(
                 )
             }
         } finally {
-            running.set(false)
+            val unlocked = redisLockUtil.unlock(PENDING_REFUND_LOCK_KEY, token)
+            if (!unlocked) {
+                log.warn("[PendingRefundScheduler] 분산락 해제 실패: key={}", PENDING_REFUND_LOCK_KEY)
+            }
         }
+    }
+
+    companion object {
+        private const val PENDING_REFUND_LOCK_KEY = "payment:pending-refund"
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
@@ -14,6 +14,20 @@ interface PaymentOrderRepository : JpaRepository<PaymentOrder, Long> {
     fun findByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): PaymentOrder?
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select po
+        from PaymentOrder po
+        where po.user.id = :userId
+          and po.groupBuy.id = :groupBuyId
+        """
+    )
+    fun findByUserIdAndGroupBuyIdForUpdate(
+        @Param("userId") userId: Long,
+        @Param("groupBuyId") groupBuyId: Long
+    ): PaymentOrder?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select po from PaymentOrder po where po.orderId = :orderId")
     fun findByOrderIdForUpdate(@Param("orderId") orderId: String): PaymentOrder?
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
@@ -4,11 +4,9 @@ import com.moongchijang.domain.groupbuy.application.GroupBuyStatusTransitionServ
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
-import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.support.GroupBuyFixture
-import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -78,17 +76,16 @@ class GroupBuyStatusTransitionServiceTest {
                 pageable
             )
         ).thenReturn(listOf(inProgress, achieved))
-        `when`(
-            participationRepository.findByGroupBuyIdAndStatusIn(
-                1L,
-                listOf(ParticipationStatus.PAID_WAITING_GOAL)
-            )
-        ).thenReturn(emptyList())
-
         service.transitionExpiredGroupBuysAt(now)
 
         assertEquals(GroupBuyStatus.FAILED, inProgress.status)
         assertEquals(GroupBuyStatus.COMPLETED, achieved.status)
+        verify(participationRepository).updateStatusByGroupBuyIdAndStatus(
+            groupBuyId = 1L,
+            oldStatus = ParticipationStatus.PAID_WAITING_GOAL,
+            newStatus = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = now
+        )
     }
 
     @Test
@@ -169,24 +166,23 @@ class GroupBuyStatusTransitionServiceTest {
                 pageable
             )
         ).thenReturn(listOf(first, second), listOf(third), emptyList())
-        `when`(
-            participationRepository.findByGroupBuyIdAndStatusIn(
-                11L,
-                listOf(ParticipationStatus.PAID_WAITING_GOAL)
-            )
-        ).thenReturn(emptyList())
-        `when`(
-            participationRepository.findByGroupBuyIdAndStatusIn(
-                13L,
-                listOf(ParticipationStatus.PAID_WAITING_GOAL)
-            )
-        ).thenReturn(emptyList())
-
         batchService.transitionExpiredGroupBuysAt(now)
 
         assertEquals(GroupBuyStatus.FAILED, first.status)
         assertEquals(GroupBuyStatus.COMPLETED, second.status)
         assertEquals(GroupBuyStatus.FAILED, third.status)
+        verify(participationRepository).updateStatusByGroupBuyIdAndStatus(
+            groupBuyId = 11L,
+            oldStatus = ParticipationStatus.PAID_WAITING_GOAL,
+            newStatus = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = now
+        )
+        verify(participationRepository).updateStatusByGroupBuyIdAndStatus(
+            groupBuyId = 13L,
+            oldStatus = ParticipationStatus.PAID_WAITING_GOAL,
+            newStatus = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = now
+        )
     }
 
     @Test
@@ -197,15 +193,6 @@ class GroupBuyStatusTransitionServiceTest {
             status = GroupBuyStatus.IN_PROGRESS,
             deadline = now.minusMinutes(1)
         )
-        val participation = Participation(
-            user = UserFixture.createKakaoUser(id = 1L),
-            groupBuy = groupBuy,
-            quantity = 2,
-            productAmount = 12_000,
-            feeAmount = 0,
-            totalAmount = 12_000,
-            status = ParticipationStatus.PAID_WAITING_GOAL,
-        )
         val pageable = PageRequest.of(0, 500, Sort.by(Sort.Order.asc("deadline"), Sort.Order.asc("id")))
         `when`(
             groupBuyRepository.findByStatusInAndDeadlineLessThanEqual(
@@ -214,17 +201,14 @@ class GroupBuyStatusTransitionServiceTest {
                 pageable
             )
         ).thenReturn(listOf(groupBuy))
-        `when`(
-            participationRepository.findByGroupBuyIdAndStatusIn(
-                21L,
-                listOf(ParticipationStatus.PAID_WAITING_GOAL)
-            )
-        ).thenReturn(listOf(participation))
-
         service.transitionExpiredGroupBuysAt(now)
 
         assertEquals(GroupBuyStatus.FAILED, groupBuy.status)
-        assertEquals(ParticipationStatus.REFUND_PENDING, participation.status)
-        assertEquals(now, participation.cancelledAt)
+        verify(participationRepository).updateStatusByGroupBuyIdAndStatus(
+            groupBuyId = 21L,
+            oldStatus = ParticipationStatus.PAID_WAITING_GOAL,
+            newStatus = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = now
+        )
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
@@ -4,8 +4,11 @@ import com.moongchijang.domain.groupbuy.application.GroupBuyStatusTransitionServ
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -75,6 +78,12 @@ class GroupBuyStatusTransitionServiceTest {
                 pageable
             )
         ).thenReturn(listOf(inProgress, achieved))
+        `when`(
+            participationRepository.findByGroupBuyIdAndStatusIn(
+                1L,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL)
+            )
+        ).thenReturn(emptyList())
 
         service.transitionExpiredGroupBuysAt(now)
 
@@ -160,11 +169,62 @@ class GroupBuyStatusTransitionServiceTest {
                 pageable
             )
         ).thenReturn(listOf(first, second), listOf(third), emptyList())
+        `when`(
+            participationRepository.findByGroupBuyIdAndStatusIn(
+                11L,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL)
+            )
+        ).thenReturn(emptyList())
+        `when`(
+            participationRepository.findByGroupBuyIdAndStatusIn(
+                13L,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL)
+            )
+        ).thenReturn(emptyList())
 
         batchService.transitionExpiredGroupBuysAt(now)
 
         assertEquals(GroupBuyStatus.FAILED, first.status)
         assertEquals(GroupBuyStatus.COMPLETED, second.status)
         assertEquals(GroupBuyStatus.FAILED, third.status)
+    }
+
+    @Test
+    fun `IN_PROGRESS 공구가 실패하면 참여를 환불대기로 전환한다`() {
+        val now = LocalDateTime.now()
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 21L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            deadline = now.minusMinutes(1)
+        )
+        val participation = Participation(
+            user = UserFixture.createKakaoUser(id = 1L),
+            groupBuy = groupBuy,
+            quantity = 2,
+            productAmount = 12_000,
+            feeAmount = 0,
+            totalAmount = 12_000,
+            status = ParticipationStatus.PAID_WAITING_GOAL,
+        )
+        val pageable = PageRequest.of(0, 500, Sort.by(Sort.Order.asc("deadline"), Sort.Order.asc("id")))
+        `when`(
+            groupBuyRepository.findByStatusInAndDeadlineLessThanEqual(
+                listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED),
+                now,
+                pageable
+            )
+        ).thenReturn(listOf(groupBuy))
+        `when`(
+            participationRepository.findByGroupBuyIdAndStatusIn(
+                21L,
+                listOf(ParticipationStatus.PAID_WAITING_GOAL)
+            )
+        ).thenReturn(listOf(participation))
+
+        service.transitionExpiredGroupBuysAt(now)
+
+        assertEquals(GroupBuyStatus.FAILED, groupBuy.status)
+        assertEquals(ParticipationStatus.REFUND_PENDING, participation.status)
+        assertEquals(now, participation.cancelledAt)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -45,6 +45,9 @@ import org.mockito.Mockito.lenient
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionStatus
@@ -574,6 +577,125 @@ class PaymentServiceTest {
     }
 
     @Test
+    fun `환불대기 참여는 PG 취소 성공 시 환불완료 처리`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.FAILED)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = "portone-payment-id",
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 2,
+            productAmount = 12_000,
+            feeAmount = 0,
+            totalAmount = 12_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0),
+        ).apply { id = 88L }
+        val refundedAt = LocalDateTime.of(2026, 5, 18, 11, 0)
+        val pageable = pendingRefundPageable()
+        stubTransaction()
+        `when`(
+            participationRepository.findByStatusOrderByCancelledAtAscCreatedAtAsc(
+                ParticipationStatus.REFUND_PENDING,
+                pageable
+            )
+        ).thenReturn(listOf(participation))
+        `when`(participationRepository.findByIdForUpdate(88L)).thenReturn(Optional.of(participation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyIdForUpdate(1L, 10L)).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate(order.orderId)).thenReturn(order)
+        `when`(paymentRepository.findByPaymentOrderOrderId(order.orderId)).thenReturn(payment)
+        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "MINIMUM_QUANTITY_NOT_MET"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "portone-payment-id",
+                    status = "CANCELLED",
+                    totalAmount = 12_000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                    cancelledAt = refundedAt,
+                )
+            )
+
+        val result = service.processPendingRefunds()
+
+        assertEquals(1, result.targetCount)
+        assertEquals(1, result.successCount)
+        assertEquals(0, result.failedCount)
+        assertEquals(PaymentOrderStatus.CANCELLED, order.status)
+        assertEquals(PaymentStatus.CANCELLED, payment.status)
+        assertEquals(ParticipationStatus.REFUNDED, participation.status)
+        assertEquals(refundedAt, participation.refundedAt)
+    }
+
+    @Test
+    fun `환불대기 참여는 PG 취소 실패 시 대기 상태를 유지`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.FAILED)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = "portone-payment-id",
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 2,
+            productAmount = 12_000,
+            feeAmount = 0,
+            totalAmount = 12_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0),
+        ).apply { id = 89L }
+        val pageable = pendingRefundPageable()
+        stubTransaction()
+        `when`(
+            participationRepository.findByStatusOrderByCancelledAtAscCreatedAtAsc(
+                ParticipationStatus.REFUND_PENDING,
+                pageable
+            )
+        ).thenReturn(listOf(participation))
+        `when`(participationRepository.findByIdForUpdate(89L)).thenReturn(Optional.of(participation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyIdForUpdate(1L, 10L)).thenReturn(order)
+        `when`(paymentRepository.findByPaymentOrderOrderId(order.orderId)).thenReturn(payment)
+        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "MINIMUM_QUANTITY_NOT_MET"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "portone-payment-id",
+                    status = "FAILED",
+                    totalAmount = 12_000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                )
+            )
+
+        val result = service.processPendingRefunds()
+
+        assertEquals(1, result.targetCount)
+        assertEquals(0, result.successCount)
+        assertEquals(1, result.failedCount)
+        assertEquals(PaymentOrderStatus.APPROVED, order.status)
+        assertEquals(PaymentStatus.APPROVED, payment.status)
+        assertEquals(ParticipationStatus.REFUND_PENDING, participation.status)
+        assertEquals(null, participation.refundedAt)
+    }
+
+    @Test
     fun `확정된 참여는 취소할 수 없다`() {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy()
@@ -686,6 +808,13 @@ class PaymentServiceTest {
                 )
             )
     }
+
+    private fun pendingRefundPageable(): Pageable =
+        PageRequest.of(
+            0,
+            100,
+            Sort.by(Sort.Order.asc("cancelledAt"), Sort.Order.asc("createdAt"), Sort.Order.asc("id"))
+        )
 
     private fun createGroupBuy(
         id: Long = 10L,

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -696,6 +696,77 @@ class PaymentServiceTest {
     }
 
     @Test
+    fun `환불대기 처리 중 개별 예외가 발생해도 다음 대기 건을 처리한다`() {
+        val firstUser = UserFixture.createKakaoUser(id = 1L)
+        val secondUser = UserFixture.createKakaoUser(id = 2L)
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.FAILED)
+        val firstParticipation = Participation(
+            user = firstUser,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 6_000,
+            feeAmount = 0,
+            totalAmount = 6_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0),
+        ).apply { id = 90L }
+        val secondOrder = createPaymentOrder(user = secondUser, groupBuy = groupBuy, quantity = 1).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val secondPayment = Payment(
+            paymentOrder = secondOrder,
+            pgPaymentId = "second-portone-payment-id",
+            orderId = secondOrder.orderId,
+            amount = secondOrder.totalAmount,
+            method = "CARD",
+            approvedAt = secondOrder.approvedAt!!,
+        )
+        val secondParticipation = Participation(
+            user = secondUser,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 6_000,
+            feeAmount = 0,
+            totalAmount = 6_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 1),
+        ).apply { id = 91L }
+        val refundedAt = LocalDateTime.of(2026, 5, 18, 11, 0)
+        val pageable = pendingRefundPageable()
+        stubTransaction()
+        `when`(
+            participationRepository.findByStatusOrderByCancelledAtAscCreatedAtAsc(
+                ParticipationStatus.REFUND_PENDING,
+                pageable
+            )
+        ).thenReturn(listOf(firstParticipation, secondParticipation))
+        `when`(participationRepository.findByIdForUpdate(90L)).thenThrow(CustomException(ErrorCode.PARTICIPATION_NOT_FOUND))
+        `when`(participationRepository.findByIdForUpdate(91L)).thenReturn(Optional.of(secondParticipation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyIdForUpdate(2L, 10L)).thenReturn(secondOrder)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate(secondOrder.orderId)).thenReturn(secondOrder)
+        `when`(paymentRepository.findByPaymentOrderOrderId(secondOrder.orderId)).thenReturn(secondPayment)
+        `when`(portOnePaymentPort.cancelPayment("second-portone-payment-id", "MINIMUM_QUANTITY_NOT_MET"))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "second-portone-payment-id",
+                    status = "CANCELLED",
+                    totalAmount = 6_000,
+                    method = "CARD",
+                    paidAt = secondOrder.approvedAt,
+                    cancelledAt = refundedAt,
+                )
+            )
+
+        val result = service.processPendingRefunds()
+
+        assertEquals(2, result.targetCount)
+        assertEquals(1, result.successCount)
+        assertEquals(1, result.failedCount)
+        assertEquals(ParticipationStatus.REFUNDED, secondParticipation.status)
+        assertEquals(refundedAt, secondParticipation.refundedAt)
+    }
+
+    @Test
     fun `확정된 참여는 취소할 수 없다`() {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy()

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PendingRefundSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PendingRefundSchedulerTest.kt
@@ -1,0 +1,59 @@
+package com.moongchijang.domain.payment.application
+
+import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mock
+
+@ExtendWith(MockitoExtension::class)
+class PendingRefundSchedulerTest {
+
+    @Mock
+    private lateinit var paymentService: PaymentService
+
+    @Mock
+    private lateinit var redisLockUtil: RedisLockUtil
+
+    @Test
+    fun `분산락 획득 성공 시 환불대기 처리를 실행하고 락을 해제한다`() {
+        val scheduler = PendingRefundScheduler(
+            paymentService = paymentService,
+            redisLockUtil = redisLockUtil,
+            batchSize = 100,
+            lockWaitMs = 100,
+            lockLeaseMs = 55_000,
+        )
+        `when`(redisLockUtil.tryLockOrThrow("payment:pending-refund", 100, 55_000)).thenReturn("lock-token")
+        `when`(paymentService.processPendingRefunds(100))
+            .thenReturn(PendingRefundProcessingResult(targetCount = 1, successCount = 1, failedCount = 0))
+
+        scheduler.processPendingRefunds()
+
+        verify(paymentService).processPendingRefunds(100)
+        verify(redisLockUtil).unlock("payment:pending-refund", "lock-token")
+    }
+
+    @Test
+    fun `분산락 획득 실패 시 환불대기 처리를 건너뛴다`() {
+        val scheduler = PendingRefundScheduler(
+            paymentService = paymentService,
+            redisLockUtil = redisLockUtil,
+            batchSize = 100,
+            lockWaitMs = 100,
+            lockLeaseMs = 55_000,
+        )
+        `when`(redisLockUtil.tryLockOrThrow("payment:pending-refund", 100, 55_000))
+            .thenThrow(CustomException(ErrorCode.GROUPBUY_LOCK_ACQUISITION_FAILED))
+
+        scheduler.processPendingRefunds()
+
+        verify(paymentService, never()).processPendingRefunds(100)
+        verify(redisLockUtil, never()).unlock("payment:pending-refund", "lock-token")
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 미달성 마감으로 `IN_PROGRESS -> FAILED` 전이되는 공구의 참여를 `REFUND_PENDING` 상태로 전환하도록 수정했습니다.
- `REFUND_PENDING` 참여를 조회해 PortOne 결제 취소를 호출하고, 성공 시 `REFUNDED`로 확정하는 처리 흐름을 추가했습니다.
- 환불대기 처리를 주기적으로 실행하는 `PendingRefundScheduler`를 추가했습니다.
- PG 취소 실패 또는 미완료 상태에서는 `REFUND_PENDING`을 유지해 다음 스케줄에서 재시도 가능하도록 했습니다.
- 상태 전이/환불 성공/환불 실패 케이스 테스트를 추가했습니다.

## 🔍 참고 사항
- 새 외부 API나 응답 필드는 추가하지 않았고, 기존 마이페이지 환불 상태 계약(`PENDING`, `COMPLETED`)은 #169에서 반영된 상태를 사용합니다.
- 환불 취소 사유는 PortOne 취소 요청에 `MINIMUM_QUANTITY_NOT_MET` 문자열로 전달합니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #164

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
