### PR TITLE
[MCJ-1517] FEAT: 알림 triggerType 식별자 추가 및 매핑 표준화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -249,7 +249,8 @@ class NotificationImmediateDispatchService(
                     body = meta.body,
                     occurredAt = event.occurredAt,
                     targetId = event.targetId,
-                    deeplinkType = meta.deeplinkType
+                    deeplinkType = meta.deeplinkType,
+                    triggerType = event.triggerType
                 )
             )
             history.markSuccess(event.occurredAt)

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.notification.application.dto
 import com.moongchijang.domain.notification.application.deeplink.NotificationDeeplinkSchema
 import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
@@ -36,6 +37,12 @@ data class NotificationItemResponse(
     val deeplinkType: NotificationDeeplinkType,
 
     @field:Schema(
+        description = "알림 트리거 타입(시나리오 식별자). 1~14 시나리오 분기 기준으로 사용합니다.",
+        example = "PICKUP_SAME_DAY_MORNING"
+    )
+    val triggerType: NotificationTriggerType?,
+
+    @field:Schema(
         description = "딥링크 파라미터. PICKUP_GUIDE는 participationId, GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 requestId를 사용합니다.",
         example = "{\"participationId\":\"2001\"}"
     )
@@ -55,6 +62,7 @@ data class NotificationItemResponse(
                 occurredAt = notification.occurredAt,
                 targetId = notification.targetId,
                 deeplinkType = notification.deeplinkType,
+                triggerType = notification.triggerType,
                 deeplinkParams = NotificationDeeplinkSchema.toParams(notification.deeplinkType, notification.targetId),
                 section = resolveSection(notification.occurredAt.toLocalDate(), today)
             )

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
@@ -54,6 +54,10 @@ class Notification(
     @Column(name = "deeplink_type", nullable = false, length = 30)
     var deeplinkType: NotificationDeeplinkType,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trigger_type", length = 50)
+    var triggerType: NotificationTriggerType? = null,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L

--- a/src/main/resources/db/migration/V23__alter_notifications_add_trigger_type.sql
+++ b/src/main/resources/db/migration/V23__alter_notifications_add_trigger_type.sql
@@ -1,0 +1,5 @@
+ALTER TABLE notifications
+    ADD COLUMN trigger_type VARCHAR(50) NULL AFTER deeplink_type;
+
+CREATE INDEX idx_notifications_user_trigger_type_occurred_at
+    ON notifications (user_id, trigger_type, occurred_at DESC);

--- a/src/main/resources/db/migration/V23__alter_notifications_add_trigger_type.sql
+++ b/src/main/resources/db/migration/V23__alter_notifications_add_trigger_type.sql
@@ -1,5 +1,2 @@
 ALTER TABLE notifications
     ADD COLUMN trigger_type VARCHAR(50) NULL AFTER deeplink_type;
-
-CREATE INDEX idx_notifications_user_trigger_type_occurred_at
-    ON notifications (user_id, trigger_type, occurred_at DESC);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3135,6 +3135,40 @@ components:
       type: string
       enum: [PICKUP_GUIDE, GROUPBUY_DETAIL, MY_APPLYING, REQUEST_STATUS]
 
+    NotificationTriggerType:
+      type: string
+      description: |
+        알림 시나리오 식별자입니다.
+        1=PICKUP_SAME_DAY_MORNING
+        2=PICKUP_DAY_BEFORE_MORNING
+        3=PICKUP_NOT_COMPLETED_AFTER_CUTOFF
+        4=WISH_DEADLINE_MINUS_3_DAYS
+        5=WISH_DEADLINE_MINUS_1_DAY
+        6=WISH_TARGET_ACHIEVED_IMMEDIATE
+        7=APPLY_PAYMENT_SUCCESS_IMMEDIATE
+        8=APPLY_GROUPBUY_ACHIEVED_IMMEDIATE
+        9=APPLY_GROUPBUY_FAILED_IMMEDIATE
+        10=REQUEST_OPENED_IMMEDIATE
+        11=REQUEST_REJECTED_IMMEDIATE
+        12=REQUEST_NEW_PARTICIPANT_IMMEDIATE
+        13=REQUEST_TARGET_ACHIEVED_IMMEDIATE
+        14=REQUEST_DEADLINE_MINUS_3_DAYS
+      enum:
+        - PICKUP_SAME_DAY_MORNING
+        - PICKUP_DAY_BEFORE_MORNING
+        - PICKUP_NOT_COMPLETED_AFTER_CUTOFF
+        - WISH_DEADLINE_MINUS_3_DAYS
+        - WISH_DEADLINE_MINUS_1_DAY
+        - WISH_TARGET_ACHIEVED_IMMEDIATE
+        - APPLY_PAYMENT_SUCCESS_IMMEDIATE
+        - APPLY_GROUPBUY_ACHIEVED_IMMEDIATE
+        - APPLY_GROUPBUY_FAILED_IMMEDIATE
+        - REQUEST_OPENED_IMMEDIATE
+        - REQUEST_REJECTED_IMMEDIATE
+        - REQUEST_NEW_PARTICIPANT_IMMEDIATE
+        - REQUEST_TARGET_ACHIEVED_IMMEDIATE
+        - REQUEST_DEADLINE_MINUS_3_DAYS
+
     NotificationSection:
       type: string
       enum: [TODAY, YESTERDAY, OLDER]
@@ -3164,6 +3198,11 @@ components:
           nullable: true
         deeplinkType:
           $ref: '#/components/schemas/NotificationDeeplinkType'
+        triggerType:
+          allOf:
+            - $ref: '#/components/schemas/NotificationTriggerType'
+          nullable: true
+          description: 알림 트리거 타입(1~14 시나리오 식별). 기존 데이터는 null일 수 있습니다.
         deeplinkParams:
           type: object
           description: 딥링크 파라미터. PICKUP_GUIDE는 participationId, GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 requestId를 사용합니다.

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchServiceTest.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.notification.application.template.NotificationTem
 import com.moongchijang.domain.notification.application.template.NotificationTemplateRenderer
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
@@ -141,7 +142,9 @@ class NotificationImmediateDispatchServiceTest {
         service.dispatch(event)
 
         assertEquals(NotificationDispatchStatus.SUCCESS, pending.status)
-        verify(notificationRepository).save(any())
+        val notificationCaptor = org.mockito.ArgumentCaptor.forClass(Notification::class.java)
+        verify(notificationRepository).save(notificationCaptor.capture())
+        assertEquals(NotificationTriggerType.WISH_TARGET_ACHIEVED_IMMEDIATE, notificationCaptor.value.triggerType)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.application.dto.NotificationCategory
 import com.moongchijang.domain.notification.application.dto.NotificationCursor
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
 import com.moongchijang.support.NotificationFixture
@@ -30,7 +31,12 @@ class NotificationQueryServiceTest {
         val user = UserFixture.createEmailUser(id = 1L)
         val occurredAt = LocalDateTime.now().minusHours(1).withNano(0)
         val notifications = listOf(
-            NotificationFixture.createNotification(user = user, id = 11L, occurredAt = occurredAt)
+            NotificationFixture.createNotification(
+                user = user,
+                id = 11L,
+                occurredAt = occurredAt,
+                triggerType = NotificationTriggerType.PICKUP_SAME_DAY_MORNING
+            )
         )
 
         `when`(
@@ -59,6 +65,7 @@ class NotificationQueryServiceTest {
         )
         assertThat(result.items).hasSize(1)
         assertThat(result.items[0].id).isEqualTo(11L)
+        assertThat(result.items[0].triggerType).isEqualTo(NotificationTriggerType.PICKUP_SAME_DAY_MORNING)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/support/NotificationFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/NotificationFixture.kt
@@ -2,6 +2,7 @@ package com.moongchijang.support
 
 import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.user.domain.entity.User
 import java.time.LocalDateTime
@@ -18,6 +19,7 @@ object NotificationFixture {
         occurredAt: LocalDateTime = LocalDateTime.now(),
         targetId: Long? = null,
         deeplinkType: NotificationDeeplinkType = NotificationDeeplinkType.PICKUP_GUIDE,
+        triggerType: NotificationTriggerType? = null,
     ): Notification {
         return Notification(
             user = user,
@@ -28,6 +30,7 @@ object NotificationFixture {
             occurredAt = occurredAt,
             targetId = targetId,
             deeplinkType = deeplinkType,
+            triggerType = triggerType,
             id = id,
         )
     }


### PR DESCRIPTION
## 📌 작업한 내용

- 알림 시나리오를 식별할 수 있도록 `Notification.triggerType` 필드를 추가했습니다.
  - DB 마이그레이션: `notifications.trigger_type (VARCHAR(50), nullable)`
- 즉시 발송 저장 경로에서 `event.triggerType`이 알림 엔티티에 저장되도록 반영했습니다.
- 알림 목록 조회 응답에 `triggerType` 필드를 추가했습니다.
  - `NotificationItemResponse.triggerType`
- OpenAPI 문서에 `NotificationTriggerType` enum을 추가하고, 1~14 매핑을 명시했습니다.
- 테스트를 보강하여 저장/조회 매핑을 검증했습니다.
  - `NotificationImmediateDispatchServiceTest`: 저장 시 triggerType 반영 검증
  - `NotificationQueryServiceTest`: 목록 응답 triggerType 노출 검증
  - `NotificationFixture` 확장: triggerType 생성 지원

### 1~14 시나리오 매핑 표

| 번호 | triggerType | 분류 |
|---|---|---|
| 1 | `PICKUP_SAME_DAY_MORNING` | 픽업 |
| 2 | `PICKUP_DAY_BEFORE_MORNING` | 픽업 |
| 3 | `PICKUP_NOT_COMPLETED_AFTER_CUTOFF` | 픽업 |
| 4 | `WISH_DEADLINE_MINUS_3_DAYS` | 찜 |
| 5 | `WISH_DEADLINE_MINUS_1_DAY` | 찜 |
| 6 | `WISH_TARGET_ACHIEVED_IMMEDIATE` | 찜 |
| 7 | `APPLY_PAYMENT_SUCCESS_IMMEDIATE` | 신청 |
| 8 | `APPLY_GROUPBUY_ACHIEVED_IMMEDIATE` | 신청 |
| 9 | `APPLY_GROUPBUY_FAILED_IMMEDIATE` | 신청 |
| 10 | `REQUEST_OPENED_IMMEDIATE` | 요청 |
| 11 | `REQUEST_REJECTED_IMMEDIATE` | 요청 |
| 12 | `REQUEST_NEW_PARTICIPANT_IMMEDIATE` | 요청 |
| 13 | `REQUEST_TARGET_ACHIEVED_IMMEDIATE` | 요청 |
| 14 | `REQUEST_DEADLINE_MINUS_3_DAYS` | 요청 |

## 🔍 참고 사항

- `triggerType`은 기존 데이터 호환을 위해 nullable로 추가했습니다.
  - 신규 생성 알림부터 triggerType이 저장됩니다.
- 역할 분리 기준:
  - `type(PICKUP/WISH/APPLY/REQUEST)`: 카테고리 필터/아이콘 그룹
  - `triggerType`: 1~14 상세 시나리오 분기
- 딥링크 파라미터 스키마는 기존 정합성 기준을 유지합니다.
  - `PICKUP_GUIDE=participationId`
  - `GROUPBUY_DETAIL/MY_APPLYING=groupBuyId`
  - `REQUEST_STATUS=requestId`

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #186 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인