### PR TITLE
[MCJ-1544] FEAT: 어드민 공구 개설 요청 검색 및 목록 응답 보강

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -33,6 +34,7 @@ class GroupBuyRequestService(
     private val groupBuyRepository: GroupBuyRepository,
     private val groupBuyOpenRequestService: GroupBuyOpenRequestService,
     private val userRepository: UserRepository,
+    private val clock: Clock,
 ) {
 
     fun create(userId: Long, request: GroupBuyRequestCreateRequest): GroupBuyRequestIdResponse {
@@ -127,7 +129,7 @@ class GroupBuyRequestService(
         }
         val groupBuysById = findOpenedGroupBuys(page.content)
 
-        return AdminGroupBuyRequestPageResponse.from(page, usersById, groupBuysById, LocalDateTime.now())
+        return AdminGroupBuyRequestPageResponse.from(page, usersById, groupBuysById, LocalDateTime.now(clock))
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -105,11 +105,17 @@ class GroupBuyRequestService(
     @Transactional(readOnly = true)
     fun getAdminRequests(
         status: AdminGroupBuyRequestStatusFilter,
+        keyword: String?,
         pageable: Pageable
     ): AdminGroupBuyRequestPageResponse {
-        val page = status.toStatus()
-            ?.let { groupBuyRequestRepository.findByStatusOrderByCreatedAtDesc(it, pageable) }
-            ?: groupBuyRequestRepository.findAllByOrderByCreatedAtDesc(pageable)
+        val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
+        val requestIdKeyword = normalizedKeyword?.toLongOrNull()
+        val page = groupBuyRequestRepository.searchAdminRequests(
+            status = status.toStatus(),
+            keyword = normalizedKeyword,
+            requestIdKeyword = requestIdKeyword,
+            pageable = pageable
+        )
 
         val userIds = page.content.map { it.userId }.distinct()
         val usersById = if (userIds.isEmpty()) {
@@ -119,8 +125,9 @@ class GroupBuyRequestService(
                 .mapNotNull { user -> user.id?.let { it to user } }
                 .toMap()
         }
+        val groupBuysById = findOpenedGroupBuys(page.content)
 
-        return AdminGroupBuyRequestPageResponse.from(page, usersById)
+        return AdminGroupBuyRequestPageResponse.from(page, usersById, groupBuysById, LocalDateTime.now())
     }
 
     @Transactional(readOnly = true)
@@ -215,5 +222,14 @@ class GroupBuyRequestService(
                 }
             }
         )
+    }
+
+    private fun findOpenedGroupBuys(requests: List<GroupBuyRequest>): Map<Long, GroupBuy> {
+        val openedGroupBuyIds = requests.mapNotNull { it.openedGroupBuyId }.distinct()
+        if (openedGroupBuyIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return groupBuyRepository.findAllById(openedGroupBuyIds).associateBy { it.id }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
@@ -3,9 +3,11 @@ package com.moongchijang.domain.groupbuy.application.dto
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
 import org.springframework.data.domain.Page
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -36,10 +38,19 @@ data class AdminGroupBuyRequestPageResponse(
     companion object {
         fun from(
             page: Page<GroupBuyRequest>,
-            usersById: Map<Long, User>
+            usersById: Map<Long, User>,
+            groupBuysById: Map<Long, GroupBuy>,
+            now: LocalDateTime
         ): AdminGroupBuyRequestPageResponse =
             AdminGroupBuyRequestPageResponse(
-                content = page.content.map { AdminGroupBuyRequestListItemResponse.from(it, usersById[it.userId]) },
+                content = page.content.map {
+                    AdminGroupBuyRequestListItemResponse.from(
+                        request = it,
+                        requester = usersById[it.userId],
+                        groupBuy = it.openedGroupBuyId?.let(groupBuysById::get),
+                        now = now
+                    )
+                },
                 totalElements = page.totalElements,
                 totalPages = page.totalPages,
                 number = page.number,
@@ -57,12 +68,18 @@ data class AdminGroupBuyRequestListItemResponse(
     val status: GroupBuyRequestStatus,
     val requesterId: Long,
     val requesterName: String?,
+    val originalPrice: Int?,
+    val price: Int?,
+    val reviewElapsedMinutes: Long?,
+    val actionable: Boolean,
     val createdAt: LocalDateTime?
 ) {
     companion object {
         fun from(
             request: GroupBuyRequest,
-            requester: User?
+            requester: User?,
+            groupBuy: GroupBuy?,
+            now: LocalDateTime
         ): AdminGroupBuyRequestListItemResponse =
             AdminGroupBuyRequestListItemResponse(
                 requestId = request.id,
@@ -73,6 +90,11 @@ data class AdminGroupBuyRequestListItemResponse(
                 status = request.status,
                 requesterId = request.userId,
                 requesterName = requester?.nickname,
+                originalPrice = groupBuy?.originalPrice,
+                price = groupBuy?.price,
+                reviewElapsedMinutes = request.createdAt?.let { Duration.between(it, now).toMinutes().coerceAtLeast(0) },
+                actionable = request.status == GroupBuyRequestStatus.IN_REVIEW ||
+                    request.status == GroupBuyRequestStatus.IN_CONTACT,
                 createdAt = request.createdAt
             )
     }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 import java.util.Optional
 
@@ -17,6 +19,46 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
 
     fun findByStatusOrderByCreatedAtDesc(
         status: GroupBuyRequestStatus,
+        pageable: Pageable
+    ): Page<GroupBuyRequest>
+
+    @Query(
+        value = """
+            SELECT request
+            FROM GroupBuyRequest request
+            LEFT JOIN User requester ON requester.id = request.userId
+            WHERE (:status IS NULL OR request.status = :status)
+              AND (
+                :keyword IS NULL
+                OR (:requestIdKeyword IS NOT NULL AND request.id = :requestIdKeyword)
+                OR LOWER(request.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(request.storeName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(COALESCE(requester.nickname, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(COALESCE(requester.email, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR COALESCE(requester.phoneNumber, '') LIKE CONCAT('%', :keyword, '%')
+              )
+            ORDER BY request.createdAt DESC
+        """,
+        countQuery = """
+            SELECT COUNT(request)
+            FROM GroupBuyRequest request
+            LEFT JOIN User requester ON requester.id = request.userId
+            WHERE (:status IS NULL OR request.status = :status)
+              AND (
+                :keyword IS NULL
+                OR (:requestIdKeyword IS NOT NULL AND request.id = :requestIdKeyword)
+                OR LOWER(request.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(request.storeName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(COALESCE(requester.nickname, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(COALESCE(requester.email, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR COALESCE(requester.phoneNumber, '') LIKE CONCAT('%', :keyword, '%')
+              )
+        """
+    )
+    fun searchAdminRequests(
+        @Param("status") status: GroupBuyRequestStatus?,
+        @Param("keyword") keyword: String?,
+        @Param("requestIdKeyword") requestIdKeyword: Long?,
         pageable: Pageable
     ): Page<GroupBuyRequest>
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -33,9 +33,9 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
                 OR (:requestIdKeyword IS NOT NULL AND request.id = :requestIdKeyword)
                 OR LOWER(request.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(request.storeName) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR LOWER(COALESCE(requester.nickname, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR LOWER(COALESCE(requester.email, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR COALESCE(requester.phoneNumber, '') LIKE CONCAT('%', :keyword, '%')
+                OR LOWER(requester.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(requester.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR requester.phoneNumber LIKE CONCAT('%', :keyword, '%')
               )
             ORDER BY request.createdAt DESC
         """,
@@ -49,9 +49,9 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
                 OR (:requestIdKeyword IS NOT NULL AND request.id = :requestIdKeyword)
                 OR LOWER(request.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(request.storeName) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR LOWER(COALESCE(requester.nickname, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR LOWER(COALESCE(requester.email, '')) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR COALESCE(requester.phoneNumber, '') LIKE CONCAT('%', :keyword, '%')
+                OR LOWER(requester.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(requester.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR requester.phoneNumber LIKE CONCAT('%', :keyword, '%')
               )
         """
     )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
@@ -31,9 +31,10 @@ class GroupBuyRequestAdminController(
     @Operation(summary = "운영자 공구 개설 요청 목록 조회")
     fun getRequests(
         @RequestParam(defaultValue = "ALL") status: AdminGroupBuyRequestStatusFilter,
+        @RequestParam(required = false) keyword: String?,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestPageResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminRequests(status, pageable)))
+        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminRequests(status, keyword, pageable)))
     }
 
     @GetMapping("/{requestId}")

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1945,6 +1945,12 @@ paths:
             type: string
             enum: [ALL, IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
             default: ALL
+        - name: keyword
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 요청 ID, 상품명, 가게명, 요청자 닉네임/이메일/전화번호 검색어
         - $ref: '#/components/parameters/Page'
         - $ref: '#/components/parameters/Size'
       responses:
@@ -4576,7 +4582,7 @@ components:
               type: array
               items:
                 type: object
-                required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, requesterId, createdAt]
+                required: [requestId, storeName, productName, desiredQuantity, desiredPickupDate, status, requesterId, actionable, createdAt]
                 properties:
                   requestId: { type: integer, format: int64 }
                   storeName: { type: string }
@@ -4588,6 +4594,22 @@ components:
                     enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
                   requesterId: { type: integer, format: int64 }
                   requesterName: { type: string, nullable: true }
+                  originalPrice:
+                    type: integer
+                    nullable: true
+                    description: 승인 후 생성된 공구 정가. 승인 전 요청은 null
+                  price:
+                    type: integer
+                    nullable: true
+                    description: 승인 후 생성된 공구가. 승인 전 요청은 null
+                  reviewElapsedMinutes:
+                    type: integer
+                    format: int64
+                    nullable: true
+                    description: 요청 생성 후 경과한 검토 시간(분)
+                  actionable:
+                    type: boolean
+                    description: 운영자가 승인/반려 등 후속 작업을 할 수 있는 상태 여부
                   createdAt: { type: string, format: date-time, nullable: true }
             totalElements: { type: integer, format: int64 }
             totalPages: { type: integer }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminControllerTest.kt
@@ -31,13 +31,13 @@ class GroupBuyRequestAdminControllerTest {
             number = 0,
             size = 20
         )
-        `when`(groupBuyRequestService.getAdminRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, pageable))
+        `when`(groupBuyRequestService.getAdminRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, "성심당", pageable))
             .thenReturn(response)
 
-        val result = controller.getRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, pageable)
+        val result = controller.getRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, "성심당", pageable)
 
         assertEquals(response, result.body?.data)
-        verify(groupBuyRequestService).getAdminRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, pageable)
+        verify(groupBuyRequestService).getAdminRequests(AdminGroupBuyRequestStatusFilter.IN_REVIEW, "성심당", pageable)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
@@ -4,9 +4,11 @@ import com.moongchijang.domain.favorite.domain.entity.Favorite
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyFeedFilter
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.FeedSortMode
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
 import com.moongchijang.domain.store.domain.entity.Store
@@ -33,6 +35,9 @@ class GroupBuyRepositoryImplIntegrationTest {
 
     @Autowired
     private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Autowired
+    private lateinit var groupBuyRequestRepository: GroupBuyRequestRepository
 
     @Autowired
     private lateinit var em: EntityManager
@@ -127,6 +132,48 @@ class GroupBuyRepositoryImplIntegrationTest {
             sameAchievementEarlyDeadline.id,
             sameAchievementLateDeadline.id
         )
+    }
+
+    @Test
+    fun `운영자 공구 요청 검색은 상태와 요청자 키워드를 함께 적용한다`() {
+        val requester = User(
+            provider = AuthProvider.EMAIL,
+            email = "eunseo@example.com",
+            passwordHash = "pw",
+            nickname = "은서",
+            role = UserRole.BUYER,
+            signupCompleted = true
+        )
+        em.persist(requester)
+        val matched = GroupBuyRequest(
+            userId = requester.id!!,
+            storeName = "성심당",
+            productName = "튀김소보로",
+            desiredQuantity = 20,
+            desiredPickupDate = LocalDate.now().plusDays(3),
+            status = GroupBuyRequestStatus.IN_REVIEW
+        )
+        em.persist(matched)
+        em.persist(
+            GroupBuyRequest(
+                userId = requester.id!!,
+                storeName = "다른 매장",
+                productName = "단팥빵",
+                desiredQuantity = 10,
+                desiredPickupDate = LocalDate.now().plusDays(3),
+                status = GroupBuyRequestStatus.REJECTED
+            )
+        )
+        flushAndClear()
+
+        val result = groupBuyRequestRepository.searchAdminRequests(
+            status = GroupBuyRequestStatus.IN_REVIEW,
+            keyword = "은서",
+            requestIdKeyword = null,
+            pageable = pageable
+        )
+
+        assertThat(result.content.map { it.id }).containsExactly(matched.id)
     }
 
     private fun searchFeed(

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -308,11 +308,11 @@ class GroupBuyRequestServiceTest {
             desiredPickupDate = LocalDate.now().plusDays(5)
         ).apply { id = 10L }
 
-        `when`(groupBuyRequestRepository.findAllByOrderByCreatedAtDesc(pageable))
+        `when`(groupBuyRequestRepository.searchAdminRequests(null, null, null, pageable))
             .thenReturn(PageImpl(listOf(request), pageable, 1))
         `when`(userRepository.findAllById(listOf(1L))).thenReturn(listOf(requester))
 
-        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, pageable)
+        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, null, pageable)
 
         assertEquals(1, result.content.size)
         assertEquals(1, result.totalElements)
@@ -326,6 +326,8 @@ class GroupBuyRequestServiceTest {
         assertEquals(GroupBuyRequestStatus.IN_REVIEW, result.content[0].status)
         assertEquals(1L, result.content[0].requesterId)
         assertEquals("은서", result.content[0].requesterName)
+        assertNull(result.content[0].price)
+        assertTrue(result.content[0].actionable)
     }
 
     @Test
@@ -340,11 +342,11 @@ class GroupBuyRequestServiceTest {
             status = GroupBuyRequestStatus.REJECTED
         ).apply { id = 11L }
 
-        `when`(groupBuyRequestRepository.findByStatusOrderByCreatedAtDesc(GroupBuyRequestStatus.REJECTED, pageable))
+        `when`(groupBuyRequestRepository.searchAdminRequests(GroupBuyRequestStatus.REJECTED, null, null, pageable))
             .thenReturn(PageImpl(listOf(request), pageable, 11))
         `when`(userRepository.findAllById(listOf(2L))).thenReturn(emptyList())
 
-        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.REJECTED, pageable)
+        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.REJECTED, null, pageable)
 
         assertEquals(1, result.content.size)
         assertEquals(11, result.totalElements)
@@ -354,20 +356,55 @@ class GroupBuyRequestServiceTest {
         assertEquals(GroupBuyRequestStatus.REJECTED, result.content[0].status)
         assertEquals(2L, result.content[0].requesterId)
         assertNull(result.content[0].requesterName)
-        verify(groupBuyRequestRepository).findByStatusOrderByCreatedAtDesc(GroupBuyRequestStatus.REJECTED, pageable)
+        assertFalse(result.content[0].actionable)
+        verify(groupBuyRequestRepository).searchAdminRequests(GroupBuyRequestStatus.REJECTED, null, null, pageable)
     }
 
     @Test
     fun `운영자 공구 요청 목록이 비어있으면 사용자 조회를 생략한다`() {
         val pageable = PageRequest.of(0, 20)
-        `when`(groupBuyRequestRepository.findAllByOrderByCreatedAtDesc(pageable))
+        `when`(groupBuyRequestRepository.searchAdminRequests(null, null, null, pageable))
             .thenReturn(PageImpl(emptyList(), pageable, 0))
 
-        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, pageable)
+        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, null, pageable)
 
         assertTrue(result.content.isEmpty())
         assertEquals(0, result.totalElements)
         verify(userRepository, never()).findAllById(anyList())
+    }
+
+    @Test
+    fun `운영자 공구 요청 목록은 검색어와 승인 공구 가격을 반영한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val request = GroupBuyRequest(
+            userId = 1L,
+            storeName = "성심당",
+            productName = "튀김소보로",
+            desiredQuantity = 20,
+            desiredPickupDate = LocalDate.now().plusDays(5),
+            status = GroupBuyRequestStatus.OPENED,
+            openedGroupBuyId = 30L
+        ).apply { id = 10L }
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 30L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            price = 9_900
+        ).apply {
+            originalPrice = 12_000
+        }
+
+        `when`(groupBuyRequestRepository.searchAdminRequests(null, "10", 10L, pageable))
+            .thenReturn(PageImpl(listOf(request), pageable, 1))
+        `when`(userRepository.findAllById(listOf(1L))).thenReturn(emptyList())
+        `when`(groupBuyRepository.findAllById(listOf(30L))).thenReturn(listOf(groupBuy))
+
+        val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, " 10 ", pageable)
+
+        assertEquals(1, result.content.size)
+        assertEquals(12_000, result.content[0].originalPrice)
+        assertEquals(9_900, result.content[0].price)
+        assertFalse(result.content[0].actionable)
+        verify(groupBuyRequestRepository).searchAdminRequests(null, "10", 10L, pageable)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -18,6 +18,7 @@ import com.moongchijang.support.GroupBuyFixture
 import com.moongchijang.support.GroupBuyRequestFixture
 import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -27,8 +28,11 @@ import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -49,8 +53,17 @@ class GroupBuyRequestServiceTest {
     @Mock
     private lateinit var userRepository: UserRepository
 
+    @Mock
+    private lateinit var clock: Clock
+
     @InjectMocks
     private lateinit var service: GroupBuyRequestService
+
+    @BeforeEach
+    fun setUpClock() {
+        lenient().`when`(clock.instant()).thenReturn(Instant.parse("2026-05-27T04:00:00Z"))
+        lenient().`when`(clock.zone).thenReturn(ZoneId.of("Asia/Seoul"))
+    }
 
     @Test
     fun `유효한 입력으로 요청 시 requestId 반환`() {


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/admin/group-buy-requests`에 `keyword` 검색 파라미터를 추가했습니다.
- 요청 ID, 상품명, 가게명, 요청자 닉네임/이메일/전화번호 기준 검색을 지원합니다.
- 어드민 목록 응답에 승인 후 공구 가격(`originalPrice`, `price`), 검토 경과 시간(`reviewElapsedMinutes`), 작업 가능 여부(`actionable`)를 추가했습니다.
- 승인 전 요청은 연결된 공구가 없으므로 가격 필드를 `null`로 반환합니다.
- 서비스/컨트롤러 테스트와 repository 통합 테스트를 보강하고 OpenAPI 문서를 갱신했습니다.

## 🔍 참고 사항
- 이번 PR은 소비자 공구 개설 요청 목록 검색/응답 보강만 포함합니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #237

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인