### PR TITLE
[MCJ-1534] FEAT: 사장님 공구 요약 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryCustom.kt
@@ -3,9 +3,12 @@ package com.moongchijang.domain.groupbuy.domain.repository
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 interface GroupBuyRepositoryCustom {
@@ -32,4 +35,23 @@ interface GroupBuyRepositoryCustom {
     fun findDistinctRegions(status: GroupBuyStatus): List<String>
 
     fun findDistinctProductNames(status: GroupBuyStatus): List<String>
+
+    fun countByStoreIdsAndStatuses(
+        storeIds: Collection<Long>,
+        statuses: Collection<GroupBuyStatus>
+    ): Long
+
+    fun countTodayPickupUsersByStoreIds(
+        storeIds: Collection<Long>,
+        pickupDate: LocalDate,
+        participationStatuses: Collection<ParticipationStatus>,
+        pickupStatuses: Collection<PickupStatus>,
+        groupBuyStatuses: Collection<GroupBuyStatus>
+    ): Long
+
+    fun sumSettlementExpectedAmountByStoreIds(
+        storeIds: Collection<Long>,
+        participationStatuses: Collection<ParticipationStatus>,
+        groupBuyStatuses: Collection<GroupBuyStatus>
+    ): Long
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
@@ -4,6 +4,9 @@ import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.entity.QGroupBuy.groupBuy
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.entity.QParticipation.participation
 import com.moongchijang.domain.store.domain.entity.QStore.store
 import com.moongchijang.domain.favorite.domain.entity.QFavorite.favorite
 import com.moongchijang.domain.store.domain.entity.DistrictType
@@ -19,6 +22,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Repository
@@ -151,5 +155,69 @@ class GroupBuyRepositoryImpl(
             .from(groupBuy)
             .where(groupBuy.status.eq(status))
             .fetch()
+    }
+
+    override fun countByStoreIdsAndStatuses(
+        storeIds: Collection<Long>,
+        statuses: Collection<GroupBuyStatus>
+    ): Long {
+        if (storeIds.isEmpty() || statuses.isEmpty()) {
+            return 0L
+        }
+
+        return queryFactory
+            .select(groupBuy.count())
+            .from(groupBuy)
+            .where(
+                groupBuy.store.id.`in`(storeIds),
+                groupBuy.status.`in`(statuses)
+            )
+            .fetchOne() ?: 0L
+    }
+
+    override fun countTodayPickupUsersByStoreIds(
+        storeIds: Collection<Long>,
+        pickupDate: LocalDate,
+        participationStatuses: Collection<ParticipationStatus>,
+        pickupStatuses: Collection<PickupStatus>,
+        groupBuyStatuses: Collection<GroupBuyStatus>
+    ): Long {
+        if (storeIds.isEmpty() || participationStatuses.isEmpty() || pickupStatuses.isEmpty() || groupBuyStatuses.isEmpty()) {
+            return 0L
+        }
+
+        return queryFactory
+            .select(participation.count())
+            .from(participation)
+            .join(participation.groupBuy, groupBuy)
+            .where(
+                groupBuy.store.id.`in`(storeIds),
+                groupBuy.pickupDate.eq(pickupDate),
+                groupBuy.status.`in`(groupBuyStatuses),
+                participation.status.`in`(participationStatuses),
+                participation.pickupStatus.`in`(pickupStatuses)
+            )
+            .fetchOne() ?: 0L
+    }
+
+    override fun sumSettlementExpectedAmountByStoreIds(
+        storeIds: Collection<Long>,
+        participationStatuses: Collection<ParticipationStatus>,
+        groupBuyStatuses: Collection<GroupBuyStatus>
+    ): Long {
+        if (storeIds.isEmpty() || participationStatuses.isEmpty() || groupBuyStatuses.isEmpty()) {
+            return 0L
+        }
+
+        return queryFactory
+            .select(participation.totalAmount.sum().longValue())
+            .from(participation)
+            .join(participation.groupBuy, groupBuy)
+            .where(
+                groupBuy.store.id.`in`(storeIds),
+                groupBuy.status.`in`(groupBuyStatuses),
+                participation.status.`in`(participationStatuses)
+            )
+            .fetchOne() ?: 0L
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -3,13 +3,19 @@ package com.moongchijang.domain.owner.application
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryResponse
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @Service
 @Transactional(readOnly = true)
@@ -18,24 +24,107 @@ class OwnerGroupBuyService(
     private val storeStaffRepository: StoreStaffRepository,
     private val groupBuyRepository: GroupBuyRepository
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun getMyGroupBuys(ownerId: Long): List<OwnerGroupBuyListItemResponse> {
+        log.info("[OwnerGroupBuyService] 사장님 공구 목록 조회 시작: ownerId={}", ownerId)
+        validateSeller(ownerId)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            log.info("[OwnerGroupBuyService] 사장님 공구 목록 조회 완료(소속 매장 없음): ownerId={}", ownerId)
+            return emptyList()
+        }
+
+        val response = groupBuyRepository
+            .findByStoreIdInAndStatusInOrderByDeadlineAsc(storeIds, OWNER_VISIBLE_STATUSES)
+            .map { OwnerGroupBuyListItemResponse.from(it) }
+
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 목록 조회 완료: ownerId={}, storeCount={}, groupBuyCount={}",
+            ownerId,
+            storeIds.size,
+            response.size
+        )
+        return response
+    }
+
+    fun getMyGroupBuySummary(ownerId: Long): OwnerGroupBuySummaryResponse {
+        log.info("[OwnerGroupBuyService] 사장님 공구 요약 조회 시작: ownerId={}", ownerId)
+        validateSeller(ownerId)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            log.info("[OwnerGroupBuyService] 사장님 공구 요약 조회 완료(소속 매장 없음): ownerId={}", ownerId)
+            return emptySummary()
+        }
+
+        val ongoingCount = groupBuyRepository.countByStoreIdsAndStatuses(
+            storeIds = storeIds,
+            statuses = ONGOING_STATUSES
+        ).toInt()
+
+        val achievedCount = groupBuyRepository.countByStoreIdsAndStatuses(
+            storeIds = storeIds,
+            statuses = ACHIEVED_STATUSES
+        ).toInt()
+
+        val todayPickupUserCount = groupBuyRepository.countTodayPickupUsersByStoreIds(
+            storeIds = storeIds,
+            pickupDate = LocalDate.now(),
+            participationStatuses = TODAY_PICKUP_PARTICIPATION_STATUSES,
+            pickupStatuses = TODAY_PICKUP_PICKUP_STATUSES,
+            groupBuyStatuses = TODAY_PICKUP_GROUP_BUY_STATUSES
+        ).toInt()
+
+        val settlementExpectedAmount = groupBuyRepository.sumSettlementExpectedAmountByStoreIds(
+            storeIds = storeIds,
+            participationStatuses = SETTLEMENT_PARTICIPATION_STATUSES,
+            groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES
+        ).toInt()
+
+        val isEmpty = ongoingCount == 0 &&
+            achievedCount == 0 &&
+            todayPickupUserCount == 0 &&
+            settlementExpectedAmount == 0
+
+        val response = OwnerGroupBuySummaryResponse(
+            ongoingCount = ongoingCount,
+            achievedCount = achievedCount,
+            todayPickupUserCount = todayPickupUserCount,
+            settlementExpectedAmount = settlementExpectedAmount,
+            isEmpty = isEmpty
+        )
+
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 요약 조회 완료: ownerId={}, ongoingCount={}, achievedCount={}, todayPickupUserCount={}, settlementExpectedAmount={}, isEmpty={}",
+            ownerId,
+            response.ongoingCount,
+            response.achievedCount,
+            response.todayPickupUserCount,
+            response.settlementExpectedAmount,
+            response.isEmpty
+        )
+        return response
+    }
+
+    private fun validateSeller(ownerId: Long): User {
         val owner = userRepository.findByIdAndDeletedAtIsNull(ownerId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
         if (owner.role != UserRole.SELLER) {
             throw CustomException(ErrorCode.FORBIDDEN)
         }
-
-        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
-        if (storeIds.isEmpty()) {
-            return emptyList()
-        }
-
-        return groupBuyRepository
-            .findByStoreIdInAndStatusInOrderByDeadlineAsc(storeIds, OWNER_VISIBLE_STATUSES)
-            .map { OwnerGroupBuyListItemResponse.from(it) }
+        return owner
     }
+
+    private fun emptySummary() = OwnerGroupBuySummaryResponse(
+        ongoingCount = 0,
+        achievedCount = 0,
+        todayPickupUserCount = 0,
+        settlementExpectedAmount = 0,
+        isEmpty = true
+    )
 
     private companion object {
         val OWNER_VISIBLE_STATUSES = listOf(
@@ -45,5 +134,12 @@ class OwnerGroupBuyService(
             GroupBuyStatus.FAILED,
             GroupBuyStatus.CLOSED
         )
+        val ONGOING_STATUSES = listOf(GroupBuyStatus.IN_PROGRESS)
+        val ACHIEVED_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val TODAY_PICKUP_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
+        val TODAY_PICKUP_PICKUP_STATUSES = listOf(PickupStatus.NOT_READY, PickupStatus.READY)
+        val TODAY_PICKUP_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val SETTLEMENT_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
+        val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.ZoneId
 
 @Service
 @Transactional(readOnly = true)
@@ -71,7 +72,7 @@ class OwnerGroupBuyService(
 
         val todayPickupUserCount = groupBuyRepository.countTodayPickupUsersByStoreIds(
             storeIds = storeIds,
-            pickupDate = LocalDate.now(),
+            pickupDate = LocalDate.now(SEOUL_ZONE_ID),
             participationStatuses = TODAY_PICKUP_PARTICIPATION_STATUSES,
             pickupStatuses = TODAY_PICKUP_PICKUP_STATUSES,
             groupBuyStatuses = TODAY_PICKUP_GROUP_BUY_STATUSES
@@ -141,5 +142,6 @@ class OwnerGroupBuyService(
         val TODAY_PICKUP_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
         val SETTLEMENT_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
         val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -82,12 +82,12 @@ class OwnerGroupBuyService(
             storeIds = storeIds,
             participationStatuses = SETTLEMENT_PARTICIPATION_STATUSES,
             groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES
-        ).toInt()
+        )
 
         val isEmpty = ongoingCount == 0 &&
             achievedCount == 0 &&
             todayPickupUserCount == 0 &&
-            settlementExpectedAmount == 0
+            settlementExpectedAmount == 0L
 
         val response = OwnerGroupBuySummaryResponse(
             ongoingCount = ongoingCount,
@@ -123,7 +123,7 @@ class OwnerGroupBuyService(
         ongoingCount = 0,
         achievedCount = 0,
         todayPickupUserCount = 0,
-        settlementExpectedAmount = 0,
+        settlementExpectedAmount = 0L,
         isEmpty = true
     )
 

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuySummaryResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuySummaryResponse.kt
@@ -15,7 +15,7 @@ data class OwnerGroupBuySummaryResponse(
     val todayPickupUserCount: Int,
 
     @field:Schema(description = "정산 예정 금액", example = "128000")
-    val settlementExpectedAmount: Int,
+    val settlementExpectedAmount: Long,
 
     @field:Schema(description = "공구 요약 데이터 비어있는지 여부", example = "false")
     val isEmpty: Boolean

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuySummaryResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuySummaryResponse.kt
@@ -1,0 +1,22 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 홈 공구 요약 응답")
+data class OwnerGroupBuySummaryResponse(
+
+    @field:Schema(description = "진행 중 공구 건수", example = "3")
+    val ongoingCount: Int,
+
+    @field:Schema(description = "달성 완료 공구 건수", example = "2")
+    val achievedCount: Int,
+
+    @field:Schema(description = "오늘 픽업 예정 인원 수", example = "14")
+    val todayPickupUserCount: Int,
+
+    @field:Schema(description = "정산 예정 금액", example = "128000")
+    val settlementExpectedAmount: Int,
+
+    @field:Schema(description = "공구 요약 데이터 비어있는지 여부", example = "false")
+    val isEmpty: Boolean
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
@@ -2,10 +2,16 @@ package com.moongchijang.domain.owner.presentation
 
 import com.moongchijang.domain.owner.application.OwnerGroupBuyService
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -18,6 +24,33 @@ import org.springframework.web.bind.annotation.RestController
 class OwnerGroupBuyController(
     private val ownerGroupBuyService: OwnerGroupBuyService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/summary")
+    @Operation(summary = "사장님 공구 요약 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "사장님 공구 요약 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "사장님 권한 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getMyGroupBuySummary(
+        @AuthenticationPrincipal principal: CustomUserPrincipal
+    ): ResponseEntity<ApiResponse<OwnerGroupBuySummaryResponse>> {
+        log.info("[OwnerGroupBuyController] 사장님 공구 요약 조회 요청 수신: ownerId={}", principal.id)
+        val response = ownerGroupBuyService.getMyGroupBuySummary(principal.id)
+        log.info("[OwnerGroupBuyController] 사장님 공구 요약 조회 응답 완료: ownerId={}, isEmpty={}", principal.id, response.isEmpty)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
 
     @GetMapping
     @Operation(summary = "사장님 진행 중인 공구 목록 조회")

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -3873,7 +3873,7 @@ components:
             ongoingCount: { type: integer, description: 진행 중 공구 건수, example: 3 }
             achievedCount: { type: integer, description: 달성 완료 공구 건수, example: 2 }
             todayPickupUserCount: { type: integer, description: 오늘 픽업 예정 인원 수, example: 14 }
-            settlementExpectedAmount: { type: integer, description: 정산 예정 금액, example: 128000 }
+            settlementExpectedAmount: { type: integer, format: int64, description: 정산 예정 금액, example: 128000 }
             isEmpty: { type: boolean, description: 공구 요약 데이터 비어있는지 여부, example: false }
         error: { nullable: true, example: null }
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1562,23 +1562,6 @@ paths:
   # ─────────────────────────────────────────────────────────────
   # Owner
   # ─────────────────────────────────────────────────────────────
-  /api/v1/owner/home/summary:
-    get:
-      tags: [Owner]
-      summary: 사장님 홈 요약 정보
-      description: 픽업 대기/완료 건수, 진행 중 공구 수, 다음 픽업 시간을 반환한다.
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: 홈 요약
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseOwnerSummary'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-
   /api/v1/owner/home/pickup-schedule:
     get:
       tags: [Owner]
@@ -1609,6 +1592,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseOwnerGroupBuyList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/owner/group-buys/summary:
+    get:
+      tags: [Owner]
+      summary: 사장님 공구 요약 조회
+      description: |
+        사장님이 소속된 매장 기준으로 공구 요약 정보를 조회한다.
+        - 진행 중 공구 건수
+        - 달성 완료 공구 건수
+        - 오늘 픽업 예정 인원 수
+        - 정산 예정 금액
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 사장님 공구 요약 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerGroupBuySummary'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3852,6 +3859,22 @@ components:
               status:
                 type: string
                 enum: [IN_PROGRESS, ACHIEVED, FAILED]
+        error: { nullable: true, example: null }
+
+    ApiResponseOwnerGroupBuySummary:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [ongoingCount, achievedCount, todayPickupUserCount, settlementExpectedAmount, isEmpty]
+          properties:
+            ongoingCount: { type: integer, description: 진행 중 공구 건수, example: 3 }
+            achievedCount: { type: integer, description: 달성 완료 공구 건수, example: 2 }
+            todayPickupUserCount: { type: integer, description: 오늘 픽업 예정 인원 수, example: 14 }
+            settlementExpectedAmount: { type: integer, description: 정산 예정 금액, example: 128000 }
+            isEmpty: { type: boolean, description: 공구 요약 데이터 비어있는지 여부, example: false }
         error: { nullable: true, example: null }
 
     OwnerGroupBuyRequestCreate:

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -155,7 +155,7 @@ class OwnerGroupBuyServiceTest {
         assertEquals(0, result.ongoingCount)
         assertEquals(0, result.achievedCount)
         assertEquals(0, result.todayPickupUserCount)
-        assertEquals(0, result.settlementExpectedAmount)
+        assertEquals(0L, result.settlementExpectedAmount)
         assertEquals(true, result.isEmpty)
         verifyNoInteractions(groupBuyRepository)
     }
@@ -173,7 +173,7 @@ class OwnerGroupBuyServiceTest {
         assertEquals(3, result.ongoingCount)
         assertEquals(2, result.achievedCount)
         assertEquals(14, result.todayPickupUserCount)
-        assertEquals(128000, result.settlementExpectedAmount)
+        assertEquals(128000L, result.settlementExpectedAmount)
         assertEquals(false, result.isEmpty)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -3,6 +3,8 @@ package com.moongchijang.domain.owner.application
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
@@ -142,8 +144,91 @@ class OwnerGroupBuyServiceTest {
         verify(storeStaffRepository, never()).findStoreIdsByUserId(1L)
     }
 
+    @Test
+    fun `소속 매장이 없으면 공구 요약 빈 상태를 반환`() {
+        val owner = seller()
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(emptyList())
+
+        val result = service.getMyGroupBuySummary(owner.id!!)
+
+        assertEquals(0, result.ongoingCount)
+        assertEquals(0, result.achievedCount)
+        assertEquals(0, result.todayPickupUserCount)
+        assertEquals(0, result.settlementExpectedAmount)
+        assertEquals(true, result.isEmpty)
+        verifyNoInteractions(groupBuyRepository)
+    }
+
+    @Test
+    fun `사장님 공구 요약 정상 집계`() {
+        val owner = seller()
+        val storeIds = listOf(1L, 2L)
+
+        mockSellerAndStoreIds(owner.id!!, owner, storeIds)
+        mockSummaryCounts(storeIds, ongoing = 3L, achieved = 2L, todayPickupUsers = 14L, settlementAmount = 128000L)
+
+        val result = service.getMyGroupBuySummary(owner.id!!)
+
+        assertEquals(3, result.ongoingCount)
+        assertEquals(2, result.achievedCount)
+        assertEquals(14, result.todayPickupUserCount)
+        assertEquals(128000, result.settlementExpectedAmount)
+        assertEquals(false, result.isEmpty)
+    }
+
+    @Test
+    fun `구매자 계정이면 사장님 공구 요약 조회 불가`() {
+        val buyer = UserFixture.createKakaoUser(id = 1L)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(buyer)
+
+        val ex = assertThrows<CustomException> {
+            service.getMyGroupBuySummary(1L)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+        verify(storeStaffRepository, never()).findStoreIdsByUserId(1L)
+    }
+
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
         role = UserRole.SELLER
+    }
+
+    private fun mockSellerAndStoreIds(ownerId: Long, owner: com.moongchijang.domain.user.domain.entity.User, storeIds: List<Long>) {
+        `when`(userRepository.findByIdAndDeletedAtIsNull(ownerId)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(ownerId)).thenReturn(storeIds)
+    }
+
+    private fun mockSummaryCounts(
+        storeIds: List<Long>,
+        ongoing: Long,
+        achieved: Long,
+        todayPickupUsers: Long,
+        settlementAmount: Long
+    ) {
+        `when`(groupBuyRepository.countByStoreIdsAndStatuses(storeIds, listOf(GroupBuyStatus.IN_PROGRESS))).thenReturn(ongoing)
+        `when`(
+            groupBuyRepository.countByStoreIdsAndStatuses(
+                storeIds,
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+            )
+        ).thenReturn(achieved)
+        `when`(
+            groupBuyRepository.countTodayPickupUsersByStoreIds(
+                storeIds = storeIds,
+                pickupDate = LocalDate.now(),
+                participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+            )
+        ).thenReturn(todayPickupUsers)
+        `when`(
+            groupBuyRepository.sumSettlementExpectedAmountByStoreIds(
+                storeIds = storeIds,
+                participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+                groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+            )
+        ).thenReturn(settlementAmount)
     }
 
     private fun groupBuy(

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -29,7 +29,7 @@ class OwnerGroupBuyControllerTest {
             ongoingCount = 3,
             achievedCount = 2,
             todayPickupUserCount = 14,
-            settlementExpectedAmount = 128000,
+            settlementExpectedAmount = 128000L,
             isEmpty = false
         )
         `when`(ownerGroupBuyService.getMyGroupBuySummary(1L)).thenReturn(response)

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.owner.presentation
 import com.moongchijang.domain.owner.application.OwnerGroupBuyService
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyStatusResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryResponse
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.security.principal.CustomUserPrincipal
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,6 +17,28 @@ class OwnerGroupBuyControllerTest {
 
     private val ownerGroupBuyService: OwnerGroupBuyService = mock(OwnerGroupBuyService::class.java)
     private val controller = OwnerGroupBuyController(ownerGroupBuyService)
+
+    @Test
+    fun `사장님 공구 요약을 조회한다`() {
+        val principal = CustomUserPrincipal(
+            id = 1L,
+            email = "seller@example.com",
+            role = UserRole.SELLER
+        )
+        val response = OwnerGroupBuySummaryResponse(
+            ongoingCount = 3,
+            achievedCount = 2,
+            todayPickupUserCount = 14,
+            settlementExpectedAmount = 128000,
+            isEmpty = false
+        )
+        `when`(ownerGroupBuyService.getMyGroupBuySummary(1L)).thenReturn(response)
+
+        val result = controller.getMyGroupBuySummary(principal)
+
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyService).getMyGroupBuySummary(1L)
+    }
 
     @Test
     fun `사장님 진행 중인 공구 목록을 조회한다`() {


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 공구 요약 조회 API를 구현했습니다.
- `GET /api/v1/owner/group-buys/summary` 엔드포인트를 추가했습니다.
- 공구 요약 응답 DTO(`OwnerGroupBuySummaryResponse`)를 추가하고 Swagger 스키마를 반영했습니다.
- 요약 집계를 위한 리포지토리 쿼리를 추가했습니다.
  - 진행 중 공구 건수
  - 달성 완료 공구 건수
  - 오늘 픽업 예정 인원 수
  - 정산 예정 금액
- 서비스 로직에서 판매자 권한 검증, 빈 상태(`isEmpty`) 처리, 로그를 추가했습니다.
- 컨트롤러에 요약 조회 `ApiResponses` 및 요청/응답 로그를 추가했습니다.
- 관련 단위 테스트(서비스/컨트롤러)를 추가 및 정리했습니다.

## 🔍 참고 사항
- 빈 상태일 때 프론트에서 안내 문구를 노출할 수 있도록 `isEmpty`를 함께 반환합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #221 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인