### PR TITLE
[MCJ-1528] FIX: 사장님 공구 개설 요청 상품 설명 길이 제한 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequest.kt
@@ -19,7 +19,7 @@ data class OwnerGroupBuyRequestCreateRequest(
     val productName: String,
 
     @field:NotBlank(message = "상품 설명은 필수입니다")
-    @field:Size(max = 500, message = "상품 설명은 500자 이하이어야 합니다")
+    @field:Size(max = 30, message = "상품 설명은 30자 이하이어야 합니다")
     val productDescription: String,
 
     @field:NotNull(message = "희망 공구 마감일시는 필수입니다")

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3592,7 +3592,7 @@ components:
           example: 두쫀쿠 세트
         productDescription:
           type: string
-          maxLength: 500
+          maxLength: 30
           description: 상품 설명
           example: 소금빵 포함
         deadline:

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequestTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequestTest.kt
@@ -1,0 +1,53 @@
+package com.moongchijang.domain.owner.application.dto
+
+import jakarta.validation.Validation
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class OwnerGroupBuyRequestCreateRequestTest {
+
+    private val validator = Validation.buildDefaultValidatorFactory().validator
+
+    @Test
+    fun `상품 설명은 30자까지 허용한다`() {
+        val request = validRequest(productDescription = "가".repeat(30))
+
+        val violations = validator.validate(request)
+
+        assertTrue(violations.none { it.propertyPath.toString() == "productDescription" })
+    }
+
+    @Test
+    fun `상품 설명이 30자를 초과하면 검증에 실패한다`() {
+        val request = validRequest(productDescription = "가".repeat(31))
+
+        val violations = validator.validate(request)
+
+        val productDescriptionViolation = violations.single { it.propertyPath.toString() == "productDescription" }
+        assertEquals("상품 설명은 30자 이하이어야 합니다", productDescriptionViolation.message)
+    }
+
+    private fun validRequest(
+        productDescription: String
+    ) = OwnerGroupBuyRequestCreateRequest(
+        storeId = 1L,
+        productName = "두쫀쿠 세트",
+        productDescription = productDescription,
+        deadline = LocalDateTime.of(2026, 6, 3, 23, 59),
+        originalPrice = 12000,
+        price = 9900,
+        targetQuantity = 20,
+        maxQuantity = 50,
+        perUserLimit = 2,
+        imageUrls = listOf("https://cdn.example.com/1.jpg"),
+        pickupDate = LocalDate.of(2026, 6, 4),
+        pickupTimeStart = LocalTime.of(12, 0),
+        pickupTimeEnd = LocalTime.of(18, 0),
+        pickupLocation = "서울 성동구 성수이로 1",
+        pickupContact = "01012345678"
+    )
+}

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequestTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestCreateRequestTest.kt
@@ -10,8 +10,6 @@ import java.time.LocalTime
 
 class OwnerGroupBuyRequestCreateRequestTest {
 
-    private val validator = Validation.buildDefaultValidatorFactory().validator
-
     @Test
     fun `상품 설명은 30자까지 허용한다`() {
         val request = validRequest(productDescription = "가".repeat(30))
@@ -37,17 +35,21 @@ class OwnerGroupBuyRequestCreateRequestTest {
         storeId = 1L,
         productName = "두쫀쿠 세트",
         productDescription = productDescription,
-        deadline = LocalDateTime.of(2026, 6, 3, 23, 59),
+        deadline = LocalDateTime.now().plusDays(8),
         originalPrice = 12000,
         price = 9900,
         targetQuantity = 20,
         maxQuantity = 50,
         perUserLimit = 2,
         imageUrls = listOf("https://cdn.example.com/1.jpg"),
-        pickupDate = LocalDate.of(2026, 6, 4),
+        pickupDate = LocalDate.now().plusDays(9),
         pickupTimeStart = LocalTime.of(12, 0),
         pickupTimeEnd = LocalTime.of(18, 0),
         pickupLocation = "서울 성동구 성수이로 1",
         pickupContact = "01012345678"
     )
+
+    private companion object {
+        val validator = Validation.buildDefaultValidatorFactory().validator
+    }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 공구 개설 요청 생성 DTO의 상품 설명 최대 길이를 명세와 동일하게 30자로 조정했습니다.
- 상품 설명 30자 허용/31자 거부 검증 테스트를 추가했습니다.
- openapi.yaml의 OwnerGroupBuyRequestCreate.productDescription maxLength를 30으로 최신화했습니다.

## 🔍 참고 사항
- DB 스키마 변경은 없어 Flyway 마이그레이션은 추가하지 않았습니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- Closes #210

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
