### PR TITLE
[MCJ-1520] FEAT: 사장님 진행 중인 공구 목록 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -30,6 +30,11 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
     @EntityGraph(attributePaths = ["store"])
     fun findWithStoreById(id: Long): Optional<GroupBuy>
 
+    fun findByStoreIdInAndStatusInOrderByDeadlineAsc(
+        storeIds: Collection<Long>,
+        statuses: Collection<GroupBuyStatus>
+    ): List<GroupBuy>
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
         """

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -41,7 +41,9 @@ class OwnerGroupBuyService(
         val OWNER_VISIBLE_STATUSES = listOf(
             GroupBuyStatus.IN_PROGRESS,
             GroupBuyStatus.ACHIEVED,
-            GroupBuyStatus.FAILED
+            GroupBuyStatus.COMPLETED,
+            GroupBuyStatus.FAILED,
+            GroupBuyStatus.CLOSED
         )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -1,0 +1,47 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class OwnerGroupBuyService(
+    private val userRepository: UserRepository,
+    private val storeStaffRepository: StoreStaffRepository,
+    private val groupBuyRepository: GroupBuyRepository
+) {
+
+    fun getMyGroupBuys(ownerId: Long): List<OwnerGroupBuyListItemResponse> {
+        val owner = userRepository.findByIdAndDeletedAtIsNull(ownerId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        if (owner.role != UserRole.SELLER) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            return emptyList()
+        }
+
+        return groupBuyRepository
+            .findByStoreIdInAndStatusInOrderByDeadlineAsc(storeIds, OWNER_VISIBLE_STATUSES)
+            .map { OwnerGroupBuyListItemResponse.from(it) }
+    }
+
+    private companion object {
+        val OWNER_VISIBLE_STATUSES = listOf(
+            GroupBuyStatus.IN_PROGRESS,
+            GroupBuyStatus.ACHIEVED,
+            GroupBuyStatus.FAILED
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyListItemResponse.kt
@@ -1,0 +1,51 @@
+package com.moongchijang.domain.owner.application.dto
+
+import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import java.time.LocalDate
+
+data class OwnerGroupBuyListItemResponse(
+    val groupBuyId: Long,
+    val productName: String,
+    val targetQuantity: Int,
+    val currentQuantity: Int,
+    val achievementRate: Int,
+    val price: Int,
+    val deadline: LocalDate,
+    val status: OwnerGroupBuyStatusResponse
+) {
+    companion object {
+        fun from(groupBuy: GroupBuy): OwnerGroupBuyListItemResponse =
+            OwnerGroupBuyListItemResponse(
+                groupBuyId = groupBuy.id,
+                productName = groupBuy.productName,
+                targetQuantity = groupBuy.targetQuantity,
+                currentQuantity = groupBuy.currentQuantity,
+                achievementRate = GroupBuyProgressCalculator.achievementRate(
+                    currentQuantity = groupBuy.currentQuantity,
+                    targetQuantity = groupBuy.targetQuantity
+                ),
+                price = groupBuy.price,
+                deadline = groupBuy.deadline.toLocalDate(),
+                status = OwnerGroupBuyStatusResponse.from(groupBuy.status)
+            )
+    }
+}
+
+enum class OwnerGroupBuyStatusResponse {
+    IN_PROGRESS,
+    ACHIEVED,
+    FAILED;
+
+    companion object {
+        fun from(status: GroupBuyStatus): OwnerGroupBuyStatusResponse =
+            when (status) {
+                GroupBuyStatus.IN_PROGRESS -> IN_PROGRESS
+                GroupBuyStatus.ACHIEVED -> ACHIEVED
+                GroupBuyStatus.FAILED -> FAILED
+                GroupBuyStatus.COMPLETED -> ACHIEVED
+                GroupBuyStatus.CLOSED -> FAILED
+            }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
@@ -1,0 +1,29 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.OwnerGroupBuyService
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/group-buys")
+@Tag(name = "OwnerGroupBuy", description = "사장님 공구 조회")
+class OwnerGroupBuyController(
+    private val ownerGroupBuyService: OwnerGroupBuyService
+) {
+
+    @GetMapping
+    @Operation(summary = "사장님 진행 중인 공구 목록 조회")
+    fun getMyGroupBuys(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<OwnerGroupBuyListItemResponse>>> {
+        return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyService.getMyGroupBuys(principal.id)))
+    }
+}

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1495,6 +1495,9 @@ paths:
     get:
       tags: [Owner]
       summary: 진행 중인 공구 목록 조회 (사장님용)
+      description: |
+        사장님이 소속된 매장의 공구를 조회한다.
+        공구 상태는 진행 중(IN_PROGRESS), 달성(ACHIEVED), 미달(FAILED) 기준으로 반환한다.
       security:
         - bearerAuth: []
       responses:
@@ -1504,6 +1507,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseOwnerGroupBuyList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/owner/group-buy-requests:
     post:
@@ -3481,13 +3488,14 @@ components:
           type: array
           items:
             type: object
-            required: [groupBuyId, productName, achievementRate, currentQuantity, targetQuantity, deadline, status]
+            required: [groupBuyId, productName, achievementRate, currentQuantity, targetQuantity, price, deadline, status]
             properties:
               groupBuyId: { type: integer, format: int64 }
               productName: { type: string }
               achievementRate: { type: integer }
               currentQuantity: { type: integer }
               targetQuantity: { type: integer }
+              price: { type: integer, description: 공구가 }
               deadline: { type: string, format: date }
               status:
                 type: string

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -55,7 +55,13 @@ class OwnerGroupBuyServiceTest {
         `when`(
             groupBuyRepository.findByStoreIdInAndStatusInOrderByDeadlineAsc(
                 listOf(1L, 2L),
-                listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED, GroupBuyStatus.FAILED)
+                listOf(
+                    GroupBuyStatus.IN_PROGRESS,
+                    GroupBuyStatus.ACHIEVED,
+                    GroupBuyStatus.COMPLETED,
+                    GroupBuyStatus.FAILED,
+                    GroupBuyStatus.CLOSED
+                )
             )
         ).thenReturn(listOf(groupBuy))
 
@@ -70,6 +76,44 @@ class OwnerGroupBuyServiceTest {
         assertEquals(9900, result[0].price)
         assertEquals(LocalDate.of(2026, 6, 1), result[0].deadline)
         assertEquals("IN_PROGRESS", result[0].status.name)
+    }
+
+    @Test
+    fun `마감 이후 완료와 종료 상태도 사장님 공구 목록에 포함한다`() {
+        val owner = seller()
+        val completed = groupBuy(
+            id = 11L,
+            status = GroupBuyStatus.COMPLETED,
+            currentQuantity = 20,
+            targetQuantity = 20,
+            price = 9900
+        )
+        val closed = groupBuy(
+            id = 12L,
+            status = GroupBuyStatus.CLOSED,
+            currentQuantity = 8,
+            targetQuantity = 20,
+            price = 9900
+        )
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(
+            groupBuyRepository.findByStoreIdInAndStatusInOrderByDeadlineAsc(
+                listOf(1L),
+                listOf(
+                    GroupBuyStatus.IN_PROGRESS,
+                    GroupBuyStatus.ACHIEVED,
+                    GroupBuyStatus.COMPLETED,
+                    GroupBuyStatus.FAILED,
+                    GroupBuyStatus.CLOSED
+                )
+            )
+        ).thenReturn(listOf(completed, closed))
+
+        val result = service.getMyGroupBuys(owner.id!!)
+
+        assertEquals(listOf("ACHIEVED", "FAILED"), result.map { it.status.name })
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -1,0 +1,120 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class OwnerGroupBuyServiceTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var storeStaffRepository: StoreStaffRepository
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @InjectMocks
+    private lateinit var service: OwnerGroupBuyService
+
+    @Test
+    fun `사장님 본인 매장의 공구 목록을 조회한다`() {
+        val owner = seller()
+        val groupBuy = groupBuy(
+            id = 10L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            currentQuantity = 12,
+            targetQuantity = 20,
+            price = 9900
+        )
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L, 2L))
+        `when`(
+            groupBuyRepository.findByStoreIdInAndStatusInOrderByDeadlineAsc(
+                listOf(1L, 2L),
+                listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED, GroupBuyStatus.FAILED)
+            )
+        ).thenReturn(listOf(groupBuy))
+
+        val result = service.getMyGroupBuys(owner.id!!)
+
+        assertEquals(1, result.size)
+        assertEquals(10L, result[0].groupBuyId)
+        assertEquals("두쫀쿠 1개", result[0].productName)
+        assertEquals(20, result[0].targetQuantity)
+        assertEquals(12, result[0].currentQuantity)
+        assertEquals(60, result[0].achievementRate)
+        assertEquals(9900, result[0].price)
+        assertEquals(LocalDate.of(2026, 6, 1), result[0].deadline)
+        assertEquals("IN_PROGRESS", result[0].status.name)
+    }
+
+    @Test
+    fun `소속 매장이 없으면 빈 목록을 반환한다`() {
+        val owner = seller()
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(emptyList())
+
+        val result = service.getMyGroupBuys(owner.id!!)
+
+        assertEquals(emptyList<Any>(), result)
+        verifyNoInteractions(groupBuyRepository)
+    }
+
+    @Test
+    fun `구매자 계정이면 사장님 공구 목록을 조회할 수 없다`() {
+        val buyer = UserFixture.createKakaoUser(id = 1L)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(buyer)
+
+        val ex = assertThrows<CustomException> {
+            service.getMyGroupBuys(1L)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+        verify(storeStaffRepository, never()).findStoreIdsByUserId(1L)
+    }
+
+    private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
+        role = UserRole.SELLER
+    }
+
+    private fun groupBuy(
+        id: Long,
+        status: GroupBuyStatus,
+        currentQuantity: Int,
+        targetQuantity: Int,
+        price: Int
+    ): GroupBuy =
+        GroupBuyFixture.createGroupBuy(
+            id = id,
+            status = status,
+            deadline = LocalDateTime.of(2026, 6, 1, 23, 59),
+            currentQuantity = currentQuantity,
+            targetQuantity = targetQuantity,
+            price = price
+        )
+}

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -1,0 +1,46 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.OwnerGroupBuyService
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyStatusResponse
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.security.principal.CustomUserPrincipal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.time.LocalDate
+
+class OwnerGroupBuyControllerTest {
+
+    private val ownerGroupBuyService: OwnerGroupBuyService = mock(OwnerGroupBuyService::class.java)
+    private val controller = OwnerGroupBuyController(ownerGroupBuyService)
+
+    @Test
+    fun `사장님 진행 중인 공구 목록을 조회한다`() {
+        val principal = CustomUserPrincipal(
+            id = 1L,
+            email = "seller@example.com",
+            role = UserRole.SELLER
+        )
+        val response = listOf(
+            OwnerGroupBuyListItemResponse(
+                groupBuyId = 10L,
+                productName = "두쫀쿠 1개",
+                targetQuantity = 20,
+                currentQuantity = 12,
+                achievementRate = 60,
+                price = 9900,
+                deadline = LocalDate.of(2026, 6, 1),
+                status = OwnerGroupBuyStatusResponse.IN_PROGRESS
+            )
+        )
+        `when`(ownerGroupBuyService.getMyGroupBuys(1L)).thenReturn(response)
+
+        val result = controller.getMyGroupBuys(principal)
+
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyService).getMyGroupBuys(1L)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/owner/group-buys` 사장님 진행 공구 목록 API를 구현했습니다.
- SELLER 권한을 검증하고, `store_staff` 기준으로 사장님 본인 매장의 공구만 조회합니다.
- 공구명, 목표 수량, 현재 달성 수량, 달성률, 공구가, 마감일, 상태를 응답합니다.
- 상태는 진행 중(`IN_PROGRESS`), 달성(`ACHIEVED`), 미달(`FAILED`) 기준으로 반환합니다.

## 🔍 참고 사항
- 기능 명세서 기준 `2.2 진행 중인 공구` 입니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #194

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
