### PR TITLE
[MCJ-1543] FEAT: 탈퇴 진입 컨텍스트 조회 API 추가 및 탈퇴 최종 검증 정합성 강화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -38,6 +38,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     ): Boolean
 
     fun existsByUserIdAndGroupBuyId(userId: Long, groupBuyId: Long): Boolean
+    fun existsByUserIdAndStatus(userId: Long, status: ParticipationStatus): Boolean
 
     @Query(
         """

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -316,6 +316,9 @@ class UserService(
         log.info("[UserService] 회원탈퇴 처리 시작: userId={}", userId)
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        if (user.hasRole(UserRole.SELLER)) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
 
         validateWithdrawalReason(request)
         validateWithdrawable(userId)

--- a/src/main/kotlin/com/moongchijang/domain/user/application/WithdrawalContextService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/WithdrawalContextService.kt
@@ -40,6 +40,7 @@ class WithdrawalContextService(
 
         val recommended = decideRecommendedScreen(
             currentRole = user.role,
+            hasSellerRole = user.hasRole(UserRole.SELLER),
             buyerCanProceed = buyer.canProceed,
             sellerCanProceed = seller.canProceed,
         )
@@ -101,10 +102,10 @@ class WithdrawalContextService(
         val storeIds = storeStaffRepository.findStoreIdsByUserId(userId)
         if (storeIds.isEmpty()) {
             return SellerWithdrawalContext(
-                canProceed = !hasPendingPickupAsBuyer,
+                canProceed = true,
                 hasOpenGroupBuy = false,
                 hasPendingCustomerPickup = false,
-                blockingReason = if (hasPendingPickupAsBuyer) SellerWithdrawalBlockingReason.PENDING_CUSTOMER_PICKUP else SellerWithdrawalBlockingReason.NONE,
+                blockingReason = SellerWithdrawalBlockingReason.NONE,
             )
         }
 
@@ -119,12 +120,12 @@ class WithdrawalContextService(
         )
         val blockingReason = when {
             hasOpenGroupBuy -> SellerWithdrawalBlockingReason.OPEN_GROUPBUY
-            hasPendingCustomerPickup || hasPendingPickupAsBuyer -> SellerWithdrawalBlockingReason.PENDING_CUSTOMER_PICKUP
+            hasPendingCustomerPickup -> SellerWithdrawalBlockingReason.PENDING_CUSTOMER_PICKUP
             else -> SellerWithdrawalBlockingReason.NONE
         }
 
         return SellerWithdrawalContext(
-            canProceed = !hasOpenGroupBuy && !hasPendingCustomerPickup && !hasPendingPickupAsBuyer,
+            canProceed = !hasOpenGroupBuy && !hasPendingCustomerPickup,
             hasOpenGroupBuy = hasOpenGroupBuy,
             hasPendingCustomerPickup = hasPendingCustomerPickup,
             blockingReason = blockingReason,
@@ -133,12 +134,16 @@ class WithdrawalContextService(
 
     private fun decideRecommendedScreen(
         currentRole: UserRole,
+        hasSellerRole: Boolean,
         buyerCanProceed: Boolean,
         sellerCanProceed: Boolean,
     ): WithdrawalScreenType {
+        val hasBuyerIssue = !buyerCanProceed
+        val hasSellerIssue = hasSellerRole && !sellerCanProceed
+
         return when {
-            buyerCanProceed && !sellerCanProceed -> WithdrawalScreenType.BUYER_WITHDRAWAL
-            !buyerCanProceed && sellerCanProceed -> WithdrawalScreenType.SELLER_WITHDRAWAL
+            hasBuyerIssue && !hasSellerIssue -> WithdrawalScreenType.BUYER_WITHDRAWAL
+            !hasBuyerIssue && hasSellerIssue -> WithdrawalScreenType.SELLER_WITHDRAWAL
             currentRole == UserRole.SELLER -> WithdrawalScreenType.SELLER_WITHDRAWAL
             else -> WithdrawalScreenType.BUYER_WITHDRAWAL
         }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/WithdrawalContextService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/WithdrawalContextService.kt
@@ -1,0 +1,146 @@
+package com.moongchijang.domain.user.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.application.dto.BuyerWithdrawalBlockingReason
+import com.moongchijang.domain.user.application.dto.BuyerWithdrawalContext
+import com.moongchijang.domain.user.application.dto.SellerWithdrawalBlockingReason
+import com.moongchijang.domain.user.application.dto.SellerWithdrawalContext
+import com.moongchijang.domain.user.application.dto.WithdrawalContextResponse
+import com.moongchijang.domain.user.application.dto.WithdrawalScreenType
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class WithdrawalContextService(
+    private val userRepository: UserRepository,
+    private val participationRepository: ParticipationRepository,
+    private val storeStaffRepository: StoreStaffRepository,
+    private val groupBuyRepository: GroupBuyRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(readOnly = true)
+    fun getContext(userId: Long): WithdrawalContextResponse {
+        log.info("[WithdrawalContextService] 탈퇴 컨텍스트 조회 시작: userId={}", userId)
+        val user = userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        val buyer = resolveBuyerContext(userId)
+        val seller = resolveSellerContext(userId, user.hasRole(UserRole.SELLER), buyer.hasPendingPickup)
+
+        val recommended = decideRecommendedScreen(
+            currentRole = user.role,
+            buyerCanProceed = buyer.canProceed,
+            sellerCanProceed = seller.canProceed,
+        )
+        val currentScreen = if (user.role == UserRole.SELLER) {
+            WithdrawalScreenType.SELLER_WITHDRAWAL
+        } else {
+            WithdrawalScreenType.BUYER_WITHDRAWAL
+        }
+        val forceRedirect = recommended != currentScreen
+
+        val response = WithdrawalContextResponse(
+            currentRole = user.role,
+            buyer = buyer,
+            seller = seller,
+            recommendedScreen = recommended,
+            forceRedirect = forceRedirect,
+            forceRedirectTarget = if (forceRedirect) recommended else null,
+        )
+        log.info(
+            "[WithdrawalContextService] 탈퇴 컨텍스트 조회 완료: userId={}, recommendedScreen={}, forceRedirect={}",
+            userId, response.recommendedScreen, response.forceRedirect
+        )
+        return response
+    }
+
+    private fun resolveBuyerContext(userId: Long): BuyerWithdrawalContext {
+        val hasPendingPickup = participationRepository.existsPendingPickupForWithdrawal(
+            userId = userId,
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+            groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+        )
+        val hasActiveParticipation = participationRepository.existsByUserIdAndStatus(
+            userId = userId,
+            status = ParticipationStatus.PAID_WAITING_GOAL,
+        )
+        return BuyerWithdrawalContext(
+            canProceed = !hasPendingPickup,
+            hasPendingPickup = hasPendingPickup,
+            hasActiveParticipation = hasActiveParticipation,
+            blockingReason = if (hasPendingPickup) BuyerWithdrawalBlockingReason.PENDING_PICKUP else BuyerWithdrawalBlockingReason.NONE,
+        )
+    }
+
+    private fun resolveSellerContext(
+        userId: Long,
+        hasSellerRole: Boolean,
+        hasPendingPickupAsBuyer: Boolean,
+    ): SellerWithdrawalContext {
+        if (!hasSellerRole) {
+            return SellerWithdrawalContext(
+                canProceed = false,
+                hasOpenGroupBuy = false,
+                hasPendingCustomerPickup = false,
+                blockingReason = SellerWithdrawalBlockingReason.NONE,
+            )
+        }
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(userId)
+        if (storeIds.isEmpty()) {
+            return SellerWithdrawalContext(
+                canProceed = !hasPendingPickupAsBuyer,
+                hasOpenGroupBuy = false,
+                hasPendingCustomerPickup = false,
+                blockingReason = if (hasPendingPickupAsBuyer) SellerWithdrawalBlockingReason.PENDING_CUSTOMER_PICKUP else SellerWithdrawalBlockingReason.NONE,
+            )
+        }
+
+        val hasOpenGroupBuy = groupBuyRepository.existsByStoreIdInAndStatusIn(
+            storeIds = storeIds,
+            statuses = listOf(GroupBuyStatus.IN_PROGRESS),
+        )
+        val hasPendingCustomerPickup = participationRepository.existsUnpickedParticipationByStoreIdsAndGroupBuyStatuses(
+            storeIds = storeIds,
+            groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+        )
+        val blockingReason = when {
+            hasOpenGroupBuy -> SellerWithdrawalBlockingReason.OPEN_GROUPBUY
+            hasPendingCustomerPickup || hasPendingPickupAsBuyer -> SellerWithdrawalBlockingReason.PENDING_CUSTOMER_PICKUP
+            else -> SellerWithdrawalBlockingReason.NONE
+        }
+
+        return SellerWithdrawalContext(
+            canProceed = !hasOpenGroupBuy && !hasPendingCustomerPickup && !hasPendingPickupAsBuyer,
+            hasOpenGroupBuy = hasOpenGroupBuy,
+            hasPendingCustomerPickup = hasPendingCustomerPickup,
+            blockingReason = blockingReason,
+        )
+    }
+
+    private fun decideRecommendedScreen(
+        currentRole: UserRole,
+        buyerCanProceed: Boolean,
+        sellerCanProceed: Boolean,
+    ): WithdrawalScreenType {
+        return when {
+            buyerCanProceed && !sellerCanProceed -> WithdrawalScreenType.BUYER_WITHDRAWAL
+            !buyerCanProceed && sellerCanProceed -> WithdrawalScreenType.SELLER_WITHDRAWAL
+            currentRole == UserRole.SELLER -> WithdrawalScreenType.SELLER_WITHDRAWAL
+            else -> WithdrawalScreenType.BUYER_WITHDRAWAL
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/BuyerWithdrawalBlockingReason.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/BuyerWithdrawalBlockingReason.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.user.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "소비자 탈퇴 차단 사유")
+enum class BuyerWithdrawalBlockingReason {
+    @Schema(description = "차단 사유 없음")
+    NONE,
+    @Schema(description = "수령 예정 공구 존재")
+    PENDING_PICKUP,
+}

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/BuyerWithdrawalContext.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/BuyerWithdrawalContext.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.user.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "소비자 탈퇴 컨텍스트")
+data class BuyerWithdrawalContext(
+
+    @field:Schema(description = "소비자 탈퇴 진행 가능 여부", example = "true")
+    val canProceed: Boolean,
+
+    @field:Schema(description = "수령 예정 공구 존재 여부", example = "false")
+    val hasPendingPickup: Boolean,
+
+    @field:Schema(description = "참여 중 공구(PAID_WAITING_GOAL) 존재 여부", example = "true")
+    val hasActiveParticipation: Boolean,
+
+    @field:Schema(description = "소비자 탈퇴 차단 사유", example = "NONE")
+    val blockingReason: BuyerWithdrawalBlockingReason,
+)

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/SellerWithdrawalBlockingReason.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/SellerWithdrawalBlockingReason.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.user.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 탈퇴 차단 사유")
+enum class SellerWithdrawalBlockingReason {
+    @Schema(description = "차단 사유 없음")
+    NONE,
+    @Schema(description = "진행중 개설 공구 존재")
+    OPEN_GROUPBUY,
+    @Schema(description = "고객 미픽업 존재")
+    PENDING_CUSTOMER_PICKUP,
+}

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/SellerWithdrawalContext.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/SellerWithdrawalContext.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.user.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 탈퇴 컨텍스트")
+data class SellerWithdrawalContext(
+
+    @field:Schema(description = "사장님 탈퇴 진행 가능 여부", example = "false")
+    val canProceed: Boolean,
+
+    @field:Schema(description = "개설된 진행중 공구 존재 여부", example = "true")
+    val hasOpenGroupBuy: Boolean,
+
+    @field:Schema(description = "달성/완료 공구 고객 미픽업 존재 여부", example = "false")
+    val hasPendingCustomerPickup: Boolean,
+
+    @field:Schema(description = "사장님 탈퇴 차단 사유", example = "OPEN_GROUPBUY")
+    val blockingReason: SellerWithdrawalBlockingReason,
+)

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawalContextResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawalContextResponse.kt
@@ -1,0 +1,26 @@
+package com.moongchijang.domain.user.application.dto
+
+import com.moongchijang.domain.user.domain.entity.UserRole
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "탈퇴 진입 컨텍스트 응답")
+data class WithdrawalContextResponse(
+
+    @field:Schema(description = "현재 사용자 활성 역할", example = "BUYER")
+    val currentRole: UserRole,
+
+    @field:Schema(description = "소비자 탈퇴 컨텍스트")
+    val buyer: BuyerWithdrawalContext,
+
+    @field:Schema(description = "사장님 탈퇴 컨텍스트")
+    val seller: SellerWithdrawalContext,
+
+    @field:Schema(description = "권장 탈퇴 화면 타입", example = "BUYER_WITHDRAWAL")
+    val recommendedScreen: WithdrawalScreenType,
+
+    @field:Schema(description = "현재 역할 화면에서 강제 이동 필요 여부", example = "false")
+    val forceRedirect: Boolean,
+
+    @field:Schema(description = "강제 이동 대상 화면 타입(forceRedirect=true일 때만 존재)", nullable = true, example = "SELLER_WITHDRAWAL")
+    val forceRedirectTarget: WithdrawalScreenType?,
+)

--- a/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawalScreenType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/dto/WithdrawalScreenType.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.user.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "탈퇴 화면 타입")
+enum class WithdrawalScreenType {
+    @Schema(description = "소비자 탈퇴 화면")
+    BUYER_WITHDRAWAL,
+    @Schema(description = "사장님 탈퇴 화면")
+    SELLER_WITHDRAWAL,
+}

--- a/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.user.presentation
 import com.moongchijang.domain.user.application.UserService
 import com.moongchijang.domain.user.application.OwnerWithdrawService
 import com.moongchijang.domain.user.application.BusinessRegistrationLookupService
+import com.moongchijang.domain.user.application.WithdrawalContextService
 import com.moongchijang.domain.auth.application.TokenService
 import com.moongchijang.domain.auth.application.dto.AuthUserResponse
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
@@ -21,6 +22,7 @@ import com.moongchijang.domain.user.application.dto.SellerSettlementInfoUpsertRe
 import com.moongchijang.domain.user.application.dto.SellerSignupStatusResponse
 import com.moongchijang.domain.user.application.dto.OwnerWithdrawRequest
 import com.moongchijang.domain.user.application.dto.WithdrawRequest
+import com.moongchijang.domain.user.application.dto.WithdrawalContextResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
@@ -51,6 +53,7 @@ import org.slf4j.LoggerFactory
 class UserController(
     private val userService: UserService,
     private val ownerWithdrawService: OwnerWithdrawService,
+    private val withdrawalContextService: WithdrawalContextService,
     private val businessRegistrationLookupService: BusinessRegistrationLookupService,
     private val tokenService: TokenService,
 ) {
@@ -87,6 +90,25 @@ class UserController(
         log.info("[UserController] 내 정보 조회 요청 수신: userId={}", principal.id)
         val response = userService.getMyInfo(principal.id)
         log.info("[UserController] 내 정보 조회 응답 완료: userId={}", principal.id)
+        return ApiResponse.success(response)
+    }
+
+    @GetMapping("/me/withdrawal-context")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "탈퇴 진입 컨텍스트 조회", description = "소비자/사장님 탈퇴 가능 상태와 권장 진입 화면을 조회합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "404", description = "사용자 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun getWithdrawalContext(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+    ): ApiResponse<WithdrawalContextResponse> {
+        log.info("[UserController] 탈퇴 컨텍스트 조회 요청 수신: userId={}", principal.id)
+        val response = withdrawalContextService.getContext(principal.id)
+        log.info("[UserController] 탈퇴 컨텍스트 조회 응답 완료: userId={}", principal.id)
         return ApiResponse.success(response)
     }
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -143,7 +143,24 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '409':
           $ref: '#/components/responses/Conflict'
-
+  /api/v1/users/me/withdrawal-context:
+    get:
+      tags: [Auth]
+      summary: 탈퇴 진입 컨텍스트 조회
+      description: 소비자/사장님 탈퇴 가능 상태와 권장 탈퇴 화면 정보를 조회한다.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 탈퇴 진입 컨텍스트 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseWithdrawalContext'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /api/v1/users/nickname/availability:
     get:
       tags: [Auth]
@@ -2397,6 +2414,15 @@ components:
           $ref: '#/components/schemas/AuthUser'
         error: { nullable: true, example: null }
 
+    ApiResponseWithdrawalContext:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/WithdrawalContextResponse'
+        error: { nullable: true, example: null }
+
     AdditionalInfoUpsertRequest:
       type: object
       required: [nickname, phoneNumber]
@@ -2425,6 +2451,76 @@ components:
           nullable: true
           maxLength: 500
           description: 탈퇴 상세 사유 (reason=OTHER 일 때 입력)
+
+    WithdrawalContextResponse:
+      type: object
+      required: [currentRole, buyer, seller, recommendedScreen, forceRedirect]
+      properties:
+        currentRole:
+          type: string
+          enum: [BUYER, SELLER, ADMIN]
+          description: 현재 사용자 활성 역할
+        buyer:
+          $ref: '#/components/schemas/BuyerWithdrawalContext'
+        seller:
+          $ref: '#/components/schemas/SellerWithdrawalContext'
+        recommendedScreen:
+          $ref: '#/components/schemas/WithdrawalScreenType'
+        forceRedirect:
+          type: boolean
+          description: 현재 역할 화면에서 강제 이동 필요 여부
+        forceRedirectTarget:
+          allOf:
+            - $ref: '#/components/schemas/WithdrawalScreenType'
+          nullable: true
+          description: 강제 이동 대상 화면 타입(forceRedirect=true일 때만 존재)
+
+    BuyerWithdrawalContext:
+      type: object
+      required: [canProceed, hasPendingPickup, hasActiveParticipation, blockingReason]
+      properties:
+        canProceed:
+          type: boolean
+          description: 소비자 탈퇴 진행 가능 여부
+        hasPendingPickup:
+          type: boolean
+          description: 수령 예정 공구 존재 여부
+        hasActiveParticipation:
+          type: boolean
+          description: 참여 중 공구(PAID_WAITING_GOAL) 존재 여부
+        blockingReason:
+          $ref: '#/components/schemas/BuyerWithdrawalBlockingReason'
+
+    SellerWithdrawalContext:
+      type: object
+      required: [canProceed, hasOpenGroupBuy, hasPendingCustomerPickup, blockingReason]
+      properties:
+        canProceed:
+          type: boolean
+          description: 사장님 탈퇴 진행 가능 여부
+        hasOpenGroupBuy:
+          type: boolean
+          description: 개설된 진행중 공구 존재 여부
+        hasPendingCustomerPickup:
+          type: boolean
+          description: 달성/완료 공구 고객 미픽업 존재 여부
+        blockingReason:
+          $ref: '#/components/schemas/SellerWithdrawalBlockingReason'
+
+    WithdrawalScreenType:
+      type: string
+      description: 탈퇴 화면 타입
+      enum: [BUYER_WITHDRAWAL, SELLER_WITHDRAWAL]
+
+    BuyerWithdrawalBlockingReason:
+      type: string
+      description: 소비자 탈퇴 차단 사유
+      enum: [NONE, PENDING_PICKUP]
+
+    SellerWithdrawalBlockingReason:
+      type: string
+      description: 사장님 탈퇴 차단 사유
+      enum: [NONE, OPEN_GROUPBUY, PENDING_CUSTOMER_PICKUP]
 
     OwnerWithdrawRequest:
       type: object

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -124,10 +124,12 @@ paths:
       summary: 회원 탈퇴
       description: |
         회원 탈퇴를 처리한다.
+        - 탈퇴 진입 컨텍스트 조회 결과와 무관하게 실행 시점 최종 검증을 다시 수행한다.
         - 수령 예정 공구(달성 완료 + 픽업 미완료)가 있으면 탈퇴할 수 없다.
         - 참여 중 공구(PAID_WAITING_GOAL)는 자동 취소된다.
         - 찜 목록은 모두 삭제된다.
         - 동일 계정은 탈퇴 후 30일 이후 재가입 가능하다.
+        - 최종 검증 실패 시 409 에러를 반환한다. (예: WITHDRAWAL_BLOCKED_PENDING_PICKUP)
       security:
         - bearerAuth: []
       requestBody:
@@ -147,7 +149,9 @@ paths:
     get:
       tags: [Auth]
       summary: 탈퇴 진입 컨텍스트 조회
-      description: 소비자/사장님 탈퇴 가능 상태와 권장 탈퇴 화면 정보를 조회한다.
+      description: |
+        소비자/사장님 탈퇴 가능 상태와 권장 탈퇴 화면 정보를 조회한다.
+        이 응답은 진입/라우팅 가이드 용도이며, 실제 탈퇴 실행 시점에는 최종 검증이 다시 수행된다.
       security:
         - bearerAuth: []
       responses:
@@ -308,9 +312,12 @@ paths:
       summary: 사장님 회원 탈퇴
       description: |
         사장님 회원 탈퇴를 처리한다.
+        - 탈퇴 진입 컨텍스트 조회 결과와 무관하게 실행 시점 최종 검증을 다시 수행한다.
         - 개설된 공구(IN_PROGRESS)가 있으면 탈퇴할 수 없다.
         - 달성 완료/완료 공구(ACHIEVED, COMPLETED)에 픽업 미완료 참여가 있으면 탈퇴할 수 없다.
+        - 소비자 수령 예정 공구가 있으면 탈퇴할 수 없다.
         - 동일 계정은 탈퇴 후 30일 이후 재가입 가능하다.
+        - 최종 검증 실패 시 409 에러를 반환한다. (예: OWNER_WITHDRAWAL_BLOCKED_OPEN_GROUPBUY, OWNER_WITHDRAWAL_BLOCKED_PENDING_CUSTOMER_PICKUP, WITHDRAWAL_BLOCKED_PENDING_PICKUP)
       security:
         - bearerAuth: []
       requestBody:

--- a/src/test/kotlin/com/moongchijang/domain/user/application/OwnerWithdrawServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/OwnerWithdrawServiceTest.kt
@@ -166,4 +166,36 @@ class OwnerWithdrawServiceTest {
         Assertions.assertEquals(null, owner.ownerWithdrawalReasonDetail)
         Assertions.assertEquals(true, owner.deletedAt != null)
     }
+
+    @Test
+    fun `사장님 회원탈퇴 컨텍스트 가능 이후 실행 시점 차단 예외`() {
+        val owner = UserFixture.createKakaoUser(id = 15L, providerId = "owner-15").apply {
+            roleAssignments.add(com.moongchijang.domain.user.domain.entity.UserRoleAssignment(user = this, role = UserRole.SELLER))
+        }
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(15L)).thenReturn(owner)
+        Mockito.`when`(
+            participationRepository.existsPendingPickupForWithdrawal(
+                userId = 15L,
+                participationStatus = ParticipationStatus.CONFIRMED,
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            )
+        ).thenReturn(false)
+        Mockito.`when`(storeStaffRepository.findStoreIdsByUserId(15L)).thenReturn(listOf(401L))
+        Mockito.`when`(
+            groupBuyRepository.existsByStoreIdInAndStatusIn(
+                listOf(401L),
+                listOf(GroupBuyStatus.IN_PROGRESS),
+            )
+        ).thenReturn(true)
+
+        val exception = assertThrows<CustomException> {
+            ownerWithdrawService.withdraw(
+                15L,
+                OwnerWithdrawRequest(reason = OwnerWithdrawalReason.INCONVENIENT_SERVICE),
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.OWNER_WITHDRAWAL_BLOCKED_OPEN_GROUPBUY, exception.errorCode)
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -525,6 +525,32 @@ class UserServiceTest {
     }
 
     @Test
+    fun `회원탈퇴 컨텍스트 가능 이후 실행 시점 차단 예외`() {
+        val user = UserFixture.createKakaoUser(id = 55L, providerId = "kakao-55", nickname = "경합유저")
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(55L)).thenReturn(user)
+        Mockito.`when`(
+            participationRepository.existsPendingPickupForWithdrawal(
+                55L,
+                ParticipationStatus.CONFIRMED,
+                listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            )
+        ).thenReturn(true)
+
+        val exception = assertThrows<CustomException> {
+            userService.withdraw(
+                55L,
+                WithdrawRequest(
+                    reason = WithdrawalReason.INCONVENIENT_SERVICE,
+                    reasonDetail = null,
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.WITHDRAWAL_BLOCKED_PENDING_PICKUP, exception.errorCode)
+    }
+
+    @Test
     fun `사장님 사업자 정보 저장할 때 사업자 정보가 저장됨`() {
         val user = UserFixture.createKakaoUser(id = 101L, providerId = "kakao-101")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(101L)).thenReturn(user)

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -551,6 +551,26 @@ class UserServiceTest {
     }
 
     @Test
+    fun `회원탈퇴 사장님 권한 사용자 차단 예외`() {
+        val sellerUser = UserFixture.createKakaoUser(id = 56L, providerId = "kakao-56", nickname = "사장님").apply {
+            roleAssignments.add(com.moongchijang.domain.user.domain.entity.UserRoleAssignment(user = this, role = UserRole.SELLER))
+        }
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(56L)).thenReturn(sellerUser)
+
+        val exception = assertThrows<CustomException> {
+            userService.withdraw(
+                56L,
+                WithdrawRequest(
+                    reason = WithdrawalReason.INCONVENIENT_SERVICE,
+                    reasonDetail = null,
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.FORBIDDEN, exception.errorCode)
+    }
+
+    @Test
     fun `사장님 사업자 정보 저장할 때 사업자 정보가 저장됨`() {
         val user = UserFixture.createKakaoUser(id = 101L, providerId = "kakao-101")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(101L)).thenReturn(user)

--- a/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawalContextServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawalContextServiceTest.kt
@@ -140,6 +140,26 @@ class WithdrawalContextServiceTest {
 
         val result = withdrawalContextService.getContext(105L)
 
+        assertEquals(WithdrawalScreenType.SELLER_WITHDRAWAL, result.recommendedScreen)
+        assertFalse(result.forceRedirect)
+        assertEquals(null, result.forceRedirectTarget)
+        assertEquals(SellerWithdrawalBlockingReason.OPEN_GROUPBUY, result.seller.blockingReason)
+    }
+
+    @Test
+    fun `탈퇴 컨텍스트 사장님 경로 진입 시 본인 수령예정은 소비자 화면 강제 이동`() {
+        val user = sellerUser(id = 106L)
+        stubBuyerContext(
+            user = user,
+            hasPendingPickup = true,
+            hasActiveParticipation = false,
+        )
+        Mockito.`when`(storeStaffRepository.findStoreIdsByUserId(106L)).thenReturn(emptyList())
+
+        val result = withdrawalContextService.getContext(106L)
+
+        assertTrue(result.seller.canProceed)
+        assertEquals(SellerWithdrawalBlockingReason.NONE, result.seller.blockingReason)
         assertEquals(WithdrawalScreenType.BUYER_WITHDRAWAL, result.recommendedScreen)
         assertTrue(result.forceRedirect)
         assertEquals(WithdrawalScreenType.BUYER_WITHDRAWAL, result.forceRedirectTarget)

--- a/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawalContextServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawalContextServiceTest.kt
@@ -1,0 +1,177 @@
+package com.moongchijang.domain.user.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.application.dto.BuyerWithdrawalBlockingReason
+import com.moongchijang.domain.user.application.dto.SellerWithdrawalBlockingReason
+import com.moongchijang.domain.user.application.dto.WithdrawalScreenType
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.entity.UserRoleAssignment
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+class WithdrawalContextServiceTest {
+
+    private val userRepository: UserRepository = Mockito.mock(UserRepository::class.java)
+    private val participationRepository: ParticipationRepository = Mockito.mock(ParticipationRepository::class.java)
+    private val storeStaffRepository: StoreStaffRepository = Mockito.mock(StoreStaffRepository::class.java)
+    private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
+
+    private val withdrawalContextService = WithdrawalContextService(
+        userRepository = userRepository,
+        participationRepository = participationRepository,
+        storeStaffRepository = storeStaffRepository,
+        groupBuyRepository = groupBuyRepository,
+    )
+
+    @Test
+    fun `탈퇴 컨텍스트 소비자 기본 진입 화면 반환`() {
+        val user = UserFixture.createKakaoUser(id = 101L, providerId = "ctx-101").apply {
+            role = UserRole.BUYER
+        }
+        stubBuyerContext(
+            user = user,
+            hasPendingPickup = false,
+            hasActiveParticipation = true,
+        )
+
+        val result = withdrawalContextService.getContext(101L)
+
+        assertEquals(WithdrawalScreenType.BUYER_WITHDRAWAL, result.recommendedScreen)
+        assertFalse(result.forceRedirect)
+        assertTrue(result.buyer.canProceed)
+        assertEquals(BuyerWithdrawalBlockingReason.NONE, result.buyer.blockingReason)
+        assertFalse(result.seller.canProceed)
+    }
+
+    @Test
+    fun `탈퇴 컨텍스트 사장님 역할일 때 사장님 화면 권장`() {
+        val user = sellerUser(id = 102L)
+        stubBuyerContext(
+            user = user,
+            hasPendingPickup = false,
+            hasActiveParticipation = false,
+        )
+        Mockito.`when`(storeStaffRepository.findStoreIdsByUserId(102L)).thenReturn(emptyList())
+
+        val result = withdrawalContextService.getContext(102L)
+
+        assertEquals(WithdrawalScreenType.SELLER_WITHDRAWAL, result.recommendedScreen)
+        assertFalse(result.forceRedirect)
+        assertTrue(result.buyer.canProceed)
+        assertTrue(result.seller.canProceed)
+    }
+
+    @Test
+    fun `탈퇴 컨텍스트 소비자 수령예정 공구 차단`() {
+        val user = UserFixture.createKakaoUser(id = 103L, providerId = "ctx-103")
+        stubBuyerContext(
+            user = user,
+            hasPendingPickup = true,
+            hasActiveParticipation = false,
+        )
+
+        val result = withdrawalContextService.getContext(103L)
+
+        assertFalse(result.buyer.canProceed)
+        assertEquals(BuyerWithdrawalBlockingReason.PENDING_PICKUP, result.buyer.blockingReason)
+    }
+
+    @Test
+    fun `탈퇴 컨텍스트 사장님 진행중 공구 차단`() {
+        val user = sellerUser(id = 104L)
+        stubBuyerContext(
+            user = user,
+            hasPendingPickup = false,
+            hasActiveParticipation = false,
+        )
+        Mockito.`when`(storeStaffRepository.findStoreIdsByUserId(104L)).thenReturn(listOf(9001L))
+        Mockito.`when`(
+            groupBuyRepository.existsByStoreIdInAndStatusIn(
+                listOf(9001L),
+                listOf(GroupBuyStatus.IN_PROGRESS),
+            )
+        ).thenReturn(true)
+        Mockito.`when`(
+            participationRepository.existsUnpickedParticipationByStoreIdsAndGroupBuyStatuses(
+                storeIds = listOf(9001L),
+                groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+                participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+            )
+        ).thenReturn(false)
+
+        val result = withdrawalContextService.getContext(104L)
+
+        assertFalse(result.seller.canProceed)
+        assertEquals(SellerWithdrawalBlockingReason.OPEN_GROUPBUY, result.seller.blockingReason)
+    }
+
+    @Test
+    fun `탈퇴 컨텍스트 사장님 화면에서 소비자 화면 강제 이동`() {
+        val user = sellerUser(id = 105L)
+        stubBuyerContext(
+            user = user,
+            hasPendingPickup = false,
+            hasActiveParticipation = false,
+        )
+        Mockito.`when`(storeStaffRepository.findStoreIdsByUserId(105L)).thenReturn(listOf(9002L))
+        Mockito.`when`(
+            groupBuyRepository.existsByStoreIdInAndStatusIn(
+                listOf(9002L),
+                listOf(GroupBuyStatus.IN_PROGRESS),
+            )
+        ).thenReturn(true)
+        Mockito.`when`(
+            participationRepository.existsUnpickedParticipationByStoreIdsAndGroupBuyStatuses(
+                storeIds = listOf(9002L),
+                groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+                participationStatuses = listOf(ParticipationStatus.CONFIRMED),
+            )
+        ).thenReturn(false)
+
+        val result = withdrawalContextService.getContext(105L)
+
+        assertEquals(WithdrawalScreenType.BUYER_WITHDRAWAL, result.recommendedScreen)
+        assertTrue(result.forceRedirect)
+        assertEquals(WithdrawalScreenType.BUYER_WITHDRAWAL, result.forceRedirectTarget)
+    }
+
+    private fun stubBuyerContext(
+        user: com.moongchijang.domain.user.domain.entity.User,
+        hasPendingPickup: Boolean,
+        hasActiveParticipation: Boolean,
+    ) {
+        val userId = user.id!!
+        Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(user)
+        Mockito.`when`(
+            participationRepository.existsPendingPickupForWithdrawal(
+                userId = userId,
+                participationStatus = ParticipationStatus.CONFIRMED,
+                pickupStatuses = listOf(PickupStatus.NOT_READY, PickupStatus.READY),
+                groupBuyStatuses = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            )
+        ).thenReturn(hasPendingPickup)
+        Mockito.`when`(
+            participationRepository.existsByUserIdAndStatus(
+                userId = userId,
+                status = ParticipationStatus.PAID_WAITING_GOAL,
+            )
+        ).thenReturn(hasActiveParticipation)
+    }
+
+    private fun sellerUser(id: Long): com.moongchijang.domain.user.domain.entity.User {
+        return UserFixture.createKakaoUser(id = id, providerId = "ctx-$id").apply {
+            role = UserRole.SELLER
+            roleAssignments.add(UserRoleAssignment(user = this, role = UserRole.SELLER))
+        }
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/users/me/withdrawal-context` API를 추가했습니다.
- 소비자/사장님 상태를 한 번에 조회할 수 있도록 컨텍스트 응답을 구성했습니다.
  - buyer: `hasActiveParticipation`, `hasPendingPickup`, `canProceed`, `blockingReason`
  - seller: `hasOpenGroupBuy`, `hasPendingCustomerPickup`, `canProceed`, `blockingReason`
- 화면 라우팅 결정을 위한 필드를 추가했습니다.
  - `recommendedScreen`
  - `forceRedirect`
  - `forceRedirectTarget`
- 탈퇴 컨텍스트 DTO/enum을 파일 분리하고 description을 보강했습니다.
- 탈퇴 컨텍스트 서비스 로직을 메서드 분리하고 로그를 추가했습니다.
- 소비자 탈퇴 API에서 사장님 권한 사용자 차단 로직을 추가해 우회 탈퇴를 방지했습니다.
- 실행 시점 정합성 보장을 위해 경합 케이스 테스트를 보강했습니다.
  - 진입 가능 상태라도 실행 시점 상태 변경 시 409 차단 검증
- OpenAPI에 컨텍스트 API 및 “실행 시점 최종 검증” 규칙을 반영했습니다.

## 🧭 라우팅 기준표
| 소비자 상태(내 공구) | 사장님 상태(판매/정산) | 유저 탈퇴 진입 경로 | 보여줄 탈퇴 화면 |
|---|---|---|---|
| 진행 중인 공구 있음 | 문제 없음(완료됨) | 소비자 마이페이지 | 소비자 탈퇴 화면 |
| 진행 중인 공구 있음 | 문제 없음(완료됨) | 사장님 마이페이지 | 소비자 탈퇴 화면으로 강제 이동 |
| 문제 없음(완료됨) | 진행 중인 판매/미정산 있음 | 소비자 마이페이지 | 사장님 탈퇴 화면으로 강제 이동 |
| 문제 없음(완료됨) | 진행 중인 판매/미정산 있음 | 사장님 마이페이지 | 사장님 탈퇴 화면 |
| 진행 중인 공구 있음 | 진행 중인 판매/미정산 있음 | 어디로 진입하든 무관 | 진입한 화면 유지(소비자/사장님) |
| 문제 없음(깔끔함) | 문제 없음(깔끔함) | 소비자 마이페이지 | 소비자 탈퇴 화면 |
| 문제 없음(깔끔함) | 문제 없음(깔끔함) | 사장님 마이페이지 | 사장님 탈퇴 화면 |

## 🔍 참고 사항
- `withdrawal-context`는 진입/화면 라우팅 가이드 용도이며, 실제 탈퇴 실행 API에서는 최종 검증을 다시 수행합니다.
- 따라서 진입 시 가능하더라도 실행 시점 상태가 변경되면 409 에러코드로 차단될 수 있습니다.
- 관련 차단 코드 예시:
  - 소비자: `WITHDRAWAL_BLOCKED_PENDING_PICKUP`
  - 사장님: `OWNER_WITHDRAWAL_BLOCKED_OPEN_GROUPBUY`, `OWNER_WITHDRAWAL_BLOCKED_PENDING_CUSTOMER_PICKUP`
- 소비자 탈퇴 API(`DELETE /api/v1/users/me`)는 사장님 권한 사용자 호출을 차단하며, 사장님 탈퇴 API(`DELETE /api/v1/users/me/seller`) 경로를 사용해야 합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #235 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인