### PR TITLE
[MCJ-1526] FIX: 마이페이지 요청 파라미터 오류 500 응답 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
@@ -42,7 +42,7 @@ class GlobalExceptionHandler {
     fun handleMissingServletRequestParameterException(
         e: MissingServletRequestParameterException
     ): ResponseEntity<ApiResponse<Nothing>> {
-        val detail = "${e.parameterName}: required request parameter is missing"
+        val detail = "${e.parameterName}: 필수 요청 파라미터가 누락되었습니다"
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, detail))
@@ -52,8 +52,7 @@ class GlobalExceptionHandler {
     fun handleMethodArgumentTypeMismatchException(
         e: MethodArgumentTypeMismatchException
     ): ResponseEntity<ApiResponse<Nothing>> {
-        val requiredType = e.requiredType?.simpleName ?: "unknown"
-        val detail = "${e.name}: must be a valid $requiredType"
+        val detail = "${e.name}: 올바른 형식이 아닙니다"
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, detail))

--- a/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/moongchijang/global/handler/GlobalExceptionHandler.kt
@@ -10,8 +10,10 @@ import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.AuthenticationException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -34,6 +36,27 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, errorMessage))
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleMissingServletRequestParameterException(
+        e: MissingServletRequestParameterException
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val detail = "${e.parameterName}: required request parameter is missing"
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, detail))
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleMethodArgumentTypeMismatchException(
+        e: MethodArgumentTypeMismatchException
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        val requiredType = e.requiredType?.simpleName ?: "unknown"
+        val detail = "${e.name}: must be a valid $requiredType"
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, detail))
     }
 
     @ExceptionHandler(AccessDeniedException::class)

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1334,6 +1334,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseMypageParticipationList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
 
   /api/v1/users/me/participations/in-progress:
     get:

--- a/src/test/kotlin/com/moongchijang/global/handler/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/moongchijang/global/handler/GlobalExceptionHandlerTest.kt
@@ -23,7 +23,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertFalse(response.body!!.success)
         assertEquals(ErrorCode.INVALID_INPUT.name, response.body!!.error?.code)
-        assertEquals("status: required request parameter is missing", response.body!!.error?.detail)
+        assertEquals("status: 필수 요청 파라미터가 누락되었습니다", response.body!!.error?.detail)
     }
 
     @Test
@@ -41,7 +41,7 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertFalse(response.body!!.success)
         assertEquals(ErrorCode.INVALID_INPUT.name, response.body!!.error?.code)
-        assertEquals("status: must be a valid MypageParticipationStatusFilter", response.body!!.error?.detail)
+        assertEquals("status: 올바른 형식이 아닙니다", response.body!!.error?.detail)
     }
 
     @Suppress("unused")

--- a/src/test/kotlin/com/moongchijang/global/handler/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/moongchijang/global/handler/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,54 @@
+package com.moongchijang.global.handler
+
+import com.moongchijang.domain.mypage.application.dto.MypageParticipationStatusFilter
+import com.moongchijang.global.exception.ErrorCode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+
+class GlobalExceptionHandlerTest {
+
+    private val handler = GlobalExceptionHandler()
+
+    @Test
+    fun `필수 status 쿼리 파라미터가 누락되면 400으로 응답한다`() {
+        val exception = MissingServletRequestParameterException("status", "MypageParticipationStatusFilter")
+
+        val response = handler.handleMissingServletRequestParameterException(exception)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.success)
+        assertEquals(ErrorCode.INVALID_INPUT.name, response.body!!.error?.code)
+        assertEquals("status: required request parameter is missing", response.body!!.error?.detail)
+    }
+
+    @Test
+    fun `status enum 변환에 실패하면 400으로 응답한다`() {
+        val exception = MethodArgumentTypeMismatchException(
+            "INVALID",
+            MypageParticipationStatusFilter::class.java,
+            "status",
+            statusMethodParameter(),
+            IllegalArgumentException("No enum constant")
+        )
+
+        val response = handler.handleMethodArgumentTypeMismatchException(exception)
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertFalse(response.body!!.success)
+        assertEquals(ErrorCode.INVALID_INPUT.name, response.body!!.error?.code)
+        assertEquals("status: must be a valid MypageParticipationStatusFilter", response.body!!.error?.detail)
+    }
+
+    @Suppress("unused")
+    private fun statusParameter(status: MypageParticipationStatusFilter) = status
+
+    private fun statusMethodParameter(): MethodParameter {
+        val method = this::class.java.getDeclaredMethod("statusParameter", MypageParticipationStatusFilter::class.java)
+        return MethodParameter(method, 0)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 필수 요청 파라미터 누락 예외를 400 INVALID_INPUT 응답으로 처리했습니다.
- 요청 파라미터 타입/enum 변환 실패 예외를 400 INVALID_INPUT 응답으로 처리했습니다.
- 마이페이지 참여 목록 status 파라미터 누락/오류 케이스를 검증하는 테스트를 추가했습니다.
- openapi.yaml에 /api/v1/users/me/participations 400 응답을 문서화했습니다.

## 🔍 참고 사항
- 프론트 마이페이지 테스트 중 status 파라미터 누락/오류가 500으로 보일 수 있는 경로를 우선 차단했습니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- Closes #205

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
