### PR TITLE
[MCJ-1521] FIX: 마이페이지 참여 목록 및 픽업 안내 응답 필드 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -132,13 +132,16 @@ class MypageService(
         if (participations.isEmpty()) return emptyMap()
         return paymentOrderRepository.findPaymentSummariesByParticipationIdIn(
             participationIds = participations.map { it.id }
-        ).associate {
-            it.participationId to MypageParticipationPaymentInfo(
-                groupBuyId = it.groupBuyId,
-                isApproved = it.orderStatus == PaymentOrderStatus.APPROVED,
-                paidAt = it.paidAt,
-                paymentMethod = it.paymentMethod
-            )
+        ).groupBy { it.participationId }
+            .mapValues { (_, summaries) ->
+                val summary = summaries.find { it.orderStatus == PaymentOrderStatus.APPROVED }
+                    ?: summaries.first()
+                MypageParticipationPaymentInfo(
+                    groupBuyId = summary.groupBuyId,
+                    isApproved = summary.orderStatus == PaymentOrderStatus.APPROVED,
+                    paidAt = summary.paidAt,
+                    paymentMethod = summary.paymentMethod
+                )
         }
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -2,12 +2,14 @@ package com.moongchijang.domain.mypage.application
 
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.mypage.application.dto.MypageGroupBuyRequestResponse
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationPaymentInfo
 import com.moongchijang.domain.mypage.application.dto.MypageParticipationResponse
 import com.moongchijang.domain.mypage.application.dto.MypageParticipationStatusFilter
 import com.moongchijang.domain.mypage.application.dto.MypageRefundResponse
 import com.moongchijang.domain.mypage.application.dto.MypageSummaryResponse
 import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
 import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
+import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
@@ -74,9 +76,18 @@ class MypageService(
         )
         if (participations.isEmpty()) return emptyList()
 
-        val inProgressGroupBuyIds = participations.map { it.groupBuy.id }.toSet()
-        val cancellableGroupBuyIds = approvedPaymentGroupBuyIds(userId, inProgressGroupBuyIds)
-        return participations.map { MypageParticipationResponse.from(it, cancellableGroupBuyIds) }
+        val paymentInfoByParticipationId = paymentInfoByParticipationId(participations)
+        val cancellableGroupBuyIds = paymentInfoByParticipationId.values
+            .filter { it.isApproved }
+            .map { it.groupBuyId }
+            .toSet()
+        return participations.map {
+            MypageParticipationResponse.from(
+                participation = it,
+                approvedPaymentGroupBuyIds = cancellableGroupBuyIds,
+                paymentInfo = paymentInfoByParticipationId[it.id]
+            )
+        }
     }
 
     fun getPickupWaitingParticipations(userId: Long): List<MypageParticipationResponse> =
@@ -86,7 +97,7 @@ class MypageService(
                 statuses = PICKUP_WAITING_PARTICIPATION_STATUSES,
                 pickupStatuses = PICKUP_WAITING_PICKUP_STATUSES
             )
-            .map(MypageParticipationResponse::from)
+            .let(::withPaymentInfo)
 
     fun getPickupCompletedParticipations(userId: Long): List<MypageParticipationResponse> =
         participationRepository
@@ -95,25 +106,40 @@ class MypageService(
                 statuses = PICKUP_COMPLETED_PARTICIPATION_STATUSES,
                 pickupStatus = PickupStatus.PICKED_UP
             )
-            .map(MypageParticipationResponse::from)
+            .let(::withPaymentInfo)
 
     fun getCancelledOrRefundedParticipations(userId: Long): List<MypageParticipationResponse> =
         participationRepository
             .findByUserIdAndStatusInOrderByCreatedAtDesc(userId, CANCELLED_OR_REFUNDED_PARTICIPATION_STATUSES)
-            .map(MypageParticipationResponse::from)
+            .let(::withPaymentInfo)
 
     fun getGroupBuyRequests(userId: Long): List<MypageGroupBuyRequestResponse> =
         groupBuyRequestRepository
             .findByUserIdOrderByCreatedAtDesc(userId)
             .map(MypageGroupBuyRequestResponse::from)
 
