### PR TITLE
[MCJ-1535] FIX: 환불 목록 응답에 결제일시 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -30,6 +30,7 @@ data class MypageRefundResponse(
     val quantity: Int,
     val cancelReason: String?,
     val cancelReasonDetail: String?,
+    val paidAt: LocalDateTime?,
     val paymentMethod: String?,
     val refundedAt: LocalDateTime?
 ) {
@@ -53,6 +54,7 @@ data class MypageRefundResponse(
                 quantity = participation.quantity,
                 cancelReason = participation.cancelReason?.name,
                 cancelReasonDetail = participation.cancelReasonDetail,
+                paidAt = paymentInfo?.paidAt,
                 paymentMethod = paymentInfo?.paymentMethod,
                 refundedAt = participation.refundedAt
             )

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3324,7 +3324,7 @@ components:
           type: array
           items:
             type: object
-            required: [participationId, thumbnailUrl, productName, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, paymentAmount, quantity, refundStatus, cancelReason, paymentMethod]
+            required: [participationId, thumbnailUrl, productName, storeName, pickupDate, pickupTimeStart, pickupTimeEnd, paymentAmount, quantity, refundStatus, cancelReason, paidAt, paymentMethod]
             properties:
               participationId: { type: integer, format: int64 }
               thumbnailUrl: { type: string, nullable: true, description: 카드 상품 이미지 URL }
@@ -3348,6 +3348,7 @@ components:
                 type: string
                 nullable: true
                 description: 취소 상세 사유
+              paidAt: { type: string, format: date-time, nullable: true, description: 결제 일시 }
               paymentMethod: { type: string, nullable: true, description: 결제 수단 }
               refundedAt: { type: string, format: date-time, nullable: true }
         error: { nullable: true, example: null }

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -148,11 +148,13 @@ class MypageServiceTest {
         assertEquals(2, result[0].quantity)
         assertEquals(ParticipationCancelReason.TIME_UNAVAILABLE.name, result[0].cancelReason)
         assertEquals("마감 전 직접 취소", result[0].cancelReasonDetail)
+        assertEquals(LocalDateTime.of(2026, 5, 18, 9, 0), result[0].paidAt)
         assertEquals("CARD", result[0].paymentMethod)
         assertEquals(null, result[0].refundedAt)
         assertEquals(10L, result[1].participationId)
         assertEquals("https://example.com/cake.jpg", result[1].thumbnailUrl)
         assertEquals("COMPLETED", result[1].refundStatus)
+        assertEquals(LocalDateTime.of(2026, 5, 19, 9, 0), result[1].paidAt)
         assertEquals("KAKAOPAY", result[1].paymentMethod)
         assertEquals(LocalDateTime.of(2026, 5, 20, 10, 0), result[1].refundedAt)
     }


### PR DESCRIPTION
## 📌 작업한 내용
- `/api/v1/users/me/refunds` 응답 DTO에 `paidAt` 필드를 추가했습니다.
- 환불 목록 조회 시 기존 결제 요약 조회 결과의 `paidAt`을 응답에 매핑했습니다.
- `MypageServiceTest`에서 환불 응답의 `paidAt` 포함 여부를 검증하도록 보강했습니다.
- `openapi.yaml`의 `ApiResponseRefundList`에 `paidAt` 필드를 반영했습니다.

## 🔍 참고 사항
- `paidAt`은 `PaymentOrderRepository.findPaymentSummariesByParticipationIdIn()`의 결제 요약 조회 결과를 사용합니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- Closes #222

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
