### PR TITLE
[MCJ-1532] FEAT: 전화번호 인증 API 경로 분리(auth, users/me) 및 인증 스펙 정리

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/auth/application/PhoneVerificationService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/PhoneVerificationService.kt
@@ -60,11 +60,27 @@ class PhoneVerificationService(
         return PhoneVerificationVerifiedResponse(verified = true)
     }
 
+    fun verifyCodeForUser(userId: Long, request: PhoneVerificationCodeVerifyRequest): PhoneVerificationVerifiedResponse {
+        val result = verifyCode(request)
+        val phoneNumber = normalizePhoneNumber(request.phoneNumber)
+        phoneVerificationStore.markVerifiedForUser(userId, phoneNumber, VERIFIED_TTL_SECONDS)
+        return result
+    }
+
     fun ensureVerified(rawPhoneNumber: String) {
         val phoneNumber = normalizePhoneNumber(rawPhoneNumber)
         validatePhoneNumber(phoneNumber)
 
         if (!phoneVerificationStore.isVerified(phoneNumber)) {
+            throw CustomException(ErrorCode.PHONE_VERIFICATION_REQUIRED)
+        }
+    }
+
+    fun ensureVerifiedForUser(userId: Long, rawPhoneNumber: String) {
+        val phoneNumber = normalizePhoneNumber(rawPhoneNumber)
+        validatePhoneNumber(phoneNumber)
+
+        if (!phoneVerificationStore.isVerifiedForUser(userId, phoneNumber)) {
             throw CustomException(ErrorCode.PHONE_VERIFICATION_REQUIRED)
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/auth/application/port/PhoneVerificationStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/port/PhoneVerificationStore.kt
@@ -7,4 +7,6 @@ interface PhoneVerificationStore {
 
     fun markVerified(phoneNumber: String, ttlSeconds: Long)
     fun isVerified(phoneNumber: String): Boolean
+    fun markVerifiedForUser(userId: Long, phoneNumber: String, ttlSeconds: Long)
+    fun isVerifiedForUser(userId: Long, phoneNumber: String): Boolean
 }

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/sms/coolsms/store/RedisPhoneVerificationStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/sms/coolsms/store/RedisPhoneVerificationStore.kt
@@ -30,8 +30,17 @@ class RedisPhoneVerificationStore(
         return redisTemplate.opsForValue().get(verifiedKey(phoneNumber)) == VERIFIED_VALUE
     }
 
+    override fun markVerifiedForUser(userId: Long, phoneNumber: String, ttlSeconds: Long) {
+        redisTemplate.opsForValue().set(verifiedForUserKey(userId, phoneNumber), VERIFIED_VALUE, Duration.ofSeconds(ttlSeconds))
+    }
+
+    override fun isVerifiedForUser(userId: Long, phoneNumber: String): Boolean {
+        return redisTemplate.opsForValue().get(verifiedForUserKey(userId, phoneNumber)) == VERIFIED_VALUE
+    }
+
     private fun codeKey(phoneNumber: String): String = "$KEY_PREFIX:code:$phoneNumber"
     private fun verifiedKey(phoneNumber: String): String = "$KEY_PREFIX:verified:$phoneNumber"
+    private fun verifiedForUserKey(userId: Long, phoneNumber: String): String = "$KEY_PREFIX:verified:$userId:$phoneNumber"
 
     companion object {
         private const val KEY_PREFIX = "auth:phone"

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/PhoneVerificationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/PhoneVerificationController.kt
@@ -100,7 +100,7 @@ class PhoneVerificationController(
         @Valid @RequestBody request: PhoneVerificationCodeVerifyRequest,
     ): ApiResponse<PhoneVerificationVerifiedResponse> {
         log.info("[PhoneVerificationController] 내 정보 전화번호 인증코드 검증 요청 수신: userId={}", principal.id)
-        val response = phoneVerificationService.verifyCode(request)
+        val response = phoneVerificationService.verifyCodeForUser(principal.id, request)
         log.info("[PhoneVerificationController] 내 정보 전화번호 인증코드 검증 응답 완료: userId={}", principal.id)
         return ApiResponse.success(response)
     }

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/PhoneVerificationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/PhoneVerificationController.kt
@@ -14,20 +14,23 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import org.slf4j.LoggerFactory
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import com.moongchijang.security.principal.CustomUserPrincipal
 
 @RestController
-@RequestMapping("/api/v1/auth/phone/verification-codes")
+@RequestMapping("/api/v1")
 @Tag(name = "Auth", description = "인증 API")
 class PhoneVerificationController(
     private val phoneVerificationService: PhoneVerificationService
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    @PostMapping
+    @PostMapping("/auth/phone/verification-codes")
     @Operation(summary = "전화번호 인증코드 발송", description = "입력한 전화번호로 6자리 인증코드를 발송합니다.")
     @ApiResponses(
         value = [
@@ -45,7 +48,7 @@ class PhoneVerificationController(
         return ApiResponse.success(response)
     }
 
-    @PostMapping("/verify")
+    @PostMapping("/auth/phone/verification-codes/verify")
     @Operation(summary = "전화번호 인증코드 확인", description = "전화번호와 인증코드를 검증해 인증 완료 상태를 처리합니다.")
     @ApiResponses(
         value = [
@@ -59,6 +62,46 @@ class PhoneVerificationController(
         log.info("[PhoneVerificationController] 전화번호 인증코드 검증 요청 수신")
         val response = phoneVerificationService.verifyCode(request)
         log.info("[PhoneVerificationController] 전화번호 인증코드 검증 응답 완료")
+        return ApiResponse.success(response)
+    }
+
+    @PostMapping("/users/me/phone/verification-codes")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "전화번호 변경 인증코드 발송", description = "로그인 사용자의 전화번호 변경을 위한 인증코드를 발송합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "인증코드 발송 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "입력값 검증 실패", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun sendVerificationCodeForMe(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @Valid @RequestBody request: PhoneVerificationCodeSendRequest,
+    ): ApiResponse<PhoneVerificationCodeSentResponse> {
+        log.info("[PhoneVerificationController] 내 정보 전화번호 인증코드 발송 요청 수신: userId={}", principal.id)
+        val response = phoneVerificationService.sendVerificationCode(request)
+        log.info("[PhoneVerificationController] 내 정보 전화번호 인증코드 발송 응답 완료: userId={}", principal.id)
+        return ApiResponse.success(response)
+    }
+
+    @PostMapping("/users/me/phone/verification-codes/verify")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "전화번호 변경 인증코드 확인", description = "로그인 사용자의 전화번호 변경을 위한 인증코드를 검증합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "인증코드 확인 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "인증코드 불일치/만료", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun verifyCodeForMe(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @Valid @RequestBody request: PhoneVerificationCodeVerifyRequest,
+    ): ApiResponse<PhoneVerificationVerifiedResponse> {
+        log.info("[PhoneVerificationController] 내 정보 전화번호 인증코드 검증 요청 수신: userId={}", principal.id)
+        val response = phoneVerificationService.verifyCode(request)
+        log.info("[PhoneVerificationController] 내 정보 전화번호 인증코드 검증 응답 완료: userId={}", principal.id)
         return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -208,7 +208,7 @@ class UserService(
     fun updatePhoneNumber(request: PhoneNumberUpdateRequest, userId: Long): PhoneNumberUpdateResponse {
         log.info("[UserService] 전화번호 변경 처리 시작: userId={}", userId)
         validatePhoneNumberFormat(request.phoneNumber)
-        phoneVerificationService.ensureVerified(request.phoneNumber)
+        phoneVerificationService.ensureVerifiedForUser(userId, request.phoneNumber)
 
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -449,23 +449,6 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /api/v1/auth/password/reset-link:
-    post:
-      tags: [Auth]
-      summary: 비밀번호 재설정 링크 발송
-      description: 가입된 이메일로 비밀번호 재설정 링크를 발송한다.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PasswordResetLinkRequest'
-      responses:
-        '200':
-          $ref: '#/components/responses/SuccessNoData'
-        '404':
-          $ref: '#/components/responses/NotFound'
-
   /api/v1/users/me/nickname:
     patch:
       tags: [Auth]
@@ -2512,14 +2495,6 @@ components:
           format: email
         password:
           type: string
-
-    PasswordResetLinkRequest:
-      type: object
-      required: [email]
-      properties:
-        email:
-          type: string
-          format: email
 
     NicknameUpdateRequest:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -346,7 +346,7 @@ class UserServiceTest {
             userId = 53L,
         )
 
-        Mockito.verify(phoneVerificationService).ensureVerified("010-9999-8888")
+        Mockito.verify(phoneVerificationService).ensureVerifiedForUser(53L, "010-9999-8888")
         Assertions.assertEquals("010-9999-8888", user.phoneNumber)
         Assertions.assertEquals(53L, response.id)
         Assertions.assertEquals("010-9999-8888", response.phoneNumber)


### PR DESCRIPTION
## 📌 작업한 내용
- 전화번호 인증 API를 용도별로 분리
- 비로그인 인증 흐름: `auth` 경로 유지
- 로그인 후 계정 변경 흐름: `users/me` 경로 추가
- `PhoneVerificationController`를 `/api/v1` 베이스로 정리하고 `auth`/`users/me` 하위 경로를 함께 관리하도록 구성
- OpenAPI(Swagger)에서 비밀번호 재설정 링크 API 스펙 제거
- 로그인 사용자 전화번호 변경 흐름에서 인증 완료 상태를 `userId + phoneNumber` 기준으로 저장/검증하도록 보완
- 전화번호 변경 시 사용자 바인딩 인증 검증을 통과한 경우에만 변경되도록 적용

## 🔍 참고 사항
- 전화번호 변경 저장 API(`PATCH /api/v1/users/me/phone-number`)는 기존처럼 인증코드 검증 완료 상태를 전제로 동작합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #219 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인