### PR TITLE
[MCJ-1514] FEAT: 사용자 조회 API 구현 및 사용자 응답 스펙 정합화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/auth/application/dto/AuthUserResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/dto/AuthUserResponse.kt
@@ -30,6 +30,9 @@ data class AuthUserResponse(
     @field:Schema(description = "서비스 역할", example = "BUYER")
     val role: UserRole,
 
+    @field:Schema(description = "마지막 사용 역할", example = "SELLER")
+    val lastRole: UserRole?,
+
     @field:Schema(description = "추가정보 입력 완료 여부", example = "false")
     val signupCompleted: Boolean,
 
@@ -51,6 +54,7 @@ data class AuthUserResponse(
             nickname = user.nickname,
             phoneNumber = user.phoneNumber,
             role = user.role,
+            lastRole = user.lastRole,
             signupCompleted = user.signupCompleted,
             deletedAt = user.deletedAt,
             createdAt = user.createdAt!!,

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.user.application
 
 import com.moongchijang.domain.auth.application.PhoneVerificationService
+import com.moongchijang.domain.auth.application.dto.AuthUserResponse
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -101,6 +102,15 @@ class UserService(
             nickname = nickname,
             available = !duplicated,
         )
+    }
+
+    @Transactional(readOnly = true)
+    fun getMyInfo(userId: Long): AuthUserResponse {
+        log.info("[UserService] 내 정보 조회 시작: userId={}", userId)
+        val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        log.info("[UserService] 내 정보 조회 완료: userId={}", userId)
+        return AuthUserResponse.from(user)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.user.presentation
 
 import com.moongchijang.domain.user.application.UserService
+import com.moongchijang.domain.auth.application.dto.AuthUserResponse
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpdatedResponse
 import com.moongchijang.domain.user.application.dto.NicknameAvailabilityResponse
@@ -47,6 +48,25 @@ class UserController(
         @RequestParam nickname: String,
     ): ApiResponse<NicknameAvailabilityResponse> {
         val response = userService.checkNicknameAvailability(nickname)
+        return ApiResponse.success(response)
+    }
+
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "내 정보 조회", description = "인증된 사용자의 계정 정보를 조회합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "404", description = "사용자 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun getMyInfo(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+    ): ApiResponse<AuthUserResponse> {
+        log.info("[UserController] 내 정보 조회 요청 수신: userId={}", principal.id)
+        val response = userService.getMyInfo(principal.id)
+        log.info("[UserController] 내 정보 조회 응답 완료: userId={}", principal.id)
         return ApiResponse.success(response)
     }
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2279,6 +2279,10 @@ components:
         role:
           type: string
           enum: [BUYER, SELLER, ADMIN]
+        lastRole:
+          type: string
+          nullable: true
+          enum: [BUYER, SELLER, ADMIN]
         signupCompleted: { type: boolean }
         deletedAt:
           type: string

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -259,6 +259,29 @@ class UserServiceTest {
     }
 
     @Test
+    fun `내 정보 조회 성공`() {
+        val user = UserFixture.createKakaoUser(id = 41L, providerId = "kakao-41", nickname = "조회유저")
+        setAuditFields(user, LocalDateTime.now(), LocalDateTime.now())
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(41L)).thenReturn(user)
+
+        val response = userService.getMyInfo(41L)
+
+        Assertions.assertEquals(41L, response.id)
+        Assertions.assertEquals(user.role, response.role)
+    }
+
+    @Test
+    fun `내 정보 조회 사용자 없음 예외`() {
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(null)
+
+        val exception = assertThrows<CustomException> {
+            userService.getMyInfo(42L)
+        }
+
+        Assertions.assertEquals(ErrorCode.USER_NOT_FOUND, exception.errorCode)
+    }
+
+    @Test
     fun `회원탈퇴 불가 예외`() {
         Mockito.`when`(
             participationRepository.existsPendingPickupForWithdrawal(
@@ -363,5 +386,17 @@ class UserServiceTest {
         }
 
         Assertions.assertEquals(ErrorCode.WITHDRAWAL_REASON_DETAIL_REQUIRED, exception.errorCode)
+    }
+
+    private fun setAuditFields(user: User, createdAt: LocalDateTime, updatedAt: LocalDateTime) {
+        val baseClass = user.javaClass.superclass
+
+        val createdAtField = baseClass.getDeclaredField("createdAt")
+        createdAtField.isAccessible = true
+        createdAtField.set(user, createdAt)
+
+        val updatedAtField = baseClass.getDeclaredField("updatedAt")
+        updatedAtField.isAccessible = true
+        updatedAtField.set(user, updatedAt)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -14,6 +14,7 @@ import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.WithdrawRequest
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.entity.WithdrawalReason
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
@@ -260,7 +261,9 @@ class UserServiceTest {
 
     @Test
     fun `내 정보 조회 성공`() {
-        val user = UserFixture.createKakaoUser(id = 41L, providerId = "kakao-41", nickname = "조회유저")
+        val user = UserFixture.createKakaoUser(id = 41L, providerId = "kakao-41", nickname = "조회유저").apply {
+            lastRole = UserRole.SELLER
+        }
         setAuditFields(user, LocalDateTime.now(), LocalDateTime.now())
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(41L)).thenReturn(user)
 
@@ -268,6 +271,7 @@ class UserServiceTest {
 
         Assertions.assertEquals(41L, response.id)
         Assertions.assertEquals(user.role, response.role)
+        Assertions.assertEquals(user.lastRole, response.lastRole)
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/users/me` 엔드포인트를 구현했습니다.
- 인증 사용자 기준으로 활성 사용자 정보를 조회하는 서비스 로직을 추가했습니다.
- 사용자 응답 DTO에 `lastRole` 필드를 반영해 실제 사용자 상태를 함께 반환하도록 맞췄습니다.
- OpenAPI `AuthUser` 스키마에 `lastRole` 필드를 반영했습니다.

## 🔍 참고 사항
- 조회 대상은 활성 사용자(`deletedAt is null`) 기준이며, 없을 경우 `USER_NOT_FOUND(404)`를 반환합니다.
- 로그인 후 초기 진입 분기에서 사용하는 `lastRole` 값을 `/users/me` 응답으로 직접 확인할 수 있습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #182 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인