### PR TITLE
[MCJ-1506] FEAT: 공구 상세 공유 메타데이터 조회 API 구현

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -9,6 +9,7 @@ REDIS_PORT=6379
 
 S3_BUCKET=YOUR_S3_BUCKET_NAME
 S3_PREFIX=dev
+APP_SHARE_BASE_URL=https://moongchijang.com
 
 KAKAO_CLIENT_ID=test-client-id
 KAKAO_CLIENT_SECRET=test-client-secret

--- a/.env.local.example
+++ b/.env.local.example
@@ -4,6 +4,7 @@ DB_PASSWORD=moongchijang
 
 REDIS_HOST=localhost
 REDIS_PORT=6379
+APP_SHARE_BASE_URL=http://localhost:3000
 
 MYSQL_DATABASE=moongchijang_local
 MYSQL_ROOT_PASSWORD=root

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -9,6 +9,7 @@ REDIS_PORT=6379
 
 S3_BUCKET=YOUR_S3_BUCKET_NAME
 S3_PREFIX=prod
+APP_SHARE_BASE_URL=https://moongchijang.com
 
 KAKAO_CLIENT_ID=test-client-id
 KAKAO_CLIENT_SECRET=test-client-secret

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -17,6 +17,7 @@ import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,6 +29,7 @@ class GroupBuyService(
     private val groupBuyImageRepository: GroupBuyImageRepository,
     private val favoriteRepository: FavoriteRepository,
     private val participationRepository: ParticipationRepository,
+    @Value("\${app.share.base-url}") private val shareBaseUrl: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -195,6 +197,6 @@ class GroupBuyService(
     }
 
     private fun buildShareUrl(groupBuyId: Long): String {
-        return "/group-buys/$groupBuyId"
+        return "${shareBaseUrl.trimEnd('/')}/group-buys/$groupBuyId"
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -8,6 +8,7 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressItem
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressResponse
+import com.moongchijang.domain.groupbuy.application.dto.ShareMetaResponse
 import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
@@ -109,6 +110,23 @@ class GroupBuyService(
         )
     }
 
+    @Transactional(readOnly = true)
+    fun getShareMeta(groupBuyId: Long): ShareMetaResponse {
+        log.info("[GroupBuyService] 공구 공유 메타데이터 조회 시작: groupBuyId={}", groupBuyId)
+
+        val groupBuy = groupBuyRepository.findWithStoreById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+        val response = ShareMetaResponse.from(
+            groupBuy = groupBuy,
+            shareUrl = buildShareUrl(groupBuy.id),
+            description = groupBuy.productDescription
+        )
+
+        log.info("[GroupBuyService] 공구 공유 메타데이터 조회 완료: groupBuyId={}", groupBuyId)
+        return response
+    }
+
     @Transactional(readOnly = true, timeout = 3)
     fun getProgress(groupBuyId: Long): GroupBuyProgressResponse {
         log.debug("[GroupBuyService] 공구 progress 단건 조회 시작: groupBuyId={}", groupBuyId)
@@ -174,5 +192,9 @@ class GroupBuyService(
                 listOf(district)
             }
         }.toSet()
+    }
+
+    private fun buildShareUrl(groupBuyId: Long): String {
+        return "/group-buys/$groupBuyId"
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -121,8 +121,7 @@ class GroupBuyService(
 
         val response = ShareMetaResponse.from(
             groupBuy = groupBuy,
-            shareUrl = buildShareUrl(groupBuy.id),
-            description = groupBuy.productDescription
+            shareUrl = buildShareUrl(groupBuy.id)
         )
 
         log.info("[GroupBuyService] 공구 공유 메타데이터 조회 완료: groupBuyId={}", groupBuyId)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -114,7 +114,7 @@ class GroupBuyService(
 
     @Transactional(readOnly = true)
     fun getShareMeta(groupBuyId: Long): ShareMetaResponse {
-        log.info("[GroupBuyService] 공구 공유 메타데이터 조회 시작: groupBuyId={}", groupBuyId)
+        log.debug("[GroupBuyService] 공구 공유 메타데이터 조회 시작: groupBuyId={}", groupBuyId)
 
         val groupBuy = groupBuyRepository.findWithStoreById(groupBuyId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
@@ -124,7 +124,7 @@ class GroupBuyService(
             shareUrl = buildShareUrl(groupBuy.id)
         )
 
-        log.info("[GroupBuyService] 공구 공유 메타데이터 조회 완료: groupBuyId={}", groupBuyId)
+        log.debug("[GroupBuyService] 공구 공유 메타데이터 조회 완료: groupBuyId={}", groupBuyId)
         return response
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/ShareMetaResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/ShareMetaResponse.kt
@@ -1,0 +1,58 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Schema(description = "공구 공유 메타데이터 응답")
+data class ShareMetaResponse(
+
+    @field:Schema(description = "공유용 상세 URL", example = "https://moongchijang.com/group-buys/101")
+    val shareUrl: String,
+
+    @field:Schema(description = "공유 카드 제목", example = "두쭌쿠 오리지널 1개")
+    val title: String,
+
+    @field:Schema(description = "공유 카드 설명", example = "지금 함께 주문하고 픽업해요.")
+    val description: String,
+
+    @field:Schema(description = "공유 카드 대표 이미지 URL", example = "https://cdn.moongchijang.com/group-buys/101/thumbnail.jpg")
+    val imageUrl: String?,
+
+    @field:Schema(description = "매장명", example = "사이드템포")
+    val storeName: String,
+
+    @field:Schema(description = "마감 일시", example = "2026-05-10T23:59:00")
+    val deadline: LocalDateTime,
+
+    @field:Schema(description = "픽업 날짜", example = "2026-05-15")
+    val pickupDate: LocalDate,
+
+    @field:Schema(description = "픽업 시작 시간", nullable = true, example = "14:00:00")
+    val pickupTimeStart: LocalTime?,
+
+    @field:Schema(description = "픽업 종료 시간", nullable = true, example = "18:00:00")
+    val pickupTimeEnd: LocalTime?
+) {
+    companion object {
+        fun from(
+            groupBuy: GroupBuy,
+            shareUrl: String,
+            description: String
+        ): ShareMetaResponse {
+            return ShareMetaResponse(
+                shareUrl = shareUrl,
+                title = groupBuy.productName,
+                description = description,
+                imageUrl = groupBuy.thumbnailUrl,
+                storeName = groupBuy.store.name,
+                deadline = groupBuy.deadline,
+                pickupDate = groupBuy.pickupDate,
+                pickupTimeStart = groupBuy.pickupTimeStart,
+                pickupTimeEnd = groupBuy.pickupTimeEnd
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/ShareMetaResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/ShareMetaResponse.kt
@@ -39,13 +39,12 @@ data class ShareMetaResponse(
     companion object {
         fun from(
             groupBuy: GroupBuy,
-            shareUrl: String,
-            description: String
+            shareUrl: String
         ): ShareMetaResponse {
             return ShareMetaResponse(
                 shareUrl = shareUrl,
                 title = groupBuy.productName,
-                description = description,
+                description = groupBuy.productDescription,
                 imageUrl = groupBuy.thumbnailUrl,
                 storeName = groupBuy.store.name,
                 deadline = groupBuy.deadline,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -118,11 +118,11 @@ class GroupBuyController(
     fun getShareMeta(
         @PathVariable groupBuyId: Long
     ): ResponseEntity<ApiResponse<ShareMetaResponse>> {
-        log.info("[GroupBuyController] 공구 공유 메타데이터 조회 요청 수신: groupBuyId={}", groupBuyId)
+        log.debug("[GroupBuyController] 공구 공유 메타데이터 조회 요청 수신: groupBuyId={}", groupBuyId)
 
         val response = groupBuyService.getShareMeta(groupBuyId)
 
-        log.info("[GroupBuyController] 공구 공유 메타데이터 조회 응답 완료: groupBuyId={}", groupBuyId)
+        log.debug("[GroupBuyController] 공구 공유 메타데이터 조회 응답 완료: groupBuyId={}", groupBuyId)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyController.kt
@@ -8,6 +8,7 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedPageResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedRequest
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressItem
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressResponse
+import com.moongchijang.domain.groupbuy.application.dto.ShareMetaResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerCountResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyViewerHeartbeatRequest
 import com.moongchijang.domain.store.domain.entity.DistrictType
@@ -99,6 +100,29 @@ class GroupBuyController(
         )
 
         log.info("[GroupBuyController] 공구 상세 조회 응답 완료: groupBuyId={}", groupBuyId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{groupBuyId}/share")
+    @Operation(summary = "공유 메타데이터 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "공유 메타데이터 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getShareMeta(
+        @PathVariable groupBuyId: Long
+    ): ResponseEntity<ApiResponse<ShareMetaResponse>> {
+        log.info("[GroupBuyController] 공구 공유 메타데이터 조회 요청 수신: groupBuyId={}", groupBuyId)
+
+        val response = groupBuyService.getShareMeta(groupBuyId)
+
+        log.info("[GroupBuyController] 공구 공유 메타데이터 조회 응답 완료: groupBuyId={}", groupBuyId)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,6 +30,8 @@ app:
   s3:
     bucket: ${S3_BUCKET}
     prefix: ${S3_PREFIX}
+  share:
+    base-url: ${APP_SHARE_BASE_URL:https://moongchijang.com}
 
 naver:
   api:

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -26,6 +26,8 @@ app:
   s3:
     bucket: local-bucket
     prefix: local
+  share:
+    base-url: ${APP_SHARE_BASE_URL:http://localhost:3000}
 
 oauth:
   kakao:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,6 +26,8 @@ app:
   s3:
     bucket: local-bucket
     prefix: local
+  share:
+    base-url: ${APP_SHARE_BASE_URL:http://localhost:3000}
 
 oauth:
   kakao:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -30,6 +30,8 @@ app:
   s3:
     bucket: ${S3_BUCKET}
     prefix: ${S3_PREFIX}
+  share:
+    base-url: ${APP_SHARE_BASE_URL:https://moongchijang.com}
 
 portone:
   store-id: ${PORTONE_STORE_ID}

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -651,6 +651,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseShareMeta'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/v1/search:
     post:
@@ -2600,7 +2602,7 @@ components:
             shareUrl: { type: string }
             title: { type: string }
             description: { type: string }
-            imageUrl: { type: string }
+            imageUrl: { type: string, nullable: true }
             storeName: { type: string }
             deadline: { type: string, format: date-time }
             pickupDate: { type: string, format: date }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -14,10 +14,10 @@ import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
@@ -46,8 +46,18 @@ class GroupBuyServiceTest {
     @Mock
     private lateinit var participationRepository: ParticipationRepository
 
-    @InjectMocks
     private lateinit var service: GroupBuyService
+
+    @BeforeEach
+    fun setUp() {
+        service = GroupBuyService(
+            groupBuyRepository = groupBuyRepository,
+            groupBuyImageRepository = groupBuyImageRepository,
+            favoriteRepository = favoriteRepository,
+            participationRepository = participationRepository,
+            shareBaseUrl = "https://moongchijang.com"
+        )
+    }
 
     @Test
     fun `공구 피드 keyword 제외 조회 검증`() {
@@ -302,6 +312,45 @@ class GroupBuyServiceTest {
         `when`(groupBuyRepository.findWithStoreById(999L)).thenReturn(Optional.empty())
 
         val ex = assertThrows<CustomException> { service.getDetail(999L, 1L) }
+
+        assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
+    }
+
+    @Test
+    fun `공구 공유 메타데이터 조회 성공`() {
+        val groupBuyId = 101L
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = groupBuyId,
+            status = GroupBuyStatus.IN_PROGRESS,
+            productName = "두쭌쿠 오리지널 1개"
+        ).apply {
+            thumbnailUrl = "https://cdn.moongchijang.com/group-buys/101/thumbnail.jpg"
+            productDescription = "지금 함께 주문하고 픽업해요."
+            pickupDate = LocalDate.of(2026, 5, 15)
+            pickupTimeStart = LocalTime.of(14, 0)
+            pickupTimeEnd = LocalTime.of(18, 0)
+        }
+
+        `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+
+        val result = service.getShareMeta(groupBuyId)
+
+        assertEquals("https://moongchijang.com/group-buys/101", result.shareUrl)
+        assertEquals("두쭌쿠 오리지널 1개", result.title)
+        assertEquals("지금 함께 주문하고 픽업해요.", result.description)
+        assertEquals("https://cdn.moongchijang.com/group-buys/101/thumbnail.jpg", result.imageUrl)
+        assertEquals(groupBuy.store.name, result.storeName)
+        assertEquals(groupBuy.deadline, result.deadline)
+        assertEquals(groupBuy.pickupDate, result.pickupDate)
+        assertEquals(groupBuy.pickupTimeStart, result.pickupTimeStart)
+        assertEquals(groupBuy.pickupTimeEnd, result.pickupTimeEnd)
+    }
+
+    @Test
+    fun `존재하지 않는 공구 공유 메타데이터 조회 시 GROUPBUY_NOT_FOUND 예외 발생`() {
+        `when`(groupBuyRepository.findWithStoreById(999L)).thenReturn(Optional.empty())
+
+        val ex = assertThrows<CustomException> { service.getShareMeta(999L) }
 
         assertEquals(ErrorCode.GROUPBUY_NOT_FOUND, ex.errorCode)
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,6 +2,10 @@ spring:
   flyway:
     enabled: false
 
+app:
+  share:
+    base-url: https://test.moongchijang.com
+
 oauth:
   kakao:
     client-id: test-client-id


### PR DESCRIPTION
## 📌 작업한 내용
- 공구 공유 메타데이터 조회 서비스 로직을 구현했습니다.
  - `GroupBuyService.getShareMeta(groupBuyId)`
  - 공구 미존재 시 `GROUPBUY_NOT_FOUND(404)` 예외를 반환합니다.
- 공유 URL 생성 규칙을 적용했습니다.
  - `app.share.base-url` + `/group-buys/{groupBuyId}` 형태로 `shareUrl`을 생성합니다.
  - `GroupBuyService`에 `shareBaseUrl` 설정값 주입을 반영했습니다.
- 공유 메타데이터 조회 API 엔드포인트를 추가했습니다.
  - `GET /api/v1/group-buys/{groupBuyId}/share`
- OpenAPI 스펙을 구현과 동기화했습니다.
  - `/share` 엔드포인트 `404` 응답 추가
  - `imageUrl`을 nullable로 수정

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #170 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인