### PR TITLE
[MCJ-1519] FEAT: 이메일 인증 메일 HTML 템플릿 적용 및 인증코드 가독성 개선

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/NoopEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/NoopEmailSender.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.auth.infrastructure.email
 
 import com.moongchijang.domain.auth.application.port.EmailSender
+import com.moongchijang.global.util.MaskingUtils.maskEmail
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
@@ -14,7 +15,7 @@ class NoopEmailSender : EmailSender {
     override fun sendVerificationCode(toEmail: String, code: String, expiresInSeconds: Long) {
         log.info(
             "[NoopEmailSender] 발송 provider 설정으로 이메일 발송 생략: toEmail={}, expiresInSeconds={}",
-            toEmail,
+            maskEmail(toEmail),
             expiresInSeconds,
         )
     }

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/VerificationEmailTemplateProvider.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/VerificationEmailTemplateProvider.kt
@@ -16,10 +16,41 @@ class VerificationEmailTemplateProvider {
 
             인증코드는 ${expiresMinutes}분간 유효합니다.
         """.trimIndent()
+        val bodyHtml = """
+            <!doctype html>
+            <html lang="ko">
+            <body style="margin:0;padding:24px;background:#f8fafc;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Noto Sans KR',Arial,sans-serif;color:#111827;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;border-radius:12px;">
+                <tr>
+                  <td style="padding:28px 24px 12px 24px;font-size:24px;font-weight:700;line-height:1.3;">이메일 인증코드를 확인해주세요</td>
+                </tr>
+                <tr>
+                  <td style="padding:0 24px 20px 24px;font-size:16px;line-height:1.7;">
+                    안녕하세요, 뭉치장입니다.<br/>
+                    이메일 인증코드는 아래와 같습니다.
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0 24px 20px 24px;">
+                    <div style="background:#f3f4f6;border:1px solid #d1d5db;border-radius:10px;text-align:center;padding:18px 12px;">
+                      <span style="font-size:34px;font-weight:800;letter-spacing:6px;color:#111827;">$code</span>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding:0 24px 28px 24px;font-size:15px;color:#374151;line-height:1.6;">
+                    인증코드는 <b>${expiresMinutes}분</b>간 유효합니다.
+                  </td>
+                </tr>
+              </table>
+            </body>
+            </html>
+        """.trimIndent()
 
         return VerificationEmailTemplate(
             subject = subject,
-            bodyText = bodyText
+            bodyText = bodyText,
+            bodyHtml = bodyHtml
         )
     }
 }
@@ -27,4 +58,5 @@ class VerificationEmailTemplateProvider {
 data class VerificationEmailTemplate(
     val subject: String,
     val bodyText: String,
+    val bodyHtml: String,
 )

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSender.kt
@@ -8,8 +8,8 @@ import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.util.MaskingUtils.maskEmail
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.stereotype.Component
 
 @Component
@@ -24,15 +24,15 @@ class GoogleSmtpEmailSender(
     override fun sendVerificationCode(toEmail: String, code: String, expiresInSeconds: Long) {
         val template = verificationEmailTemplateProvider.build(code, expiresInSeconds)
 
-        val message = SimpleMailMessage().apply {
-            from = googleSmtpProperties.from
-            setTo(toEmail)
-            this.subject = template.subject
-            text = template.bodyText
-        }
-
         try {
-            javaMailSender.send(message)
+            val mimeMessage = javaMailSender.createMimeMessage()
+            val helper = MimeMessageHelper(mimeMessage, true, "UTF-8")
+            helper.setFrom(googleSmtpProperties.from)
+            helper.setTo(toEmail)
+            helper.setSubject(template.subject)
+            helper.setText(template.bodyText, template.bodyHtml)
+
+            javaMailSender.send(mimeMessage)
             log.info("[GoogleSmtpEmailSender] 이메일 발송 완료: toEmail={}", maskEmail(toEmail))
         } catch (e: Exception) {
             log.error("[GoogleSmtpEmailSender] 이메일 발송 실패: toEmail={}", maskEmail(toEmail), e)

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSender.kt
@@ -26,7 +26,7 @@ class GoogleSmtpEmailSender(
 
         try {
             val mimeMessage = javaMailSender.createMimeMessage()
-            val helper = MimeMessageHelper(mimeMessage, false, "UTF-8")
+            val helper = MimeMessageHelper(mimeMessage, true, "UTF-8")
             helper.setFrom(googleSmtpProperties.from)
             helper.setTo(toEmail)
             helper.setSubject(template.subject)

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSender.kt
@@ -26,7 +26,7 @@ class GoogleSmtpEmailSender(
 
         try {
             val mimeMessage = javaMailSender.createMimeMessage()
-            val helper = MimeMessageHelper(mimeMessage, true, "UTF-8")
+            val helper = MimeMessageHelper(mimeMessage, false, "UTF-8")
             helper.setFrom(googleSmtpProperties.from)
             helper.setTo(toEmail)
             helper.setSubject(template.subject)

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/ses/SesEmailSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/ses/SesEmailSender.kt
@@ -45,6 +45,7 @@ class SesEmailSender(
                             .body(
                                 Body.builder()
                                     .text(Content.builder().data(template.bodyText).charset("UTF-8").build())
+                                    .html(Content.builder().data(template.bodyHtml).charset("UTF-8").build())
                                     .build(),
                             )
                             .build(),

--- a/src/test/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSenderTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSenderTest.kt
@@ -4,18 +4,20 @@ import com.moongchijang.domain.auth.infrastructure.email.VerificationEmailTempla
 import com.moongchijang.global.config.GoogleSmtpProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import jakarta.mail.Session
+import jakarta.mail.internet.MimeMessage
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.any
 import org.springframework.mail.MailSendException
-import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
+import java.util.Properties
 
 class GoogleSmtpEmailSenderTest {
 
@@ -36,28 +38,27 @@ class GoogleSmtpEmailSenderTest {
 
     @Test
     fun `인증코드 메일 발송 성공`() {
+        val mimeMessage = MimeMessage(Session.getInstance(Properties()))
+        doReturn(mimeMessage).`when`(javaMailSender).createMimeMessage()
+
         sender.sendVerificationCode(
             toEmail = "user@example.com",
             code = "123456",
             expiresInSeconds = 180L
         )
 
-        val captor = ArgumentCaptor.forClass(SimpleMailMessage::class.java)
-        verify(javaMailSender, times(1)).send(captor.capture())
-        val sentMessage = captor.value
-
-        assertEquals("noreply.moongchijang@gmail.com", sentMessage.from)
-        assertEquals("user@example.com", sentMessage.to?.first())
-        assertEquals("[뭉치장] 이메일 인증코드를 확인해주세요", sentMessage.subject)
-        assert(sentMessage.text?.contains("123456") == true)
-        assert(sentMessage.text?.contains("3분간 유효") == true)
+        verify(javaMailSender, times(1)).send(mimeMessage)
+        assertEquals("[뭉치장] 이메일 인증코드를 확인해주세요", mimeMessage.subject)
     }
 
     @Test
     fun `인증코드 메일 발송 실패 시 EMAIL_SEND_FAILED 예외`() {
+        val mimeMessage = MimeMessage(Session.getInstance(Properties()))
+        doReturn(mimeMessage).`when`(javaMailSender).createMimeMessage()
+
         doThrow(MailSendException("fail"))
             .`when`(javaMailSender)
-            .send(any(SimpleMailMessage::class.java))
+            .send(any(MimeMessage::class.java))
 
         val ex = assertThrows<CustomException> {
             sender.sendVerificationCode(

--- a/src/test/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSenderTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/auth/infrastructure/email/google/GoogleSmtpEmailSenderTest.kt
@@ -5,6 +5,9 @@ import com.moongchijang.global.config.GoogleSmtpProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import jakarta.mail.Session
+import jakarta.mail.Multipart
+import jakarta.mail.Part
+import jakarta.mail.internet.InternetAddress
 import jakarta.mail.internet.MimeMessage
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -48,7 +51,11 @@ class GoogleSmtpEmailSenderTest {
         )
 
         verify(javaMailSender, times(1)).send(mimeMessage)
+        assertEquals("noreply.moongchijang@gmail.com", (mimeMessage.from.first() as InternetAddress).address)
         assertEquals("[뭉치장] 이메일 인증코드를 확인해주세요", mimeMessage.subject)
+        val bodies = collectBodyTexts(mimeMessage)
+        assert(bodies.any { it.contains("123456") })
+        assert(bodies.any { it.contains("3분") })
     }
 
     @Test
@@ -69,5 +76,18 @@ class GoogleSmtpEmailSenderTest {
         }
 
         assertEquals(ErrorCode.EMAIL_SEND_FAILED, ex.errorCode)
+    }
+
+    private fun collectBodyTexts(part: Part): List<String> {
+        val content = part.content
+        return when (content) {
+            is String -> listOf(content)
+            is Multipart -> {
+                (0 until content.count).flatMap { idx ->
+                    collectBodyTexts(content.getBodyPart(idx))
+                }
+            }
+            else -> emptyList()
+        }
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 이메일 인증 메일 템플릿을 text 전용에서 text+HTML 구조로 확장했습니다.
- 인증코드 가독성 개선을 위해 HTML 본문에 코드 강조 UI를 적용했습니다.
  - 큰 폰트, 굵은 글씨, letter-spacing, 박스 배경
- 인증 메일 템플릿 생성 로직을 공통 컴포넌트로 분리했습니다.
  - `VerificationEmailTemplateProvider`
- SES 발송 경로에 HTML 본문을 함께 포함하도록 반영했습니다.
- Google SMTP 발송 경로를 `MimeMessageHelper` 기반으로 전환하여 HTML 메일 발송을 지원했습니다.
- Google SMTP sender 테스트를 신규/수정하여 발송 성공/실패 케이스를 검증했습니다.
- Google SMTP 설정값 검증 및 타임아웃 설정을 프로퍼티로 분리했습니다.
  - `@Validated`, `@NotBlank(username/appPassword/from)`
  - `connectionTimeout`, `timeout`, `writeTimeout`
- 로그 개인정보 보호 보강:
  - `NoopEmailSender`의 수신 이메일 로그를 마스킹하도록 수정했습니다.

## 🔍 참고 사항
- 메일 본문은 HTML + plain text fallback을 함께 전송합니다.
- Google SMTP 사용 시 아래 설정이 필요합니다.
  - `EMAIL_PROVIDER=GOOGLE`
  - `GOOGLE_SMTP_USERNAME`
  - `GOOGLE_SMTP_APP_PASSWORD` (16자리 앱 비밀번호, 공백 없이 입력)
  - `GOOGLE_SMTP_FROM`
- SES 권한 이슈 발생 시 `EMAIL_PROVIDER=GOOGLE`로 즉시 우회 가능하며, 이후 `SES`로 롤백 가능합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #190 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인