### PR TITLE
[MCJ-1540] FIX: 활성 조회수 heartbeat API 비로그인 접근 403 오류 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -51,6 +51,11 @@ class SecurityConfig(
                     "/api/v1/group-buys/*",
                     "/api/v1/group-buys/progress",
                     "/api/v1/group-buys/*/progress",
+                    "/api/v1/group-buys/*/share",
+                ).permitAll()
+                it.requestMatchers(
+                    HttpMethod.POST,
+                    "/api/v1/group-buys/*/viewers/heartbeat",
                 ).permitAll()
                 it.requestMatchers(
                     HttpMethod.POST,


### PR DESCRIPTION
## 📌 작업한 내용
- `POST /api/v1/group-buys/{groupBuyId}/viewers/heartbeat` 엔드포인트에 대해 비로그인 접근이 가능하도록 보안 설정을 수정했습니다.
- `SecurityConfig`에 heartbeat 경로 `permitAll` 매처를 추가해, 인증 없이도 활성 조회수 heartbeat 호출이 가능하도록 처리했습니다.
- 기존 활성 조회수 쿠키 발급/재사용 및 로그인 사용자 집계 로직이 정상 동작하는지 컨트롤러 테스트로 회귀 확인했습니다.

## 🔍 참고 사항
- 이번 수정은 접근 제어(403) 이슈 해결이 목적이며, heartbeat의 쿠키 기반 식별/집계 로직 자체 변경은 없습니다.
- 비로그인 첫 호출 시 `viewerSessionId` 쿠키가 발급되고, 이후 재호출에서 재사용되는 흐름을 유지합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #233 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인