### PR TITLE
[MCJ-1518] FEAT: 사장님 공구 개설 요청 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -15,6 +15,7 @@ import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Service
@@ -24,7 +25,8 @@ class OwnerGroupBuyRequestService(
     private val storeRepository: StoreRepository,
     private val storeStaffRepository: StoreStaffRepository,
     private val ownerGroupBuyRequestRepository: OwnerGroupBuyRequestRepository,
-    private val ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository
+    private val ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository,
+    private val clock: Clock
 ) {
 
     fun create(ownerId: Long, request: OwnerGroupBuyRequestCreateRequest): OwnerGroupBuyRequestCreateResponse {
@@ -83,7 +85,7 @@ class OwnerGroupBuyRequestService(
     }
 
     private fun validateRequest(request: OwnerGroupBuyRequestCreateRequest) {
-        if (request.deadline.isBefore(LocalDateTime.now().plusDays(MIN_RECRUITING_DAYS))) {
+        if (request.deadline.isBefore(LocalDateTime.now(clock).plusDays(MIN_RECRUITING_DAYS))) {
             throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_DEADLINE)
         }
 
@@ -99,7 +101,7 @@ class OwnerGroupBuyRequestService(
             throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_TIME)
         }
 
-        if (request.pickupDate.isBefore(request.deadline.toLocalDate())) {
+        if (!request.pickupDate.isAfter(request.deadline.toLocalDate())) {
             throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_DATE)
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -1,0 +1,110 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestImageRepository
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
+import com.moongchijang.domain.store.domain.repository.StoreRepository
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class OwnerGroupBuyRequestService(
+    private val userRepository: UserRepository,
+    private val storeRepository: StoreRepository,
+    private val storeStaffRepository: StoreStaffRepository,
+    private val ownerGroupBuyRequestRepository: OwnerGroupBuyRequestRepository,
+    private val ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository
+) {
+
+    fun create(ownerId: Long, request: OwnerGroupBuyRequestCreateRequest): OwnerGroupBuyRequestCreateResponse {
+        val owner = userRepository.findByIdAndDeletedAtIsNull(ownerId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        if (owner.role != UserRole.SELLER) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val store = storeRepository.findById(request.storeId)
+            .orElseThrow { CustomException(ErrorCode.STORE_NOT_FOUND) }
+
+        if (!storeStaffRepository.existsByUserIdAndStoreId(ownerId, request.storeId)) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        validateRequest(request)
+
+        val saved = ownerGroupBuyRequestRepository.save(
+            OwnerGroupBuyRequest(
+                owner = owner,
+                store = store,
+                productName = request.productName.trim(),
+                productDescription = request.productDescription.trim(),
+                originalPrice = request.originalPrice,
+                price = request.price,
+                targetQuantity = request.targetQuantity,
+                maxQuantity = request.maxQuantity,
+                perUserLimit = request.perUserLimit,
+                thumbnailUrl = request.imageUrls.first().trim(),
+                deadline = request.deadline,
+                pickupDate = request.pickupDate,
+                pickupTimeStart = request.pickupTimeStart,
+                pickupTimeEnd = request.pickupTimeEnd,
+                pickupLocation = request.pickupLocation.trim(),
+                pickupContact = request.pickupContact?.trim()?.ifBlank { null },
+                status = OwnerGroupBuyRequestStatus.PENDING
+            )
+        )
+
+        ownerGroupBuyRequestImageRepository.saveAll(
+            request.imageUrls.mapIndexed { index, imageUrl ->
+                OwnerGroupBuyRequestImage(
+                    request = saved,
+                    imageUrl = imageUrl.trim(),
+                    sortOrder = index
+                )
+            }
+        )
+
+        return OwnerGroupBuyRequestCreateResponse(
+            requestId = saved.id,
+            status = saved.status
+        )
+    }
+
+    private fun validateRequest(request: OwnerGroupBuyRequestCreateRequest) {
+        if (request.deadline.isBefore(LocalDateTime.now().plusDays(MIN_RECRUITING_DAYS))) {
+            throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_DEADLINE)
+        }
+
+        if (request.maxQuantity < request.targetQuantity) {
+            throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_QUANTITY)
+        }
+
+        if (request.perUserLimit != null && request.perUserLimit > request.maxQuantity) {
+            throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_QUANTITY)
+        }
+
+        if (!request.pickupTimeEnd.isAfter(request.pickupTimeStart)) {
+            throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_TIME)
+        }
+
+        if (request.pickupDate.isBefore(request.deadline.toLocalDate())) {
+            throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_DATE)
+        }
+    }
+
+    private companion object {
+        const val MIN_RECRUITING_DAYS = 7L
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequest.kt
@@ -1,0 +1,65 @@
+package com.moongchijang.domain.owner.application.dto
+
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+data class OwnerGroupBuyRequestCreateRequest(
+
+    @field:NotNull(message = "매장 ID는 필수입니다")
+    val storeId: Long,
+
+    @field:NotBlank(message = "공구명은 필수입니다")
+    @field:Size(max = 30, message = "공구명은 30자 이하이어야 합니다")
+    val productName: String,
+
+    @field:NotBlank(message = "상품 설명은 필수입니다")
+    @field:Size(max = 30, message = "상품 설명은 30자 이하이어야 합니다")
+    val productDescription: String,
+
+    @field:NotNull(message = "희망 공구 마감일시는 필수입니다")
+    val deadline: LocalDateTime,
+
+    @field:Min(value = 1, message = "정가는 1원 이상이어야 합니다")
+    val originalPrice: Int? = null,
+
+    @field:NotNull(message = "공구가는 필수입니다")
+    @field:Min(value = 1, message = "공구가는 1원 이상이어야 합니다")
+    val price: Int,
+
+    @field:NotNull(message = "목표 수량은 필수입니다")
+    @field:Min(value = 1, message = "목표 수량은 1개 이상이어야 합니다")
+    val targetQuantity: Int,
+
+    @field:NotNull(message = "최대 수량은 필수입니다")
+    @field:Min(value = 1, message = "최대 수량은 1개 이상이어야 합니다")
+    val maxQuantity: Int,
+
+    @field:Min(value = 1, message = "1인 구매 제한은 1개 이상이어야 합니다")
+    val perUserLimit: Int? = null,
+
+    @field:NotEmpty(message = "대표 이미지는 최소 1장 이상 필요합니다")
+    @field:Size(max = 5, message = "이미지는 최대 5장까지 등록할 수 있습니다")
+    val imageUrls: List<@NotBlank(message = "이미지 URL은 비어 있을 수 없습니다") String>,
+
+    @field:NotNull(message = "픽업일은 필수입니다")
+    val pickupDate: LocalDate,
+
+    @field:NotNull(message = "픽업 시작 시간은 필수입니다")
+    val pickupTimeStart: LocalTime,
+
+    @field:NotNull(message = "픽업 종료 시간은 필수입니다")
+    val pickupTimeEnd: LocalTime,
+
+    @field:NotBlank(message = "픽업 장소는 필수입니다")
+    @field:Size(max = 200, message = "픽업 장소는 200자 이하이어야 합니다")
+    val pickupLocation: String,
+
+    @field:Size(max = 20, message = "픽업 연락처는 20자 이하이어야 합니다")
+    val pickupContact: String? = null
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequest.kt
@@ -19,7 +19,7 @@ data class OwnerGroupBuyRequestCreateRequest(
     val productName: String,
 
     @field:NotBlank(message = "상품 설명은 필수입니다")
-    @field:Size(max = 30, message = "상품 설명은 30자 이하이어야 합니다")
+    @field:Size(max = 500, message = "상품 설명은 500자 이하이어야 합니다")
     val productDescription: String,
 
     @field:NotNull(message = "희망 공구 마감일시는 필수입니다")

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateResponse.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.owner.application.dto
+
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+
+data class OwnerGroupBuyRequestCreateResponse(
+    val requestId: Long,
+    val status: OwnerGroupBuyRequestStatus
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
@@ -1,0 +1,36 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.OwnerGroupBuyRequestService
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/group-buy-requests")
+@Tag(name = "OwnerGroupBuyRequest", description = "사장님 공구 개설 요청")
+class OwnerGroupBuyRequestController(
+    private val ownerGroupBuyRequestService: OwnerGroupBuyRequestService
+) {
+
+    @PostMapping
+    @Operation(summary = "사장님 공구 개설 요청 제출")
+    fun create(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @Valid @RequestBody request: OwnerGroupBuyRequestCreateRequest
+    ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestCreateResponse>> {
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(ownerGroupBuyRequestService.create(principal.id, request)))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/config/TimeConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/TimeConfig.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class TimeConfig {
+
+    @Bean
+    fun clock(): Clock = Clock.systemDefaultZone()
+}

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -87,6 +87,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
 
     // Store(250~299)
     STORE_SEARCH_FAILED(502_250, "매장 검색 중 오류가 발생했습니다.", 502),
+    STORE_NOT_FOUND(404_250, "매장을 찾을 수 없습니다.", 404),
     INVALID_REGION_TYPE_LABEL(400_251, "유효하지 않은 지역 값입니다.", 400),
     INVALID_DISTRICT_TYPE_LABEL(400_252, "유효하지 않은 세부지역 값입니다.", 400),
 
@@ -124,6 +125,11 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PICKUP_LOCKED(400_400, "픽업일 00시 이후 이용할 수 있습니다.", 400),
     PICKUP_QR_NOT_FOUND(404_401, "픽업 QR을 찾을 수 없습니다.", 404),
     PICKUP_ALREADY_USED(409_400, "이미 사용된 픽업 QR입니다.", 409),
+
+    OWNER_GROUPBUY_REQUEST_INVALID_DEADLINE(400_450, "희망 공구 기간은 최소 7일 이상이어야 합니다.", 400),
+    OWNER_GROUPBUY_REQUEST_INVALID_QUANTITY(400_451, "공구 수량 조건이 올바르지 않습니다.", 400),
+    OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_TIME(400_452, "픽업 종료 시간은 시작 시간 이후여야 합니다.", 400),
+    OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_DATE(400_453, "픽업일은 공구 마감일 이후여야 합니다.", 400),
 
     // Notification(360~369)
     NOTIFICATION_NOT_FOUND(404_360, "알림을 찾을 수 없습니다.", 404),

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3549,7 +3549,7 @@ components:
           example: 두쫀쿠 세트
         productDescription:
           type: string
-          maxLength: 30
+          maxLength: 500
           description: 상품 설명
           example: 소금빵 포함
         deadline:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1533,6 +1533,40 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponseOwnerGroupBuyList'
 
+  /api/v1/owner/group-buy-requests:
+    post:
+      tags: [Owner]
+      summary: 사장님 공구 개설 요청 제출
+      description: |
+        사장님이 본인 매장에 대한 공구 개설 요청을 제출한다.
+        - SELLER 권한만 요청할 수 있다.
+        - storeId는 요청자에게 연결된 매장이어야 한다.
+        - imageUrls의 첫 번째 이미지를 대표 이미지(thumbnailUrl)로 저장한다.
+        - 희망 공구 기간은 현재 시각 기준 최소 7일 이상이어야 한다.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnerGroupBuyRequestCreate'
+      responses:
+        '201':
+          description: 사장님 공구 개설 요청 생성 완료
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerGroupBuyRequestCreated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/owner/reservations:
     get:
       tags: [Owner]
@@ -3485,6 +3519,121 @@ components:
               status:
                 type: string
                 enum: [IN_PROGRESS, ACHIEVED, FAILED]
+        error: { nullable: true, example: null }
+
+    OwnerGroupBuyRequestCreate:
+      type: object
+      required:
+        - storeId
+        - productName
+        - productDescription
+        - deadline
+        - price
+        - targetQuantity
+        - maxQuantity
+        - imageUrls
+        - pickupDate
+        - pickupTimeStart
+        - pickupTimeEnd
+        - pickupLocation
+      properties:
+        storeId:
+          type: integer
+          format: int64
+          description: 요청자가 소속된 매장 ID
+          example: 1
+        productName:
+          type: string
+          maxLength: 30
+          description: 공구명
+          example: 두쫀쿠 세트
+        productDescription:
+          type: string
+          maxLength: 30
+          description: 상품 설명
+          example: 소금빵 포함
+        deadline:
+          type: string
+          format: date-time
+          description: 희망 모집 마감일시. 현재 시각 기준 최소 7일 이후여야 한다.
+          example: "2026-06-03T23:59:00"
+        originalPrice:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: 상품 정가
+          example: 12000
+        price:
+          type: integer
+          minimum: 1
+          description: 공구가
+          example: 9900
+        targetQuantity:
+          type: integer
+          minimum: 1
+          description: 목표 수량
+          example: 20
+        maxQuantity:
+          type: integer
+          minimum: 1
+          description: 최대 수량. 목표 수량 이상이어야 한다.
+          example: 50
+        perUserLimit:
+          type: integer
+          nullable: true
+          minimum: 1
+          description: 1인 구매 제한 수량
+          example: 2
+        imageUrls:
+          type: array
+          minItems: 1
+          maxItems: 5
+          description: 상품 이미지 URL 목록. 첫 번째 이미지를 대표 이미지로 사용한다.
+          items:
+            type: string
+          example:
+            - https://cdn.example.com/owner-requests/1.jpg
+            - https://cdn.example.com/owner-requests/2.jpg
+        pickupDate:
+          type: string
+          format: date
+          description: 픽업일. 공구 마감일 이후여야 한다.
+          example: "2026-06-04"
+        pickupTimeStart:
+          type: string
+          format: time
+          example: "12:00:00"
+        pickupTimeEnd:
+          type: string
+          format: time
+          example: "18:00:00"
+        pickupLocation:
+          type: string
+          maxLength: 200
+          example: 서울 성동구 성수이로 1
+        pickupContact:
+          type: string
+          nullable: true
+          maxLength: 20
+          example: "01012345678"
+
+    ApiResponseOwnerGroupBuyRequestCreated:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [requestId, status]
+          properties:
+            requestId:
+              type: integer
+              format: int64
+              example: 101
+            status:
+              type: string
+              enum: [PENDING, APPROVED, REJECTED]
+              example: PENDING
         error: { nullable: true, example: null }
     
     ApiResponseReservationPage:

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
@@ -19,15 +19,18 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.any
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -48,8 +51,16 @@ class OwnerGroupBuyRequestServiceTest {
     @Mock
     private lateinit var ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository
 
-    @InjectMocks
-    private lateinit var service: OwnerGroupBuyRequestService
+    private val service: OwnerGroupBuyRequestService by lazy {
+        OwnerGroupBuyRequestService(
+            userRepository = userRepository,
+            storeRepository = storeRepository,
+            storeStaffRepository = storeStaffRepository,
+            ownerGroupBuyRequestRepository = ownerGroupBuyRequestRepository,
+            ownerGroupBuyRequestImageRepository = ownerGroupBuyRequestImageRepository,
+            clock = FIXED_CLOCK
+        )
+    }
 
     @Test
     fun `사장님이 본인 매장 공구 개설 요청을 제출하면 PENDING 요청과 이미지를 저장한다`() {
@@ -118,7 +129,7 @@ class OwnerGroupBuyRequestServiceTest {
     @Test
     fun `희망 공구 기간이 7일 미만이면 예외가 발생한다`() {
         val owner = seller()
-        val request = validRequest(deadline = LocalDateTime.now().plusDays(6))
+        val request = validRequest(deadline = FIXED_NOW.plusDays(6))
 
         `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
         `when`(storeRepository.findById(request.storeId)).thenReturn(Optional.of(GroupBuyFixture.createStore()))
@@ -147,14 +158,35 @@ class OwnerGroupBuyRequestServiceTest {
         assertEquals(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_QUANTITY, ex.errorCode)
     }
 
+    @Test
+    fun `픽업일이 공구 마감일과 같으면 예외가 발생한다`() {
+        val owner = seller()
+        val deadline = FIXED_NOW.plusDays(8)
+        val request = validRequest(
+            deadline = deadline,
+            pickupDate = deadline.toLocalDate()
+        )
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeRepository.findById(request.storeId)).thenReturn(Optional.of(GroupBuyFixture.createStore()))
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(owner.id!!, request.storeId)).thenReturn(true)
+
+        val ex = assertThrows<CustomException> {
+            service.create(owner.id!!, request)
+        }
+
+        assertEquals(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_DATE, ex.errorCode)
+    }
+
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
         role = UserRole.SELLER
     }
 
     private fun validRequest(
-        deadline: LocalDateTime = LocalDateTime.now().plusDays(8),
+        deadline: LocalDateTime = FIXED_NOW.plusDays(8),
         targetQuantity: Int = 20,
-        maxQuantity: Int = 50
+        maxQuantity: Int = 50,
+        pickupDate: LocalDate = deadline.toLocalDate().plusDays(1)
     ) = OwnerGroupBuyRequestCreateRequest(
         storeId = 1L,
         productName = "두쫀쿠 세트",
@@ -166,7 +198,7 @@ class OwnerGroupBuyRequestServiceTest {
         maxQuantity = maxQuantity,
         perUserLimit = 2,
         imageUrls = listOf("https://cdn.example.com/1.jpg", "https://cdn.example.com/2.jpg"),
-        pickupDate = deadline.toLocalDate().plusDays(1),
+        pickupDate = pickupDate,
         pickupTimeStart = LocalTime.of(12, 0),
         pickupTimeEnd = LocalTime.of(18, 0),
         pickupLocation = "서울 성동구 성수이로 1",
@@ -174,4 +206,12 @@ class OwnerGroupBuyRequestServiceTest {
     )
 
     private inline fun <reified T> argumentCaptor() = org.mockito.ArgumentCaptor.forClass(T::class.java)
+
+    private companion object {
+        val FIXED_CLOCK: Clock = Clock.fixed(
+            Instant.parse("2026-05-25T00:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+        )
+        val FIXED_NOW: LocalDateTime = LocalDateTime.now(FIXED_CLOCK)
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
@@ -1,0 +1,177 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestImageRepository
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
+import com.moongchijang.domain.store.domain.repository.StoreRepository
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class OwnerGroupBuyRequestServiceTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var storeRepository: StoreRepository
+
+    @Mock
+    private lateinit var storeStaffRepository: StoreStaffRepository
+
+    @Mock
+    private lateinit var ownerGroupBuyRequestRepository: OwnerGroupBuyRequestRepository
+
+    @Mock
+    private lateinit var ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository
+
+    @InjectMocks
+    private lateinit var service: OwnerGroupBuyRequestService
+
+    @Test
+    fun `사장님이 본인 매장 공구 개설 요청을 제출하면 PENDING 요청과 이미지를 저장한다`() {
+        val owner = seller()
+        val store = GroupBuyFixture.createStore()
+        val request = validRequest()
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeRepository.findById(request.storeId)).thenReturn(Optional.of(store))
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(owner.id!!, request.storeId)).thenReturn(true)
+        `when`(ownerGroupBuyRequestRepository.save(any(OwnerGroupBuyRequest::class.java))).thenAnswer {
+            (it.arguments[0] as OwnerGroupBuyRequest).apply { id = 101L }
+        }
+
+        val result = service.create(owner.id!!, request)
+
+        assertEquals(101L, result.requestId)
+        assertEquals(OwnerGroupBuyRequestStatus.PENDING, result.status)
+
+        val requestCaptor = argumentCaptor<OwnerGroupBuyRequest>()
+        verify(ownerGroupBuyRequestRepository).save(requestCaptor.capture())
+        assertEquals(owner, requestCaptor.value.owner)
+        assertEquals(store, requestCaptor.value.store)
+        assertEquals("두쫀쿠 세트", requestCaptor.value.productName)
+        assertEquals("https://cdn.example.com/1.jpg", requestCaptor.value.thumbnailUrl)
+
+        val imageCaptor = argumentCaptor<Iterable<OwnerGroupBuyRequestImage>>()
+        verify(ownerGroupBuyRequestImageRepository).saveAll(imageCaptor.capture())
+        val images = imageCaptor.value.toList()
+        assertEquals(2, images.size)
+        assertEquals(listOf(0, 1), images.map { it.sortOrder })
+        assertEquals(listOf("https://cdn.example.com/1.jpg", "https://cdn.example.com/2.jpg"), images.map { it.imageUrl })
+        assertTrue(images.all { it.request.id == 101L })
+    }
+
+    @Test
+    fun `구매자 계정이면 사장님 공구 개설 요청을 제출할 수 없다`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
+
+        val ex = assertThrows<CustomException> {
+            service.create(1L, validRequest())
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+        verify(ownerGroupBuyRequestRepository, never()).save(any(OwnerGroupBuyRequest::class.java))
+    }
+
+    @Test
+    fun `본인 매장이 아니면 사장님 공구 개설 요청을 제출할 수 없다`() {
+        val owner = seller()
+        val request = validRequest()
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeRepository.findById(request.storeId)).thenReturn(Optional.of(GroupBuyFixture.createStore()))
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(owner.id!!, request.storeId)).thenReturn(false)
+
+        val ex = assertThrows<CustomException> {
+            service.create(owner.id!!, request)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+        verify(ownerGroupBuyRequestRepository, never()).save(any(OwnerGroupBuyRequest::class.java))
+    }
+
+    @Test
+    fun `희망 공구 기간이 7일 미만이면 예외가 발생한다`() {
+        val owner = seller()
+        val request = validRequest(deadline = LocalDateTime.now().plusDays(6))
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeRepository.findById(request.storeId)).thenReturn(Optional.of(GroupBuyFixture.createStore()))
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(owner.id!!, request.storeId)).thenReturn(true)
+
+        val ex = assertThrows<CustomException> {
+            service.create(owner.id!!, request)
+        }
+
+        assertEquals(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_DEADLINE, ex.errorCode)
+    }
+
+    @Test
+    fun `최대 수량이 목표 수량보다 작으면 예외가 발생한다`() {
+        val owner = seller()
+        val request = validRequest(targetQuantity = 30, maxQuantity = 20)
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeRepository.findById(request.storeId)).thenReturn(Optional.of(GroupBuyFixture.createStore()))
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(owner.id!!, request.storeId)).thenReturn(true)
+
+        val ex = assertThrows<CustomException> {
+            service.create(owner.id!!, request)
+        }
+
+        assertEquals(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_QUANTITY, ex.errorCode)
+    }
+
+    private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
+        role = UserRole.SELLER
+    }
+
+    private fun validRequest(
+        deadline: LocalDateTime = LocalDateTime.now().plusDays(8),
+        targetQuantity: Int = 20,
+        maxQuantity: Int = 50
+    ) = OwnerGroupBuyRequestCreateRequest(
+        storeId = 1L,
+        productName = "두쫀쿠 세트",
+        productDescription = "소금빵 포함",
+        deadline = deadline,
+        originalPrice = 12000,
+        price = 9900,
+        targetQuantity = targetQuantity,
+        maxQuantity = maxQuantity,
+        perUserLimit = 2,
+        imageUrls = listOf("https://cdn.example.com/1.jpg", "https://cdn.example.com/2.jpg"),
+        pickupDate = deadline.toLocalDate().plusDays(1),
+        pickupTimeStart = LocalTime.of(12, 0),
+        pickupTimeEnd = LocalTime.of(18, 0),
+        pickupLocation = "서울 성동구 성수이로 1",
+        pickupContact = "01012345678"
+    )
+
+    private inline fun <reified T> argumentCaptor() = org.mockito.ArgumentCaptor.forClass(T::class.java)
+}

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestControllerTest.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.OwnerGroupBuyRequestService
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.security.principal.CustomUserPrincipal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.http.HttpStatus
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class OwnerGroupBuyRequestControllerTest {
+
+    private val ownerGroupBuyRequestService: OwnerGroupBuyRequestService = mock(OwnerGroupBuyRequestService::class.java)
+    private val controller = OwnerGroupBuyRequestController(ownerGroupBuyRequestService)
+
+    @Test
+    fun `사장님 공구 개설 요청 제출 시 201과 요청 ID를 반환한다`() {
+        val principal = CustomUserPrincipal(
+            id = 1L,
+            email = "seller@example.com",
+            role = UserRole.SELLER
+        )
+        val deadline = LocalDateTime.now().plusDays(8)
+        val request = OwnerGroupBuyRequestCreateRequest(
+            storeId = 1L,
+            productName = "두쫀쿠 세트",
+            productDescription = "소금빵 포함",
+            deadline = deadline,
+            originalPrice = 12000,
+            price = 9900,
+            targetQuantity = 20,
+            maxQuantity = 50,
+            perUserLimit = 2,
+            imageUrls = listOf("https://cdn.example.com/1.jpg"),
+            pickupDate = deadline.toLocalDate().plusDays(1),
+            pickupTimeStart = LocalTime.of(12, 0),
+            pickupTimeEnd = LocalTime.of(18, 0),
+            pickupLocation = "서울 성동구 성수이로 1",
+            pickupContact = "01012345678"
+        )
+        val response = OwnerGroupBuyRequestCreateResponse(
+            requestId = 101L,
+            status = OwnerGroupBuyRequestStatus.PENDING
+        )
+        `when`(ownerGroupBuyRequestService.create(1L, request)).thenReturn(response)
+
+        val result = controller.create(principal, request)
+
+        assertEquals(HttpStatus.CREATED, result.statusCode)
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyRequestService).create(1L, request)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- `POST /api/v1/owner/group-buy-requests` 사장님 공구 개설 요청 API를 추가했습니다.
- SELLER 권한, 매장 소속 여부, 최소 7일 모집 기간, 수량/픽업 시간/픽업일 검증을 추가했습니다.
- 요청은 `PENDING` 상태로 저장하고, `imageUrls` 첫 번째 값을 대표 이미지로 저장하며 이미지 정렬 순서를 함께 저장합니다.
- 서비스/컨트롤러 단위 테스트와 `openapi.yaml` 명세를 추가했습니다.

## 🔍 참고 사항
- 사장님 요청/이미지 테이블은 기존 `V22__create_owner_group_buy_request_tables.sql`을 사용합니다.

## 🖼️ 스크린샷
- 백엔드 API 변경으로 해당 없음

## 🔗 관련 이슈
- Closes #188

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