-    private fun approvedPaymentGroupBuyIds(userId: Long, groupBuyIds: Collection<Long>): Set<Long> {
-        if (groupBuyIds.isEmpty()) return emptySet()
-        return paymentOrderRepository.findGroupBuyIdsByUserIdAndStatusAndGroupBuyIdIn(
-            userId = userId,
-            status = PaymentOrderStatus.APPROVED,
-            groupBuyIds = groupBuyIds
-        ).toSet()
+    private fun withPaymentInfo(participations: List<Participation>): List<MypageParticipationResponse> {
+        val paymentInfoByParticipationId = paymentInfoByParticipationId(participations)
+        return participations.map {
+            MypageParticipationResponse.from(
+                participation = it,
+                paymentInfo = paymentInfoByParticipationId[it.id]
+            )
+        }
+    }
+
+    private fun paymentInfoByParticipationId(participations: List<Participation>): Map<Long, MypageParticipationPaymentInfo> {
+        if (participations.isEmpty()) return emptyMap()
+        return paymentOrderRepository.findPaymentSummariesByParticipationIdIn(
+            participationIds = participations.map { it.id }
+        ).associate {
+            it.participationId to MypageParticipationPaymentInfo(
+                groupBuyId = it.groupBuyId,
+                isApproved = it.orderStatus == PaymentOrderStatus.APPROVED,
+                paidAt = it.paidAt,
+                paymentMethod = it.paymentMethod
+            )
+        }
     }
 
     private companion object {

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -63,6 +63,7 @@ data class MypageRefundResponse(
 data class MypageParticipationResponse(
     val participationId: Long,
     val groupBuyId: Long,
+    val thumbnailUrl: String?,
     val productName: String,
     val participationStatus: String,
     val achievementRate: Int,
@@ -74,6 +75,8 @@ data class MypageParticipationResponse(
     val pickupTimeEnd: LocalTime,
     val pickupLocation: String,
     val paymentAmount: Int,
+    val paidAt: LocalDateTime?,
+    val paymentMethod: String?,
     val quantity: Int,
     val pickupStatus: String,
     val dDay: Int,
@@ -85,7 +88,8 @@ data class MypageParticipationResponse(
     companion object {
         fun from(
             participation: Participation,
-            approvedPaymentGroupBuyIds: Set<Long> = emptySet()
+            approvedPaymentGroupBuyIds: Set<Long> = emptySet(),
+            paymentInfo: MypageParticipationPaymentInfo? = null
         ): MypageParticipationResponse {
             val groupBuy = participation.groupBuy
             val canViewPickupOrQr = participation.status == ParticipationStatus.CONFIRMED &&
@@ -94,6 +98,7 @@ data class MypageParticipationResponse(
             return MypageParticipationResponse(
                 participationId = participation.id,
                 groupBuyId = groupBuy.id,
+                thumbnailUrl = groupBuy.thumbnailUrl,
                 productName = groupBuy.productName,
                 participationStatus = participation.status.name,
                 achievementRate = achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity),
@@ -105,6 +110,8 @@ data class MypageParticipationResponse(
                 pickupTimeEnd = groupBuy.pickupTimeEnd,
                 pickupLocation = groupBuy.pickupLocation,
                 paymentAmount = participation.totalAmount,
+                paidAt = paymentInfo?.paidAt,
+                paymentMethod = paymentInfo?.paymentMethod,
                 quantity = participation.quantity,
                 pickupStatus = participation.pickupStatus.name,
                 dDay = ChronoUnit.DAYS.between(LocalDate.now(), groupBuy.deadline.toLocalDate())
@@ -148,6 +155,13 @@ data class MypageParticipationResponse(
             }
     }
 }
+
+data class MypageParticipationPaymentInfo(
+    val groupBuyId: Long,
+    val isApproved: Boolean,
+    val paidAt: LocalDateTime?,
+    val paymentMethod: String?
+)
 
 data class MypageGroupBuyRequestResponse(
     val productName: String,

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentOrderRepository.kt
@@ -7,6 +7,15 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+
+interface ParticipationPaymentSummary {
+    val participationId: Long
+    val groupBuyId: Long
+    val orderStatus: PaymentOrderStatus
+    val paidAt: LocalDateTime?
+    val paymentMethod: String?
+}
 
 interface PaymentOrderRepository : JpaRepository<PaymentOrder, Long> {
     fun findByOrderId(orderId: String): PaymentOrder?
@@ -33,16 +42,18 @@ interface PaymentOrderRepository : JpaRepository<PaymentOrder, Long> {
 
     @Query(
         """
-        select po.groupBuy.id
+        select p.id as participationId,
+               po.groupBuy.id as groupBuyId,
+               po.status as orderStatus,
+               coalesce(pay.approvedAt, po.approvedAt) as paidAt,
+               pay.method as paymentMethod
         from PaymentOrder po
-        where po.user.id = :userId
-          and po.status = :status
-          and po.groupBuy.id in :groupBuyIds
+        left join Payment pay on pay.paymentOrder = po
+        join Participation p on p.user = po.user and p.groupBuy = po.groupBuy
+        where p.id in :participationIds
         """
     )
-    fun findGroupBuyIdsByUserIdAndStatusAndGroupBuyIdIn(
-        @Param("userId") userId: Long,
-        @Param("status") status: PaymentOrderStatus,
-        @Param("groupBuyIds") groupBuyIds: Collection<Long>,
-    ): List<Long>
+    fun findPaymentSummariesByParticipationIdIn(
+        @Param("participationIds") participationIds: Collection<Long>
+    ): List<ParticipationPaymentSummary>
 }

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -43,6 +43,7 @@ class PickupService(
             latitude = store.latitude,
             longitude = store.longitude,
             transitInfo = null,
+            thumbnailUrl = groupBuy.thumbnailUrl,
             productName = groupBuy.productName,
             quantity = participation.quantity,
             pickupDate = groupBuy.pickupDate,

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
@@ -21,6 +21,7 @@ data class PickupGuideResponse(
     val latitude: Double?,
     val longitude: Double?,
     val transitInfo: String?,
+    val thumbnailUrl: String?,
     val productName: String,
     val quantity: Int,
     val pickupDate: LocalDate,

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3008,7 +3008,7 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [participationId, availabilityStatus, pickupStatus, storeName, storeAddress, productName, quantity, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation]
+          required: [participationId, availabilityStatus, pickupStatus, storeName, storeAddress, thumbnailUrl, productName, quantity, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation]
           properties:
             participationId: { type: integer, format: int64 }
             availabilityStatus:
@@ -3023,6 +3023,7 @@ components:
             latitude: { type: number, format: double, nullable: true }
             longitude: { type: number, format: double, nullable: true }
             transitInfo: { type: string, nullable: true, description: "대중교통 안내. 현재 저장 원천이 없으면 null" }
+            thumbnailUrl: { type: string, nullable: true, description: 픽업 안내 상단 카드 이미지 URL }
             productName: { type: string }
             quantity: { type: integer }
             pickupDate: { type: string, format: date }
@@ -3266,10 +3267,11 @@ components:
           type: array
           items:
             type: object
-            required: [participationId, groupBuyId, productName, participationStatus, achievementRate, achievementStatus, displayStatus, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, paymentAmount, quantity, pickupStatus, dDay, canCancel, canViewPickup, canViewQr, qrAvailability]
+            required: [participationId, groupBuyId, thumbnailUrl, productName, participationStatus, achievementRate, achievementStatus, displayStatus, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, paymentAmount, paidAt, paymentMethod, quantity, pickupStatus, dDay, canCancel, canViewPickup, canViewQr, qrAvailability]
             properties:
               participationId: { type: integer, format: int64 }
               groupBuyId: { type: integer, format: int64 }
+              thumbnailUrl: { type: string, nullable: true, description: 카드 상품 이미지 URL }
               productName: { type: string }
               participationStatus:
                 type: string
@@ -3292,6 +3294,8 @@ components:
               pickupTimeEnd: { type: string, format: time }
               pickupLocation: { type: string }
               paymentAmount: { type: integer }
+              paidAt: { type: string, format: date-time, nullable: true, description: 주문 상세 결제 날짜 }
+              paymentMethod: { type: string, nullable: true, description: 결제 내역 결제 수단 }
               quantity: { type: integer }
               pickupStatus:
                 type: string

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -157,6 +157,13 @@ class MypageServiceTest {
                 paymentSummary(
                     participationId = 11L,
                     groupBuyId = 101L,
+                    orderStatus = PaymentOrderStatus.CANCELLED,
+                    paidAt = LocalDateTime.of(2026, 5, 23, 8, 0),
+                    paymentMethod = "KAKAOPAY"
+                ),
+                paymentSummary(
+                    participationId = 11L,
+                    groupBuyId = 101L,
                     orderStatus = PaymentOrderStatus.APPROVED,
                     paidAt = LocalDateTime.of(2026, 5, 24, 9, 30),
                     paymentMethod = "CARD"

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.mypage.application.dto.MypageParticipationStatusFilter
 import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
+import com.moongchijang.domain.payment.domain.repository.ParticipationPaymentSummary
 import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
@@ -150,18 +151,25 @@ class MypageServiceTest {
             )
         ).thenReturn(listOf(participation))
         `when`(
-            paymentOrderRepository.findGroupBuyIdsByUserIdAndStatusAndGroupBuyIdIn(
-                userId,
-                PaymentOrderStatus.APPROVED,
-                setOf(101L)
+            paymentOrderRepository.findPaymentSummariesByParticipationIdIn(listOf(11L))
+        ).thenReturn(
+            listOf(
+                paymentSummary(
+                    participationId = 11L,
+                    groupBuyId = 101L,
+                    orderStatus = PaymentOrderStatus.APPROVED,
+                    paidAt = LocalDateTime.of(2026, 5, 24, 9, 30),
+                    paymentMethod = "CARD"
+                )
             )
-        ).thenReturn(listOf(101L))
+        )
 
         val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.IN_PROGRESS)
 
         assertEquals(1, result.size)
         assertEquals(11L, result[0].participationId)
         assertEquals(101L, result[0].groupBuyId)
+        assertEquals("https://example.com/cake.jpg", result[0].thumbnailUrl)
         assertEquals("초코 케이크", result[0].productName)
         assertEquals(ParticipationStatus.PAID_WAITING_GOAL.name, result[0].participationStatus)
         assertEquals(60, result[0].achievementRate)
@@ -173,6 +181,8 @@ class MypageServiceTest {
         assertEquals(LocalTime.of(15, 0), result[0].pickupTimeEnd)
         assertEquals("문치 베이커리", result[0].pickupLocation)
         assertEquals(24_000, result[0].paymentAmount)
+        assertEquals(LocalDateTime.of(2026, 5, 24, 9, 30), result[0].paidAt)
+        assertEquals("CARD", result[0].paymentMethod)
         assertEquals(2, result[0].quantity)
         assertEquals(PickupStatus.NOT_READY.name, result[0].pickupStatus)
         assertEquals(1, result[0].dDay)
@@ -196,11 +206,7 @@ class MypageServiceTest {
         val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.IN_PROGRESS)
 
         assertEquals(emptyList<Any>(), result)
-        verify(paymentOrderRepository, never()).findGroupBuyIdsByUserIdAndStatusAndGroupBuyIdIn(
-            userId,
-            PaymentOrderStatus.APPROVED,
-            emptyList()
-        )
+        verify(paymentOrderRepository, never()).findPaymentSummariesByParticipationIdIn(emptyList())
     }
 
     @Test
@@ -220,12 +226,26 @@ class MypageServiceTest {
                 PickupStatus.PICKED_UP
             )
         ).thenReturn(listOf(participation))
+        `when`(
+            paymentOrderRepository.findPaymentSummariesByParticipationIdIn(listOf(12L))
+        ).thenReturn(
+            listOf(
+                paymentSummary(
+                    participationId = 12L,
+                    groupBuyId = 102L,
+                    orderStatus = PaymentOrderStatus.CANCELLED,
+                    paidAt = LocalDateTime.of(2026, 5, 23, 8, 0),
+                    paymentMethod = "KAKAOPAY"
+                )
+            )
+        )
 
         val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.PICKUP_COMPLETED)
 
         assertEquals(1, result.size)
         assertEquals(12L, result[0].participationId)
         assertEquals(102L, result[0].groupBuyId)
+        assertEquals("https://example.com/cake.jpg", result[0].thumbnailUrl)
         assertEquals("초코 케이크", result[0].productName)
         assertEquals(ParticipationStatus.CONFIRMED.name, result[0].participationStatus)
         assertEquals(0, result[0].achievementRate)
@@ -236,6 +256,8 @@ class MypageServiceTest {
         assertEquals(LocalTime.of(13, 0), result[0].pickupTimeStart)
         assertEquals(LocalTime.of(15, 0), result[0].pickupTimeEnd)
         assertEquals(24_000, result[0].paymentAmount)
+        assertEquals(LocalDateTime.of(2026, 5, 23, 8, 0), result[0].paidAt)
+        assertEquals("KAKAOPAY", result[0].paymentMethod)
         assertEquals(2, result[0].quantity)
         assertEquals(PickupStatus.PICKED_UP.name, result[0].pickupStatus)
         assertEquals(false, result[0].canCancel)
@@ -258,6 +280,9 @@ class MypageServiceTest {
                 listOf(ParticipationStatus.CANCELLED, ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
             )
         ).thenReturn(listOf(participation))
+        `when`(
+            paymentOrderRepository.findPaymentSummariesByParticipationIdIn(listOf(13L))
+        ).thenReturn(emptyList())
 
         val result = mypageService.getParticipations(userId, MypageParticipationStatusFilter.CANCELLED_OR_REFUNDED)
 
@@ -318,6 +343,7 @@ class MypageServiceTest {
         val groupBuy = com.moongchijang.domain.groupbuy.domain.entity.GroupBuy(
             store = store,
             groupBuyRequest = groupBuyRequest,
+            thumbnailUrl = "https://example.com/cake.jpg",
             productName = "초코 케이크",
             productDescription = "진한 초코 케이크",
             price = 12_000,
@@ -342,4 +368,19 @@ class MypageServiceTest {
             pickupStatus = PickupStatus.NOT_READY
         )
     }
+
+    private fun paymentSummary(
+        participationId: Long,
+        groupBuyId: Long,
+        orderStatus: PaymentOrderStatus,
+        paidAt: LocalDateTime?,
+        paymentMethod: String?
+    ): ParticipationPaymentSummary =
+        object : ParticipationPaymentSummary {
+            override val participationId: Long = participationId
+            override val groupBuyId: Long = groupBuyId
+            override val orderStatus: PaymentOrderStatus = orderStatus
+            override val paidAt: LocalDateTime? = paidAt
+            override val paymentMethod: String? = paymentMethod
+        }
 }

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -66,6 +66,7 @@ class PickupServiceTest {
         assertEquals(37.54, result.latitude)
         assertEquals(127.05, result.longitude)
         assertNull(result.transitInfo)
+        assertEquals("https://example.com/image.jpg", result.thumbnailUrl)
         assertEquals("두쫀쿠", result.productName)
         assertEquals(2, result.quantity)
         assertEquals(participation.groupBuy.pickupDate, result.pickupDate)


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/users/me/participations` 응답에 `thumbnailUrl`, `paidAt`, `paymentMethod`를 추가했습니다.
- 참여 목록 응답의 결제 메타 정보는 참여 ID 목록 기준으로 한 번에 조회해 N+1을 피하도록 구성했습니다.
- `GET /api/v1/participations/{participationId}/pickup` 응답에 `thumbnailUrl`을 추가했습니다.
- 서비스 테스트와 `openapi.yaml` 명세를 최신화했습니다.

## 🔍 참고 사항
- 결제일은 `Payment.approvedAt`이 있으면 우선 사용하고, 없으면 `PaymentOrder.approvedAt`을 사용합니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #196

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
