### PR TITLE
[MCJ-1536] FEAT: 사장님 공구 관리(목록/상세/연장/마감) API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -72,6 +72,10 @@ class GroupBuy(
     @Column(name = "close_requested_at")
     var closeRequestedAt: LocalDateTime? = null,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "closed_by_type", length = 20)
+    var closedByType: GroupBuyClosedByType? = null,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
@@ -119,6 +123,7 @@ class GroupBuy(
         closeReason = reason
         closeReasonDetail = reasonDetail
         closeRequestedAt = requestedAt
+        closedByType = GroupBuyClosedByType.OWNER
         transitionToClosed()
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -62,6 +62,16 @@ class GroupBuy(
     @Column(nullable = false)
     var shareCount: Int = 0,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "close_reason", length = 30)
+    var closeReason: GroupBuyCloseReason? = null,
+
+    @Column(name = "close_reason_detail", length = 100)
+    var closeReasonDetail: String? = null,
+
+    @Column(name = "close_requested_at")
+    var closeRequestedAt: LocalDateTime? = null,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
@@ -99,6 +109,17 @@ class GroupBuy(
             "CLOSED 는 IN_PROGRESS 또는 ACHIEVED 상태에서만 전이할 수 있습니다."
         }
         status = GroupBuyStatus.CLOSED
+    }
+
+    fun closeByOwner(
+        reason: GroupBuyCloseReason,
+        reasonDetail: String?,
+        requestedAt: LocalDateTime = LocalDateTime.now()
+    ) {
+        closeReason = reason
+        closeReasonDetail = reasonDetail
+        closeRequestedAt = requestedAt
+        transitionToClosed()
     }
 
     fun isTerminalStatus(): Boolean {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyCloseReason.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyCloseReason.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.groupbuy.domain.entity
+
+enum class GroupBuyCloseReason {
+    SOLD_OUT,
+    STORE_CONDITION,
+    OTHER
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyClosedByType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyClosedByType.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.groupbuy.domain.entity
+
+enum class GroupBuyClosedByType {
+    OWNER,
+    ADMIN,
+    SYSTEM
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -7,6 +7,9 @@ import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterTy
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageListItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageParticipantSummary
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyParticipantItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseReasonType
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseRequest
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyExtensionRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryResponse
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
@@ -185,6 +188,57 @@ class OwnerGroupBuyService(
         return getManageGroupBuyDetail(ownerId, groupBuyId, ACHIEVED_DETAIL_GROUP_BUY_STATUSES)
     }
 
+    @Transactional
+    fun requestGroupBuyExtension(ownerId: Long, groupBuyId: Long, request: OwnerGroupBuyExtensionRequest) {
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 기간 연장 요청 시작: ownerId={}, groupBuyId={}, extendedDeadline={}",
+            ownerId,
+            groupBuyId,
+            request.extendedDeadline
+        )
+        val groupBuy = findOwnedGroupBuy(ownerId, groupBuyId)
+        if (groupBuy.status != GroupBuyStatus.IN_PROGRESS) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+        if (!request.extendedDeadline.isAfter(groupBuy.deadline)) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+
+        groupBuy.deadline = request.extendedDeadline
+        groupBuyRepository.save(groupBuy)
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 기간 연장 요청 완료: ownerId={}, groupBuyId={}, newDeadline={}",
+            ownerId,
+            groupBuyId,
+            groupBuy.deadline
+        )
+    }
+
+    @Transactional
+    fun requestGroupBuyClose(ownerId: Long, groupBuyId: Long, request: OwnerGroupBuyCloseRequest) {
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 마감 요청 시작: ownerId={}, groupBuyId={}, reason={}",
+            ownerId,
+            groupBuyId,
+            request.reason
+        )
+        val groupBuy = findOwnedGroupBuy(ownerId, groupBuyId)
+        if (groupBuy.status !in CLOSE_ALLOWED_STATUSES) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+        validateCloseReason(request)
+
+        groupBuy.transitionToClosed()
+        groupBuyRepository.save(groupBuy)
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 마감 요청 완료: ownerId={}, groupBuyId={}, reason={}, reasonDetail={}",
+            ownerId,
+            groupBuyId,
+            request.reason,
+            request.reasonDetail
+        )
+    }
+
     private fun getManageGroupBuyDetail(
         ownerId: Long,
         groupBuyId: Long,
@@ -258,6 +312,28 @@ class OwnerGroupBuyService(
         return response
     }
 
+    private fun findOwnedGroupBuy(ownerId: Long, groupBuyId: Long): com.moongchijang.domain.groupbuy.domain.entity.GroupBuy {
+        validateSeller(ownerId)
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val groupBuy = groupBuyRepository.findWithStoreById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+        if (groupBuy.store.id !in storeIds) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+        return groupBuy
+    }
+
+    private fun validateCloseReason(request: OwnerGroupBuyCloseRequest) {
+        if (request.reason == OwnerGroupBuyCloseReasonType.OTHER && request.reasonDetail.isNullOrBlank()) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+
     private fun mapPaymentsByUserId(groupBuyId: Long, participations: List<Participation>): Map<Long, Payment> {
         val userIds = participations.mapNotNull { it.user.id }.distinct()
         if (userIds.isEmpty()) {
@@ -324,6 +400,7 @@ class OwnerGroupBuyService(
         val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
         val IN_PROGRESS_DETAIL_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.IN_PROGRESS)
         val ACHIEVED_DETAIL_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val CLOSE_ALLOWED_STATUSES = listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED)
         val DETAIL_PARTICIPATION_STATUSES = listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED)
         const val UNKNOWN_PAYMENT_METHOD = "UNKNOWN"
         const val UNKNOWN_PAYMENT_STATUS = "UNKNOWN"

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -204,6 +204,10 @@ class OwnerGroupBuyService(
         if (!request.extendedDeadline.isAfter(groupBuy.deadline)) {
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
+        val pickupStartDateTime = java.time.LocalDateTime.of(groupBuy.pickupDate, groupBuy.pickupTimeStart)
+        if (!request.extendedDeadline.isBefore(pickupStartDateTime)) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
 
         groupBuy.deadline = request.extendedDeadline
         groupBuyRepository.save(groupBuy)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -289,15 +289,8 @@ class OwnerGroupBuyService(
             )
         }
 
-        val completedCount = participationRepository.countByGroupBuyIdAndStatusInAndPickupStatus(
-            groupBuyId = groupBuyId,
-            statuses = DETAIL_PARTICIPATION_STATUSES,
-            pickupStatus = PickupStatus.PICKED_UP
-        ).toInt()
-        val totalCount = participationRepository.countByGroupBuyIdAndStatusIn(
-            groupBuyId = groupBuyId,
-            statuses = DETAIL_PARTICIPATION_STATUSES
-        ).toInt()
+        val totalCount = participations.size
+        val completedCount = participations.count { it.pickupStatus == PickupStatus.PICKED_UP }
         val waitingCount = totalCount - completedCount
 
         val response = OwnerGroupBuyManageDetailResponse(

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -2,10 +2,21 @@ package com.moongchijang.domain.owner.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageDetailResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageParticipantSummary
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyParticipantItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryResponse
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
+import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.domain.entity.Payment
+import com.moongchijang.domain.payment.domain.repository.PaymentRepository
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.entity.UserRole
@@ -16,6 +27,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import java.time.ZoneId
 
 @Service
@@ -23,7 +35,10 @@ import java.time.ZoneId
 class OwnerGroupBuyService(
     private val userRepository: UserRepository,
     private val storeStaffRepository: StoreStaffRepository,
-    private val groupBuyRepository: GroupBuyRepository
+    private val groupBuyRepository: GroupBuyRepository,
+    private val ownerGroupBuyRequestRepository: OwnerGroupBuyRequestRepository,
+    private val participationRepository: ParticipationRepository,
+    private val paymentRepository: PaymentRepository
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -109,6 +124,171 @@ class OwnerGroupBuyService(
         return response
     }
 
+    fun getManageGroupBuys(ownerId: Long, filter: OwnerGroupBuyManageFilterType): List<OwnerGroupBuyManageListItemResponse> {
+        log.info("[OwnerGroupBuyService] 사장님 공구 관리 목록 조회 시작: ownerId={}, filter={}", ownerId, filter)
+        validateSeller(ownerId)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            log.info("[OwnerGroupBuyService] 사장님 공구 관리 목록 조회 완료(소속 매장 없음): ownerId={}, filter={}", ownerId, filter)
+            return emptyList()
+        }
+
+        val today = LocalDate.now(SEOUL_ZONE_ID)
+        val response = when (filter) {
+            OwnerGroupBuyManageFilterType.PENDING_APPROVAL -> {
+                ownerGroupBuyRequestRepository
+                    .findByOwnerIdAndStoreIdInAndStatusOrderByCreatedAtDesc(ownerId, storeIds, OwnerGroupBuyRequestStatus.PENDING)
+                    .map {
+                        OwnerGroupBuyManageListItemResponse(
+                            groupBuyId = it.id,
+                            productName = it.productName,
+                            price = it.price,
+                            pickupDate = it.pickupDate,
+                            status = OwnerGroupBuyManageFilterType.PENDING_APPROVAL
+                        )
+                    }
+            }
+            else -> {
+                val statuses = toGroupBuyStatuses(filter)
+                groupBuyRepository.findByStoreIdInAndStatusInOrderByDeadlineAsc(storeIds, statuses)
+                    .map {
+                        OwnerGroupBuyManageListItemResponse(
+                            groupBuyId = it.id,
+                            productName = it.productName,
+                            price = it.price,
+                            pickupDate = it.pickupDate,
+                            deadlineDday = if (it.status == GroupBuyStatus.IN_PROGRESS) calculateDday(today, it.deadline.toLocalDate()) else null,
+                            achievementRate = ((it.currentQuantity * 100L) / it.targetQuantity.coerceAtLeast(1)).toInt(),
+                            currentParticipants = it.currentQuantity,
+                            targetParticipants = it.targetQuantity,
+                            status = toManageFilterType(it.status)
+                        )
+                    }
+            }
+        }
+
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 관리 목록 조회 완료: ownerId={}, filter={}, count={}",
+            ownerId,
+            filter,
+            response.size
+        )
+        return response
+    }
+
+    fun getInProgressGroupBuyDetail(ownerId: Long, groupBuyId: Long): OwnerGroupBuyManageDetailResponse {
+        return getManageGroupBuyDetail(ownerId, groupBuyId, IN_PROGRESS_DETAIL_GROUP_BUY_STATUSES)
+    }
+
+    fun getAchievedGroupBuyDetail(ownerId: Long, groupBuyId: Long): OwnerGroupBuyManageDetailResponse {
+        return getManageGroupBuyDetail(ownerId, groupBuyId, ACHIEVED_DETAIL_GROUP_BUY_STATUSES)
+    }
+
+    private fun getManageGroupBuyDetail(
+        ownerId: Long,
+        groupBuyId: Long,
+        allowedStatuses: Collection<GroupBuyStatus>
+    ): OwnerGroupBuyManageDetailResponse {
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 관리 상세 조회 시작: ownerId={}, groupBuyId={}, allowedStatuses={}",
+            ownerId,
+            groupBuyId,
+            allowedStatuses
+        )
+        validateSeller(ownerId)
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val groupBuy = groupBuyRepository.findWithStoreById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+        if (groupBuy.store.id !in storeIds || groupBuy.status !in allowedStatuses) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val participations = participationRepository.findByGroupBuyIdAndStatusInOrderByCreatedAtAsc(
+            groupBuyId = groupBuyId,
+            statuses = DETAIL_PARTICIPATION_STATUSES
+        )
+        val paymentByUserId = mapPaymentsByUserId(groupBuyId, participations)
+        val participants = participations.map {
+            val payment = paymentByUserId[it.user.id!!]
+            OwnerGroupBuyParticipantItemResponse(
+                name = it.user.nickname ?: "",
+                phoneNumber = it.user.phoneNumber ?: "",
+                productName = it.groupBuy.productName,
+                quantity = it.quantity,
+                paymentMethod = payment?.method ?: UNKNOWN_PAYMENT_METHOD,
+                paymentStatus = payment?.status?.name ?: UNKNOWN_PAYMENT_STATUS,
+                pickupTime = it.groupBuy.pickupTimeStart
+            )
+        }
+
+        val completedCount = participationRepository.countByGroupBuyIdAndStatusInAndPickupStatus(
+            groupBuyId = groupBuyId,
+            statuses = DETAIL_PARTICIPATION_STATUSES,
+            pickupStatus = PickupStatus.PICKED_UP
+        ).toInt()
+        val totalCount = participationRepository.countByGroupBuyIdAndStatusIn(
+            groupBuyId = groupBuyId,
+            statuses = DETAIL_PARTICIPATION_STATUSES
+        ).toInt()
+        val waitingCount = totalCount - completedCount
+
+        val response = OwnerGroupBuyManageDetailResponse(
+            groupBuyId = groupBuy.id,
+            status = toManageFilterType(groupBuy.status),
+            participantSummary = OwnerGroupBuyManageParticipantSummary(
+                totalCount = totalCount,
+                completedCount = completedCount,
+                waitingCount = waitingCount
+            ),
+            participants = participants
+        )
+
+        log.info(
+            "[OwnerGroupBuyService] 사장님 공구 관리 상세 조회 완료: ownerId={}, groupBuyId={}, totalCount={}",
+            ownerId,
+            groupBuyId,
+            response.participantSummary.totalCount
+        )
+        return response
+    }
+
+    private fun mapPaymentsByUserId(groupBuyId: Long, participations: List<Participation>): Map<Long, Payment> {
+        val userIds = participations.mapNotNull { it.user.id }.distinct()
+        if (userIds.isEmpty()) {
+            return emptyMap()
+        }
+        return paymentRepository.findAllByGroupBuyIdAndUserIdIn(groupBuyId, userIds)
+            .associateBy { it.paymentOrder.user.id!! }
+    }
+
+    private fun toGroupBuyStatuses(filter: OwnerGroupBuyManageFilterType): Collection<GroupBuyStatus> {
+        return when (filter) {
+            OwnerGroupBuyManageFilterType.ALL -> OWNER_VISIBLE_STATUSES
+            OwnerGroupBuyManageFilterType.IN_PROGRESS -> listOf(GroupBuyStatus.IN_PROGRESS)
+            OwnerGroupBuyManageFilterType.ACHIEVED -> listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+            OwnerGroupBuyManageFilterType.ENDED -> listOf(GroupBuyStatus.FAILED, GroupBuyStatus.CLOSED)
+            OwnerGroupBuyManageFilterType.PENDING_APPROVAL -> emptyList()
+        }
+    }
+
+    private fun toManageFilterType(status: GroupBuyStatus): OwnerGroupBuyManageFilterType {
+        return when (status) {
+            GroupBuyStatus.IN_PROGRESS -> OwnerGroupBuyManageFilterType.IN_PROGRESS
+            GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED -> OwnerGroupBuyManageFilterType.ACHIEVED
+            GroupBuyStatus.FAILED, GroupBuyStatus.CLOSED -> OwnerGroupBuyManageFilterType.ENDED
+        }
+    }
+
+    private fun calculateDday(today: LocalDate, deadlineDate: LocalDate): Int {
+        return ChronoUnit.DAYS.between(today, deadlineDate).toInt()
+    }
+
     private fun validateSeller(ownerId: Long): User {
         val owner = userRepository.findByIdAndDeletedAtIsNull(ownerId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
@@ -142,6 +322,11 @@ class OwnerGroupBuyService(
         val TODAY_PICKUP_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
         val SETTLEMENT_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
         val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val IN_PROGRESS_DETAIL_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.IN_PROGRESS)
+        val ACHIEVED_DETAIL_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val DETAIL_PARTICIPATION_STATUSES = listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED)
+        const val UNKNOWN_PAYMENT_METHOD = "UNKNOWN"
+        const val UNKNOWN_PAYMENT_STATUS = "UNKNOWN"
         val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.owner.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageDetailResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
@@ -228,7 +229,10 @@ class OwnerGroupBuyService(
         }
         validateCloseReason(request)
 
-        groupBuy.transitionToClosed()
+        groupBuy.closeByOwner(
+            reason = toGroupBuyCloseReason(request.reason),
+            reasonDetail = request.reasonDetail?.trim()?.takeIf { it.isNotBlank() }
+        )
         groupBuyRepository.save(groupBuy)
         log.info(
             "[OwnerGroupBuyService] 사장님 공구 마감 요청 완료: ownerId={}, groupBuyId={}, reason={}, reasonDetail={}",
@@ -331,6 +335,14 @@ class OwnerGroupBuyService(
     private fun validateCloseReason(request: OwnerGroupBuyCloseRequest) {
         if (request.reason == OwnerGroupBuyCloseReasonType.OTHER && request.reasonDetail.isNullOrBlank()) {
             throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+
+    private fun toGroupBuyCloseReason(reasonType: OwnerGroupBuyCloseReasonType): GroupBuyCloseReason {
+        return when (reasonType) {
+            OwnerGroupBuyCloseReasonType.SOLD_OUT -> GroupBuyCloseReason.SOLD_OUT
+            OwnerGroupBuyCloseReasonType.STORE_CONDITION -> GroupBuyCloseReason.STORE_CONDITION
+            OwnerGroupBuyCloseReasonType.OTHER -> GroupBuyCloseReason.OTHER
         }
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -164,8 +164,8 @@ class OwnerGroupBuyService(
                             pickupDate = it.pickupDate,
                             deadlineDday = if (it.status == GroupBuyStatus.IN_PROGRESS) calculateDday(today, it.deadline.toLocalDate()) else null,
                             achievementRate = ((it.currentQuantity * 100L) / it.targetQuantity.coerceAtLeast(1)).toInt(),
-                            currentParticipants = it.currentQuantity,
-                            targetParticipants = it.targetQuantity,
+                            currentQuantity = it.currentQuantity,
+                            targetQuantity = it.targetQuantity,
                             status = toManageFilterType(it.status)
                         )
                     }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -349,7 +349,7 @@ class OwnerGroupBuyService(
             return emptyMap()
         }
         return paymentRepository.findAllByGroupBuyIdAndUserIdIn(groupBuyId, userIds)
-            .associateBy { it.paymentOrder.user.id!! }
+            .associateBy { it.paymentOrder.user.id ?: error("paymentOrder.user.id must not be null") }
     }
 
     private fun toGroupBuyStatuses(filter: OwnerGroupBuyManageFilterType): Collection<GroupBuyStatus> {

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -235,7 +235,8 @@ class OwnerGroupBuyService(
 
         groupBuy.closeByOwner(
             reason = toGroupBuyCloseReason(request.reason),
-            reasonDetail = request.reasonDetail?.trim()?.takeIf { it.isNotBlank() }
+            reasonDetail = request.reasonDetail?.trim()?.takeIf { it.isNotBlank() },
+            requestedAt = java.time.LocalDateTime.now(SEOUL_ZONE_ID)
         )
         groupBuyRepository.save(groupBuy)
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyCloseReasonType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyCloseReasonType.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 공구 마감 사유")
+enum class OwnerGroupBuyCloseReasonType {
+    SOLD_OUT,
+    STORE_CONDITION,
+    OTHER
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyCloseRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyCloseRequest.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 공구 마감 요청")
+data class OwnerGroupBuyCloseRequest(
+    @field:Schema(description = "마감 사유", example = "STORE_CONDITION")
+    val reason: OwnerGroupBuyCloseReasonType,
+
+    @field:Schema(description = "기타 사유 (최대 100자)", example = "재고 수급 이슈로 조기 마감합니다.", nullable = true)
+    val reasonDetail: String? = null
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyCloseRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyCloseRequest.kt
@@ -1,12 +1,16 @@
 package com.moongchijang.domain.owner.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 
 @Schema(description = "사장님 공구 마감 요청")
 data class OwnerGroupBuyCloseRequest(
+    @field:NotNull(message = "마감 사유는 필수입니다")
     @field:Schema(description = "마감 사유", example = "STORE_CONDITION")
     val reason: OwnerGroupBuyCloseReasonType,
 
+    @field:Size(max = 100, message = "기타 사유는 100자 이하여야 합니다")
     @field:Schema(description = "기타 사유 (최대 100자)", example = "재고 수급 이슈로 조기 마감합니다.", nullable = true)
     val reasonDetail: String? = null
 )

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyExtensionRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyExtensionRequest.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "사장님 공구 기간 연장 요청")
+data class OwnerGroupBuyExtensionRequest(
+    @field:Schema(description = "연장 희망 마감일시", example = "2026-06-05T23:59:00")
+    val extendedDeadline: LocalDateTime
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyExtensionRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyExtensionRequest.kt
@@ -1,10 +1,12 @@
 package com.moongchijang.domain.owner.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
 import java.time.LocalDateTime
 
 @Schema(description = "사장님 공구 기간 연장 요청")
 data class OwnerGroupBuyExtensionRequest(
+    @field:NotNull(message = "연장 희망 마감일시는 필수입니다")
     @field:Schema(description = "연장 희망 마감일시", example = "2026-06-05T23:59:00")
     val extendedDeadline: LocalDateTime
 )

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageDetailResponse.kt
@@ -1,0 +1,18 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 공구 관리 상세 응답")
+data class OwnerGroupBuyManageDetailResponse(
+    @field:Schema(description = "공구 ID", example = "101")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "공구 상태", example = "IN_PROGRESS")
+    val status: OwnerGroupBuyManageFilterType,
+
+    @field:Schema(description = "참여자 요약")
+    val participantSummary: OwnerGroupBuyManageParticipantSummary,
+
+    @field:Schema(description = "참여자 목록")
+    val participants: List<OwnerGroupBuyParticipantItemResponse>
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageFilterType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageFilterType.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 공구 관리 목록 필터")
+enum class OwnerGroupBuyManageFilterType {
+    ALL,
+    IN_PROGRESS,
+    ACHIEVED,
+    ENDED,
+    PENDING_APPROVAL
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageListItemResponse.kt
@@ -23,11 +23,11 @@ data class OwnerGroupBuyManageListItemResponse(
     @field:Schema(description = "달성률(%)", example = "60", nullable = true)
     val achievementRate: Int? = null,
 
-    @field:Schema(description = "현재 참여 인원", example = "12", nullable = true)
-    val currentParticipants: Int? = null,
+    @field:Schema(description = "현재 참여 수량", example = "12", nullable = true)
+    val currentQuantity: Int? = null,
 
-    @field:Schema(description = "목표 인원", example = "20", nullable = true)
-    val targetParticipants: Int? = null,
+    @field:Schema(description = "목표 수량", example = "20", nullable = true)
+    val targetQuantity: Int? = null,
 
     @field:Schema(description = "공구 상태", example = "IN_PROGRESS")
     val status: OwnerGroupBuyManageFilterType

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageListItemResponse.kt
@@ -1,0 +1,34 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "사장님 공구 관리 목록 아이템 응답")
+data class OwnerGroupBuyManageListItemResponse(
+    @field:Schema(description = "공구 ID", example = "101")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "공구명", example = "두쫀쿠 세트")
+    val productName: String,
+
+    @field:Schema(description = "공구 금액", example = "9900")
+    val price: Int,
+
+    @field:Schema(description = "픽업일", example = "2026-06-01")
+    val pickupDate: LocalDate,
+
+    @field:Schema(description = "마감 D-day (모집중 탭 전용)", example = "3", nullable = true)
+    val deadlineDday: Int? = null,
+
+    @field:Schema(description = "달성률(%)", example = "60", nullable = true)
+    val achievementRate: Int? = null,
+
+    @field:Schema(description = "현재 참여 인원", example = "12", nullable = true)
+    val currentParticipants: Int? = null,
+
+    @field:Schema(description = "목표 인원", example = "20", nullable = true)
+    val targetParticipants: Int? = null,
+
+    @field:Schema(description = "공구 상태", example = "IN_PROGRESS")
+    val status: OwnerGroupBuyManageFilterType
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageParticipantSummary.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageParticipantSummary.kt
@@ -1,0 +1,15 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 공구 관리 상세 상단 요약")
+data class OwnerGroupBuyManageParticipantSummary(
+    @field:Schema(description = "총 참여자 수", example = "20")
+    val totalCount: Int,
+
+    @field:Schema(description = "완료 인원 수", example = "8")
+    val completedCount: Int,
+
+    @field:Schema(description = "대기 중 인원 수", example = "12")
+    val waitingCount: Int
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyParticipantItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyParticipantItemResponse.kt
@@ -1,0 +1,28 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalTime
+
+@Schema(description = "사장님 공구 상세 참여자 정보")
+data class OwnerGroupBuyParticipantItemResponse(
+    @field:Schema(description = "참여자 이름", example = "홍길동")
+    val name: String,
+
+    @field:Schema(description = "참여자 전화번호", example = "01012345678")
+    val phoneNumber: String,
+
+    @field:Schema(description = "상품명", example = "두쫀쿠 세트")
+    val productName: String,
+
+    @field:Schema(description = "수량", example = "2")
+    val quantity: Int,
+
+    @field:Schema(description = "결제수단", example = "CARD")
+    val paymentMethod: String,
+
+    @field:Schema(description = "결제상태", example = "CONFIRMED")
+    val paymentStatus: String,
+
+    @field:Schema(description = "픽업시간", example = "14:00:00")
+    val pickupTime: LocalTime
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
@@ -33,5 +33,21 @@ interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, L
         pageable: Pageable
     ): Page<OwnerGroupBuyRequest>
 
+    @Query(
+        """
+            SELECT r FROM OwnerGroupBuyRequest r
+            JOIN FETCH r.store
+            WHERE r.owner.id = :ownerId
+              AND r.store.id IN :storeIds
+              AND r.status = :status
+            ORDER BY r.createdAt DESC
+        """
+    )
+    fun findByOwnerIdAndStoreIdInAndStatusOrderByCreatedAtDesc(
+        @Param("ownerId") ownerId: Long,
+        @Param("storeIds") storeIds: Collection<Long>,
+        @Param("status") status: OwnerGroupBuyRequestStatus
+    ): List<OwnerGroupBuyRequest>
+
     fun findByStatusOrderByCreatedAtAsc(status: OwnerGroupBuyRequestStatus): List<OwnerGroupBuyRequest>
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
@@ -1,6 +1,8 @@
 package com.moongchijang.domain.owner.presentation
 
 import com.moongchijang.domain.owner.application.OwnerGroupBuyService
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseRequest
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyExtensionRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageDetailResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
@@ -14,11 +16,14 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -155,5 +160,81 @@ class OwnerGroupBuyController(
         val response = ownerGroupBuyService.getAchievedGroupBuyDetail(principal.id, groupBuyId)
         log.info("[OwnerGroupBuyController] 사장님 달성 공구 상세 조회 응답 완료: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
         return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @PostMapping("/{groupBuyId}/extension-requests")
+    @Operation(summary = "사장님 공구 기간 연장 요청")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "사장님 공구 기간 연장 요청 성공"),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = "유효하지 않은 요청",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "사장님 권한 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun requestGroupBuyExtension(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable groupBuyId: Long,
+        @Valid @RequestBody request: OwnerGroupBuyExtensionRequest
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.info("[OwnerGroupBuyController] 사장님 공구 기간 연장 요청 수신: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
+        ownerGroupBuyService.requestGroupBuyExtension(principal.id, groupBuyId, request)
+        log.info("[OwnerGroupBuyController] 사장님 공구 기간 연장 요청 응답 완료: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
+        return ResponseEntity.ok(ApiResponse.success())
+    }
+
+    @PostMapping("/{groupBuyId}/close-requests")
+    @Operation(summary = "사장님 공구 마감 요청")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "사장님 공구 마감 요청 성공"),
+            SwaggerApiResponse(
+                responseCode = "400",
+                description = "유효하지 않은 요청",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "사장님 권한 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun requestGroupBuyClose(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable groupBuyId: Long,
+        @Valid @RequestBody request: OwnerGroupBuyCloseRequest
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        log.info("[OwnerGroupBuyController] 사장님 공구 마감 요청 수신: ownerId={}, groupBuyId={}, reason={}", principal.id, groupBuyId, request.reason)
+        ownerGroupBuyService.requestGroupBuyClose(principal.id, groupBuyId, request)
+        log.info("[OwnerGroupBuyController] 사장님 공구 마감 요청 응답 완료: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
+        return ResponseEntity.ok(ApiResponse.success())
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyController.kt
@@ -2,6 +2,9 @@ package com.moongchijang.domain.owner.presentation
 
 import com.moongchijang.domain.owner.application.OwnerGroupBuyService
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageDetailResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageListItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
@@ -15,7 +18,9 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -58,5 +63,97 @@ class OwnerGroupBuyController(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<OwnerGroupBuyListItemResponse>>> {
         return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyService.getMyGroupBuys(principal.id)))
+    }
+
+    @GetMapping("/manage")
+    @Operation(summary = "사장님 공구 관리 목록 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "사장님 공구 관리 목록 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "사장님 권한 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getManageGroupBuys(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @RequestParam(required = false, defaultValue = "ALL")
+        filter: OwnerGroupBuyManageFilterType
+    ): ResponseEntity<ApiResponse<List<OwnerGroupBuyManageListItemResponse>>> {
+        log.info("[OwnerGroupBuyController] 사장님 공구 관리 목록 조회 요청 수신: ownerId={}, filter={}", principal.id, filter)
+        val response = ownerGroupBuyService.getManageGroupBuys(principal.id, filter)
+        log.info("[OwnerGroupBuyController] 사장님 공구 관리 목록 조회 응답 완료: ownerId={}, filter={}, count={}", principal.id, filter, response.size)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{groupBuyId}/manage/in-progress")
+    @Operation(summary = "사장님 모집중 공구 상세 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "사장님 모집중 공구 상세 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "사장님 권한 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getInProgressGroupBuyDetail(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable groupBuyId: Long
+    ): ResponseEntity<ApiResponse<OwnerGroupBuyManageDetailResponse>> {
+        log.info("[OwnerGroupBuyController] 사장님 모집중 공구 상세 조회 요청 수신: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
+        val response = ownerGroupBuyService.getInProgressGroupBuyDetail(principal.id, groupBuyId)
+        log.info("[OwnerGroupBuyController] 사장님 모집중 공구 상세 조회 응답 완료: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{groupBuyId}/manage/achieved")
+    @Operation(summary = "사장님 달성 공구 상세 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "사장님 달성 공구 상세 조회 성공"),
+            SwaggerApiResponse(
+                responseCode = "401",
+                description = "인증 필요",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "403",
+                description = "사장님 권한 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            ),
+            SwaggerApiResponse(
+                responseCode = "404",
+                description = "공구를 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ApiResponse::class))]
+            )
+        ]
+    )
+    fun getAchievedGroupBuyDetail(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable groupBuyId: Long
+    ): ResponseEntity<ApiResponse<OwnerGroupBuyManageDetailResponse>> {
+        log.info("[OwnerGroupBuyController] 사장님 달성 공구 상세 조회 요청 수신: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
+        val response = ownerGroupBuyService.getAchievedGroupBuyDetail(principal.id, groupBuyId)
+        log.info("[OwnerGroupBuyController] 사장님 달성 공구 상세 조회 응답 완료: ownerId={}, groupBuyId={}", principal.id, groupBuyId)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -255,6 +255,26 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     fun countByUserIdAndStatusIn(userId: Long, statuses: Collection<ParticipationStatus>): Long
 
+    fun countByGroupBuyIdAndStatusIn(groupBuyId: Long, statuses: Collection<ParticipationStatus>): Long
+
+    fun countByGroupBuyIdAndStatusInAndPickupStatus(groupBuyId: Long, statuses: Collection<ParticipationStatus>, pickupStatus: PickupStatus): Long
+
+    @Query(
+        """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        where gb.id = :groupBuyId
+          and p.status in :statuses
+        order by p.createdAt asc
+        """
+    )
+    fun findByGroupBuyIdAndStatusInOrderByCreatedAtAsc(
+        @Param("groupBuyId") groupBuyId: Long,
+        @Param("statuses") statuses: Collection<ParticipationStatus>
+    ): List<Participation>
+
     fun existsByPickupToken(pickupToken: String): Boolean
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentRepository.kt
@@ -2,7 +2,23 @@ package com.moongchijang.domain.payment.domain.repository
 
 import com.moongchijang.domain.payment.domain.entity.Payment
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface PaymentRepository : JpaRepository<Payment, Long> {
     fun findByPaymentOrderOrderId(orderId: String): Payment?
+
+    @Query(
+        """
+        select p
+        from Payment p
+        join fetch p.paymentOrder po
+        where po.groupBuy.id = :groupBuyId
+          and po.user.id in :userIds
+        """
+    )
+    fun findAllByGroupBuyIdAndUserIdIn(
+        @Param("groupBuyId") groupBuyId: Long,
+        @Param("userIds") userIds: Collection<Long>
+    ): List<Payment>
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentRepository.kt
@@ -13,6 +13,7 @@ interface PaymentRepository : JpaRepository<Payment, Long> {
         select p
         from Payment p
         join fetch p.paymentOrder po
+        join fetch po.user u
         where po.groupBuy.id = :groupBuyId
           and po.user.id in :userIds
         """

--- a/src/main/resources/db/migration/V29__alter_group_buys_add_close_request_fields.sql
+++ b/src/main/resources/db/migration/V29__alter_group_buys_add_close_request_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE group_buys
+    ADD COLUMN close_reason VARCHAR(30) NULL,
+    ADD COLUMN close_reason_detail VARCHAR(100) NULL,
+    ADD COLUMN close_requested_at DATETIME NULL;

--- a/src/main/resources/db/migration/V30__alter_group_buys_add_closed_by_type.sql
+++ b/src/main/resources/db/migration/V30__alter_group_buys_add_closed_by_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE group_buys
+    ADD COLUMN closed_by_type VARCHAR(20) NULL;

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -4042,8 +4042,8 @@ components:
         pickupDate: { type: string, format: date, example: "2026-06-01" }
         deadlineDday: { type: integer, nullable: true, example: 3 }
         achievementRate: { type: integer, nullable: true, example: 60 }
-        currentParticipants: { type: integer, nullable: true, example: 12 }
-        targetParticipants: { type: integer, nullable: true, example: 20 }
+        currentQuantity: { type: integer, nullable: true, example: 12 }
+        targetQuantity: { type: integer, nullable: true, example: 20 }
         status:
           type: string
           enum: [ALL, IN_PROGRESS, ACHIEVED, ENDED, PENDING_APPROVAL]

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1621,6 +1621,149 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/owner/group-buys/manage:
+    get:
+      tags: [Owner]
+      summary: 사장님 공구 관리 목록 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: filter
+          in: query
+          required: false
+          description: 상태 필터 (기본값 ALL)
+          schema:
+            type: string
+            enum: [ALL, IN_PROGRESS, ACHIEVED, ENDED, PENDING_APPROVAL]
+            default: ALL
+      responses:
+        '200':
+          description: 사장님 공구 관리 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerGroupBuyManageList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/owner/group-buys/{groupBuyId}/manage/in-progress:
+    get:
+      tags: [Owner]
+      summary: 사장님 모집중 공구 상세 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupBuyId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: 사장님 모집중 공구 상세 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerGroupBuyManageDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/owner/group-buys/{groupBuyId}/manage/achieved:
+    get:
+      tags: [Owner]
+      summary: 사장님 달성 공구 상세 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupBuyId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: 사장님 달성 공구 상세 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerGroupBuyManageDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/owner/group-buys/{groupBuyId}/extension-requests:
+    post:
+      tags: [Owner]
+      summary: 사장님 공구 기간 연장 요청
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupBuyId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnerGroupBuyExtensionRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessNoData'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/owner/group-buys/{groupBuyId}/close-requests:
+    post:
+      tags: [Owner]
+      summary: 사장님 공구 마감 요청
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupBuyId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnerGroupBuyCloseRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/SuccessNoData'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/owner/group-buy-requests:
     get:
       tags: [Owner]
@@ -3877,6 +4020,106 @@ components:
             settlementExpectedAmount: { type: integer, format: int64, description: 정산 예정 금액, example: 128000 }
             isEmpty: { type: boolean, description: 공구 요약 데이터 비어있는지 여부, example: false }
         error: { nullable: true, example: null }
+
+    ApiResponseOwnerGroupBuyManageList:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/OwnerGroupBuyManageListItem'
+        error: { nullable: true, example: null }
+
+    OwnerGroupBuyManageListItem:
+      type: object
+      required: [groupBuyId, productName, price, pickupDate, status]
+      properties:
+        groupBuyId: { type: integer, format: int64, example: 101 }
+        productName: { type: string, example: 두쫀쿠 세트 }
+        price: { type: integer, example: 9900 }
+        pickupDate: { type: string, format: date, example: "2026-06-01" }
+        deadlineDday: { type: integer, nullable: true, example: 3 }
+        achievementRate: { type: integer, nullable: true, example: 60 }
+        currentParticipants: { type: integer, nullable: true, example: 12 }
+        targetParticipants: { type: integer, nullable: true, example: 20 }
+        status:
+          type: string
+          enum: [ALL, IN_PROGRESS, ACHIEVED, ENDED, PENDING_APPROVAL]
+          example: IN_PROGRESS
+
+    ApiResponseOwnerGroupBuyManageDetail:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/OwnerGroupBuyManageDetail'
+        error: { nullable: true, example: null }
+
+    OwnerGroupBuyManageDetail:
+      type: object
+      required: [groupBuyId, status, participantSummary, participants]
+      properties:
+        groupBuyId: { type: integer, format: int64, example: 101 }
+        status:
+          type: string
+          enum: [ALL, IN_PROGRESS, ACHIEVED, ENDED, PENDING_APPROVAL]
+          example: IN_PROGRESS
+        participantSummary:
+          $ref: '#/components/schemas/OwnerGroupBuyManageParticipantSummary'
+        participants:
+          type: array
+          items:
+            $ref: '#/components/schemas/OwnerGroupBuyParticipantItem'
+
+    OwnerGroupBuyManageParticipantSummary:
+      type: object
+      required: [totalCount, completedCount, waitingCount]
+      properties:
+        totalCount: { type: integer, example: 20 }
+        completedCount: { type: integer, example: 8 }
+        waitingCount: { type: integer, example: 12 }
+
+    OwnerGroupBuyParticipantItem:
+      type: object
+      required: [name, phoneNumber, productName, quantity, paymentMethod, paymentStatus, pickupTime]
+      properties:
+        name: { type: string, example: 홍길동 }
+        phoneNumber: { type: string, example: "01012345678" }
+        productName: { type: string, example: 두쫀쿠 세트 }
+        quantity: { type: integer, example: 2 }
+        paymentMethod: { type: string, example: CARD }
+        paymentStatus: { type: string, example: APPROVED }
+        pickupTime: { type: string, format: time, example: "14:00:00" }
+
+    OwnerGroupBuyExtensionRequest:
+      type: object
+      required: [extendedDeadline]
+      properties:
+        extendedDeadline:
+          type: string
+          format: date-time
+          description: 연장 희망 마감일시 (기존 마감일 이후)
+          example: "2026-06-05T23:59:00"
+
+    OwnerGroupBuyCloseReasonType:
+      type: string
+      enum: [SOLD_OUT, STORE_CONDITION, OTHER]
+
+    OwnerGroupBuyCloseRequest:
+      type: object
+      required: [reason]
+      properties:
+        reason:
+          $ref: '#/components/schemas/OwnerGroupBuyCloseReasonType'
+        reasonDetail:
+          type: string
+          nullable: true
+          maxLength: 100
+          description: reason이 OTHER일 때 필수
+          example: 재고 수급 이슈로 조기 마감합니다.
 
     OwnerGroupBuyRequestCreate:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -253,6 +253,7 @@ class OwnerGroupBuyServiceTest {
             targetQuantity = 20,
             price = 9900
         )
+        groupBuy.pickupDate = groupBuy.deadline.toLocalDate().plusDays(3)
         val request = OwnerGroupBuyExtensionRequest(extendedDeadline = groupBuy.deadline.plusDays(2))
 
         `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -3,8 +3,13 @@ package com.moongchijang.domain.owner.application
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.domain.repository.PaymentRepository
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
@@ -25,6 +30,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 
 @ExtendWith(MockitoExtension::class)
 class OwnerGroupBuyServiceTest {
@@ -37,6 +43,15 @@ class OwnerGroupBuyServiceTest {
 
     @Mock
     private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var ownerGroupBuyRequestRepository: OwnerGroupBuyRequestRepository
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var paymentRepository: PaymentRepository
 
     @InjectMocks
     private lateinit var service: OwnerGroupBuyService
@@ -190,6 +205,37 @@ class OwnerGroupBuyServiceTest {
         verify(storeStaffRepository, never()).findStoreIdsByUserId(1L)
     }
 
+    @Test
+    fun `사장님 공구 관리 승인대기 목록 조회`() {
+        val owner = seller()
+        val storeIds = listOf(1L)
+        mockSellerAndStoreIds(owner.id!!, owner, storeIds)
+        `when`(
+            ownerGroupBuyRequestRepository.findByOwnerIdAndStoreIdInAndStatusOrderByCreatedAtDesc(
+                owner.id!!,
+                storeIds,
+                OwnerGroupBuyRequestStatus.PENDING
+            )
+        ).thenReturn(emptyList())
+
+        val result = service.getManageGroupBuys(owner.id!!, OwnerGroupBuyManageFilterType.PENDING_APPROVAL)
+
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `사장님 공구 관리 상세 조회 시 소속 매장이 없으면 권한 예외`() {
+        val owner = seller()
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(emptyList())
+
+        val ex = assertThrows<CustomException> {
+            service.getInProgressGroupBuyDetail(owner.id!!, 10L)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+    }
+
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
         role = UserRole.SELLER
     }
@@ -216,7 +262,7 @@ class OwnerGroupBuyServiceTest {
         `when`(
             groupBuyRepository.countTodayPickupUsersByStoreIds(
                 storeIds = storeIds,
-                pickupDate = LocalDate.now(),
+                pickupDate = LocalDate.now(ZoneId.of("Asia/Seoul")),
                 participationStatuses = listOf(ParticipationStatus.CONFIRMED),
                 pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
                 groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.owner.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyClosedByType
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseReasonType
@@ -307,6 +308,7 @@ class OwnerGroupBuyServiceTest {
 
         assertEquals(GroupBuyStatus.CLOSED, groupBuy.status)
         assertEquals(GroupBuyCloseReason.STORE_CONDITION, groupBuy.closeReason)
+        assertEquals(GroupBuyClosedByType.OWNER, groupBuy.closedByType)
         assertNull(groupBuy.closeReasonDetail)
         verify(groupBuyRepository).save(groupBuy)
     }

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -3,6 +3,9 @@ package com.moongchijang.domain.owner.application
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseReasonType
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseRequest
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyExtensionRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
@@ -31,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class OwnerGroupBuyServiceTest {
@@ -234,6 +238,99 @@ class OwnerGroupBuyServiceTest {
         }
 
         assertEquals(ErrorCode.FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `사장님 공구 기간 연장 요청 성공`() {
+        val owner = seller()
+        val groupBuy = groupBuy(
+            id = 10L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            currentQuantity = 12,
+            targetQuantity = 20,
+            price = 9900
+        )
+        val request = OwnerGroupBuyExtensionRequest(extendedDeadline = groupBuy.deadline.plusDays(2))
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(groupBuyRepository.findWithStoreById(groupBuy.id)).thenReturn(Optional.of(groupBuy))
+
+        service.requestGroupBuyExtension(owner.id!!, groupBuy.id, request)
+
+        assertEquals(request.extendedDeadline, groupBuy.deadline)
+        verify(groupBuyRepository).save(groupBuy)
+    }
+
+    @Test
+    fun `사장님 공구 기간 연장 요청 시 기존 마감 이전 날짜는 실패`() {
+        val owner = seller()
+        val groupBuy = groupBuy(
+            id = 11L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            currentQuantity = 12,
+            targetQuantity = 20,
+            price = 9900
+        )
+        val request = OwnerGroupBuyExtensionRequest(extendedDeadline = groupBuy.deadline.minusDays(1))
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(groupBuyRepository.findWithStoreById(groupBuy.id)).thenReturn(Optional.of(groupBuy))
+
+        val ex = assertThrows<CustomException> {
+            service.requestGroupBuyExtension(owner.id!!, groupBuy.id, request)
+        }
+
+        assertEquals(ErrorCode.INVALID_INPUT, ex.errorCode)
+    }
+
+    @Test
+    fun `사장님 공구 마감 요청 성공`() {
+        val owner = seller()
+        val groupBuy = groupBuy(
+            id = 12L,
+            status = GroupBuyStatus.ACHIEVED,
+            currentQuantity = 20,
+            targetQuantity = 20,
+            price = 9900
+        )
+        val request = OwnerGroupBuyCloseRequest(reason = OwnerGroupBuyCloseReasonType.STORE_CONDITION)
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(groupBuyRepository.findWithStoreById(groupBuy.id)).thenReturn(Optional.of(groupBuy))
+
+        service.requestGroupBuyClose(owner.id!!, groupBuy.id, request)
+
+        assertEquals(GroupBuyStatus.CLOSED, groupBuy.status)
+        verify(groupBuyRepository).save(groupBuy)
+    }
+
+    @Test
+    fun `사장님 공구 마감 요청에서 기타 사유 상세 누락 시 실패`() {
+        val owner = seller()
+        val groupBuy = groupBuy(
+            id = 13L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            currentQuantity = 12,
+            targetQuantity = 20,
+            price = 9900
+        )
+        val request = OwnerGroupBuyCloseRequest(
+            reason = OwnerGroupBuyCloseReasonType.OTHER,
+            reasonDetail = "   "
+        )
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(groupBuyRepository.findWithStoreById(groupBuy.id)).thenReturn(Optional.of(groupBuy))
+
+        val ex = assertThrows<CustomException> {
+            service.requestGroupBuyClose(owner.id!!, groupBuy.id, request)
+        }
+
+        assertEquals(ErrorCode.INVALID_INPUT, ex.errorCode)
     }
 
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.owner.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseReasonType
@@ -21,6 +22,7 @@ import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.support.GroupBuyFixture
 import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -304,6 +306,8 @@ class OwnerGroupBuyServiceTest {
         service.requestGroupBuyClose(owner.id!!, groupBuy.id, request)
 
         assertEquals(GroupBuyStatus.CLOSED, groupBuy.status)
+        assertEquals(GroupBuyCloseReason.STORE_CONDITION, groupBuy.closeReason)
+        assertNull(groupBuy.closeReasonDetail)
         verify(groupBuyRepository).save(groupBuy)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -2,6 +2,10 @@ package com.moongchijang.domain.owner.presentation
 
 import com.moongchijang.domain.owner.application.OwnerGroupBuyService
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageDetailResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageListItemResponse
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageParticipantSummary
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyStatusResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryResponse
 import com.moongchijang.domain.user.domain.entity.UserRole
@@ -65,5 +69,63 @@ class OwnerGroupBuyControllerTest {
 
         assertEquals(response, result.body?.data)
         verify(ownerGroupBuyService).getMyGroupBuys(1L)
+    }
+
+    @Test
+    fun `사장님 공구 관리 목록을 조회한다`() {
+        val principal = CustomUserPrincipal(id = 1L, email = "seller@example.com", role = UserRole.SELLER)
+        val response = listOf(
+            OwnerGroupBuyManageListItemResponse(
+                groupBuyId = 101L,
+                productName = "두쫀쿠 세트",
+                price = 9900,
+                pickupDate = LocalDate.of(2026, 6, 1),
+                deadlineDday = 3,
+                achievementRate = 60,
+                currentParticipants = 12,
+                targetParticipants = 20,
+                status = OwnerGroupBuyManageFilterType.IN_PROGRESS
+            )
+        )
+        `when`(ownerGroupBuyService.getManageGroupBuys(1L, OwnerGroupBuyManageFilterType.ALL)).thenReturn(response)
+
+        val result = controller.getManageGroupBuys(principal, OwnerGroupBuyManageFilterType.ALL)
+
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyService).getManageGroupBuys(1L, OwnerGroupBuyManageFilterType.ALL)
+    }
+
+    @Test
+    fun `사장님 모집중 공구 상세를 조회한다`() {
+        val principal = CustomUserPrincipal(id = 1L, email = "seller@example.com", role = UserRole.SELLER)
+        val response = OwnerGroupBuyManageDetailResponse(
+            groupBuyId = 101L,
+            status = OwnerGroupBuyManageFilterType.IN_PROGRESS,
+            participantSummary = OwnerGroupBuyManageParticipantSummary(totalCount = 20, completedCount = 8, waitingCount = 12),
+            participants = emptyList()
+        )
+        `when`(ownerGroupBuyService.getInProgressGroupBuyDetail(1L, 101L)).thenReturn(response)
+
+        val result = controller.getInProgressGroupBuyDetail(principal, 101L)
+
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyService).getInProgressGroupBuyDetail(1L, 101L)
+    }
+
+    @Test
+    fun `사장님 달성 공구 상세를 조회한다`() {
+        val principal = CustomUserPrincipal(id = 1L, email = "seller@example.com", role = UserRole.SELLER)
+        val response = OwnerGroupBuyManageDetailResponse(
+            groupBuyId = 102L,
+            status = OwnerGroupBuyManageFilterType.ACHIEVED,
+            participantSummary = OwnerGroupBuyManageParticipantSummary(totalCount = 20, completedCount = 8, waitingCount = 12),
+            participants = emptyList()
+        )
+        `when`(ownerGroupBuyService.getAchievedGroupBuyDetail(1L, 102L)).thenReturn(response)
+
+        val result = controller.getAchievedGroupBuyDetail(principal, 102L)
+
+        assertEquals(response, result.body?.data)
+        verify(ownerGroupBuyService).getAchievedGroupBuyDetail(1L, 102L)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -1,6 +1,9 @@
 package com.moongchijang.domain.owner.presentation
 
 import com.moongchijang.domain.owner.application.OwnerGroupBuyService
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseReasonType
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyCloseRequest
+import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyExtensionRequest
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyListItemResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageDetailResponse
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
@@ -11,11 +14,13 @@ import com.moongchijang.domain.owner.application.dto.OwnerGroupBuySummaryRespons
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.security.principal.CustomUserPrincipal
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class OwnerGroupBuyControllerTest {
 
@@ -127,5 +132,34 @@ class OwnerGroupBuyControllerTest {
 
         assertEquals(response, result.body?.data)
         verify(ownerGroupBuyService).getAchievedGroupBuyDetail(1L, 102L)
+    }
+
+    @Test
+    fun `사장님 공구 기간 연장 요청을 한다`() {
+        val principal = CustomUserPrincipal(id = 1L, email = "seller@example.com", role = UserRole.SELLER)
+        val request = OwnerGroupBuyExtensionRequest(
+            extendedDeadline = LocalDateTime.of(2026, 6, 10, 23, 59)
+        )
+
+        val result = controller.requestGroupBuyExtension(principal, 101L, request)
+
+        assertEquals(true, result.body?.success)
+        assertNull(result.body?.data)
+        verify(ownerGroupBuyService).requestGroupBuyExtension(1L, 101L, request)
+    }
+
+    @Test
+    fun `사장님 공구 마감 요청을 한다`() {
+        val principal = CustomUserPrincipal(id = 1L, email = "seller@example.com", role = UserRole.SELLER)
+        val request = OwnerGroupBuyCloseRequest(
+            reason = OwnerGroupBuyCloseReasonType.OTHER,
+            reasonDetail = "재고 수급 이슈로 조기 마감합니다."
+        )
+
+        val result = controller.requestGroupBuyClose(principal, 101L, request)
+
+        assertEquals(true, result.body?.success)
+        assertNull(result.body?.data)
+        verify(ownerGroupBuyService).requestGroupBuyClose(1L, 101L, request)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -87,8 +87,8 @@ class OwnerGroupBuyControllerTest {
                 pickupDate = LocalDate.of(2026, 6, 1),
                 deadlineDday = 3,
                 achievementRate = 60,
-                currentParticipants = 12,
-                targetParticipants = 20,
+                currentQuantity = 12,
+                targetQuantity = 20,
                 status = OwnerGroupBuyManageFilterType.IN_PROGRESS
             )
         )


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 공구 관리 목록 조회 API를 구현했습니다.
  - `GET /api/v1/owner/group-buys/manage`
  - 필터 지원: `ALL`, `IN_PROGRESS`, `ACHIEVED`, `ENDED`, `PENDING_APPROVAL` (기본값 `ALL`)
- 모집중/달성 상세 조회 API를 구현했습니다.
  - `GET /api/v1/owner/group-buys/{groupBuyId}/manage/in-progress`
  - `GET /api/v1/owner/group-buys/{groupBuyId}/manage/achieved`
  - 상세 응답: 총 참여자/완료/대기 + 참여자 정보(이름, 전화번호, 상품, 수량, 결제수단, 결제상태, 픽업시간)
- 공구 기간 연장 요청 API를 구현했습니다.
  - `POST /api/v1/owner/group-buys/{groupBuyId}/extension-requests`
  - 모집중 상태 + 기존 마감일 이후 날짜 검증
- 공구 마감 요청 API를 구현했습니다.
  - `POST /api/v1/owner/group-buys/{groupBuyId}/close-requests`
  - `OTHER` 선택 시 상세 사유 필수, 상세 사유 최대 100자 검증
- 공구 마감 사유/요청시각/마감주체(OWNER/ADMIN/SYSTEM) 저장 필드를 추가했습니다.
- 관련 DTO/리포지토리/서비스/컨트롤러/테스트 및 OpenAPI를 반영했습니다.

## ✨ 코드리뷰 반영 내용
- 정산 예정 금액 오버플로우 가능성이 있었습니다.
  - `settlementExpectedAmount`를 `Int`에서 `Long`으로 변경하고, `.toInt()` 변환을 제거했습니다.
  - DTO/테스트/OpenAPI(`int64`)까지 일관되게 수정했습니다.
- 날짜/시간대 기준이 서버 기본 시간대에 의존할 수 있었습니다.
  - 오늘 픽업 예정 집계 날짜를 `LocalDate.now(ZoneId.of("Asia/Seoul"))`로 고정했습니다.
  - 공구 마감 요청 시각 저장도 `LocalDateTime.now(SEOUL_ZONE_ID)`로 명시해 KST 기준으로 저장하도록 수정했습니다.
- 공구 기간 연장 시 비즈니스 모순 가능성이 있었습니다.
  - 기존에는 “기존 마감일 이후”만 검증했는데, 추가로 “픽업 시작 시각 이전” 검증을 넣었습니다.
  - 픽업 시작 이후로 마감일이 밀리는 케이스를 차단했습니다.
- 목록 필드명이 도메인 의미와 불일치했습니다.
  - `currentParticipants/targetParticipants`를 `currentQuantity/targetQuantity`로 변경했습니다.
  - 실제 `GroupBuy.currentQuantity/targetQuantity` 의미(수량)와 맞추고, OpenAPI/테스트도 함께 수정했습니다.
- 상세 조회 집계에서 불필요한 추가 count 쿼리가 있었습니다.
  - 이미 조회한 `participations` 리스트를 재사용해 `total/completed/waiting`를 메모리에서 계산하도록 변경했습니다.
  - DB count 쿼리 2회를 제거했습니다.
- 결제 조회 시 지연 로딩/N+1 위험이 있었습니다.
  - `PaymentRepository` 조회 쿼리에 `po.user` fetch join을 추가했습니다.
  - 서비스 코드에서 `user.id!!` non-null 단언을 제거하고 안전하게 처리했습니다.
- 공구 마감 사유가 요청으로만 받고 저장되지 않는 문제가 있었습니다.
  - `group_buys`에 `close_reason`, `close_reason_detail`, `close_requested_at`, `closed_by_type` 컬럼을 추가했습니다.
  - 사장님 마감 플로우에서 `closeByOwner` 호출 시 사유/상세/요청시각/주체(`OWNER`)가 저장되도록 반영했습니다.

## 🔍 참고 사항
- 권한 검증: SELLER + 본인 소속 매장 공구만 접근/요청 가능
- `PENDING_APPROVAL` 탭은 사장님 공구 개설 요청(`OwnerGroupBuyRequestStatus.PENDING`) 기준으로 조회됩니다.
- 공구 마감 사유는 DB에 저장되며, 현재 사장님 요청 플로우는 `closedByType=OWNER`로 저장됩니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #225 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인