### PR TITLE
[MCJ-1524] FEAT: 사장님 QR 픽업 완료 처리 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -143,7 +143,7 @@ class PickupService(
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
         validatePickupProcessor(processedBy, participation.groupBuy.store.id)
 
-        val pickedUpAt = LocalDateTime.now()
+        val pickedUpAt = nowKst()
         participation.markPickedUp(processedBy, pickedUpAt)
 
         return PickupVerifyResponse(
@@ -153,7 +153,7 @@ class PickupService(
             productName = participation.groupBuy.productName,
             quantity = participation.quantity,
             pickedUpAt = pickedUpAt,
-            pickupProcessedByUserId = processedBy?.id,
+            pickupProcessedByUserId = processedBy.id,
         )
     }
 
@@ -197,8 +197,7 @@ class PickupService(
         when (processedBy.role) {
             UserRole.ADMIN -> return
             UserRole.SELLER -> {
-                val userId = processedBy.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
-                if (storeStaffRepository.existsByUserIdAndStoreId(userId, storeId)) {
+                if (storeStaffRepository.existsByUserIdAndStoreId(processedBy.id!!, storeId)) {
                     return
                 }
             }

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -10,6 +10,9 @@ import com.moongchijang.domain.pickup.application.dto.PickupAvailabilityStatus
 import com.moongchijang.domain.pickup.application.dto.PickupGuideResponse
 import com.moongchijang.domain.pickup.application.dto.PickupQrResponse
 import com.moongchijang.domain.pickup.application.dto.PickupVerifyResponse
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -25,6 +28,7 @@ import java.util.UUID
 class PickupService(
     private val participationRepository: ParticipationRepository,
     private val userRepository: UserRepository,
+    private val storeStaffRepository: StoreStaffRepository,
 ) {
 
     @Transactional(readOnly = true)
@@ -131,15 +135,23 @@ class PickupService(
         if (participation.pickupStatus == PickupStatus.PICKED_UP) {
             throw CustomException(ErrorCode.PICKUP_ALREADY_USED)
         }
+        if (participation.pickupStatus != PickupStatus.READY) {
+            throw CustomException(ErrorCode.PICKUP_NOT_READY)
+        }
 
         val processedBy = userRepository.findByIdAndDeletedAtIsNull(processedByUserId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        validatePickupProcessor(processedBy, participation.groupBuy.store.id)
+
         val pickedUpAt = LocalDateTime.now()
         participation.markPickedUp(processedBy, pickedUpAt)
 
         return PickupVerifyResponse(
             participationId = participation.id,
             pickupStatus = participation.pickupStatus,
+            userName = participation.user.nickname,
+            productName = participation.groupBuy.productName,
+            quantity = participation.quantity,
             pickedUpAt = pickedUpAt,
             pickupProcessedByUserId = processedBy?.id,
         )
@@ -180,6 +192,21 @@ class PickupService(
 
     private fun Participation.reservationNumber(): String =
         "MCJ-P%06d".format(id)
+
+    private fun validatePickupProcessor(processedBy: User, storeId: Long) {
+        when (processedBy.role) {
+            UserRole.ADMIN -> return
+            UserRole.SELLER -> {
+                val userId = processedBy.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+                if (storeStaffRepository.existsByUserIdAndStoreId(userId, storeId)) {
+                    return
+                }
+            }
+            UserRole.BUYER -> Unit
+        }
+
+        throw CustomException(ErrorCode.FORBIDDEN)
+    }
 
     private fun todayKst(): LocalDate = LocalDate.now(KST_ZONE)
 

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/dto/PickupDtos.kt
@@ -66,6 +66,9 @@ data class NearestPickupQrResponse(
 data class PickupVerifyResponse(
     val participationId: Long,
     val pickupStatus: PickupStatus,
+    val userName: String?,
+    val productName: String,
+    val quantity: Int,
     val pickedUpAt: LocalDateTime,
     val pickupProcessedByUserId: Long?,
 )

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -125,6 +125,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     PICKUP_LOCKED(400_400, "픽업일 00시 이후 이용할 수 있습니다.", 400),
     PICKUP_QR_NOT_FOUND(404_401, "픽업 QR을 찾을 수 없습니다.", 404),
     PICKUP_ALREADY_USED(409_400, "이미 사용된 픽업 QR입니다.", 409),
+    PICKUP_NOT_READY(409_401, "픽업 대기 상태인 QR만 완료 처리할 수 있습니다.", 409),
 
     OWNER_GROUPBUY_REQUEST_INVALID_DEADLINE(400_450, "희망 공구 기간은 최소 7일 이상이어야 합니다.", 400),
     OWNER_GROUPBUY_REQUEST_INVALID_QUANTITY(400_451, "공구 수량 조건이 올바르지 않습니다.", 400),

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1187,7 +1187,10 @@ paths:
     post:
       tags: [Pickup]
       summary: QR 코드 스캔 검증 및 수령 처리
-      description: ADMIN 또는 SELLER 권한 사용자가 소비자 QR을 스캔하면 대기 → 완료로 자동 전환된다.
+      description: |
+        SELLER 권한 사용자가 본인 매장 공구의 소비자 QR을 스캔하면 READY → PICKED_UP으로 자동 전환한다.
+        ADMIN 권한 사용자는 운영 대리 처리 용도로 매장 소속 검증 없이 처리할 수 있다.
+        응답에는 사장님 스캔 결과 화면에 필요한 유저이름, 상품명, 수량, 픽업 상태를 포함한다.
       security:
         - bearerAuth: []
       parameters:
@@ -1204,6 +1207,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponsePickupVerify'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
         '409':
@@ -3178,12 +3183,15 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [participationId, pickupStatus, pickedUpAt]
+          required: [participationId, pickupStatus, productName, quantity, pickedUpAt]
           properties:
             participationId: { type: integer, format: int64 }
             pickupStatus:
               type: string
               enum: [NOT_READY, READY, PICKED_UP, NO_SHOW]
+            userName: { type: string, nullable: true, example: 테스트유저 }
+            productName: { type: string, example: 두쫀쿠 }
+            quantity: { type: integer, example: 2 }
             pickedUpAt: { type: string, format: date-time }
             pickupProcessedByUserId: { type: integer, format: int64, nullable: true }
         error: { nullable: true, example: null }

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -12,7 +12,9 @@ import com.moongchijang.domain.pickup.application.dto.PickupAvailabilityStatus
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
 import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -43,10 +45,14 @@ class PickupServiceTest {
     @Mock
     private lateinit var userRepository: UserRepository
 
+    @Mock
+    private lateinit var storeStaffRepository: StoreStaffRepository
+
     private val service: PickupService by lazy {
         PickupService(
             participationRepository = participationRepository,
             userRepository = userRepository,
+            storeStaffRepository = storeStaffRepository,
         )
     }
 
@@ -281,7 +287,7 @@ class PickupServiceTest {
 
     @Test
     fun `QR 검증 성공은 픽업 완료 처리하고 처리자를 저장한다`() {
-        val processor = UserFixture.createKakaoUser(id = 7L)
+        val processor = seller(id = 7L)
         val participation = createParticipation(
             pickupDate = todayKst(),
             pickupStatus = PickupStatus.READY,
@@ -289,10 +295,14 @@ class PickupServiceTest {
         )
         `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
         `when`(userRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(processor)
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(7L, 20L)).thenReturn(true)
 
         val result = service.verifyPickup("qr-token", 7L)
 
         assertEquals(PickupStatus.PICKED_UP, result.pickupStatus)
+        assertEquals("테스트유저", result.userName)
+        assertEquals("두쫀쿠", result.productName)
+        assertEquals(2, result.quantity)
         assertNotNull(result.pickedUpAt)
         assertEquals(7L, result.pickupProcessedByUserId)
         assertEquals(PickupStatus.PICKED_UP, participation.pickupStatus)
@@ -316,6 +326,64 @@ class PickupServiceTest {
 
         assertEquals(ErrorCode.PICKUP_ALREADY_USED, ex.errorCode)
         verify(userRepository, never()).findByIdAndDeletedAtIsNull(7L)
+    }
+
+    @Test
+    fun `픽업 준비 상태가 아닌 QR은 완료 처리할 수 없다`() {
+        val participation = createParticipation(
+            pickupDate = todayKst(),
+            pickupStatus = PickupStatus.NOT_READY,
+            pickupToken = "qr-token",
+        )
+        `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
+
+        val ex = assertThrows<CustomException> {
+            service.verifyPickup("qr-token", 7L)
+        }
+
+        assertEquals(ErrorCode.PICKUP_NOT_READY, ex.errorCode)
+        verify(userRepository, never()).findByIdAndDeletedAtIsNull(7L)
+    }
+
+    @Test
+    fun `사장님이 본인 매장 공구가 아닌 QR을 스캔하면 거부한다`() {
+        val processor = seller(id = 7L)
+        val participation = createParticipation(
+            pickupDate = todayKst(),
+            pickupStatus = PickupStatus.READY,
+            pickupToken = "qr-token",
+        )
+        `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(processor)
+        `when`(storeStaffRepository.existsByUserIdAndStoreId(7L, 20L)).thenReturn(false)
+
+        val ex = assertThrows<CustomException> {
+            service.verifyPickup("qr-token", 7L)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+        assertEquals(PickupStatus.READY, participation.pickupStatus)
+        assertNull(participation.pickedUpAt)
+    }
+
+    @Test
+    fun `소비자 계정은 QR 픽업 완료 처리를 할 수 없다`() {
+        val processor = UserFixture.createKakaoUser(id = 7L)
+        val participation = createParticipation(
+            pickupDate = todayKst(),
+            pickupStatus = PickupStatus.READY,
+            pickupToken = "qr-token",
+        )
+        `when`(participationRepository.findByPickupTokenForUpdate("qr-token")).thenReturn(participation)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(processor)
+
+        val ex = assertThrows<CustomException> {
+            service.verifyPickup("qr-token", 7L)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+        assertEquals(PickupStatus.READY, participation.pickupStatus)
+        assertNull(participation.pickedUpAt)
     }
 
     private fun createParticipation(
@@ -391,6 +459,11 @@ class PickupServiceTest {
             desiredQuantity = 50,
             desiredPickupDate = pickupDate,
         ).apply { id = 30L }
+
+    private fun seller(id: Long): User =
+        UserFixture.createKakaoUser(id = id).apply {
+            role = UserRole.SELLER
+        }
 
     private fun todayKst(): LocalDate = LocalDate.now(KST_ZONE)
 

--- a/src/test/kotlin/com/moongchijang/domain/pickup/presentation/PickupControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/presentation/PickupControllerTest.kt
@@ -39,6 +39,9 @@ class PickupControllerTest {
         val response = PickupVerifyResponse(
             participationId = 99L,
             pickupStatus = PickupStatus.PICKED_UP,
+            userName = "테스트유저",
+            productName = "두쫀쿠",
+            quantity = 2,
             pickedUpAt = LocalDateTime.now(),
             pickupProcessedByUserId = 7L,
         )
@@ -55,6 +58,9 @@ class PickupControllerTest {
         val response = PickupVerifyResponse(
             participationId = 99L,
             pickupStatus = PickupStatus.PICKED_UP,
+            userName = "테스트유저",
+            productName = "두쫀쿠",
+            quantity = 2,
             pickedUpAt = LocalDateTime.now(),
             pickupProcessedByUserId = 8L,
         )


### PR DESCRIPTION
## 📌 작업한 내용
- `/api/v1/pickups/{qrCode}/verify`에서 사장님 QR 스캔 픽업 완료 처리 검증을 보강했습니다.
- SELLER는 본인 매장 공구 참여 건만 `READY -> PICKED_UP` 처리할 수 있도록 매장 소속을 검증합니다.
- ADMIN은 운영 대리 처리 용도로 매장 소속 검증 없이 처리할 수 있도록 유지했습니다.
- 스캔 결과 응답에 `userName`, `productName`, `quantity`를 추가했습니다.
- 픽업 준비 상태가 아닌 QR 처리용 `PICKUP_NOT_READY` 에러를 추가했습니다.
- `openapi.yaml`을 최신 응답 스키마에 맞게 갱신했습니다.

## 🔍 참고 사항
- QR 토큰 검증과 픽업 완료 상태 변경을 구현했습니다.
- 기존 소비자 QR 조회/생성 API는 유지했습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #201

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

완료 기능:
- 1.2 픽업 완료 처리 백엔드 구현 완료
- 1.2.1 픽업 완료 처리 안내 백엔드 구현 완료
