### PR TITLE
[MCJ-1525] FEAT: 운영자 공구 개설 요청 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -111,8 +111,14 @@ class GroupBuyRequestService(
             ?.let { groupBuyRequestRepository.findByStatusOrderByCreatedAtDesc(it, pageable) }
             ?: groupBuyRequestRepository.findAllByOrderByCreatedAtDesc(pageable)
 
-        val usersById = userRepository.findAllById(page.content.map { it.userId }.distinct())
-            .associateBy { it.id!! }
+        val userIds = page.content.map { it.userId }.distinct()
+        val usersById = if (userIds.isEmpty()) {
+            emptyMap()
+        } else {
+            userRepository.findAllById(userIds)
+                .mapNotNull { user -> user.id?.let { it to user } }
+                .toMap()
+        }
 
         return AdminGroupBuyRequestPageResponse.from(page, usersById)
     }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -1,5 +1,8 @@
 package com.moongchijang.domain.groupbuy.application
 
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestDetailResponse
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestPageResponse
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestStatusFilter
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestCreateRequest
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestIdResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestResponse
@@ -11,8 +14,10 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHisto
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
@@ -27,6 +32,7 @@ class GroupBuyRequestService(
     private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository,
     private val groupBuyRepository: GroupBuyRepository,
     private val groupBuyOpenRequestService: GroupBuyOpenRequestService,
+    private val userRepository: UserRepository,
 ) {
 
     fun create(userId: Long, request: GroupBuyRequestCreateRequest): GroupBuyRequestIdResponse {
@@ -94,6 +100,32 @@ class GroupBuyRequestService(
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
 
         return GroupBuyRequestResponse.from(request, history)
+    }
+
+    @Transactional(readOnly = true)
+    fun getAdminRequests(
+        status: AdminGroupBuyRequestStatusFilter,
+        pageable: Pageable
+    ): AdminGroupBuyRequestPageResponse {
+        val page = status.toStatus()
+            ?.let { groupBuyRequestRepository.findByStatusOrderByCreatedAtDesc(it, pageable) }
+            ?: groupBuyRequestRepository.findAllByOrderByCreatedAtDesc(pageable)
+
+        val usersById = userRepository.findAllById(page.content.map { it.userId }.distinct())
+            .associateBy { it.id!! }
+
+        return AdminGroupBuyRequestPageResponse.from(page, usersById)
+    }
+
+    @Transactional(readOnly = true)
+    fun getAdminDetail(requestId: Long): AdminGroupBuyRequestDetailResponse {
+        val request = groupBuyRequestRepository.findById(requestId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
+        val requester = userRepository.findById(request.userId).orElse(null)
+        val history = groupBuyRequestStatusHistoryRepository
+            .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
+
+        return AdminGroupBuyRequestDetailResponse.from(request, requester, history)
     }
 
     fun updateStatus(requestId: Long, request: GroupBuyRequestStatusUpdateRequest): GroupBuyRequestResponse {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
@@ -1,0 +1,163 @@
+package com.moongchijang.domain.groupbuy.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import com.moongchijang.domain.user.domain.entity.User
+import org.springframework.data.domain.Page
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+enum class AdminGroupBuyRequestStatusFilter {
+    ALL,
+    IN_REVIEW,
+    IN_CONTACT,
+    OPENED,
+    REJECTED;
+
+    fun toStatus(): GroupBuyRequestStatus? =
+        when (this) {
+            ALL -> null
+            IN_REVIEW -> GroupBuyRequestStatus.IN_REVIEW
+            IN_CONTACT -> GroupBuyRequestStatus.IN_CONTACT
+            OPENED -> GroupBuyRequestStatus.OPENED
+            REJECTED -> GroupBuyRequestStatus.REJECTED
+        }
+}
+
+data class AdminGroupBuyRequestPageResponse(
+    val content: List<AdminGroupBuyRequestListItemResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int
+) {
+    companion object {
+        fun from(
+            page: Page<GroupBuyRequest>,
+            usersById: Map<Long, User>
+        ): AdminGroupBuyRequestPageResponse =
+            AdminGroupBuyRequestPageResponse(
+                content = page.content.map { AdminGroupBuyRequestListItemResponse.from(it, usersById[it.userId]) },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                number = page.number,
+                size = page.size
+            )
+    }
+}
+
+data class AdminGroupBuyRequestListItemResponse(
+    val requestId: Long,
+    val storeName: String,
+    val productName: String,
+    val desiredQuantity: Int,
+    val desiredPickupDate: LocalDate,
+    val status: GroupBuyRequestStatus,
+    val requesterId: Long,
+    val requesterName: String?,
+    val createdAt: LocalDateTime?
+) {
+    companion object {
+        fun from(
+            request: GroupBuyRequest,
+            requester: User?
+        ): AdminGroupBuyRequestListItemResponse =
+            AdminGroupBuyRequestListItemResponse(
+                requestId = request.id,
+                storeName = request.storeName,
+                productName = request.productName,
+                desiredQuantity = request.desiredQuantity,
+                desiredPickupDate = request.desiredPickupDate,
+                status = request.status,
+                requesterId = request.userId,
+                requesterName = requester?.nickname,
+                createdAt = request.createdAt
+            )
+    }
+}
+
+data class AdminGroupBuyRequestDetailResponse(
+    val requestId: Long,
+    val requester: AdminGroupBuyRequestRequesterResponse,
+    val storeName: String,
+    val storeAddress: String?,
+    val placeId: String?,
+    val roadAddress: String?,
+    val lotAddress: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+    val productName: String,
+    val desiredQuantity: Int,
+    val desiredPickupDate: LocalDate,
+    val additionalNote: String?,
+    val status: GroupBuyRequestStatus,
+    val rejectionReason: String?,
+    val openedGroupBuyId: Long?,
+    val statusHistory: List<AdminGroupBuyRequestStatusHistoryResponse>,
+    val createdAt: LocalDateTime?
+) {
+    companion object {
+        fun from(
+            request: GroupBuyRequest,
+            requester: User?,
+            history: List<GroupBuyRequestStatusHistory>
+        ): AdminGroupBuyRequestDetailResponse =
+            AdminGroupBuyRequestDetailResponse(
+                requestId = request.id,
+                requester = AdminGroupBuyRequestRequesterResponse.from(request.userId, requester),
+                storeName = request.storeName,
+                storeAddress = request.storeAddress,
+                placeId = request.placeId,
+                roadAddress = request.roadAddress,
+                lotAddress = request.lotAddress,
+                latitude = request.latitude,
+                longitude = request.longitude,
+                productName = request.productName,
+                desiredQuantity = request.desiredQuantity,
+                desiredPickupDate = request.desiredPickupDate,
+                additionalNote = request.additionalNote,
+                status = request.status,
+                rejectionReason = request.rejectionReason,
+                openedGroupBuyId = request.openedGroupBuyId,
+                statusHistory = history.map { AdminGroupBuyRequestStatusHistoryResponse.from(it) },
+                createdAt = request.createdAt
+            )
+    }
+}
+
+data class AdminGroupBuyRequestRequesterResponse(
+    val userId: Long,
+    val nickname: String?,
+    val phoneNumber: String?,
+    val email: String?,
+    val provider: AuthProvider?
+) {
+    companion object {
+        fun from(
+            userId: Long,
+            user: User?
+        ): AdminGroupBuyRequestRequesterResponse =
+            AdminGroupBuyRequestRequesterResponse(
+                userId = userId,
+                nickname = user?.nickname,
+                phoneNumber = user?.phoneNumber,
+                email = user?.email,
+                provider = user?.provider
+            )
+    }
+}
+
+data class AdminGroupBuyRequestStatusHistoryResponse(
+    val status: GroupBuyRequestStatus,
+    val changedAt: LocalDateTime
+) {
+    companion object {
+        fun from(history: GroupBuyRequestStatusHistory): AdminGroupBuyRequestStatusHistoryResponse =
+            AdminGroupBuyRequestStatusHistoryResponse(
+                status = history.status,
+                changedAt = history.changedAt
+            )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -2,11 +2,20 @@ package com.moongchijang.domain.groupbuy.domain.repository
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDate
 
 interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
     fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<GroupBuyRequest>
+
+    fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<GroupBuyRequest>
+
+    fun findByStatusOrderByCreatedAtDesc(
+        status: GroupBuyRequestStatus,
+        pageable: Pageable
+    ): Page<GroupBuyRequest>
 
     fun countByUserId(userId: Long): Long
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
@@ -1,17 +1,23 @@
 package com.moongchijang.domain.groupbuy.presentation
 
 import com.moongchijang.domain.groupbuy.application.GroupBuyRequestService
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestDetailResponse
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestPageResponse
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestStatusFilter
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestResponse
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestStatusUpdateRequest
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -20,6 +26,23 @@ import org.springframework.web.bind.annotation.RestController
 class GroupBuyRequestAdminController(
     private val groupBuyRequestService: GroupBuyRequestService
 ) {
+
+    @GetMapping
+    @Operation(summary = "운영자 공구 개설 요청 목록 조회")
+    fun getRequests(
+        @RequestParam(defaultValue = "ALL") status: AdminGroupBuyRequestStatusFilter,
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<AdminGroupBuyRequestPageResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminRequests(status, pageable)))
+    }
+
+    @GetMapping("/{requestId}")
+    @Operation(summary = "운영자 공구 개설 요청 상세 조회")
+    fun getDetail(
+        @PathVariable requestId: Long
+    ): ResponseEntity<ApiResponse<AdminGroupBuyRequestDetailResponse>> {
+        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminDetail(requestId)))
+    }
 
     @PatchMapping("/{requestId}/status")
     @Operation(summary = "공구 개설 요청 상태 변경")

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3832,13 +3832,13 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [content, totalElements, totalPages]
+          required: [content, totalElements, totalPages, number, size]
           properties:
             content:
               type: array
               items:
                 type: object
-                required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, requesterName, createdAt]
+                required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, requesterId, createdAt]
                 properties:
                   requestId: { type: integer, format: int64 }
                   storeName: { type: string }
@@ -3848,10 +3848,13 @@ components:
                   status:
                     type: string
                     enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
-                  requesterName: { type: string }
-                  createdAt: { type: string, format: date-time }
-            totalElements: { type: integer }
+                  requesterId: { type: integer, format: int64 }
+                  requesterName: { type: string, nullable: true }
+                  createdAt: { type: string, format: date-time, nullable: true }
+            totalElements: { type: integer, format: int64 }
             totalPages: { type: integer }
+            number: { type: integer }
+            size: { type: integer }
         error: { nullable: true, example: null }
 
     ApiResponseAdminRequestDetail:
@@ -3861,10 +3864,28 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, additionalNote, status, rejectionReason, requesterName, createdAt]
+          required: [requestId, requester, storeName, productName, desiredQuantity, desiredPickupDate, status, statusHistory, createdAt]
           properties:
             requestId: { type: integer, format: int64 }
