### PR TITLE
HOTFIX: OpenAPI YAML 파싱 오류(line 230 description) 수정

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -227,7 +227,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiResponseBusinessRegistrationLookup'
         '400':
-          description: 입력값 검증 실패 (예: INVALID_BUSINESS_REGISTRATION_NUMBER_FORMAT)
+          description: "입력값 검증 실패 (예: INVALID_BUSINESS_REGISTRATION_NUMBER_FORMAT)"
           content:
             application/json:
               schema:


### PR DESCRIPTION
## 📌 작업한 내용
- `openapi.yaml` 230줄의 `description` 문자열에 포함된 콜론(`:`)으로 인해 YAML 파싱이 실패하던 문제를 수정했습니다.
- 해당 `description` 값을 따옴표로 감싸 Swagger/OpenAPI 파서가 정상 인식하도록 처리했습니다.

## 🔍 참고 사항
- 기능 로직 변경은 없고, 문서 파싱 오류 수정만 포함됩니다.
- 수정 후 YAML 파싱 검증 완료했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인