### PR TITLE
[MCJ-1516] FEAT: 알림 딥링크 타겟 ID 매핑 정합성 반영

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -78,7 +78,7 @@ class GroupBuyOpenRequestService(
         )
         if (result.targetUserIds.isNotEmpty()) {
             notificationEventPublisher.publishRequestOpened(
-                targetGroupBuyId = groupBuy.id,
+                requestId = groupBuy.groupBuyRequest.id,
                 requesterUserIds = result.targetUserIds,
                 occurredAt = java.time.LocalDateTime.now()
             )

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
@@ -69,44 +69,44 @@ class NotificationEventPublisher(
     }
 
     fun publishRequestOpened(
-        targetGroupBuyId: Long,
+        requestId: Long,
         requesterUserIds: List<Long>,
         occurredAt: LocalDateTime
     ) {
         publish(
             triggerType = NotificationTriggerType.REQUEST_OPENED_IMMEDIATE,
-            targetId = targetGroupBuyId,
+            targetId = requestId,
             userIds = requesterUserIds,
-            scheduleKey = "request-opened:$targetGroupBuyId",
+            scheduleKey = "request-opened:$requestId",
             occurredAt = occurredAt
         )
     }
 
     fun publishRequestNewParticipant(
-        targetGroupBuyId: Long,
+        requestId: Long,
         requesterUserId: Long,
         participationId: Long,
         occurredAt: LocalDateTime
     ) {
         publish(
             triggerType = NotificationTriggerType.REQUEST_NEW_PARTICIPANT_IMMEDIATE,
-            targetId = targetGroupBuyId,
+            targetId = requestId,
             userIds = listOf(requesterUserId),
-            scheduleKey = "request-new-participant:$targetGroupBuyId:$participationId",
+            scheduleKey = "request-new-participant:$requestId:$participationId",
             occurredAt = occurredAt
         )
     }
 
     fun publishRequestTargetAchieved(
-        targetGroupBuyId: Long,
+        requestId: Long,
         requesterUserId: Long,
         occurredAt: LocalDateTime
     ) {
         publish(
             triggerType = NotificationTriggerType.REQUEST_TARGET_ACHIEVED_IMMEDIATE,
-            targetId = targetGroupBuyId,
+            targetId = requestId,
             userIds = listOf(requesterUserId),
-            scheduleKey = "request-target-achieved:$targetGroupBuyId",
+            scheduleKey = "request-target-achieved:$requestId",
             occurredAt = occurredAt
         )
     }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -152,7 +152,10 @@ class NotificationImmediateDispatchService(
         val variables = mutableMapOf<String, String>()
 
         when (triggerType) {
+            NotificationTriggerType.REQUEST_OPENED_IMMEDIATE,
             NotificationTriggerType.REQUEST_REJECTED_IMMEDIATE,
+            NotificationTriggerType.REQUEST_NEW_PARTICIPANT_IMMEDIATE,
+            NotificationTriggerType.REQUEST_TARGET_ACHIEVED_IMMEDIATE,
             NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS -> {
                 val groupBuyRequest = groupBuyRequestRepository.findById(targetId)
                     .orElseThrow {
@@ -164,6 +167,11 @@ class NotificationImmediateDispatchService(
 
                 variables["상품명"] = groupBuyRequest.productName
                 variables["목표참여개수"] = groupBuyRequest.desiredQuantity.toString()
+                groupBuyRequest.openedGroupBuyId?.let { openedGroupBuyId ->
+                    groupBuyRepository.findWithStoreById(openedGroupBuyId).ifPresent { groupBuy ->
+                        variables["현재참여개수"] = groupBuy.currentQuantity.toString()
+                    }
+                }
             }
 
             else -> {

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -108,7 +108,7 @@ class NotificationTriggerScheduler(
             ).plusMinutes(30)
             notificationEventPublisher.publishScheduledTrigger(
                 triggerType = NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF,
-                targetId = participation.groupBuy.id,
+                targetId = participation.id,
                 userIds = listOf(participation.user.id!!),
                 scheduleKey = "pickup-cutoff:${participation.id}:${cutoffAt}",
                 occurredAt = now
@@ -140,14 +140,13 @@ class NotificationTriggerScheduler(
             pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY)
         )
 
-        participations.groupBy { it.groupBuy.id }.forEach { (groupBuyId, items) ->
-            val userIds = items.mapNotNull { it.user.id }.distinct()
-            if (userIds.isEmpty()) return@forEach
+        participations.forEach { participation ->
+            val userId = participation.user.id ?: return@forEach
             notificationEventPublisher.publishScheduledTrigger(
                 triggerType = triggerType,
-                targetId = groupBuyId,
-                userIds = userIds,
-                scheduleKey = "$scheduleKeyPrefix:$groupBuyId:$pickupDate",
+                targetId = participation.id,
+                userIds = listOf(userId),
+                scheduleKey = "$scheduleKeyPrefix:${participation.id}:$pickupDate",
                 occurredAt = occurredAt
             )
         }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -106,10 +106,11 @@ class NotificationTriggerScheduler(
                 participation.groupBuy.pickupDate,
                 participation.groupBuy.pickupTimeEnd
             ).plusMinutes(30)
+            val userId = requireNotNull(participation.user.id) { "참여자 userId는 null일 수 없습니다." }
             notificationEventPublisher.publishScheduledTrigger(
                 triggerType = NotificationTriggerType.PICKUP_NOT_COMPLETED_AFTER_CUTOFF,
                 targetId = participation.id,
-                userIds = listOf(participation.user.id!!),
+                userIds = listOf(userId),
                 scheduleKey = "pickup-cutoff:${participation.id}:${cutoffAt}",
                 occurredAt = now
             )
@@ -141,7 +142,7 @@ class NotificationTriggerScheduler(
         )
 
         participations.forEach { participation ->
-            val userId = participation.user.id ?: return@forEach
+            val userId = requireNotNull(participation.user.id) { "참여자 userId는 null일 수 없습니다." }
             notificationEventPublisher.publishScheduledTrigger(
                 triggerType = triggerType,
                 targetId = participation.id,

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/deeplink/NotificationDeeplinkSchema.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/deeplink/NotificationDeeplinkSchema.kt
@@ -10,10 +10,10 @@ object NotificationDeeplinkSchema {
         }
 
         return when (deeplinkType) {
-            NotificationDeeplinkType.PICKUP_GUIDE -> mapOf("groupBuyId" to targetId.toString())
+            NotificationDeeplinkType.PICKUP_GUIDE -> mapOf("participationId" to targetId.toString())
             NotificationDeeplinkType.GROUPBUY_DETAIL -> mapOf("groupBuyId" to targetId.toString())
             NotificationDeeplinkType.MY_APPLYING -> mapOf("groupBuyId" to targetId.toString())
-            NotificationDeeplinkType.REQUEST_STATUS -> mapOf("targetId" to targetId.toString())
+            NotificationDeeplinkType.REQUEST_STATUS -> mapOf("requestId" to targetId.toString())
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
@@ -36,8 +36,8 @@ data class NotificationItemResponse(
     val deeplinkType: NotificationDeeplinkType,
 
     @field:Schema(
-        description = "딥링크 파라미터. PICKUP_GUIDE/GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 targetId를 사용합니다.",
-        example = "{\"groupBuyId\":\"2001\"}"
+        description = "딥링크 파라미터. PICKUP_GUIDE는 participationId, GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 requestId를 사용합니다.",
+        example = "{\"participationId\":\"2001\"}"
     )
     val deeplinkParams: Map<String, String>,
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -438,11 +438,12 @@ class PaymentService(
         occurredAt: LocalDateTime
     ) {
         val requesterUserId = groupBuy.groupBuyRequest.userId
+        val requestId = groupBuy.groupBuyRequest.id
         val participantUserId = participation.user.id ?: return
         if (requesterUserId == participantUserId) return
 
         notificationEventPublisher.publishRequestNewParticipant(
-            targetGroupBuyId = groupBuy.id,
+            requestId = requestId,
             requesterUserId = requesterUserId,
             participationId = participation.id,
             occurredAt = occurredAt
@@ -451,8 +452,9 @@ class PaymentService(
 
     private fun publishRequestTargetAchievedEvent(groupBuy: GroupBuy, occurredAt: LocalDateTime) {
         val requesterUserId = groupBuy.groupBuyRequest.userId
+        val requestId = groupBuy.groupBuyRequest.id
         notificationEventPublisher.publishRequestTargetAchieved(
-            targetGroupBuyId = groupBuy.id,
+            requestId = requestId,
             requesterUserId = requesterUserId,
             occurredAt = occurredAt
         )

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3166,11 +3166,11 @@ components:
           $ref: '#/components/schemas/NotificationDeeplinkType'
         deeplinkParams:
           type: object
-          description: 딥링크 파라미터. PICKUP_GUIDE/GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 targetId를 사용합니다.
+          description: 딥링크 파라미터. PICKUP_GUIDE는 participationId, GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 requestId를 사용합니다.
           additionalProperties:
             type: string
           example:
-            groupBuyId: "2001"
+            participationId: "2001"
         section:
           $ref: '#/components/schemas/NotificationSection'
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -295,6 +295,11 @@ class GroupBuyOpenRequestServiceTest {
         assertEquals(1, result.sentCount)
         assertEquals(0, result.failedCount)
         verify(aligoAlimtalkClient).send("01012345678", "[뭉치장] 요청하신 서울 전체 소금빵 공구가 열렸어요.")
+        val invocation = mockingDetails(notificationEventPublisher).invocations
+            .first { it.method.name == "publishRequestOpened" }
+        assertEquals(200L, invocation.arguments[0])
+        assertEquals(listOf(1L), invocation.arguments[1])
+        assertTrue(invocation.arguments[2] is LocalDateTime)
     }
 
     private fun createUser(id: Long, phoneNumber: String?): User =
@@ -319,7 +324,7 @@ class GroupBuyOpenRequestServiceTest {
                 productName = productName,
                 desiredQuantity = 10,
                 desiredPickupDate = LocalDate.now().plusDays(3),
-            ),
+            ).apply { id = 200L },
             productName = productName,
             productDescription = "설명",
             price = 6000,

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationDeeplinkSchemaTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationDeeplinkSchemaTest.kt
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test
 class NotificationDeeplinkSchemaTest {
 
     @Test
-    fun `PICKUP_GUIDE 딥링크 파라미터는 groupBuyId 반환`() {
+    fun `PICKUP_GUIDE 딥링크 파라미터는 participationId 반환`() {
         val params = NotificationDeeplinkSchema.toParams(NotificationDeeplinkType.PICKUP_GUIDE, 11L)
-        assertEquals("11", params["groupBuyId"])
+        assertEquals("11", params["participationId"])
     }
 
     @Test
@@ -27,9 +27,9 @@ class NotificationDeeplinkSchemaTest {
     }
 
     @Test
-    fun `REQUEST_STATUS 딥링크 파라미터는 targetId 반환`() {
+    fun `REQUEST_STATUS 딥링크 파라미터는 requestId 반환`() {
         val params = NotificationDeeplinkSchema.toParams(NotificationDeeplinkType.REQUEST_STATUS, 14L)
-        assertEquals("14", params["targetId"])
+        assertEquals("14", params["requestId"])
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
@@ -106,16 +106,16 @@ class NotificationTriggerSchedulerTest {
 
         verify(notificationEventPublisher).publishScheduledTrigger(
             NotificationTriggerType.PICKUP_SAME_DAY_MORNING,
-            11L,
+            1L,
             listOf(1L),
-            "pickup-same-day-morning:11:${now.toLocalDate()}",
+            "pickup-same-day-morning:1:${now.toLocalDate()}",
             now
         )
         verify(notificationEventPublisher).publishScheduledTrigger(
             NotificationTriggerType.PICKUP_DAY_BEFORE_MORNING,
-            12L,
+            2L,
             listOf(1L),
-            "pickup-day-before-morning:12:${now.toLocalDate().plusDays(1)}",
+            "pickup-day-before-morning:2:${now.toLocalDate().plusDays(1)}",
             now
         )
     }

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -302,6 +302,7 @@ class PaymentServiceTest {
         val user = UserFixture.createKakaoUser(id = 1L)
         val groupBuy = createGroupBuy(currentQuantity = 49)
         val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        val approvedAt = LocalDateTime.of(2026, 5, 17, 12, 0)
         stubTransaction()
         `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
         `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
@@ -312,7 +313,7 @@ class PaymentServiceTest {
         `when`(groupBuyRepository.findById(10L)).thenReturn(Optional.of(groupBuy))
         `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(false)
         `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
-            .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 6000, "CARD", LocalDateTime.now()))
+            .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 6000, "CARD", approvedAt))
         `when`(participationRepository.save(any(Participation::class.java))).thenAnswer {
             (it.arguments[0] as Participation).apply { id = 100L }
         }
@@ -322,6 +323,45 @@ class PaymentServiceTest {
 
         assertEquals(ParticipationStatus.CONFIRMED, result.participationStatus)
         assertEquals(GroupBuyStatus.ACHIEVED, groupBuy.status)
+        verify(notificationEventPublisher).publishRequestTargetAchieved(20L, 1L, approvedAt)
+    }
+
+    @Test
+    fun `요청공구에 다른 사용자가 참여할 때 requestId 기준 새 참여자 알림 발행`() {
+        val requester = UserFixture.createKakaoUser(id = 1L)
+        val participantUser = UserFixture.createKakaoUser(id = 2L)
+        val groupBuy = createGroupBuy().apply {
+            groupBuyRequest = GroupBuyRequest(
+                userId = 1L,
+                storeName = "뭉치장 베이커리",
+                storeAddress = "서울 성동구",
+                productName = "두쫀쿠",
+                desiredQuantity = 50,
+                desiredPickupDate = LocalDate.now().plusDays(5)
+            ).apply { id = 320L }
+        }
+        val order = createPaymentOrder(user = participantUser, groupBuy = groupBuy, quantity = 1)
+        val approvedAt = LocalDateTime.of(2026, 5, 17, 12, 0)
+
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate("MCJ-10-test")).thenReturn(order)
+        `when`(groupBuyRepository.increaseCurrentQuantityIfAvailable(10L, 1)).thenAnswer {
+            groupBuy.currentQuantity += 1
+            1
+        }
+        `when`(groupBuyRepository.findById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(2L, 10L)).thenReturn(false)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenReturn(PortOnePaymentResult("MCJ-10-test", "PAID", 6000, "CARD", approvedAt))
+        `when`(participationRepository.save(any(Participation::class.java))).thenAnswer {
+            (it.arguments[0] as Participation).apply { id = 210L }
+        }
+        `when`(paymentOrderRepository.save(any(PaymentOrder::class.java))).thenAnswer { it.arguments[0] }
+
+        service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 6000), 2L)
+
+        verify(notificationEventPublisher).publishRequestNewParticipant(320L, 1L, 210L, approvedAt)
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업한 내용
- 알림 딥링크 타입별 `targetId` 매핑을 정합성 있게 정리했습니다.
- `NotificationDeeplinkSchema` 기준을 아래와 같이 확정했습니다.
  - `PICKUP_GUIDE` → `participationId`
  - `GROUPBUY_DETAIL` → `groupBuyId`
  - `MY_APPLYING` → `groupBuyId`
  - `REQUEST_STATUS` → `requestId`
- 요청공구 관련 즉시 알림(개설/신규 참여/목표 달성) 발행 시 `targetId`를 `groupBuyId`가 아닌 `requestId`로 전달하도록 반영했습니다.
- 픽업 리마인드/픽업 완료 확인 알림의 타겟 식별이 참여 단위로 이어지도록 매핑을 정리했습니다.
- 매핑 회귀 방지를 위해 서비스 테스트를 보강했습니다.
  - `GroupBuyOpenRequestServiceTest`: 요청공구 개설 알림 발행 시 `requestId` 기준 검증
  - `PaymentServiceTest`: 신규 참여/목표 달성 알림 발행 시 `requestId` 기준 검증

## 🔍 참고 사항
- 이번 PR은 “딥링크 타겟 ID 정합성”에 집중한 변경입니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #184 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인