### PR TITLE
FIX: 매장 추천 OpenAPI 설명 정정

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -854,13 +854,25 @@ paths:
   /api/v1/group-buy-open-requests/store-recommendations:
     post:
       tags: [GroupBuyRequest]
-      summary: AI 매장 추천 바텀시트용 매장 후보 조회
+      summary: 매장 추천 바텀시트용 네이버 Local Search 매장 후보 조회
       description: |
-        동네와 상품 조건이 확정된 뒤 네이버 Local Search API와 자사 공구 이력을 기반으로
-        최대 10개의 매장 후보를 추천한다.
+        1.1.4-9 매장 추천 바텀시트용 API.
+
+        Case 1~4의 바텀시트에서 동네·상품 조건이 모두 확정된 후 CTA 버튼을 탭하면,
+        백엔드는 네이버 Local Search API를 조회하여 해당 조건에 맞는 매장 후보를 검색한다.
+
+        매장 후보는 최대 10개까지 반환하며, 추천 매장 후보는 다음 기준을 반영해 정렬한다.
+
+        - 네이버 Local Search API의 기본 관련도 순서
+        - 매장 주소가 선택한 동네와 일치하거나 포함되는지 여부
+        - 매장 카테고리가 상품 조건과 관련 있는지 여부
+        - 자사 DB에 등록된 매장인지 여부
+        - 해당 매장의 과거 공구 이력이 있는지 여부
 
         네이버 결과가 0건이거나 네이버 API 호출 실패/timeout이 발생하면 `stores=[]`를 반환하며,
         프론트는 기존 공구 개설 요청 플로우로 fallback한다.
+
+        중복 매장은 하나로 합쳐 반환하고, 매장명에 포함된 HTML 태그는 제거해서 반환한다.
       security:
         - bearerAuth: []
       requestBody:


### PR DESCRIPTION
## 📌 작업한 내용
- `1.1.4-9 매장 추천 바텀시트` 최종 기능명세에 맞춰 OpenAPI 설명을 정정했습니다.
- `AI 매장 추천` 표현을 제거하고 네이버 Local Search API 기반 매장 후보 조회로 명확히 수정했습니다.
- 정렬 기준, fallback 조건, 중복 매장 병합, HTML 태그 제거 설명을 보강했습니다.

## 🔍 참고 사항
- API 동작, 요청/응답 필드, 스키마 변경은 없습니다.
- 실제 엔드포인트는 `/api/v1/group-buy-open-requests/store-recommendations`입니다.

## 🖼️ 스크린샷


## 🔗 관련 이슈
- N/A

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인