### PR TITLE
[MCJ-1511] FEAT: 사장님 공구 개설 요청 도메인 및 DB 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequest.kt
@@ -1,0 +1,106 @@
+package com.moongchijang.domain.owner.domain.entity
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Entity
+@Table(
+    name = "owner_group_buy_requests",
+    indexes = [
+        Index(name = "idx_owner_gbr_owner_id", columnList = "owner_id"),
+        Index(name = "idx_owner_gbr_store_id", columnList = "store_id"),
+        Index(name = "idx_owner_gbr_status", columnList = "status"),
+        Index(name = "idx_owner_gbr_created_at", columnList = "created_at")
+    ]
+)
+class OwnerGroupBuyRequest(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    var owner: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    var store: Store,
+
+    @Column(name = "product_name", nullable = false, length = 100)
+    var productName: String,
+
+    @Column(name = "product_description", nullable = false, columnDefinition = "TEXT")
+    var productDescription: String,
+
+    @Column(name = "original_price")
+    var originalPrice: Int? = null,
+
+    @Column(nullable = false)
+    var price: Int,
+
+    @Column(name = "target_quantity", nullable = false)
+    var targetQuantity: Int,
+
+    @Column(name = "max_quantity", nullable = false)
+    var maxQuantity: Int,
+
+    @Column(name = "per_user_limit")
+    var perUserLimit: Int? = null,
+
+    @Column(name = "thumbnail_url", nullable = false, length = 500)
+    var thumbnailUrl: String,
+
+    @Column(nullable = false)
+    var deadline: LocalDateTime,
+
+    @Column(name = "pickup_date", nullable = false)
+    var pickupDate: LocalDate,
+
+    @Column(name = "pickup_time_start", nullable = false)
+    var pickupTimeStart: LocalTime,
+
+    @Column(name = "pickup_time_end", nullable = false)
+    var pickupTimeEnd: LocalTime,
+
+    @Column(name = "pickup_location", nullable = false, length = 200)
+    var pickupLocation: String,
+
+    @Column(name = "pickup_contact", length = 20)
+    var pickupContact: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    var status: OwnerGroupBuyRequestStatus = OwnerGroupBuyRequestStatus.PENDING,
+
+    @Column(name = "rejection_reason", length = 200)
+    var rejectionReason: String? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "approved_group_buy_id")
+    var approvedGroupBuy: GroupBuy? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewed_by")
+    var reviewedBy: User? = null,
+
+    @Column(name = "reviewed_at")
+    var reviewedAt: LocalDateTime? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity()

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequestImage.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequestImage.kt
@@ -1,0 +1,44 @@
+package com.moongchijang.domain.owner.domain.entity
+
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "owner_group_buy_request_images",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_owner_gbr_images_request_sort",
+            columnNames = ["request_id", "sort_order"]
+        )
+    ],
+    indexes = [
+        Index(name = "idx_owner_gbr_images_request_id", columnList = "request_id")
+    ]
+)
+class OwnerGroupBuyRequestImage(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id", nullable = false)
+    var request: OwnerGroupBuyRequest,
+
+    @Column(name = "image_url", nullable = false, length = 500)
+    var imageUrl: String,
+
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity()

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequestStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequestStatus.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.owner.domain.entity
+
+enum class OwnerGroupBuyRequestStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestImageRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestImageRepository.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.domain.owner.domain.repository
+
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface OwnerGroupBuyRequestImageRepository : JpaRepository<OwnerGroupBuyRequestImage, Long> {
+
+    @Query("SELECT i FROM OwnerGroupBuyRequestImage i WHERE i.request.id = :requestId ORDER BY i.sortOrder ASC")
+    fun findAllByRequestIdOrderBySortOrderAsc(@Param("requestId") requestId: Long): List<OwnerGroupBuyRequestImage>
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
@@ -1,0 +1,15 @@
+package com.moongchijang.domain.owner.domain.repository
+
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, Long> {
+
+    @Query("SELECT r FROM OwnerGroupBuyRequest r WHERE r.owner.id = :ownerId ORDER BY r.createdAt DESC")
+    fun findByOwnerIdOrderByCreatedAtDesc(@Param("ownerId") ownerId: Long): List<OwnerGroupBuyRequest>
+
+    fun findByStatusOrderByCreatedAtAsc(status: OwnerGroupBuyRequestStatus): List<OwnerGroupBuyRequest>
+}

--- a/src/main/kotlin/com/moongchijang/domain/store/domain/repository/StoreStaffRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/domain/repository/StoreStaffRepository.kt
@@ -1,0 +1,17 @@
+package com.moongchijang.domain.store.domain.repository
+
+import com.moongchijang.domain.store.domain.entity.StoreStaff
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface StoreStaffRepository : JpaRepository<StoreStaff, Long> {
+
+    fun existsByUserIdAndStoreId(userId: Long, storeId: Long): Boolean
+
+    @Query("SELECT ss FROM StoreStaff ss JOIN FETCH ss.store WHERE ss.user.id = :userId")
+    fun findAllByUserId(@Param("userId") userId: Long): List<StoreStaff>
+
+    @Query("SELECT ss.store.id FROM StoreStaff ss WHERE ss.user.id = :userId")
+    fun findStoreIdsByUserId(@Param("userId") userId: Long): List<Long>
+}

--- a/src/main/resources/db/migration/V22__create_owner_group_buy_request_tables.sql
+++ b/src/main/resources/db/migration/V22__create_owner_group_buy_request_tables.sql
@@ -1,0 +1,50 @@
+CREATE TABLE owner_group_buy_requests (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    owner_id BIGINT NOT NULL,
+    store_id BIGINT NOT NULL,
+    product_name VARCHAR(100) NOT NULL,
+    product_description TEXT NOT NULL,
+    original_price INT NULL,
+    price INT NOT NULL,
+    target_quantity INT NOT NULL,
+    max_quantity INT NOT NULL,
+    per_user_limit INT NULL,
+    thumbnail_url VARCHAR(500) NOT NULL,
+    deadline DATETIME NOT NULL,
+    pickup_date DATE NOT NULL,
+    pickup_time_start TIME NOT NULL,
+    pickup_time_end TIME NOT NULL,
+    pickup_location VARCHAR(200) NOT NULL,
+    pickup_contact VARCHAR(20) NULL,
+    status VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+    rejection_reason VARCHAR(200) NULL,
+    approved_group_buy_id BIGINT NULL,
+    reviewed_by BIGINT NULL,
+    reviewed_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_owner_gbr_owner_id FOREIGN KEY (owner_id) REFERENCES users (id),
+    CONSTRAINT fk_owner_gbr_store_id FOREIGN KEY (store_id) REFERENCES stores (id),
+    CONSTRAINT fk_owner_gbr_approved_group_buy_id FOREIGN KEY (approved_group_buy_id) REFERENCES group_buys (id),
+    CONSTRAINT fk_owner_gbr_reviewed_by FOREIGN KEY (reviewed_by) REFERENCES users (id)
+);
+
+CREATE INDEX idx_owner_gbr_owner_id ON owner_group_buy_requests (owner_id);
+CREATE INDEX idx_owner_gbr_store_id ON owner_group_buy_requests (store_id);
+CREATE INDEX idx_owner_gbr_status ON owner_group_buy_requests (status);
+CREATE INDEX idx_owner_gbr_created_at ON owner_group_buy_requests (created_at);
+
+CREATE TABLE owner_group_buy_request_images (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    request_id BIGINT NOT NULL,
+    image_url VARCHAR(500) NOT NULL,
+    sort_order INT NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_owner_gbr_images_request_id FOREIGN KEY (request_id) REFERENCES owner_group_buy_requests (id)
+);
+
+CREATE INDEX idx_owner_gbr_images_request_id ON owner_group_buy_request_images (request_id);
+CREATE UNIQUE INDEX uk_owner_gbr_images_request_sort ON owner_group_buy_request_images (request_id, sort_order);


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 공구 개설 요청을 소비자 요청과 분리해 저장할 `owner_group_buy_requests` 테이블을 추가했습니다.
- 사장님 요청 이미지 정렬 저장을 위한 `owner_group_buy_request_images` 테이블을 추가했습니다.
- 사장님 공구 개설 요청 상태 enum, JPA Entity, Repository를 추가했습니다.
- 사장님-매장 권한 검증 기반으로 사용할 `StoreStaffRepository`를 추가했습니다.

## 🔍 참고 사항
- 이번 PR은 도메인/DB 기반 작업만 포함하며 API 엔드포인트는 추가하지 않았습니다.
- 따라서 `openapi.yaml`은 이번 PR에서 변경하지 않았고, 다음 API 구현 PR에서 요청/응답 스펙과 함께 최신화할 예정입니다.

## 🖼️ 스크린샷
없음

## 🔗 관련 이슈
Closes #178

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
