### PR TITLE
[MCJ-1529] FIX: 환불 목록 응답에 썸네일과 결제수단 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -48,14 +48,21 @@ class MypageService(
             requestCount = groupBuyRequestRepository.countByUserId(userId)
         )
 
-    fun getRefunds(userId: Long): List<MypageRefundResponse> =
-        participationRepository
-            .findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
-                userId = userId,
-                statuses = REFUND_PARTICIPATION_STATUSES,
-                refundPendingStatus = ParticipationStatus.REFUND_PENDING
+    fun getRefunds(userId: Long): List<MypageRefundResponse> {
+        val participations = participationRepository.findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
+            userId = userId,
+            statuses = REFUND_PARTICIPATION_STATUSES,
+            refundPendingStatus = ParticipationStatus.REFUND_PENDING
+        )
+        val paymentInfoByParticipationId = paymentInfoByParticipationId(participations)
+
+        return participations.map {
+            MypageRefundResponse.from(
+                participation = it,
+                paymentInfo = paymentInfoByParticipationId[it.id]
             )
-            .map(MypageRefundResponse::from)
+        }
+    }
 
     fun getParticipations(
         userId: Long,

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -19,6 +19,7 @@ data class MypageSummaryResponse(
 
 data class MypageRefundResponse(
     val participationId: Long,
+    val thumbnailUrl: String?,
     val productName: String,
     val refundStatus: String,
     val storeName: String,
@@ -29,14 +30,19 @@ data class MypageRefundResponse(
     val quantity: Int,
     val cancelReason: String?,
     val cancelReasonDetail: String?,
+    val paymentMethod: String?,
     val refundedAt: LocalDateTime?
 ) {
     companion object {
-        fun from(participation: Participation): MypageRefundResponse {
+        fun from(
+            participation: Participation,
+            paymentInfo: MypageParticipationPaymentInfo? = null
+        ): MypageRefundResponse {
             val groupBuy = participation.groupBuy
 
             return MypageRefundResponse(
                 participationId = participation.id,
+                thumbnailUrl = groupBuy.thumbnailUrl,
                 productName = groupBuy.productName,
                 refundStatus = refundStatus(participation),
                 storeName = groupBuy.store.name,
@@ -47,6 +53,7 @@ data class MypageRefundResponse(
                 quantity = participation.quantity,
                 cancelReason = participation.cancelReason?.name,
                 cancelReasonDetail = participation.cancelReasonDetail,
+                paymentMethod = paymentInfo?.paymentMethod,
                 refundedAt = participation.refundedAt
             )
         }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3294,9 +3294,10 @@ components:
           type: array
           items:
             type: object
-            required: [participationId, productName, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, paymentAmount, quantity, refundStatus, cancelReason]
+            required: [participationId, thumbnailUrl, productName, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, paymentAmount, quantity, refundStatus, cancelReason, paymentMethod]
             properties:
               participationId: { type: integer, format: int64 }
+              thumbnailUrl: { type: string, nullable: true, description: 카드 상품 이미지 URL }
               productName: { type: string }
               storeName: { type: string }
               pickupDate: { type: string, format: date, nullable: true }
@@ -3317,6 +3318,7 @@ components:
                 type: string
                 nullable: true
                 description: 취소 상세 사유
+              paymentMethod: { type: string, nullable: true, description: 결제 수단 }
               refundedAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }
 

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -112,11 +112,32 @@ class MypageServiceTest {
                 ParticipationStatus.REFUND_PENDING
             )
         ).thenReturn(listOf(pending, completed))
+        `when`(
+            paymentOrderRepository.findPaymentSummariesByParticipationIdIn(listOf(9L, 10L))
+        ).thenReturn(
+            listOf(
+                paymentSummary(
+                    participationId = 9L,
+                    groupBuyId = 100L,
+                    orderStatus = PaymentOrderStatus.APPROVED,
+                    paidAt = LocalDateTime.of(2026, 5, 18, 9, 0),
+                    paymentMethod = "CARD"
+                ),
+                paymentSummary(
+                    participationId = 10L,
+                    groupBuyId = 100L,
+                    orderStatus = PaymentOrderStatus.APPROVED,
+                    paidAt = LocalDateTime.of(2026, 5, 19, 9, 0),
+                    paymentMethod = "KAKAOPAY"
+                )
+            )
+        )
 
         val result = mypageService.getRefunds(userId)
 
         assertEquals(2, result.size)
         assertEquals(9L, result[0].participationId)
+        assertEquals("https://example.com/cake.jpg", result[0].thumbnailUrl)
         assertEquals("초코 케이크", result[0].productName)
         assertEquals("PENDING", result[0].refundStatus)
         assertEquals("문치 베이커리", result[0].storeName)
@@ -127,9 +148,12 @@ class MypageServiceTest {
         assertEquals(2, result[0].quantity)
         assertEquals(ParticipationCancelReason.TIME_UNAVAILABLE.name, result[0].cancelReason)
         assertEquals("마감 전 직접 취소", result[0].cancelReasonDetail)
+        assertEquals("CARD", result[0].paymentMethod)
         assertEquals(null, result[0].refundedAt)
         assertEquals(10L, result[1].participationId)
+        assertEquals("https://example.com/cake.jpg", result[1].thumbnailUrl)
         assertEquals("COMPLETED", result[1].refundStatus)
+        assertEquals("KAKAOPAY", result[1].paymentMethod)
         assertEquals(LocalDateTime.of(2026, 5, 20, 10, 0), result[1].refundedAt)
     }
 


### PR DESCRIPTION
## 📌 작업한 내용
- `/api/v1/users/me/refunds` 응답 DTO에 `thumbnailUrl`, `paymentMethod` 필드를 추가했습니다.
- 환불 목록 조회 시 기존 결제 요약 조회를 재사용해 참여별 결제수단을 매핑했습니다.
- `openapi.yaml`의 `ApiResponseRefundList`에 신규 필드를 반영했습니다.
- `MypageServiceTest`에서 환불 응답의 `thumbnailUrl`, `paymentMethod` 포함 여부를 검증하도록 보강했습니다.


## 🔍 참고 사항
- `thumbnailUrl`은 `participation.groupBuy.thumbnailUrl`에서 내려줍니다.
- `paymentMethod`는 `PaymentOrderRepository.findPaymentSummariesByParticipationIdIn()` 조회 결과를 사용합니다.


## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
Closes #213

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
