### PR TITLE
[MCJ-1522] FEAT: 사장님 공구 개설 요청 내역 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -3,7 +3,7 @@ package com.moongchijang.domain.owner.application
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestDetailResponse
-import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestPageResponse
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
@@ -15,6 +15,9 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -32,17 +35,17 @@ class OwnerGroupBuyRequestService(
 ) {
 
     @Transactional(readOnly = true)
-    fun getMyRequests(ownerId: Long): List<OwnerGroupBuyRequestListItemResponse> {
+    fun getMyRequests(ownerId: Long, pageable: Pageable): OwnerGroupBuyRequestPageResponse {
         validateSeller(ownerId)
 
         val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
         if (storeIds.isEmpty()) {
-            return emptyList()
+            return OwnerGroupBuyRequestPageResponse.from(PageImpl(emptyList(), pageable, 0))
         }
 
-        return ownerGroupBuyRequestRepository
-            .findByOwnerIdAndStoreIdInOrderByCreatedAtDesc(ownerId, storeIds)
-            .map { OwnerGroupBuyRequestListItemResponse.from(it) }
+        val page: Page<OwnerGroupBuyRequest> = ownerGroupBuyRequestRepository
+            .findPageByOwnerIdAndStoreIdIn(ownerId, storeIds, pageable)
+        return OwnerGroupBuyRequestPageResponse.from(page)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -2,6 +2,8 @@ package com.moongchijang.domain.owner.application
 
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestDetailResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestListItemResponse
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
@@ -29,13 +31,37 @@ class OwnerGroupBuyRequestService(
     private val clock: Clock
 ) {
 
-    fun create(ownerId: Long, request: OwnerGroupBuyRequestCreateRequest): OwnerGroupBuyRequestCreateResponse {
-        val owner = userRepository.findByIdAndDeletedAtIsNull(ownerId)
-            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+    @Transactional(readOnly = true)
+    fun getMyRequests(ownerId: Long): List<OwnerGroupBuyRequestListItemResponse> {
+        validateSeller(ownerId)
 
-        if (owner.role != UserRole.SELLER) {
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            return emptyList()
+        }
+
+        return ownerGroupBuyRequestRepository
+            .findByOwnerIdAndStoreIdInOrderByCreatedAtDesc(ownerId, storeIds)
+            .map { OwnerGroupBuyRequestListItemResponse.from(it) }
+    }
+
+    @Transactional(readOnly = true)
+    fun getDetail(ownerId: Long, requestId: Long): OwnerGroupBuyRequestDetailResponse {
+        validateSeller(ownerId)
+
+        val request = ownerGroupBuyRequestRepository.findById(requestId)
+            .orElseThrow { CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_NOT_FOUND) }
+
+        if (request.owner.id != ownerId || !storeStaffRepository.existsByUserIdAndStoreId(ownerId, request.store.id)) {
             throw CustomException(ErrorCode.FORBIDDEN)
         }
+
+        val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
+        return OwnerGroupBuyRequestDetailResponse.from(request, images)
+    }
+
+    fun create(ownerId: Long, request: OwnerGroupBuyRequestCreateRequest): OwnerGroupBuyRequestCreateResponse {
+        val owner = validateSeller(ownerId)
 
         val store = storeRepository.findById(request.storeId)
             .orElseThrow { CustomException(ErrorCode.STORE_NOT_FOUND) }
@@ -83,6 +109,15 @@ class OwnerGroupBuyRequestService(
             status = saved.status
         )
     }
+
+    private fun validateSeller(ownerId: Long) =
+        userRepository.findByIdAndDeletedAtIsNull(ownerId)
+            ?.also {
+                if (it.role != UserRole.SELLER) {
+                    throw CustomException(ErrorCode.FORBIDDEN)
+                }
+            }
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
     private fun validateRequest(request: OwnerGroupBuyRequestCreateRequest) {
         if (request.deadline.isBefore(LocalDateTime.now(clock).plusDays(MIN_RECRUITING_DAYS))) {

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestQueryResponses.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestQueryResponses.kt
@@ -1,0 +1,97 @@
+package com.moongchijang.domain.owner.application.dto
+
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+data class OwnerGroupBuyRequestListItemResponse(
+    val requestId: Long,
+    val productName: String,
+    val storeName: String,
+    val originalPrice: Int?,
+    val price: Int,
+    val targetQuantity: Int,
+    val pickupDate: LocalDate,
+    val requestedAt: LocalDateTime?,
+    val status: OwnerGroupBuyRequestStatus,
+    val rejectionReason: String?,
+    val approvedGroupBuyId: Long?
+) {
+    companion object {
+        fun from(request: OwnerGroupBuyRequest): OwnerGroupBuyRequestListItemResponse =
+            OwnerGroupBuyRequestListItemResponse(
+                requestId = request.id,
+                productName = request.productName,
+                storeName = request.store.name,
+                originalPrice = request.originalPrice,
+                price = request.price,
+                targetQuantity = request.targetQuantity,
+                pickupDate = request.pickupDate,
+                requestedAt = request.createdAt,
+                status = request.status,
+                rejectionReason = request.rejectionReason,
+                approvedGroupBuyId = request.approvedGroupBuy?.id
+            )
+    }
+}
+
+data class OwnerGroupBuyRequestDetailResponse(
+    val requestId: Long,
+    val storeId: Long,
+    val storeName: String,
+    val productName: String,
+    val productDescription: String,
+    val originalPrice: Int?,
+    val price: Int,
+    val targetQuantity: Int,
+    val maxQuantity: Int,
+    val perUserLimit: Int?,
+    val thumbnailUrl: String,
+    val imageUrls: List<String>,
+    val deadline: LocalDateTime,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: LocalTime,
+    val pickupTimeEnd: LocalTime,
+    val pickupLocation: String,
+    val pickupContact: String?,
+    val status: OwnerGroupBuyRequestStatus,
+    val rejectionReason: String?,
+    val approvedGroupBuyId: Long?,
+    val reviewedAt: LocalDateTime?,
+    val requestedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(
+            request: OwnerGroupBuyRequest,
+            images: List<OwnerGroupBuyRequestImage>
+        ): OwnerGroupBuyRequestDetailResponse =
+            OwnerGroupBuyRequestDetailResponse(
+                requestId = request.id,
+                storeId = request.store.id,
+                storeName = request.store.name,
+                productName = request.productName,
+                productDescription = request.productDescription,
+                originalPrice = request.originalPrice,
+                price = request.price,
+                targetQuantity = request.targetQuantity,
+                maxQuantity = request.maxQuantity,
+                perUserLimit = request.perUserLimit,
+                thumbnailUrl = request.thumbnailUrl,
+                imageUrls = images.map { it.imageUrl },
+                deadline = request.deadline,
+                pickupDate = request.pickupDate,
+                pickupTimeStart = request.pickupTimeStart,
+                pickupTimeEnd = request.pickupTimeEnd,
+                pickupLocation = request.pickupLocation,
+                pickupContact = request.pickupContact,
+                status = request.status,
+                rejectionReason = request.rejectionReason,
+                approvedGroupBuyId = request.approvedGroupBuy?.id,
+                reviewedAt = request.reviewedAt,
+                requestedAt = request.createdAt
+            )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestQueryResponses.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestQueryResponses.kt
@@ -3,9 +3,29 @@ package com.moongchijang.domain.owner.application.dto
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import org.springframework.data.domain.Page
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+
+data class OwnerGroupBuyRequestPageResponse(
+    val content: List<OwnerGroupBuyRequestListItemResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int
+) {
+    companion object {
+        fun from(page: Page<OwnerGroupBuyRequest>): OwnerGroupBuyRequestPageResponse =
+            OwnerGroupBuyRequestPageResponse(
+                content = page.content.map { OwnerGroupBuyRequestListItemResponse.from(it) },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                number = page.number,
+                size = page.size
+            )
+    }
+}
 
 data class OwnerGroupBuyRequestListItemResponse(
     val requestId: Long,

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
@@ -2,6 +2,8 @@ package com.moongchijang.domain.owner.domain.repository
 
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -11,10 +13,25 @@ interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, L
     @Query("SELECT r FROM OwnerGroupBuyRequest r WHERE r.owner.id = :ownerId ORDER BY r.createdAt DESC")
     fun findByOwnerIdOrderByCreatedAtDesc(@Param("ownerId") ownerId: Long): List<OwnerGroupBuyRequest>
 
-    fun findByOwnerIdAndStoreIdInOrderByCreatedAtDesc(
-        ownerId: Long,
-        storeIds: Collection<Long>
-    ): List<OwnerGroupBuyRequest>
+    @Query(
+        value = """
+            SELECT r FROM OwnerGroupBuyRequest r
+            JOIN FETCH r.store
+            WHERE r.owner.id = :ownerId
+            AND r.store.id IN :storeIds
+            ORDER BY r.createdAt DESC
+        """,
+        countQuery = """
+            SELECT COUNT(r) FROM OwnerGroupBuyRequest r
+            WHERE r.owner.id = :ownerId
+            AND r.store.id IN :storeIds
+        """
+    )
+    fun findPageByOwnerIdAndStoreIdIn(
+        @Param("ownerId") ownerId: Long,
+        @Param("storeIds") storeIds: Collection<Long>,
+        pageable: Pageable
+    ): Page<OwnerGroupBuyRequest>
 
     fun findByStatusOrderByCreatedAtAsc(status: OwnerGroupBuyRequestStatus): List<OwnerGroupBuyRequest>
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
@@ -11,5 +11,10 @@ interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, L
     @Query("SELECT r FROM OwnerGroupBuyRequest r WHERE r.owner.id = :ownerId ORDER BY r.createdAt DESC")
     fun findByOwnerIdOrderByCreatedAtDesc(@Param("ownerId") ownerId: Long): List<OwnerGroupBuyRequest>
 
+    fun findByOwnerIdAndStoreIdInOrderByCreatedAtDesc(
+        ownerId: Long,
+        storeIds: Collection<Long>
+    ): List<OwnerGroupBuyRequest>
+
     fun findByStatusOrderByCreatedAtAsc(status: OwnerGroupBuyRequestStatus): List<OwnerGroupBuyRequest>
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
@@ -4,12 +4,13 @@ import com.moongchijang.domain.owner.application.OwnerGroupBuyRequestService
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestDetailResponse
-import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestPageResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -30,9 +31,10 @@ class OwnerGroupBuyRequestController(
     @GetMapping
     @Operation(summary = "사장님 공구 개설 요청 목록 조회")
     fun getMyRequests(
-        @AuthenticationPrincipal principal: CustomUserPrincipal
-    ): ResponseEntity<ApiResponse<List<OwnerGroupBuyRequestListItemResponse>>> {
-        return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getMyRequests(principal.id)))
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestPageResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getMyRequests(principal.id, pageable)))
     }
 
     @GetMapping("/{requestId}")

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
@@ -3,6 +3,8 @@ package com.moongchijang.domain.owner.presentation
 import com.moongchijang.domain.owner.application.OwnerGroupBuyRequestService
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestDetailResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestListItemResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -11,6 +13,8 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,6 +26,23 @@ import org.springframework.web.bind.annotation.RestController
 class OwnerGroupBuyRequestController(
     private val ownerGroupBuyRequestService: OwnerGroupBuyRequestService
 ) {
+
+    @GetMapping
+    @Operation(summary = "사장님 공구 개설 요청 목록 조회")
+    fun getMyRequests(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<List<OwnerGroupBuyRequestListItemResponse>>> {
+        return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getMyRequests(principal.id)))
+    }
+
+    @GetMapping("/{requestId}")
+    @Operation(summary = "사장님 공구 개설 요청 상세 조회")
+    fun getDetail(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable requestId: Long
+    ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestDetailResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getDetail(principal.id, requestId)))
+    }
 
     @PostMapping
     @Operation(summary = "사장님 공구 개설 요청 제출")

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -130,6 +130,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     OWNER_GROUPBUY_REQUEST_INVALID_QUANTITY(400_451, "공구 수량 조건이 올바르지 않습니다.", 400),
     OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_TIME(400_452, "픽업 종료 시간은 시작 시간 이후여야 합니다.", 400),
     OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_DATE(400_453, "픽업일은 공구 마감일 이후여야 합니다.", 400),
+    OWNER_GROUPBUY_REQUEST_NOT_FOUND(404_450, "사장님 공구 개설 요청을 찾을 수 없습니다.", 404),
 
     // Notification(360~369)
     NOTIFICATION_NOT_FOUND(404_360, "알림을 찾을 수 없습니다.", 404),

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1519,6 +1519,9 @@ paths:
       description: 사장님이 본인 매장 기준으로 제출한 공구 개설 요청 목록을 조회한다.
       security:
         - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
       responses:
         '200':
           description: 사장님 공구 개설 요청 목록
@@ -3668,24 +3671,32 @@ components:
       properties:
         success: { type: boolean, example: true }
         data:
-          type: array
-          items:
-            type: object
-            required: [requestId, productName, storeName, price, targetQuantity, pickupDate, status]
-            properties:
-              requestId: { type: integer, format: int64, example: 101 }
-              productName: { type: string, example: 두쫀쿠 세트 }
-              storeName: { type: string, example: 뭉치장 베이커리 }
-              originalPrice: { type: integer, nullable: true, example: 12000 }
-              price: { type: integer, example: 9900 }
-              targetQuantity: { type: integer, example: 20 }
-              pickupDate: { type: string, format: date, example: "2026-06-03" }
-              requestedAt: { type: string, format: date-time, nullable: true }
-              status:
-                type: string
-                enum: [PENDING, APPROVED, REJECTED]
-              rejectionReason: { type: string, nullable: true, example: 매장 사정으로 어렵습니다 }
-              approvedGroupBuyId: { type: integer, format: int64, nullable: true, example: 300 }
+          type: object
+          required: [content, totalElements, totalPages, number, size]
+          properties:
+            content:
+              type: array
+              items:
+                type: object
+                required: [requestId, productName, storeName, price, targetQuantity, pickupDate, status]
+                properties:
+                  requestId: { type: integer, format: int64, example: 101 }
+                  productName: { type: string, example: 두쫀쿠 세트 }
+                  storeName: { type: string, example: 뭉치장 베이커리 }
+                  originalPrice: { type: integer, nullable: true, example: 12000 }
+                  price: { type: integer, example: 9900 }
+                  targetQuantity: { type: integer, example: 20 }
+                  pickupDate: { type: string, format: date, example: "2026-06-03" }
+                  requestedAt: { type: string, format: date-time, nullable: true }
+                  status:
+                    type: string
+                    enum: [PENDING, APPROVED, REJECTED]
+                  rejectionReason: { type: string, nullable: true, example: 매장 사정으로 어렵습니다 }
+                  approvedGroupBuyId: { type: integer, format: int64, nullable: true, example: 300 }
+            totalElements: { type: integer, format: int64, example: 1 }
+            totalPages: { type: integer, example: 1 }
+            number: { type: integer, example: 0 }
+            size: { type: integer, example: 20 }
         error: { nullable: true, example: null }
 
     ApiResponseOwnerGroupBuyRequestDetail:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1513,6 +1513,23 @@ paths:
           $ref: '#/components/responses/Forbidden'
 
   /api/v1/owner/group-buy-requests:
+    get:
+      tags: [Owner]
+      summary: 사장님 공구 개설 요청 목록 조회
+      description: 사장님이 본인 매장 기준으로 제출한 공구 개설 요청 목록을 조회한다.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 사장님 공구 개설 요청 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerGroupBuyRequestList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
     post:
       tags: [Owner]
       summary: 사장님 공구 개설 요청 제출
@@ -1539,6 +1556,34 @@ paths:
                 $ref: '#/components/schemas/ApiResponseOwnerGroupBuyRequestCreated'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/owner/group-buy-requests/{requestId}:
+    get:
+      tags: [Owner]
+      summary: 사장님 공구 개설 요청 상세 조회
+      description: 사장님이 본인 매장 기준으로 제출한 공구 개설 요청 상세와 승인/반려 상태를 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: requestId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: 사장님 공구 개설 요청 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerGroupBuyRequestDetail'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3615,6 +3660,90 @@ components:
               type: string
               enum: [PENDING, APPROVED, REJECTED]
               example: PENDING
+        error: { nullable: true, example: null }
+
+    ApiResponseOwnerGroupBuyRequestList:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: array
+          items:
+            type: object
+            required: [requestId, productName, storeName, price, targetQuantity, pickupDate, status]
+            properties:
+              requestId: { type: integer, format: int64, example: 101 }
+              productName: { type: string, example: 두쫀쿠 세트 }
+              storeName: { type: string, example: 뭉치장 베이커리 }
+              originalPrice: { type: integer, nullable: true, example: 12000 }
+              price: { type: integer, example: 9900 }
+              targetQuantity: { type: integer, example: 20 }
+              pickupDate: { type: string, format: date, example: "2026-06-03" }
+              requestedAt: { type: string, format: date-time, nullable: true }
+              status:
+                type: string
+                enum: [PENDING, APPROVED, REJECTED]
+              rejectionReason: { type: string, nullable: true, example: 매장 사정으로 어렵습니다 }
+              approvedGroupBuyId: { type: integer, format: int64, nullable: true, example: 300 }
+        error: { nullable: true, example: null }
+
+    ApiResponseOwnerGroupBuyRequestDetail:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required:
+            - requestId
+            - storeId
+            - storeName
+            - productName
+            - productDescription
+            - price
+            - targetQuantity
+            - maxQuantity
+            - thumbnailUrl
+            - imageUrls
+            - deadline
+            - pickupDate
+            - pickupTimeStart
+            - pickupTimeEnd
+            - pickupLocation
+            - status
+          properties:
+            requestId: { type: integer, format: int64, example: 101 }
+            storeId: { type: integer, format: int64, example: 1 }
+            storeName: { type: string, example: 뭉치장 베이커리 }
+            productName: { type: string, example: 두쫀쿠 세트 }
+            productDescription: { type: string, example: 소금빵 포함 }
+            originalPrice: { type: integer, nullable: true, example: 12000 }
+            price: { type: integer, example: 9900 }
+            targetQuantity: { type: integer, example: 20 }
+            maxQuantity: { type: integer, example: 50 }
+            perUserLimit: { type: integer, nullable: true, example: 2 }
+            thumbnailUrl: { type: string, example: https://cdn.example.com/owner-requests/1.jpg }
+            imageUrls:
+              type: array
+              items:
+                type: string
+              example:
+                - https://cdn.example.com/owner-requests/1.jpg
+                - https://cdn.example.com/owner-requests/2.jpg
+            deadline: { type: string, format: date-time, example: "2026-06-02T23:59:00" }
+            pickupDate: { type: string, format: date, example: "2026-06-03" }
+            pickupTimeStart: { type: string, format: time, example: "12:00:00" }
+            pickupTimeEnd: { type: string, format: time, example: "18:00:00" }
+            pickupLocation: { type: string, example: 서울 성동구 성수이로 1 }
+            pickupContact: { type: string, nullable: true, example: "01012345678" }
+            status:
+              type: string
+              enum: [PENDING, APPROVED, REJECTED]
+            rejectionReason: { type: string, nullable: true, example: 매장 사정으로 어렵습니다 }
+            approvedGroupBuyId: { type: integer, format: int64, nullable: true, example: 300 }
+            reviewedAt: { type: string, format: date-time, nullable: true }
+            requestedAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
     
     ApiResponseReservationPage:

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
@@ -26,6 +26,8 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -100,6 +102,7 @@ class OwnerGroupBuyRequestServiceTest {
     @Test
     fun `사장님 본인 매장의 공구 개설 요청 목록을 조회한다`() {
         val owner = seller()
+        val pageable = PageRequest.of(0, 20)
         val request = ownerRequest(owner = owner).apply {
             id = 101L
             status = OwnerGroupBuyRequestStatus.REJECTED
@@ -108,32 +111,41 @@ class OwnerGroupBuyRequestServiceTest {
 
         `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
         `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
-        `when`(ownerGroupBuyRequestRepository.findByOwnerIdAndStoreIdInOrderByCreatedAtDesc(owner.id!!, listOf(1L)))
-            .thenReturn(listOf(request))
+        `when`(ownerGroupBuyRequestRepository.findPageByOwnerIdAndStoreIdIn(owner.id!!, listOf(1L), pageable))
+            .thenReturn(PageImpl(listOf(request), pageable, 1))
 
-        val result = service.getMyRequests(owner.id!!)
+        val result = service.getMyRequests(owner.id!!, pageable)
 
-        assertEquals(1, result.size)
-        assertEquals(101L, result[0].requestId)
-        assertEquals("두쫀쿠 세트", result[0].productName)
-        assertEquals("뭉치장 베이커리", result[0].storeName)
-        assertEquals(12000, result[0].originalPrice)
-        assertEquals(9900, result[0].price)
-        assertEquals(20, result[0].targetQuantity)
-        assertEquals(OwnerGroupBuyRequestStatus.REJECTED, result[0].status)
-        assertEquals("매장 사정으로 어렵습니다", result[0].rejectionReason)
+        assertEquals(1, result.content.size)
+        assertEquals(1, result.totalElements)
+        assertEquals(1, result.totalPages)
+        assertEquals(0, result.number)
+        assertEquals(20, result.size)
+        assertEquals(101L, result.content[0].requestId)
+        assertEquals("두쫀쿠 세트", result.content[0].productName)
+        assertEquals("뭉치장 베이커리", result.content[0].storeName)
+        assertEquals(12000, result.content[0].originalPrice)
+        assertEquals(9900, result.content[0].price)
+        assertEquals(20, result.content[0].targetQuantity)
+        assertEquals(OwnerGroupBuyRequestStatus.REJECTED, result.content[0].status)
+        assertEquals("매장 사정으로 어렵습니다", result.content[0].rejectionReason)
     }
 
     @Test
     fun `사장님 소속 매장이 없으면 공구 개설 요청 목록은 빈 목록이다`() {
         val owner = seller()
+        val pageable = PageRequest.of(0, 20)
 
         `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
         `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(emptyList())
 
-        val result = service.getMyRequests(owner.id!!)
+        val result = service.getMyRequests(owner.id!!, pageable)
 
-        assertEquals(emptyList<Any>(), result)
+        assertEquals(emptyList<Any>(), result.content)
+        assertEquals(0, result.totalElements)
+        assertEquals(0, result.totalPages)
+        assertEquals(0, result.number)
+        assertEquals(20, result.size)
         verifyNoInteractions(ownerGroupBuyRequestRepository)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
@@ -23,6 +23,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.any
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.Clock
@@ -94,6 +95,94 @@ class OwnerGroupBuyRequestServiceTest {
         assertEquals(listOf(0, 1), images.map { it.sortOrder })
         assertEquals(listOf("https://cdn.example.com/1.jpg", "https://cdn.example.com/2.jpg"), images.map { it.imageUrl })
         assertTrue(images.all { it.request.id == 101L })
+    }
+
+    @Test
+    fun `사장님 본인 매장의 공구 개설 요청 목록을 조회한다`() {
+        val owner = seller()
+        val request = ownerRequest(owner = owner).apply {
+            id = 101L
+            status = OwnerGroupBuyRequestStatus.REJECTED
+            rejectionReason = "매장 사정으로 어렵습니다"
+        }
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(ownerGroupBuyRequestRepository.findByOwnerIdAndStoreIdInOrderByCreatedAtDesc(owner.id!!, listOf(1L)))
+            .thenReturn(listOf(request))
+
+        val result = service.getMyRequests(owner.id!!)
+
+        assertEquals(1, result.size)
+        assertEquals(101L, result[0].requestId)
+        assertEquals("두쫀쿠 세트", result[0].productName)
+        assertEquals("뭉치장 베이커리", result[0].storeName)
+        assertEquals(12000, result[0].originalPrice)
+        assertEquals(9900, result[0].price)
+        assertEquals(20, result[0].targetQuantity)
+        assertEquals(OwnerGroupBuyRequestStatus.REJECTED, result[0].status)
+        assertEquals("매장 사정으로 어렵습니다", result[0].rejectionReason)
+    }
+
+    @Test
+    fun `사장님 소속 매장이 없으면 공구 개설 요청 목록은 빈 목록이다`() {
+        val owner = seller()
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(emptyList())
+
+        val result = service.getMyRequests(owner.id!!)
+
+        assertEquals(emptyList<Any>(), result)
+        verifyNoInteractions(ownerGroupBuyRequestRepository)
+    }
+
+    @Test
+    fun `사장님 공구 개설 요청 상세를 조회한다`() {
+        val owner = seller()
+        val request = ownerRequest(owner = owner).apply { id = 101L }
+        val images = listOf(
+            OwnerGroupBuyRequestImage(request = request, imageUrl = "https://cdn.example.com/1.jpg", sortOrder = 0),
+            OwnerGroupBuyRequestImage(request = request, imageUrl = "https://cdn.example.com/2.jpg", sortOrder = 1)
+        )
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(ownerGroupBuyRequestRepository.findById(101L)).thenReturn(Optional.of(request))
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(owner.id!!, 1L)).thenReturn(true)
+        `when`(ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(101L)).thenReturn(images)
+
+        val result = service.getDetail(owner.id!!, 101L)
+
+        assertEquals(101L, result.requestId)
+        assertEquals(1L, result.storeId)
+        assertEquals("뭉치장 베이커리", result.storeName)
+        assertEquals("두쫀쿠 세트", result.productName)
+        assertEquals("소금빵 포함", result.productDescription)
+        assertEquals(12000, result.originalPrice)
+        assertEquals(9900, result.price)
+        assertEquals(20, result.targetQuantity)
+        assertEquals(50, result.maxQuantity)
+        assertEquals(2, result.perUserLimit)
+        assertEquals("https://cdn.example.com/1.jpg", result.thumbnailUrl)
+        assertEquals(listOf("https://cdn.example.com/1.jpg", "https://cdn.example.com/2.jpg"), result.imageUrls)
+        assertEquals(OwnerGroupBuyRequestStatus.PENDING, result.status)
+    }
+
+    @Test
+    fun `본인 요청이 아니면 사장님 공구 개설 요청 상세를 조회할 수 없다`() {
+        val owner = seller()
+        val otherOwner = seller().apply { id = 2L }
+        val request = ownerRequest(owner = otherOwner).apply { id = 101L }
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(ownerGroupBuyRequestRepository.findById(101L)).thenReturn(Optional.of(request))
+
+        val ex = assertThrows<CustomException> {
+            service.getDetail(owner.id!!, 101L)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+        verifyNoInteractions(ownerGroupBuyRequestImageRepository)
     }
 
     @Test
@@ -181,6 +270,27 @@ class OwnerGroupBuyRequestServiceTest {
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
         role = UserRole.SELLER
     }
+
+    private fun ownerRequest(
+        owner: com.moongchijang.domain.user.domain.entity.User = seller()
+    ) = OwnerGroupBuyRequest(
+        owner = owner,
+        store = GroupBuyFixture.createStore(),
+        productName = "두쫀쿠 세트",
+        productDescription = "소금빵 포함",
+        originalPrice = 12000,
+        price = 9900,
+        targetQuantity = 20,
+        maxQuantity = 50,
+        perUserLimit = 2,
+        thumbnailUrl = "https://cdn.example.com/1.jpg",
+        deadline = FIXED_NOW.plusDays(8),
+        pickupDate = FIXED_NOW.toLocalDate().plusDays(9),
+        pickupTimeStart = LocalTime.of(12, 0),
+        pickupTimeEnd = LocalTime.of(18, 0),
+        pickupLocation = "서울 성동구 성수이로 1",
+        pickupContact = "01012345678"
+    )
 
     private fun validRequest(
         deadline: LocalDateTime = FIXED_NOW.plusDays(8),

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestControllerTest.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateR
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestDetailResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestPageResponse
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.security.principal.CustomUserPrincipal
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -26,27 +28,34 @@ class OwnerGroupBuyRequestControllerTest {
     @Test
     fun `사장님 공구 개설 요청 목록을 조회한다`() {
         val principal = principal()
-        val response = listOf(
-            OwnerGroupBuyRequestListItemResponse(
-                requestId = 101L,
-                productName = "두쫀쿠 세트",
-                storeName = "뭉치장 베이커리",
-                originalPrice = 12000,
-                price = 9900,
-                targetQuantity = 20,
-                pickupDate = LocalDate.of(2026, 6, 3),
-                requestedAt = LocalDateTime.of(2026, 5, 25, 12, 0),
-                status = OwnerGroupBuyRequestStatus.PENDING,
-                rejectionReason = null,
-                approvedGroupBuyId = null
-            )
+        val pageable = PageRequest.of(0, 20)
+        val response = OwnerGroupBuyRequestPageResponse(
+            content = listOf(
+                OwnerGroupBuyRequestListItemResponse(
+                    requestId = 101L,
+                    productName = "두쫀쿠 세트",
+                    storeName = "뭉치장 베이커리",
+                    originalPrice = 12000,
+                    price = 9900,
+                    targetQuantity = 20,
+                    pickupDate = LocalDate.of(2026, 6, 3),
+                    requestedAt = LocalDateTime.of(2026, 5, 25, 12, 0),
+                    status = OwnerGroupBuyRequestStatus.PENDING,
+                    rejectionReason = null,
+                    approvedGroupBuyId = null
+                )
+            ),
+            totalElements = 1,
+            totalPages = 1,
+            number = 0,
+            size = 20
         )
-        `when`(ownerGroupBuyRequestService.getMyRequests(1L)).thenReturn(response)
+        `when`(ownerGroupBuyRequestService.getMyRequests(1L, pageable)).thenReturn(response)
 
-        val result = controller.getMyRequests(principal)
+        val result = controller.getMyRequests(principal, pageable)
 
         assertEquals(response, result.body?.data)
-        verify(ownerGroupBuyRequestService).getMyRequests(1L)
+        verify(ownerGroupBuyRequestService).getMyRequests(1L, pageable)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestControllerTest.kt
@@ -3,6 +3,8 @@ package com.moongchijang.domain.owner.presentation
 import com.moongchijang.domain.owner.application.OwnerGroupBuyRequestService
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestCreateResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestDetailResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyRequestListItemResponse
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.security.principal.CustomUserPrincipal
@@ -12,6 +14,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.springframework.http.HttpStatus
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
@@ -21,12 +24,71 @@ class OwnerGroupBuyRequestControllerTest {
     private val controller = OwnerGroupBuyRequestController(ownerGroupBuyRequestService)
 
     @Test
-    fun `사장님 공구 개설 요청 제출 시 201과 요청 ID를 반환한다`() {
-        val principal = CustomUserPrincipal(
-            id = 1L,
-            email = "seller@example.com",
-            role = UserRole.SELLER
+    fun `사장님 공구 개설 요청 목록을 조회한다`() {
+        val principal = principal()
+        val response = listOf(
+            OwnerGroupBuyRequestListItemResponse(
+                requestId = 101L,
+                productName = "두쫀쿠 세트",
+                storeName = "뭉치장 베이커리",
+                originalPrice = 12000,
+                price = 9900,
+                targetQuantity = 20,
+                pickupDate = LocalDate.of(2026, 6, 3),
+                requestedAt = LocalDateTime.of(2026, 5, 25, 12, 0),
+                status = OwnerGroupBuyRequestStatus.PENDING,
+                rejectionReason = null,
+                approvedGroupBuyId = null
+            )
         )
+        `when`(ownerGroupBuyRequestService.getMyRequests(1L)).thenReturn(response)
+
+        val result = controller.getMyRequests(principal)
+
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyRequestService).getMyRequests(1L)
+    }
+
+    @Test
+    fun `사장님 공구 개설 요청 상세를 조회한다`() {
+        val principal = principal()
+        val deadline = LocalDateTime.of(2026, 6, 2, 23, 59)
+        val response = OwnerGroupBuyRequestDetailResponse(
+            requestId = 101L,
+            storeId = 1L,
+            storeName = "뭉치장 베이커리",
+            productName = "두쫀쿠 세트",
+            productDescription = "소금빵 포함",
+            originalPrice = 12000,
+            price = 9900,
+            targetQuantity = 20,
+            maxQuantity = 50,
+            perUserLimit = 2,
+            thumbnailUrl = "https://cdn.example.com/1.jpg",
+            imageUrls = listOf("https://cdn.example.com/1.jpg"),
+            deadline = deadline,
+            pickupDate = LocalDate.of(2026, 6, 3),
+            pickupTimeStart = LocalTime.of(12, 0),
+            pickupTimeEnd = LocalTime.of(18, 0),
+            pickupLocation = "서울 성동구 성수이로 1",
+            pickupContact = "01012345678",
+            status = OwnerGroupBuyRequestStatus.PENDING,
+            rejectionReason = null,
+            approvedGroupBuyId = null,
+            reviewedAt = null,
+            requestedAt = LocalDateTime.of(2026, 5, 25, 12, 0)
+        )
+        `when`(ownerGroupBuyRequestService.getDetail(1L, 101L)).thenReturn(response)
+
+        val result = controller.getDetail(principal, 101L)
+
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyRequestService).getDetail(1L, 101L)
+    }
+
+    @Test
+    fun `사장님 공구 개설 요청 제출 시 201과 요청 ID를 반환한다`() {
+        val principal = principal()
         val deadline = LocalDateTime.now().plusDays(8)
         val request = OwnerGroupBuyRequestCreateRequest(
             storeId = 1L,
@@ -57,4 +119,10 @@ class OwnerGroupBuyRequestControllerTest {
         assertEquals(response, result.body?.data)
         verify(ownerGroupBuyRequestService).create(1L, request)
     }
+
+    private fun principal() = CustomUserPrincipal(
+        id = 1L,
+        email = "seller@example.com",
+        role = UserRole.SELLER
+    )
 }


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/owner/group-buy-requests` 사장님 공구 개설 요청 목록 조회 API를 추가했습니다.
- `GET /api/v1/owner/group-buy-requests/{requestId}` 사장님 공구 개설 요청 상세 조회 API를 추가했습니다.
- SELLER 권한과 `store_staff` 기준 본인 매장 요청 접근을 검증합니다.
- 목록 응답에 요청 ID, 공구명, 매장명, 가격, 목표 수량, 픽업일, 요청일시, 상태를 반환합니다.
- 상세 응답에 상품/가격/수량/이미지/모집/픽업/승인·반려 정보를 반환합니다.
- 서비스/컨트롤러 테스트와 `openapi.yaml` 명세를 갱신했습니다.

## 🔍 참고 사항
- 이전 PR에서 추가된 `owner_group_buy_requests`, `owner_group_buy_request_images` 테이블을 조회합니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #198

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
