### PR TITLE
[MCJ-1451] FEAT: 로그아웃 마지막 역할 저장 및 회원탈퇴 검증/처리 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
@@ -11,6 +11,7 @@ import com.moongchijang.domain.auth.application.dto.KakaoAuthUser
 import com.moongchijang.domain.auth.application.dto.KakaoLoginRequest
 import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
 import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -97,8 +98,9 @@ class AuthService(
     }
 
     @Transactional
-    fun logout(userId: Long) {
+    fun logout(userId: Long, role: UserRole) {
         log.info("[AuthService] 로그아웃 처리 시작: userId={}", userId)
+        userService.saveLastRole(userId, role)
         tokenService.deleteByUserId(userId)
         log.info("[AuthService] 로그아웃 처리 완료: userId={}", userId)
     }

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/AuthController.kt
@@ -158,7 +158,7 @@ class AuthController(
         val userId = principal.id
         log.info("[AuthController] 로그아웃 요청 수신: userId={}", userId)
 
-        authService.logout(userId)
+        authService.logout(userId, principal.role)
         tokenService.clearRefreshTokenCookie(response)
 
         log.info("[AuthController] 로그아웃 응답 완료: userId={}", userId)

--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.favorite.domain.repository
 
 import com.moongchijang.domain.favorite.domain.entity.Favorite
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
@@ -10,7 +11,9 @@ interface FavoriteRepository : JpaRepository<Favorite, Long>, FavoriteRepository
 
     fun existsByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Boolean
 
-    fun deleteByUserId(userId: Long): Int
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Favorite f where f.user.id = :userId")
+    fun deleteByUserId(@Param("userId") userId: Long): Int
 
     fun deleteByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Int
 

--- a/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/domain/repository/FavoriteRepository.kt
@@ -10,6 +10,8 @@ interface FavoriteRepository : JpaRepository<Favorite, Long>, FavoriteRepository
 
     fun existsByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Boolean
 
+    fun deleteByUserId(userId: Long): Int
+
     fun deleteByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Int
 
     fun findByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Favorite?

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.participation.domain.repository
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -17,6 +18,24 @@ import java.time.LocalDateTime
 import java.util.Optional
 
 interface ParticipationRepository : JpaRepository<Participation, Long> {
+
+    @Query(
+        """
+        select case when count(p) > 0 then true else false end
+        from Participation p
+        join p.groupBuy gb
+        where p.user.id = :userId
+          and p.status = :participationStatus
+          and p.pickupStatus in :pickupStatuses
+          and gb.status in :groupBuyStatuses
+        """
+    )
+    fun existsPendingPickupForWithdrawal(
+        @Param("userId") userId: Long,
+        @Param("participationStatus") participationStatus: ParticipationStatus,
+        @Param("pickupStatuses") pickupStatuses: Collection<PickupStatus>,
+        @Param("groupBuyStatuses") groupBuyStatuses: Collection<GroupBuyStatus>,
+    ): Boolean
 
     fun existsByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Boolean
 

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -7,6 +7,7 @@ import com.moongchijang.domain.user.application.dto.EmailAvailabilityResponse
 import com.moongchijang.domain.user.application.dto.NicknameAvailabilityResponse
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -129,6 +130,14 @@ class UserService(
         user.completeSignup(request.nickname, request.phoneNumber)
         log.info("[UserService] 추가정보 입력 처리 완료: userId={}", userId)
         return AdditionalInfoUpdatedResponse.from(user)
+    }
+
+    @Transactional
+    fun saveLastRole(userId: Long, role: UserRole) {
+        val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        user.saveLastRole(role)
     }
 
     private fun findActiveKakaoUser(providerId: String): User? {

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -1,10 +1,14 @@
 package com.moongchijang.domain.user.application
 
 import com.moongchijang.domain.auth.application.PhoneVerificationService
+import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.application.PaymentService
+import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpdatedResponse
 import com.moongchijang.domain.user.application.dto.EmailAvailabilityResponse
@@ -27,6 +31,8 @@ class UserService(
     private val userRepository: UserRepository,
     private val phoneVerificationService: PhoneVerificationService,
     private val participationRepository: ParticipationRepository,
+    private val favoriteRepository: FavoriteRepository,
+    private val paymentService: PaymentService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -149,6 +155,9 @@ class UserService(
     fun withdraw(userId: Long) {
         log.info("[UserService] 회원탈퇴 처리 시작: userId={}", userId)
         validateWithdrawable(userId)
+        cancelActiveParticipationsForWithdrawal(userId)
+        val deletedFavoriteCount = favoriteRepository.deleteByUserId(userId)
+        log.info("[UserService] 회원탈퇴 찜 삭제 완료: userId={}, deletedCount={}", userId, deletedFavoriteCount)
 
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
@@ -169,6 +178,31 @@ class UserService(
         if (hasPendingPickup) {
             throw CustomException(ErrorCode.WITHDRAWAL_BLOCKED_PENDING_PICKUP)
         }
+    }
+
+    private fun cancelActiveParticipationsForWithdrawal(userId: Long) {
+        val activeParticipations = participationRepository.findByUserIdAndStatusOrderByCreatedAtDesc(
+            userId = userId,
+            status = ParticipationStatus.PAID_WAITING_GOAL,
+        )
+
+        if (activeParticipations.isEmpty()) {
+            return
+        }
+
+        log.info("[UserService] 회원탈퇴 참여중 공구 자동 취소 시작: userId={}, targetCount={}", userId, activeParticipations.size)
+        val request = CancelParticipationRequest(
+            reason = ParticipationCancelReason.OTHER,
+            reasonDetail = "회원탈퇴 자동 취소",
+        )
+        activeParticipations.forEach { participation ->
+            paymentService.cancelParticipation(
+                participationId = participation.id,
+                userId = userId,
+                request = request,
+            )
+        }
+        log.info("[UserService] 회원탈퇴 참여중 공구 자동 취소 완료: userId={}, targetCount={}", userId, activeParticipations.size)
     }
 
     private fun findActiveKakaoUser(providerId: String): User? {

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -156,14 +156,15 @@ class UserService(
     @Transactional
     fun withdraw(userId: Long, request: WithdrawRequest) {
         log.info("[UserService] 회원탈퇴 처리 시작: userId={}", userId)
+        val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
         validateWithdrawalReason(request)
         validateWithdrawable(userId)
         cancelActiveParticipationsForWithdrawal(userId)
         val deletedFavoriteCount = favoriteRepository.deleteByUserId(userId)
         log.info("[UserService] 회원탈퇴 찜 삭제 완료: userId={}, deletedCount={}", userId, deletedFavoriteCount)
 
-        val user = userRepository.findByIdAndDeletedAtIsNull(userId)
-            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
         user.withdraw(
             reason = request.reason,
             reasonDetail = normalizedReasonDetail(request),

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -153,7 +153,6 @@ class UserService(
         user.saveLastRole(role)
     }
 
-    @Transactional
     fun withdraw(userId: Long, request: WithdrawRequest) {
         log.info("[UserService] 회원탈퇴 처리 시작: userId={}", userId)
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
@@ -169,6 +168,7 @@ class UserService(
             reason = request.reason,
             reasonDetail = normalizedReasonDetail(request),
         )
+        userRepository.save(user)
 
         log.info("[UserService] 회원탈퇴 처리 완료: userId={}", userId)
     }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -13,9 +13,11 @@ import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpdatedResponse
 import com.moongchijang.domain.user.application.dto.EmailAvailabilityResponse
 import com.moongchijang.domain.user.application.dto.NicknameAvailabilityResponse
+import com.moongchijang.domain.user.application.dto.WithdrawRequest
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.entity.WithdrawalReason
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -152,8 +154,9 @@ class UserService(
     }
 
     @Transactional
-    fun withdraw(userId: Long) {
+    fun withdraw(userId: Long, request: WithdrawRequest) {
         log.info("[UserService] 회원탈퇴 처리 시작: userId={}", userId)
+        validateWithdrawalReason(request)
         validateWithdrawable(userId)
         cancelActiveParticipationsForWithdrawal(userId)
         val deletedFavoriteCount = favoriteRepository.deleteByUserId(userId)
@@ -161,7 +164,10 @@ class UserService(
 
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
-        user.withdraw()
+        user.withdraw(
+            reason = request.reason,
+            reasonDetail = normalizedReasonDetail(request),
+        )
 
         log.info("[UserService] 회원탈퇴 처리 완료: userId={}", userId)
     }
@@ -204,6 +210,15 @@ class UserService(
         }
         log.info("[UserService] 회원탈퇴 참여중 공구 자동 취소 완료: userId={}, targetCount={}", userId, activeParticipations.size)
     }
+
+    private fun validateWithdrawalReason(request: WithdrawRequest) {
+        if (request.reason == WithdrawalReason.OTHER && request.reasonDetail.isNullOrBlank()) {
+            throw CustomException(ErrorCode.WITHDRAWAL_REASON_DETAIL_REQUIRED)
+        }
+    }
+
+    private fun normalizedReasonDetail(request: WithdrawRequest): String? =
+        request.reasonDetail?.trim()?.takeIf { it.isNotBlank() }
 
     private fun findActiveKakaoUser(providerId: String): User? {
         return userRepository.findByProviderAndProviderIdAndDeletedAtIsNull(

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -1,6 +1,10 @@
 package com.moongchijang.domain.user.application
 
 import com.moongchijang.domain.auth.application.PhoneVerificationService
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpdatedResponse
 import com.moongchijang.domain.user.application.dto.EmailAvailabilityResponse
@@ -22,6 +26,7 @@ import java.time.LocalDateTime
 class UserService(
     private val userRepository: UserRepository,
     private val phoneVerificationService: PhoneVerificationService,
+    private val participationRepository: ParticipationRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -138,6 +143,32 @@ class UserService(
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
         user.saveLastRole(role)
+    }
+
+    @Transactional
+    fun withdraw(userId: Long) {
+        log.info("[UserService] 회원탈퇴 처리 시작: userId={}", userId)
+        validateWithdrawable(userId)
+
+        val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        user.withdraw()
+
+        log.info("[UserService] 회원탈퇴 처리 완료: userId={}", userId)
+    }
+
+    @Transactional(readOnly = true)
+    fun validateWithdrawable(userId: Long) {
+        val hasPendingPickup = participationRepository.existsPendingPickupForWithdrawal(
+            userId = userId,
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+            groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+        )
+
+        if (hasPendingPickup) {
+            throw CustomException(ErrorCode.WITHDRAWAL_BLOCKED_PENDING_PICKUP)
+        }
     }
 
     private fun findActiveKakaoUser(providerId: String): User? {

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawRequest.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.user.application.dto
+
+import com.moongchijang.domain.user.domain.entity.WithdrawalReason
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+
+data class WithdrawRequest(
+    @field:Schema(
+        description = "탈퇴 사유 (선택)",
+        example = "NO_LONGER_INTERESTED",
+    )
+    val reason: WithdrawalReason? = null,
+    @field:Schema(
+        description = "탈퇴 상세 사유 (기타 선택 시 입력)",
+        example = "근처 다른 매장을 주로 이용해요.",
+    )
+    @field:Size(max = 500)
+    val reasonDetail: String? = null,
+)

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
@@ -44,6 +44,10 @@ class User(
     @Column(nullable = false, length = 20)
     var role: UserRole = UserRole.BUYER,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "last_role", length = 20)
+    var lastRole: UserRole? = null,
+
     @Column(name = "signup_completed", nullable = false)
     var signupCompleted: Boolean = false,
 
@@ -62,6 +66,10 @@ class User(
 
     fun withdraw(now: LocalDateTime = LocalDateTime.now()) {
         this.deletedAt = now
+    }
+
+    fun saveLastRole(role: UserRole) {
+        this.lastRole = role
     }
 
     companion object {

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
@@ -54,6 +54,13 @@ class User(
     @Column(name = "deleted_at")
     var deletedAt: LocalDateTime? = null,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "withdrawal_reason", length = 50)
+    var withdrawalReason: WithdrawalReason? = null,
+
+    @Column(name = "withdrawal_reason_detail", length = 500)
+    var withdrawalReasonDetail: String? = null,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null,
@@ -64,7 +71,13 @@ class User(
         this.signupCompleted = true
     }
 
-    fun withdraw(now: LocalDateTime = LocalDateTime.now()) {
+    fun withdraw(
+        reason: WithdrawalReason?,
+        reasonDetail: String?,
+        now: LocalDateTime = LocalDateTime.now(),
+    ) {
+        this.withdrawalReason = reason
+        this.withdrawalReasonDetail = reasonDetail
         this.deletedAt = now
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/entity/WithdrawalReason.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/entity/WithdrawalReason.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.user.domain.entity
+
+enum class WithdrawalReason {
+    TIME_NOT_AVAILABLE,
+    NO_LONGER_INTERESTED,
+    PREFER_DIRECT_VISIT,
+    BUYING_ELSEWHERE,
+    OTHER,
+}

--- a/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpdatedResponse
 import com.moongchijang.domain.user.application.dto.NicknameAvailabilityResponse
+import com.moongchijang.domain.user.application.dto.WithdrawRequest
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -80,9 +81,10 @@ class UserController(
     )
     fun withdraw(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @Valid @RequestBody request: WithdrawRequest,
     ): ApiResponse<Nothing> {
         log.info("[UserController] 회원탈퇴 요청 수신: userId={}", principal.id)
-        userService.withdraw(principal.id)
+        userService.withdraw(principal.id, request)
         log.info("[UserController] 회원탈퇴 응답 완료: userId={}", principal.id)
         return ApiResponse.success()
     }

--- a/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
@@ -17,11 +17,13 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.slf4j.LoggerFactory
 
 @Validated
 @RestController
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController
 class UserController(
     private val userService: UserService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/nickname/availability")
     @Operation(summary = "닉네임 중복 확인", description = "입력한 닉네임의 사용 가능 여부를 반환합니다.")
@@ -63,5 +66,24 @@ class UserController(
     ): ApiResponse<AdditionalInfoUpdatedResponse> {
         val response = userService.updateAdditionalInfo(request, principal.id)
         return ApiResponse.success(response)
+    }
+
+    @DeleteMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴를 처리합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "409", description = "탈퇴 불가", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun withdraw(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+    ): ApiResponse<Nothing> {
+        log.info("[UserController] 회원탈퇴 요청 수신: userId={}", principal.id)
+        userService.withdraw(principal.id)
+        log.info("[UserController] 회원탈퇴 응답 완료: userId={}", principal.id)
+        return ApiResponse.success()
     }
 }

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -64,6 +64,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     REJOIN_NOT_AVAILABLE_YET(409_102, "탈퇴 후 30일 이후에 다시 가입할 수 있습니다.", 409),
     DUPLICATE_NICKNAME(409_103, "이미 사용 중인 닉네임이에요.", 409),
     WITHDRAWAL_BLOCKED_PENDING_PICKUP(409_104, "수령 예정인 공구가 있어요. 카카오 채널로 문의해주세요.", 409),
+    WITHDRAWAL_REASON_DETAIL_REQUIRED(400_109, "기타 탈퇴 사유를 입력해주세요.", 400),
 
     // Token (150~199)
     TOKEN_EXPIRED(401_151, "토큰이 만료되었습니다.", 401),

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -63,6 +63,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     DUPLICATE_EMAIL(409_101, "이미 사용 중인 이메일입니다.", 409),
     REJOIN_NOT_AVAILABLE_YET(409_102, "탈퇴 후 30일 이후에 다시 가입할 수 있습니다.", 409),
     DUPLICATE_NICKNAME(409_103, "이미 사용 중인 닉네임이에요.", 409),
+    WITHDRAWAL_BLOCKED_PENDING_PICKUP(409_104, "수령 예정인 공구가 있어요. 카카오 채널로 문의해주세요.", 409),
 
     // Token (150~199)
     TOKEN_EXPIRED(401_151, "토큰이 만료되었습니다.", 401),

--- a/src/main/resources/db/migration/V20__alter_users_add_last_role.sql
+++ b/src/main/resources/db/migration/V20__alter_users_add_last_role.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN last_role VARCHAR(20) NULL;

--- a/src/main/resources/db/migration/V21__alter_users_add_withdrawal_reason.sql
+++ b/src/main/resources/db/migration/V21__alter_users_add_withdrawal_reason.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+ADD COLUMN withdrawal_reason VARCHAR(50) NULL,
+ADD COLUMN withdrawal_reason_detail VARCHAR(500) NULL;

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -17,7 +17,7 @@ info:
   version: v1
 
 servers:
-  - url: http://43.203.191.30/dev
+  - url: https://api.moongchijang.com/dev
     description: 개발 서버
   - url: http://localhost:8080
     description: 로컬 서버
@@ -130,6 +130,12 @@ paths:
         - 동일 계정은 탈퇴 후 30일 이후 재가입 가능하다.
       security:
         - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WithdrawRequest'
       responses:
         '200':
           $ref: '#/components/responses/SuccessNoData'
@@ -2019,6 +2025,20 @@ components:
           type: string
           description: 하이픈 포함 휴대폰 번호 (01X-XXXX-XXXX)
           pattern: "^01[0-9]-[0-9]{3,4}-[0-9]{4}$"
+
+    WithdrawRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          nullable: true
+          description: 탈퇴 사유(선택)
+          enum: [TIME_NOT_AVAILABLE, NO_LONGER_INTERESTED, PREFER_DIRECT_VISIT, BUYING_ELSEWHERE, OTHER]
+        reasonDetail:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: 탈퇴 상세 사유 (reason=OTHER 일 때 입력)
 
     ApiResponseNicknameAvailability:
       type: object

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -122,11 +122,21 @@ paths:
     delete:
       tags: [Auth]
       summary: 회원 탈퇴
+      description: |
+        회원 탈퇴를 처리한다.
+        - 수령 예정 공구(달성 완료 + 픽업 미완료)가 있으면 탈퇴할 수 없다.
+        - 참여 중 공구(PAID_WAITING_GOAL)는 자동 취소된다.
+        - 찜 목록은 모두 삭제된다.
+        - 동일 계정은 탈퇴 후 30일 이후 재가입 가능하다.
       security:
         - bearerAuth: []
       responses:
         '200':
           $ref: '#/components/responses/SuccessNoData'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
 
   /api/v1/users/nickname/availability:
     get:

--- a/src/test/kotlin/com/moongchijang/domain/auth/application/AuthServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/auth/application/AuthServiceTest.kt
@@ -8,6 +8,7 @@ import com.moongchijang.domain.auth.application.port.EmailSignupTokenStore
 import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.security.jwt.JwtTokenProvider
@@ -99,7 +100,8 @@ class AuthServiceTest {
 
     @Test
     fun `로그아웃 시 리프레시 토큰 삭제 호출`() {
-        authService.logout(9L)
+        authService.logout(9L, UserRole.SELLER)
+        Mockito.verify(userService).saveLastRole(9L, UserRole.SELLER)
         Mockito.verify(tokenService).deleteByUserId(9L)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -3,10 +3,13 @@ package com.moongchijang.domain.user.application
 import com.moongchijang.domain.auth.application.PhoneVerificationService
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.payment.application.PaymentService
+import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
@@ -269,5 +272,64 @@ class UserServiceTest {
         }
 
         Assertions.assertEquals(ErrorCode.WITHDRAWAL_BLOCKED_PENDING_PICKUP, exception.errorCode)
+    }
+
+    @Test
+    fun `회원탈퇴 성공 처리`() {
+        val user = UserFixture.createKakaoUser(id = 1L, providerId = "kakao-1", nickname = "탈퇴대상")
+        val participation = Mockito.mock(Participation::class.java)
+        Mockito.`when`(participation.id).thenReturn(100L)
+
+        Mockito.`when`(
+            participationRepository.existsPendingPickupForWithdrawal(
+                1L,
+                ParticipationStatus.CONFIRMED,
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            )
+        ).thenReturn(false)
+        Mockito.`when`(
+            participationRepository.findByUserIdAndStatusOrderByCreatedAtDesc(1L, ParticipationStatus.PAID_WAITING_GOAL)
+        ).thenReturn(listOf(participation))
+        Mockito.`when`(favoriteRepository.deleteByUserId(1L)).thenReturn(3)
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
+
+        userService.withdraw(1L)
+
+        Mockito.verify(paymentService).cancelParticipation(
+            100L,
+            1L,
+            CancelParticipationRequest(
+                reason = ParticipationCancelReason.OTHER,
+                reasonDetail = "회원탈퇴 자동 취소",
+            )
+        )
+        Mockito.verify(favoriteRepository).deleteByUserId(1L)
+        Assertions.assertEquals(true, user.deletedAt != null)
+    }
+
+    @Test
+    fun `회원탈퇴 참여중 공구 없음 처리`() {
+        val user = UserFixture.createKakaoUser(id = 2L, providerId = "kakao-2", nickname = "탈퇴대상2")
+
+        Mockito.`when`(
+            participationRepository.existsPendingPickupForWithdrawal(
+                2L,
+                ParticipationStatus.CONFIRMED,
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            )
+        ).thenReturn(false)
+        Mockito.`when`(
+            participationRepository.findByUserIdAndStatusOrderByCreatedAtDesc(2L, ParticipationStatus.PAID_WAITING_GOAL)
+        ).thenReturn(emptyList())
+        Mockito.`when`(favoriteRepository.deleteByUserId(2L)).thenReturn(0)
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(user)
+
+        userService.withdraw(2L)
+
+        Mockito.verifyNoInteractions(paymentService)
+        Mockito.verify(favoriteRepository).deleteByUserId(2L)
+        Assertions.assertEquals(true, user.deletedAt != null)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -1,6 +1,10 @@
 package com.moongchijang.domain.user.application
 
 import com.moongchijang.domain.auth.application.PhoneVerificationService
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
@@ -19,7 +23,8 @@ class UserServiceTest {
     private val userRepository: UserRepository = Mockito.mock(UserRepository::class.java)
     private val phoneVerificationService: PhoneVerificationService =
         Mockito.mock(PhoneVerificationService::class.java)
-    private val userService = UserService(userRepository, phoneVerificationService)
+    private val participationRepository: ParticipationRepository = Mockito.mock(ParticipationRepository::class.java)
+    private val userService = UserService(userRepository, phoneVerificationService, participationRepository)
 
     @Test
     fun `활성 카카오 사용자 존재 시 기존 사용자 반환`() {
@@ -236,5 +241,23 @@ class UserServiceTest {
         }
 
         Assertions.assertEquals(ErrorCode.INVALID_EMAIL_FORMAT, exception.errorCode)
+    }
+
+    @Test
+    fun `회원탈퇴 불가 예외`() {
+        Mockito.`when`(
+            participationRepository.existsPendingPickupForWithdrawal(
+                1L,
+                ParticipationStatus.CONFIRMED,
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            )
+        ).thenReturn(true)
+
+        val exception = assertThrows<CustomException> {
+            userService.validateWithdrawable(1L)
+        }
+
+        Assertions.assertEquals(ErrorCode.WITHDRAWAL_BLOCKED_PENDING_PICKUP, exception.errorCode)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -11,8 +11,10 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.payment.application.PaymentService
 import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
+import com.moongchijang.domain.user.application.dto.WithdrawRequest
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.WithdrawalReason
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -294,7 +296,13 @@ class UserServiceTest {
         Mockito.`when`(favoriteRepository.deleteByUserId(1L)).thenReturn(3)
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
 
-        userService.withdraw(1L)
+        userService.withdraw(
+            1L,
+            WithdrawRequest(
+                reason = WithdrawalReason.NO_LONGER_INTERESTED,
+                reasonDetail = null,
+            )
+        )
 
         Mockito.verify(paymentService).cancelParticipation(
             100L,
@@ -326,10 +334,31 @@ class UserServiceTest {
         Mockito.`when`(favoriteRepository.deleteByUserId(2L)).thenReturn(0)
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(user)
 
-        userService.withdraw(2L)
+        userService.withdraw(
+            2L,
+            WithdrawRequest(
+                reason = WithdrawalReason.TIME_NOT_AVAILABLE,
+                reasonDetail = null,
+            )
+        )
 
         Mockito.verifyNoInteractions(paymentService)
         Mockito.verify(favoriteRepository).deleteByUserId(2L)
         Assertions.assertEquals(true, user.deletedAt != null)
+    }
+
+    @Test
+    fun `회원탈퇴 기타 사유 상세 미입력 예외`() {
+        val exception = assertThrows<CustomException> {
+            userService.withdraw(
+                1L,
+                WithdrawRequest(
+                    reason = WithdrawalReason.OTHER,
+                    reasonDetail = "   ",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.WITHDRAWAL_REASON_DETAIL_REQUIRED, exception.errorCode)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -2,9 +2,11 @@ package com.moongchijang.domain.user.application
 
 import com.moongchijang.domain.auth.application.PhoneVerificationService
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.application.PaymentService
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
@@ -24,7 +26,15 @@ class UserServiceTest {
     private val phoneVerificationService: PhoneVerificationService =
         Mockito.mock(PhoneVerificationService::class.java)
     private val participationRepository: ParticipationRepository = Mockito.mock(ParticipationRepository::class.java)
-    private val userService = UserService(userRepository, phoneVerificationService, participationRepository)
+    private val favoriteRepository: FavoriteRepository = Mockito.mock(FavoriteRepository::class.java)
+    private val paymentService: PaymentService = Mockito.mock(PaymentService::class.java)
+    private val userService = UserService(
+        userRepository,
+        phoneVerificationService,
+        participationRepository,
+        favoriteRepository,
+        paymentService,
+    )
 
     @Test
     fun `활성 카카오 사용자 존재 시 기존 사용자 반환`() {

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -349,6 +349,9 @@ class UserServiceTest {
 
     @Test
     fun `회원탈퇴 기타 사유 상세 미입력 예외`() {
+        val user = UserFixture.createKakaoUser(id = 1L, providerId = "kakao-1", nickname = "탈퇴대상")
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
+
         val exception = assertThrows<CustomException> {
             userService.withdraw(
                 1L,


### PR DESCRIPTION
## 📌 작업한 내용
- 로그아웃 시 사용자 마지막 역할(lastRole)을 서버에 저장하도록 반영했습니다.
- 회원탈퇴 시 최종 검증 로직을 추가했습니다.
  - 수령 예정 공구(달성 완료 + 픽업 미완료)가 있으면 탈퇴를 차단합니다.
- 탈퇴 가능 시 후처리를 구현했습니다.
  - 참여 중 공구 자동 취소
  - 찜 목록 전체 삭제
  - 사용자 탈퇴 처리(비활성화)

## 🔍 참고 사항
- 탈퇴 차단은 ErrorCode.WITHDRAWAL_BLOCKED_PENDING_PICKUP(409)으로 응답합니다.
- 재가입 30일 제한 정책은 기존 로직(REJOIN_NOT_AVAILABLE_YET)을 유지합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #89 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인