### PR TITLE
[MCJ-1537] REFACTOR: 회원탈퇴 사유 enum/검증 로직 정합화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -375,8 +375,12 @@ class UserService(
         }
     }
 
-    private fun normalizedReasonDetail(request: WithdrawRequest): String? =
-        request.reasonDetail?.trim()?.takeIf { it.isNotBlank() }
+    private fun normalizedReasonDetail(request: WithdrawRequest): String? {
+        if (request.reason != WithdrawalReason.OTHER) {
+            return null
+        }
+        return request.reasonDetail?.trim()?.takeIf { it.isNotBlank() }
+    }
 
     private fun normalizeBusinessRegistrationNumber(raw: String): String = raw.replace(Regex("[^0-9]"), "")
 

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawRequest.kt
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
 
 data class WithdrawRequest(
+
     @field:Schema(
         description = "탈퇴 사유 (선택)",
-        example = "NO_LONGER_INTERESTED",
+        example = "NO_DESIRED_GROUPBUY",
     )
     val reason: WithdrawalReason? = null,
+
     @field:Schema(
         description = "탈퇴 상세 사유 (기타 선택 시 입력)",
         example = "근처 다른 매장을 주로 이용해요.",

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/entity/WithdrawalReason.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/entity/WithdrawalReason.kt
@@ -1,9 +1,8 @@
 package com.moongchijang.domain.user.domain.entity
 
 enum class WithdrawalReason {
-    TIME_NOT_AVAILABLE,
-    NO_LONGER_INTERESTED,
-    PREFER_DIRECT_VISIT,
-    BUYING_ELSEWHERE,
+    NO_DESIRED_GROUPBUY,
+    INCONVENIENT_SERVICE,
+    PRIVACY_CONCERN,
     OTHER,
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2346,7 +2346,7 @@ components:
           type: string
           nullable: true
           description: 탈퇴 사유(선택)
-          enum: [TIME_NOT_AVAILABLE, NO_LONGER_INTERESTED, PREFER_DIRECT_VISIT, BUYING_ELSEWHERE, OTHER]
+          enum: [NO_DESIRED_GROUPBUY, INCONVENIENT_SERVICE, PRIVACY_CONCERN, OTHER]
         reasonDetail:
           type: string
           nullable: true

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -458,7 +458,7 @@ class UserServiceTest {
         userService.withdraw(
             1L,
             WithdrawRequest(
-                reason = WithdrawalReason.NO_LONGER_INTERESTED,
+                reason = WithdrawalReason.NO_DESIRED_GROUPBUY,
                 reasonDetail = null,
             )
         )
@@ -496,7 +496,7 @@ class UserServiceTest {
         userService.withdraw(
             2L,
             WithdrawRequest(
-                reason = WithdrawalReason.TIME_NOT_AVAILABLE,
+                reason = WithdrawalReason.INCONVENIENT_SERVICE,
                 reasonDetail = null,
             )
         )


### PR DESCRIPTION
## 📌 작업한 내용
- 회원탈퇴 사유 enum을 UI 기준으로 정합화했습니다.
  - `NO_DESIRED_GROUPBUY`, `INCONVENIENT_SERVICE`, `PRIVACY_CONCERN`, `OTHER`
- 탈퇴 사유 저장 규칙을 정리했습니다.
  - `OTHER`가 아니면 `reasonDetail`은 저장하지 않도록 `null` 처리
  - `OTHER` 선택 시 `reasonDetail` 미입력은 예외 처리 유지
- OpenAPI `WithdrawRequest.reason` enum을 서버/UI 기준과 동일하게 맞췄습니다.
- 관련 서비스 테스트의 사유 값/검증 케이스를 최신 기준으로 정리했습니다.

## 🔍 참고 사항
<!-- 이 PR에서 참고해야 할 사항이 있으면 적어주세요. -->

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #227 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인