+            requester:
+              type: object
+              required: [userId]
+              properties:
+                userId: { type: integer, format: int64 }
+                nickname: { type: string, nullable: true }
+                phoneNumber: { type: string, nullable: true }
+                email: { type: string, nullable: true }
+                provider:
+                  type: string
+                  nullable: true
+                  enum: [KAKAO, EMAIL]
             storeName: { type: string }
+            storeAddress: { type: string, nullable: true }
+            placeId: { type: string, nullable: true }
+            roadAddress: { type: string, nullable: true }
+            lotAddress: { type: string, nullable: true }
+            latitude: { type: number, format: double, nullable: true }
+            longitude: { type: number, format: double, nullable: true }
             productName: { type: string }
             desiredQuantity: { type: integer }
             desiredPickupDate: { type: string, format: date }
@@ -3873,8 +3894,18 @@ components:
               type: string
               enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
             rejectionReason: { type: string, nullable: true }
-            requesterName: { type: string }
-            createdAt: { type: string, format: date-time }
+            openedGroupBuyId: { type: integer, format: int64, nullable: true }
+            statusHistory:
+              type: array
+              items:
+                type: object
+                required: [status, changedAt]
+                properties:
+                  status:
+                    type: string
+                    enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
+                  changedAt: { type: string, format: date-time }
+            createdAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 
     AdminRequestStatusUpdate:

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminControllerTest.kt
@@ -1,0 +1,78 @@
+package com.moongchijang.domain.groupbuy.presentation
+
+import com.moongchijang.domain.groupbuy.application.GroupBuyRequestService
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestDetailResponse
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestPageResponse
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestRequesterResponse
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestStatusFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.user.domain.entity.AuthProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class GroupBuyRequestAdminControllerTest {
+
+    private val groupBuyRequestService: GroupBuyRequestService = mock(GroupBuyRequestService::class.java)
+    private val controller = GroupBuyRequestAdminController(groupBuyRequestService)
+
+    @Test
+    fun `운영자 공구 요청 목록 조회는 상태 필터와 페이징을 서비스로 전달한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val response = AdminGroupBuyRequestPageResponse(
+            content = emptyList(),
+            totalElements = 0,
+            totalPages = 0,
+            number = 0,
+            size = 20
+        )
+        `when`(groupBuyRequestService.getAdminRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, pageable))
+            .thenReturn(response)
+
+        val result = controller.getRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, pageable)
+
+        assertEquals(response, result.body?.data)
+        verify(groupBuyRequestService).getAdminRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, pageable)
+    }
+
+    @Test
+    fun `운영자 공구 요청 상세 조회는 요청 id를 서비스로 전달한다`() {
+        val response = AdminGroupBuyRequestDetailResponse(
+            requestId = 10L,
+            requester = AdminGroupBuyRequestRequesterResponse(
+                userId = 1L,
+                nickname = "요청자",
+                phoneNumber = "01012345678",
+                email = "requester@example.com",
+                provider = AuthProvider.KAKAO
+            ),
+            storeName = "성심당",
+            storeAddress = "대전 중구",
+            placeId = null,
+            roadAddress = null,
+            lotAddress = null,
+            latitude = null,
+            longitude = null,
+            productName = "튀김소보로",
+            desiredQuantity = 20,
+            desiredPickupDate = LocalDate.of(2026, 6, 1),
+            additionalNote = "오전 픽업 희망",
+            status = GroupBuyRequestStatus.IN_REVIEW,
+            rejectionReason = null,
+            openedGroupBuyId = null,
+            statusHistory = emptyList(),
+            createdAt = LocalDateTime.of(2026, 5, 25, 12, 0)
+        )
+        `when`(groupBuyRequestService.getAdminDetail(10L)).thenReturn(response)
+
+        val result = controller.getDetail(10L)
+
+        assertEquals(response, result.body?.data)
+        verify(groupBuyRequestService).getAdminDetail(10L)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.groupbuy.service
 
 import com.moongchijang.domain.groupbuy.application.GroupBuyRequestService
 import com.moongchijang.domain.groupbuy.application.GroupBuyOpenRequestService
+import com.moongchijang.domain.groupbuy.application.dto.AdminGroupBuyRequestStatusFilter
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyRequestStatusUpdateRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
@@ -10,10 +11,12 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHisto
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.support.GroupBuyFixture
 import com.moongchijang.support.GroupBuyRequestFixture
+import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -22,6 +25,8 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
@@ -40,6 +45,9 @@ class GroupBuyRequestServiceTest {
 
     @Mock
     private lateinit var groupBuyOpenRequestService: GroupBuyOpenRequestService
+
+    @Mock
+    private lateinit var userRepository: UserRepository
 
     @InjectMocks
     private lateinit var service: GroupBuyRequestService
@@ -286,6 +294,126 @@ class GroupBuyRequestServiceTest {
 
         val ex = assertThrows<CustomException> { service.getDetail(1L, requestId) }
         assertEquals(ErrorCode.GROUPBUY_REQUEST_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `운영자는 전체 공구 요청 목록을 페이징 조회한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val requester = UserFixture.createKakaoUser(id = 1L, nickname = "은서")
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "성심당",
+            productName = "튀김소보로",
+            desiredQuantity = 20,
+            desiredPickupDate = LocalDate.now().plusDays(5)
+        ).apply { id = 10L }
+
+        `when`(groupBuyRequestRepository.findAllByOrderByCreatedAtDesc(pageable))
+            .thenReturn(PageImpl(listOf(request), pageable, 1))
+        `when`(userRepository.findAllById(listOf(1L))).thenReturn(listOf(requester))
+
+        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, pageable)
+
+        assertEquals(1, result.content.size)
+        assertEquals(1, result.totalElements)
+        assertEquals(1, result.totalPages)
+        assertEquals(0, result.number)
+        assertEquals(20, result.size)
+        assertEquals(10L, result.content[0].requestId)
+        assertEquals("성심당", result.content[0].storeName)
+        assertEquals("튀김소보로", result.content[0].productName)
+        assertEquals(20, result.content[0].desiredQuantity)
+        assertEquals(GroupBuyRequestStatus.IN_REVIEW, result.content[0].status)
+        assertEquals(1L, result.content[0].requesterId)
+        assertEquals("은서", result.content[0].requesterName)
+    }
+
+    @Test
+    fun `운영자는 상태별 공구 요청 목록을 페이징 조회한다`() {
+        val pageable = PageRequest.of(1, 10)
+        val request = GroupBuyRequest(
+            userId = 2L,
+            storeName = "파리바게뜨",
+            productName = "단팥빵",
+            desiredQuantity = 5,
+            desiredPickupDate = LocalDate.now().plusDays(3),
+            status = GroupBuyRequestStatus.REJECTED
+        ).apply { id = 11L }
+
+        `when`(groupBuyRequestRepository.findByStatusOrderByCreatedAtDesc(GroupBuyRequestStatus.REJECTED, pageable))
+            .thenReturn(PageImpl(listOf(request), pageable, 11))
+        `when`(userRepository.findAllById(listOf(2L))).thenReturn(emptyList())
+
+        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.REJECTED, pageable)
+
+        assertEquals(1, result.content.size)
+        assertEquals(11, result.totalElements)
+        assertEquals(2, result.totalPages)
+        assertEquals(1, result.number)
+        assertEquals(10, result.size)
+        assertEquals(GroupBuyRequestStatus.REJECTED, result.content[0].status)
+        assertEquals(2L, result.content[0].requesterId)
+        assertNull(result.content[0].requesterName)
+        verify(groupBuyRequestRepository).findByStatusOrderByCreatedAtDesc(GroupBuyRequestStatus.REJECTED, pageable)
+    }
+
+    @Test
+    fun `운영자는 공구 요청 상세를 조회한다`() {
+        val requestId = 12L
+        val requester = UserFixture.createKakaoUser(
+            id = 3L,
+            email = "requester@example.com",
+            nickname = "요청자"
+        ).apply { phoneNumber = "01012345678" }
+        val request = GroupBuyRequest(
+            userId = 3L,
+            storeName = "뚜레쥬르",
+            storeAddress = "서울 성동구",
+            placeId = "place-1",
+            roadAddress = "서울 성동구 도로명",
+            lotAddress = "서울 성동구 지번",
+            latitude = 37.1,
+            longitude = 127.1,
+            productName = "크림빵",
+            desiredQuantity = 30,
+            desiredPickupDate = LocalDate.now().plusDays(7),
+            additionalNote = "오전 픽업 희망",
+            status = GroupBuyRequestStatus.IN_CONTACT
+        ).apply { id = requestId }
+        val history = listOf(
+            GroupBuyRequestStatusHistory(
+                groupBuyRequestId = requestId,
+                status = GroupBuyRequestStatus.IN_REVIEW,
+                changedAt = LocalDateTime.now().minusDays(1)
+            ),
+            GroupBuyRequestStatusHistory(
+                groupBuyRequestId = requestId,
+                status = GroupBuyRequestStatus.IN_CONTACT,
+                changedAt = LocalDateTime.now()
+            )
+        )
+
+        `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(request))
+        `when`(userRepository.findById(3L)).thenReturn(Optional.of(requester))
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+            .thenReturn(history)
+
+        val result = service.getAdminDetail(requestId)
+
+        assertEquals(requestId, result.requestId)
+        assertEquals(3L, result.requester.userId)
+        assertEquals("요청자", result.requester.nickname)
+        assertEquals("01012345678", result.requester.phoneNumber)
+        assertEquals("requester@example.com", result.requester.email)
+        assertEquals("뚜레쥬르", result.storeName)
+        assertEquals("place-1", result.placeId)
+        assertEquals("크림빵", result.productName)
+        assertEquals(30, result.desiredQuantity)
+        assertEquals("오전 픽업 희망", result.additionalNote)
+        assertEquals(GroupBuyRequestStatus.IN_CONTACT, result.status)
+        assertEquals(2, result.statusHistory.size)
+        assertEquals(GroupBuyRequestStatus.IN_REVIEW, result.statusHistory[0].status)
+        assertEquals(GroupBuyRequestStatus.IN_CONTACT, result.statusHistory[1].status)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -358,6 +358,19 @@ class GroupBuyRequestServiceTest {
     }
 
     @Test
+    fun `운영자 공구 요청 목록이 비어있으면 사용자 조회를 생략한다`() {
+        val pageable = PageRequest.of(0, 20)
+        `when`(groupBuyRequestRepository.findAllByOrderByCreatedAtDesc(pageable))
+            .thenReturn(PageImpl(emptyList(), pageable, 0))
+
+        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, pageable)
+
+        assertTrue(result.content.isEmpty())
+        assertEquals(0, result.totalElements)
+        verify(userRepository, never()).findAllById(anyList())
+    }
+
+    @Test
     fun `운영자는 공구 요청 상세를 조회한다`() {
         val requestId = 12L
         val requester = UserFixture.createKakaoUser(


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/admin/group-buy-requests` 운영자 공구 개설 요청 목록 조회 API를 추가했습니다.
- `ALL`, `IN_REVIEW`, `IN_CONTACT`, `OPENED`, `REJECTED` 상태 필터와 페이징을 지원합니다.
- `GET /api/v1/admin/group-buy-requests/{requestId}` 운영자 공구 개설 요청 상세 조회 API를 추가했습니다.
- 목록/상세 응답에 요청자 정보, 매장 정보, 요청 상품 정보, 상태/상태 이력을 포함했습니다.
- 서비스/컨트롤러 테스트를 추가하고 `openapi.yaml`을 최신화했습니다.

## 🔍 참고 사항
- 이번 PR은 조회 API만 포함합니다.
- 승인/반려 및 실제 공구 생성 처리는 다음 PR 범위로 분리합니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- Closes #203

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

완료 기능:
- 3.1 검색창/필터 기반 공구 개설 요청 목록 조회 백엔드 구현 완료
- 3.1.1 승인대기 중 소비자 요청 공구 상세 조회 백엔드 구현 완료
- 3.1.2 승인완료 요청 조회 백엔드 구현 완료
- 3.1.3 반려 요청 조회 백엔드 구현 완료
- 3.1.4 전체 요청 조회 백엔드 구현 완료
