### PR TITLE
[MCJ-1547] FEAT: 사장님 정산 예정/환불 요청 확인 API 및 환불 검토 처리 로직 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
 
@@ -106,4 +107,18 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
 
     @Query("SELECT DISTINCT gb.store.id FROM GroupBuy gb WHERE gb.store.id IN :storeIds")
     fun findStoreIdsWithGroupBuyHistory(@Param("storeIds") storeIds: Collection<Long>): List<Long>
+
+    @Query(
+        """
+        select distinct gb.pickupDate
+        from GroupBuy gb
+        where gb.store.id in :storeIds
+          and gb.status in :statuses
+        order by gb.pickupDate desc
+        """
+    )
+    fun findDistinctPickupDatesByStoreIdsAndStatuses(
+        @Param("storeIds") storeIds: Collection<Long>,
+        @Param("statuses") statuses: Collection<GroupBuyStatus>,
+    ): List<LocalDate>
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -7,6 +7,9 @@ import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestLi
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestListResponse
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestStatus
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewActionType
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitRequest
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipListResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthlySummaryResponse
@@ -176,6 +179,48 @@ class OwnerSettlementService(
         )
     }
 
+    @Transactional
+    fun submitRefundReview(
+        ownerId: Long,
+        participationId: Long,
+        request: OwnerRefundReviewSubmitRequest,
+    ): OwnerRefundReviewSubmitResponse {
+        log.info(
+            "[OwnerSettlementService] 환불 요청 검토 제출 시작: ownerId={}, participationId={}, action={}",
+            ownerId,
+            participationId,
+            request.action,
+        )
+        validateSeller(ownerId)
+        validateRefundReviewRequest(request)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val participation = participationRepository.findById(participationId).orElseThrow {
+            CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
+        }
+        if (participation.groupBuy.store.id !in storeIds) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+        if (participation.status != ParticipationStatus.REFUND_PENDING) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+
+        log.info(
+            "[OwnerSettlementService] 환불 요청 검토 제출 완료: ownerId={}, participationId={}, action={}",
+            ownerId,
+            participationId,
+            request.action,
+        )
+        return OwnerRefundReviewSubmitResponse(
+            participationId = participation.id,
+            processed = true,
+        )
+    }
+
     private fun toRefundListItem(participation: Participation): OwnerRefundRequestListItemResponse {
         val requestedAt = participation.cancelledAt ?: participation.createdAt!!
         return OwnerRefundRequestListItemResponse(
@@ -212,6 +257,12 @@ class OwnerSettlementService(
         }
     }
 
+    private fun validateRefundReviewRequest(request: OwnerRefundReviewSubmitRequest) {
+        if (request.action == OwnerRefundReviewActionType.DISPUTE && request.disputeReason.isNullOrBlank()) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+
     private fun validateYearMonth(year: Int, month: Int) {
         if (year !in 2000..2100 || month !in 1..12) {
             throw CustomException(ErrorCode.INVALID_INPUT)
@@ -237,4 +288,3 @@ class OwnerSettlementService(
         val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
     }
 }
-

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -232,7 +232,7 @@ class OwnerSettlementService(
     }
 
     private fun toRefundListItem(participation: Participation): OwnerRefundRequestListItemResponse {
-        val requestedAt = participation.cancelledAt ?: participation.createdAt!!
+        val requestedAt = participation.cancelledAt ?: participation.createdAt ?: java.time.LocalDateTime.now()
         return OwnerRefundRequestListItemResponse(
             participationId = participation.id,
             groupBuyId = participation.groupBuy.id,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -124,6 +124,7 @@ class OwnerSettlementService(
         val allRequests = participationRepository.findRefundRequestsByStoreIdsAndStatuses(
             storeIds = storeIds,
             statuses = REFUND_STATUSES,
+            fromDateTime = LocalDate.now(SEOUL_ZONE_ID).minusMonths(REFUND_LIST_LOOKBACK_MONTHS).atStartOfDay(),
         )
 
         val pendingCount = allRequests.count { request -> isReviewPending(request) }
@@ -305,5 +306,6 @@ class OwnerSettlementService(
         val SETTLEMENT_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
         val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
         val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+        const val REFUND_LIST_LOOKBACK_MONTHS: Long = 6
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -166,7 +166,7 @@ class OwnerSettlementService(
             groupBuyId = participation.groupBuy.id,
             productName = participation.groupBuy.productName,
             requesterName = participation.user.nickname ?: "",
-            requestedDate = (participation.cancelledAt ?: participation.createdAt!!).toLocalDate(),
+            requestedDate = (participation.cancelledAt ?: participation.createdAt ?: java.time.LocalDateTime.now()).toLocalDate(),
             paymentAmount = participation.totalAmount,
             penaltyAmount = penaltyAmount,
             refundExpectedAmount = refundExpectedAmount,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -1,0 +1,240 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestDetailResponse
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestListItemResponse
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestListResponse
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestStatus
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipListResponse
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipResponse
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthlySummaryResponse
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Service
+@Transactional(readOnly = true)
+class OwnerSettlementService(
+    private val userRepository: UserRepository,
+    private val storeStaffRepository: StoreStaffRepository,
+    private val groupBuyRepository: GroupBuyRepository,
+    private val participationRepository: ParticipationRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun getMonthlySettlementSummary(ownerId: Long, year: Int, month: Int): OwnerSettlementMonthlySummaryResponse {
+        log.info("[OwnerSettlementService] 월별 정산 요약 조회 시작: ownerId={}, year={}, month={}", ownerId, year, month)
+        validateSeller(ownerId)
+        validateYearMonth(year, month)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            return OwnerSettlementMonthlySummaryResponse(
+                year = year,
+                month = month,
+                settlementExpectedAmount = 0L,
+                grossRevenueAmount = 0L,
+                refundFeeAmount = 0L,
+            )
+        }
+
+        val grossRevenueAmount = participationRepository.sumTotalAmountByStoreIdsAndStatusesAndYearMonth(
+            storeIds = storeIds,
+            groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,
+            participationStatuses = SETTLEMENT_PARTICIPATION_STATUSES,
+            year = year,
+            month = month,
+        )
+        val refundFeeAmount = participationRepository.sumRefundFeeAmountByStoreIdsAndYearMonth(
+            storeIds = storeIds,
+            refundStatuses = REFUND_STATUSES,
+            year = year,
+            month = month,
+        )
+        val settlementExpectedAmount = (grossRevenueAmount - refundFeeAmount).coerceAtLeast(0L)
+
+        return OwnerSettlementMonthlySummaryResponse(
+            year = year,
+            month = month,
+            settlementExpectedAmount = settlementExpectedAmount,
+            grossRevenueAmount = grossRevenueAmount,
+            refundFeeAmount = refundFeeAmount,
+        )
+    }
+
+    fun getSettlementMonthChips(ownerId: Long): OwnerSettlementMonthChipListResponse {
+        log.info("[OwnerSettlementService] 정산 월 칩 조회 시작: ownerId={}", ownerId)
+        validateSeller(ownerId)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            return OwnerSettlementMonthChipListResponse(emptyList())
+        }
+
+        val chips = groupBuyRepository.findDistinctPickupDatesByStoreIdsAndStatuses(
+            storeIds = storeIds,
+            statuses = SETTLEMENT_GROUP_BUY_STATUSES,
+        )
+            .map { YearMonth.from(it) }
+            .distinct()
+            .sortedDescending()
+            .map {
+                OwnerSettlementMonthChipResponse(
+                    year = it.year,
+                    month = it.monthValue,
+                    label = "${it.year}년 ${it.monthValue}월",
+                )
+            }
+
+        return OwnerSettlementMonthChipListResponse(chips)
+    }
+
+    fun getRefundRequests(ownerId: Long, tab: OwnerRefundRequestTab): OwnerRefundRequestListResponse {
+        log.info("[OwnerSettlementService] 환불 요청 목록 조회 시작: ownerId={}, tab={}", ownerId, tab)
+        validateSeller(ownerId)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            return OwnerRefundRequestListResponse(
+                pendingCount = 0,
+                completedCount = 0,
+                hasPendingItems = false,
+                items = emptyList(),
+            )
+        }
+
+        val allRequests = participationRepository.findRefundRequestsByStoreIdsAndStatuses(
+            storeIds = storeIds,
+            statuses = REFUND_STATUSES,
+        )
+
+        val pendingCount = participationRepository.countRefundRequestsByStoreIdsAndStatus(
+            storeIds = storeIds,
+            status = ParticipationStatus.REFUND_PENDING,
+        ).toInt()
+        val completedCount = participationRepository.countRefundRequestsByStoreIdsAndStatus(
+            storeIds = storeIds,
+            status = ParticipationStatus.REFUNDED,
+        ).toInt()
+
+        val filtered = when (tab) {
+            OwnerRefundRequestTab.ALL -> allRequests
+            OwnerRefundRequestTab.PENDING -> allRequests.filter { it.status == ParticipationStatus.REFUND_PENDING }
+            OwnerRefundRequestTab.COMPLETED -> allRequests.filter { it.status == ParticipationStatus.REFUNDED }
+        }
+
+        return OwnerRefundRequestListResponse(
+            pendingCount = pendingCount,
+            completedCount = completedCount,
+            hasPendingItems = pendingCount > 0,
+            items = filtered.map { toRefundListItem(it) },
+        )
+    }
+
+    fun getRefundRequestDetail(ownerId: Long, participationId: Long): OwnerRefundRequestDetailResponse {
+        log.info("[OwnerSettlementService] 환불 요청 상세 조회 시작: ownerId={}, participationId={}", ownerId, participationId)
+        validateSeller(ownerId)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val participation = participationRepository.findById(participationId).orElseThrow {
+            CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
+        }
+        if (participation.groupBuy.store.id !in storeIds || participation.status !in REFUND_STATUSES) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+
+        val penaltyAmount = participation.feeAmount.coerceAtLeast(0)
+        val refundExpectedAmount = (participation.totalAmount - penaltyAmount).coerceAtLeast(0)
+        return OwnerRefundRequestDetailResponse(
+            participationId = participation.id,
+            groupBuyId = participation.groupBuy.id,
+            productName = participation.groupBuy.productName,
+            requesterName = participation.user.nickname ?: "",
+            requestedDate = (participation.cancelledAt ?: participation.createdAt!!).toLocalDate(),
+            paymentAmount = participation.totalAmount,
+            penaltyAmount = penaltyAmount,
+            refundExpectedAmount = refundExpectedAmount,
+            refundReasonDetail = participation.cancelReasonDetail,
+            status = toRefundStatus(participation.status),
+        )
+    }
+
+    private fun toRefundListItem(participation: Participation): OwnerRefundRequestListItemResponse {
+        val requestedAt = participation.cancelledAt ?: participation.createdAt!!
+        return OwnerRefundRequestListItemResponse(
+            participationId = participation.id,
+            groupBuyId = participation.groupBuy.id,
+            productName = participation.groupBuy.productName,
+            paymentAmount = participation.totalAmount,
+            requesterName = participation.user.nickname ?: "",
+            requesterCode = "P${participation.id.toString().padStart(3, '0')}",
+            refundReasonLabel = toRefundReasonLabel(participation.cancelReason),
+            requestedDate = requestedAt.toLocalDate(),
+            status = toRefundStatus(participation.status),
+            exceeded24Hours = participation.status == ParticipationStatus.REFUND_PENDING &&
+                requestedAt.isBefore(java.time.LocalDateTime.now().minusHours(24)),
+        )
+    }
+
+    private fun toRefundStatus(status: ParticipationStatus): OwnerRefundRequestStatus {
+        return when (status) {
+            ParticipationStatus.REFUND_PENDING -> OwnerRefundRequestStatus.PENDING
+            ParticipationStatus.REFUNDED -> OwnerRefundRequestStatus.COMPLETED
+            else -> throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+
+    private fun toRefundReasonLabel(reason: ParticipationCancelReason?): String {
+        return when (reason) {
+            ParticipationCancelReason.TIME_UNAVAILABLE -> "픽업 불가"
+            ParticipationCancelReason.NO_LONGER_WANTED -> "구매 의사 없음"
+            ParticipationCancelReason.PREFER_DIRECT_VISIT -> "매장 직접 구매"
+            ParticipationCancelReason.BOUGHT_ELSEWHERE -> "타 채널 구매"
+            ParticipationCancelReason.OTHER -> "기타"
+            null -> "기타"
+        }
+    }
+
+    private fun validateYearMonth(year: Int, month: Int) {
+        if (year !in 2000..2100 || month !in 1..12) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+        val requested = YearMonth.of(year, month)
+        if (requested.isAfter(YearMonth.from(LocalDate.now()))) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+    }
+
+    private fun validateSeller(ownerId: Long) {
+        val owner = userRepository.findByIdAndDeletedAtIsNull(ownerId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        if (owner.role != UserRole.SELLER) {
+            throw CustomException(ErrorCode.FORBIDDEN)
+        }
+    }
+
+    private companion object {
+        val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val SETTLEMENT_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
+        val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+    }
+}
+

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -69,7 +69,7 @@ class OwnerSettlementService(
             year = year,
             month = month,
         )
-        val settlementExpectedAmount = (grossRevenueAmount - refundFeeAmount).coerceAtLeast(0L)
+        val settlementExpectedAmount = (grossRevenueAmount + refundFeeAmount).coerceAtLeast(0L)
 
         return OwnerSettlementMonthlySummaryResponse(
             year = year,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -153,9 +153,8 @@ class OwnerSettlementService(
             throw CustomException(ErrorCode.FORBIDDEN)
         }
 
-        val participation = participationRepository.findById(participationId).orElseThrow {
-            CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
-        }
+        val participation = participationRepository.findPickupDetailById(participationId)
+            ?: throw CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
         if (participation.groupBuy.store.id !in storeIds || participation.status !in REFUND_STATUSES) {
             throw CustomException(ErrorCode.FORBIDDEN)
         }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -212,7 +212,11 @@ class OwnerSettlementService(
             OwnerRefundReviewActionType.APPROVE -> OwnerRefundReviewStatus.APPROVED
             OwnerRefundReviewActionType.DISPUTE -> OwnerRefundReviewStatus.DISPUTED
         }
-        participation.ownerRefundDisputeReason = request.disputeReason?.trim()?.takeIf { it.isNotBlank() }
+        participation.ownerRefundDisputeReason = if (request.action == OwnerRefundReviewActionType.DISPUTE) {
+            request.disputeReason?.trim()?.takeIf { it.isNotBlank() }
+        } else {
+            null
+        }
         participation.ownerRefundReviewedAt = java.time.LocalDateTime.now()
 
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -15,6 +15,7 @@ import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementM
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthlySummaryResponse
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
@@ -124,19 +125,13 @@ class OwnerSettlementService(
             statuses = REFUND_STATUSES,
         )
 
-        val pendingCount = participationRepository.countRefundRequestsByStoreIdsAndStatus(
-            storeIds = storeIds,
-            status = ParticipationStatus.REFUND_PENDING,
-        ).toInt()
-        val completedCount = participationRepository.countRefundRequestsByStoreIdsAndStatus(
-            storeIds = storeIds,
-            status = ParticipationStatus.REFUNDED,
-        ).toInt()
+        val pendingCount = allRequests.count { request -> isReviewPending(request) }
+        val completedCount = allRequests.count { request -> isReviewCompleted(request) }
 
         val filtered = when (tab) {
             OwnerRefundRequestTab.ALL -> allRequests
-            OwnerRefundRequestTab.PENDING -> allRequests.filter { it.status == ParticipationStatus.REFUND_PENDING }
-            OwnerRefundRequestTab.COMPLETED -> allRequests.filter { it.status == ParticipationStatus.REFUNDED }
+            OwnerRefundRequestTab.PENDING -> allRequests.filter { request -> isReviewPending(request) }
+            OwnerRefundRequestTab.COMPLETED -> allRequests.filter { request -> isReviewCompleted(request) }
         }
 
         return OwnerRefundRequestListResponse(
@@ -199,7 +194,7 @@ class OwnerSettlementService(
             throw CustomException(ErrorCode.FORBIDDEN)
         }
 
-        val participation = participationRepository.findById(participationId).orElseThrow {
+        val participation = participationRepository.findByIdForUpdate(participationId).orElseThrow {
             CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
         }
         if (participation.groupBuy.store.id !in storeIds) {
@@ -208,6 +203,16 @@ class OwnerSettlementService(
         if (participation.status != ParticipationStatus.REFUND_PENDING) {
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
+        if (isReviewCompleted(participation)) {
+            throw CustomException(ErrorCode.OWNER_REFUND_REVIEW_ALREADY_PROCESSED)
+        }
+
+        participation.ownerRefundReviewStatus = when (request.action) {
+            OwnerRefundReviewActionType.APPROVE -> OwnerRefundReviewStatus.APPROVED
+            OwnerRefundReviewActionType.DISPUTE -> OwnerRefundReviewStatus.DISPUTED
+        }
+        participation.ownerRefundDisputeReason = request.disputeReason?.trim()?.takeIf { it.isNotBlank() }
+        participation.ownerRefundReviewedAt = java.time.LocalDateTime.now()
 
         log.info(
             "[OwnerSettlementService] 환불 요청 검토 제출 완료: ownerId={}, participationId={}, action={}",
@@ -239,10 +244,10 @@ class OwnerSettlementService(
     }
 
     private fun toRefundStatus(status: ParticipationStatus): OwnerRefundRequestStatus {
-        return when (status) {
-            ParticipationStatus.REFUND_PENDING -> OwnerRefundRequestStatus.PENDING
-            ParticipationStatus.REFUNDED -> OwnerRefundRequestStatus.COMPLETED
-            else -> throw CustomException(ErrorCode.INVALID_INPUT)
+        return if (status == ParticipationStatus.REFUNDED) {
+            OwnerRefundRequestStatus.COMPLETED
+        } else {
+            OwnerRefundRequestStatus.PENDING
         }
     }
 
@@ -261,6 +266,18 @@ class OwnerSettlementService(
         if (request.action == OwnerRefundReviewActionType.DISPUTE && request.disputeReason.isNullOrBlank()) {
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
+    }
+
+    private fun isReviewPending(participation: Participation): Boolean {
+        return participation.status == ParticipationStatus.REFUND_PENDING &&
+            participation.ownerRefundReviewStatus != OwnerRefundReviewStatus.APPROVED &&
+            participation.ownerRefundReviewStatus != OwnerRefundReviewStatus.DISPUTED
+    }
+
+    private fun isReviewCompleted(participation: Participation): Boolean {
+        return participation.ownerRefundReviewStatus == OwnerRefundReviewStatus.APPROVED ||
+            participation.ownerRefundReviewStatus == OwnerRefundReviewStatus.DISPUTED ||
+            participation.status == ParticipationStatus.REFUNDED
     }
 
     private fun validateYearMonth(year: Int, month: Int) {

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.ZoneId
 
 @Service
 @Transactional(readOnly = true)
@@ -285,7 +286,7 @@ class OwnerSettlementService(
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
         val requested = YearMonth.of(year, month)
-        if (requested.isAfter(YearMonth.from(LocalDate.now()))) {
+        if (requested.isAfter(YearMonth.from(LocalDate.now(SEOUL_ZONE_ID)))) {
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
     }
@@ -303,5 +304,6 @@ class OwnerSettlementService(
         val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
         val SETTLEMENT_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
         val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestDetailResponse.kt
@@ -1,0 +1,38 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "사장님 환불 요청 상세 응답")
+data class OwnerRefundRequestDetailResponse(
+
+    @field:Schema(description = "참여 ID", example = "1001")
+    val participationId: Long,
+
+    @field:Schema(description = "공구 ID", example = "901001")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "공구명", example = "초코 크루아상&소금빵 세트")
+    val productName: String,
+
+    @field:Schema(description = "요청자 이름", example = "김민지")
+    val requesterName: String,
+
+    @field:Schema(description = "요청일", example = "2026-04-29")
+    val requestedDate: LocalDate,
+
+    @field:Schema(description = "결제 금액", example = "24000")
+    val paymentAmount: Int,
+
+    @field:Schema(description = "위약금 차감액", example = "2400")
+    val penaltyAmount: Int,
+
+    @field:Schema(description = "환불 예정 금액", example = "21600")
+    val refundExpectedAmount: Int,
+
+    @field:Schema(description = "환불 사유", example = "일정 변경으로 픽업이 어려워졌어요. 환불 부탁드립니다")
+    val refundReasonDetail: String?,
+
+    @field:Schema(description = "처리 상태", example = "PENDING")
+    val status: OwnerRefundRequestStatus,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestListItemResponse.kt
@@ -1,0 +1,38 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "사장님 환불 요청 목록 아이템")
+data class OwnerRefundRequestListItemResponse(
+
+    @field:Schema(description = "참여 ID", example = "1001")
+    val participationId: Long,
+
+    @field:Schema(description = "공구 ID", example = "901001")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "공구명", example = "초코 크루아상&소금빵 세트")
+    val productName: String,
+
+    @field:Schema(description = "결제 금액", example = "24000")
+    val paymentAmount: Int,
+
+    @field:Schema(description = "요청자 이름", example = "김민지")
+    val requesterName: String,
+
+    @field:Schema(description = "요청자 표기 코드", example = "P001")
+    val requesterCode: String,
+
+    @field:Schema(description = "환불 사유 라벨", example = "픽업 불가")
+    val refundReasonLabel: String,
+
+    @field:Schema(description = "요청일", example = "2026-05-02")
+    val requestedDate: LocalDate,
+
+    @field:Schema(description = "처리 상태", example = "PENDING")
+    val status: OwnerRefundRequestStatus,
+
+    @field:Schema(description = "검토 대기 24시간 초과 여부", example = "true")
+    val exceeded24Hours: Boolean,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestListResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestListResponse.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 환불 요청 목록 응답")
+data class OwnerRefundRequestListResponse(
+
+    @field:Schema(description = "검토 대기 건수", example = "1")
+    val pendingCount: Int,
+
+    @field:Schema(description = "처리 완료 건수", example = "2")
+    val completedCount: Int,
+
+    @field:Schema(description = "검토 대기 항목 존재 여부", example = "true")
+    val hasPendingItems: Boolean,
+
+    @field:Schema(description = "목록 아이템")
+    val items: List<OwnerRefundRequestListItemResponse>,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestStatus.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "환불 요청 처리 상태")
+enum class OwnerRefundRequestStatus {
+    PENDING,
+    COMPLETED,
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestTab.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundRequestTab.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "환불 요청 탭 필터")
+enum class OwnerRefundRequestTab {
+    ALL,
+    PENDING,
+    COMPLETED,
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundReviewActionType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundReviewActionType.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "환불 요청 검토 액션")
+enum class OwnerRefundReviewActionType {
+    APPROVE,
+    DISPUTE,
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundReviewSubmitRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundReviewSubmitRequest.kt
@@ -1,0 +1,17 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+@Schema(description = "사장님 환불 요청 검토 제출 요청")
+data class OwnerRefundReviewSubmitRequest(
+
+    @field:NotNull(message = "검토 액션은 필수입니다.")
+    @field:Schema(description = "검토 액션", example = "APPROVE")
+    val action: OwnerRefundReviewActionType,
+
+    @field:Size(max = 500, message = "의의 제기 사유는 500자 이하여야 합니다.")
+    @field:Schema(description = "의의 제기 사유(action=DISPUTE일 때 입력)", example = "픽업 요청 시간 변경이 선행되어야 합니다.")
+    val disputeReason: String? = null,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundReviewSubmitResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/refund/OwnerRefundReviewSubmitResponse.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.owner.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 환불 요청 검토 제출 응답")
+data class OwnerRefundReviewSubmitResponse(
+
+    @field:Schema(description = "참여 ID", example = "1001")
+    val participationId: Long,
+
+    @field:Schema(description = "처리 완료 여부", example = "true")
+    val processed: Boolean,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementMonthChipListResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementMonthChipListResponse.kt
@@ -1,0 +1,10 @@
+package com.moongchijang.domain.owner.application.dto.settlement
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 정산 조회용 연월 칩 목록 응답")
+data class OwnerSettlementMonthChipListResponse(
+
+    @field:Schema(description = "칩 목록")
+    val chips: List<OwnerSettlementMonthChipResponse>,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementMonthChipResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementMonthChipResponse.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.owner.application.dto.settlement
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 정산 조회용 연월 칩 응답")
+data class OwnerSettlementMonthChipResponse(
+
+    @field:Schema(description = "연도", example = "2026")
+    val year: Int,
+
+    @field:Schema(description = "월(1~12)", example = "5")
+    val month: Int,
+
+    @field:Schema(description = "표시 라벨(YYYY년 M월)", example = "2026년 5월")
+    val label: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementMonthlySummaryResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementMonthlySummaryResponse.kt
@@ -1,0 +1,22 @@
+package com.moongchijang.domain.owner.application.dto.settlement
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 월별 정산 예정 요약 응답")
+data class OwnerSettlementMonthlySummaryResponse(
+
+    @field:Schema(description = "조회 기준 연도", example = "2026")
+    val year: Int,
+
+    @field:Schema(description = "조회 기준 월(1~12)", example = "5")
+    val month: Int,
+
+    @field:Schema(description = "정산 예정 금액", example = "216000")
+    val settlementExpectedAmount: Long,
+
+    @field:Schema(description = "공구 수익금 합계", example = "240000")
+    val grossRevenueAmount: Long,
+
+    @field:Schema(description = "환불 수수료 합계", example = "24000")
+    val refundFeeAmount: Long,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerSettlementController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerSettlementController.kt
@@ -1,0 +1,112 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.OwnerSettlementService
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestDetailResponse
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestListResponse
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipListResponse
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthlySummaryResponse
+import com.moongchijang.global.response.ApiResponse
+import com.moongchijang.security.principal.CustomUserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/owner/settlements")
+@Tag(name = "OwnerSettlement", description = "사장님 정산/환불 확인")
+class OwnerSettlementController(
+    private val ownerSettlementService: OwnerSettlementService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping("/monthly-summary")
+    @Operation(summary = "사장님 월별 정산 예정 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "요청 파라미터 오류", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "403", description = "사장님 권한 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun getMonthlySummary(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @RequestParam year: Int,
+        @RequestParam month: Int,
+    ): ResponseEntity<ApiResponse<OwnerSettlementMonthlySummaryResponse>> {
+        log.info("[OwnerSettlementController] 월별 정산 예정 조회 요청 수신: ownerId={}, year={}, month={}", principal.id, year, month)
+        val response = ownerSettlementService.getMonthlySettlementSummary(principal.id, year, month)
+        log.info("[OwnerSettlementController] 월별 정산 예정 조회 응답 완료: ownerId={}, year={}, month={}", principal.id, year, month)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/month-chips")
+    @Operation(summary = "사장님 정산 월 칩 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "403", description = "사장님 권한 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun getMonthChips(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+    ): ResponseEntity<ApiResponse<OwnerSettlementMonthChipListResponse>> {
+        log.info("[OwnerSettlementController] 정산 월 칩 조회 요청 수신: ownerId={}", principal.id)
+        val response = ownerSettlementService.getSettlementMonthChips(principal.id)
+        log.info("[OwnerSettlementController] 정산 월 칩 조회 응답 완료: ownerId={}, count={}", principal.id, response.chips.size)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/refund-requests")
+    @Operation(summary = "사장님 환불 요청 목록 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "403", description = "사장님 권한 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun getRefundRequests(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @RequestParam(required = false, defaultValue = "ALL") tab: OwnerRefundRequestTab,
+    ): ResponseEntity<ApiResponse<OwnerRefundRequestListResponse>> {
+        log.info("[OwnerSettlementController] 환불 요청 목록 조회 요청 수신: ownerId={}, tab={}", principal.id, tab)
+        val response = ownerSettlementService.getRefundRequests(principal.id, tab)
+        log.info("[OwnerSettlementController] 환불 요청 목록 조회 응답 완료: ownerId={}, tab={}, count={}", principal.id, tab, response.items.size)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/refund-requests/{participationId}")
+    @Operation(summary = "사장님 환불 요청 상세 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "403", description = "사장님 권한 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "404", description = "대상 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun getRefundRequestDetail(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable participationId: Long,
+    ): ResponseEntity<ApiResponse<OwnerRefundRequestDetailResponse>> {
+        log.info("[OwnerSettlementController] 환불 요청 상세 조회 요청 수신: ownerId={}, participationId={}", principal.id, participationId)
+        val response = ownerSettlementService.getRefundRequestDetail(principal.id, participationId)
+        log.info("[OwnerSettlementController] 환불 요청 상세 조회 응답 완료: ownerId={}, participationId={}", principal.id, participationId)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+}
+

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerSettlementController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerSettlementController.kt
@@ -4,6 +4,8 @@ import com.moongchijang.domain.owner.application.OwnerSettlementService
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestDetailResponse
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestListResponse
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitRequest
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipListResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthlySummaryResponse
 import com.moongchijang.global.response.ApiResponse
@@ -19,9 +21,12 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import jakarta.validation.Valid
 
 @RestController
 @RequestMapping("/api/v1/owner/settlements")
@@ -108,5 +113,36 @@ class OwnerSettlementController(
         log.info("[OwnerSettlementController] 환불 요청 상세 조회 응답 완료: ownerId={}, participationId={}", principal.id, participationId)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
-}
 
+    @PostMapping("/refund-requests/{participationId}/review-submissions")
+    @Operation(summary = "사장님 환불 요청 검토 제출")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "제출 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "요청값/상태 오류", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "403", description = "사장님 권한 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "404", description = "대상 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun submitRefundReview(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @PathVariable participationId: Long,
+        @Valid @RequestBody request: OwnerRefundReviewSubmitRequest,
+    ): ResponseEntity<ApiResponse<OwnerRefundReviewSubmitResponse>> {
+        log.info(
+            "[OwnerSettlementController] 환불 요청 검토 제출 요청 수신: ownerId={}, participationId={}, action={}",
+            principal.id,
+            participationId,
+            request.action,
+        )
+        val response = ownerSettlementService.submitRefundReview(principal.id, participationId, request)
+        log.info(
+            "[OwnerSettlementController] 환불 요청 검토 제출 응답 완료: ownerId={}, participationId={}, action={}",
+            principal.id,
+            participationId,
+            request.action,
+        )
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/OwnerRefundReviewStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/OwnerRefundReviewStatus.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.participation.domain.entity
+
+enum class OwnerRefundReviewStatus {
+    PENDING,
+    APPROVED,
+    DISPUTED,
+}
+

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
@@ -85,6 +85,16 @@ class Participation(
     @Column(name = "refunded_at")
     var refundedAt: LocalDateTime? = null,
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "owner_refund_review_status", length = 30)
+    var ownerRefundReviewStatus: OwnerRefundReviewStatus? = null,
+
+    @Column(name = "owner_refund_dispute_reason", length = 500)
+    var ownerRefundDisputeReason: String? = null,
+
+    @Column(name = "owner_refund_reviewed_at")
+    var ownerRefundReviewedAt: LocalDateTime? = null,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -336,20 +336,6 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     @Query(
         """
-        select count(p)
-        from Participation p
-        join p.groupBuy gb
-        where gb.store.id in :storeIds
-          and p.status = :status
-        """
-    )
-    fun countRefundRequestsByStoreIdsAndStatus(
-        @Param("storeIds") storeIds: Collection<Long>,
-        @Param("status") status: ParticipationStatus,
-    ): Long
-
-    @Query(
-        """
         select p
         from Participation p
         join fetch p.user

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -324,12 +324,14 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         join fetch gb.store
         where gb.store.id in :storeIds
           and p.status in :statuses
+          and coalesce(p.cancelledAt, p.createdAt) >= :fromDateTime
         order by p.cancelledAt desc, p.createdAt desc
         """
     )
     fun findRefundRequestsByStoreIdsAndStatuses(
         @Param("storeIds") storeIds: Collection<Long>,
         @Param("statuses") statuses: Collection<ParticipationStatus>,
+        @Param("fromDateTime") fromDateTime: LocalDateTime,
     ): List<Participation>
 
     @Query(

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -279,6 +279,75 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     @Query(
         """
+        select coalesce(sum(p.totalAmount), 0)
+        from Participation p
+        join p.groupBuy gb
+        where gb.store.id in :storeIds
+          and gb.status in :groupBuyStatuses
+          and p.status in :participationStatuses
+          and year(gb.pickupDate) = :year
+          and month(gb.pickupDate) = :month
+        """
+    )
+    fun sumTotalAmountByStoreIdsAndStatusesAndYearMonth(
+        @Param("storeIds") storeIds: Collection<Long>,
+        @Param("groupBuyStatuses") groupBuyStatuses: Collection<GroupBuyStatus>,
+        @Param("participationStatuses") participationStatuses: Collection<ParticipationStatus>,
+        @Param("year") year: Int,
+        @Param("month") month: Int,
+    ): Long
+
+    @Query(
+        """
+        select coalesce(sum(p.feeAmount), 0)
+        from Participation p
+        join p.groupBuy gb
+        where gb.store.id in :storeIds
+          and p.status in :refundStatuses
+          and year(gb.pickupDate) = :year
+          and month(gb.pickupDate) = :month
+        """
+    )
+    fun sumRefundFeeAmountByStoreIdsAndYearMonth(
+        @Param("storeIds") storeIds: Collection<Long>,
+        @Param("refundStatuses") refundStatuses: Collection<ParticipationStatus>,
+        @Param("year") year: Int,
+        @Param("month") month: Int,
+    ): Long
+
+    @Query(
+        """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where gb.store.id in :storeIds
+          and p.status in :statuses
+        order by p.cancelledAt desc, p.createdAt desc
+        """
+    )
+    fun findRefundRequestsByStoreIdsAndStatuses(
+        @Param("storeIds") storeIds: Collection<Long>,
+        @Param("statuses") statuses: Collection<ParticipationStatus>,
+    ): List<Participation>
+
+    @Query(
+        """
+        select count(p)
+        from Participation p
+        join p.groupBuy gb
+        where gb.store.id in :storeIds
+          and p.status = :status
+        """
+    )
+    fun countRefundRequestsByStoreIdsAndStatus(
+        @Param("storeIds") storeIds: Collection<Long>,
+        @Param("status") status: ParticipationStatus,
+    ): Long
+
+    @Query(
+        """
         select p
         from Participation p
         join fetch p.user

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -9,6 +9,7 @@ import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
@@ -657,6 +658,10 @@ class PaymentService(
         val participation = participationRepository.findByIdForUpdate(participationId)
             .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
         if (participation.status != ParticipationStatus.REFUND_PENDING) {
+            return null
+        }
+        // 사용자 환불 요청(cancelReason 존재)은 사장님 동의(APPROVED) 이후에만 환불 처리 대상으로 잡는다.
+        if (participation.cancelReason != null && participation.ownerRefundReviewStatus != OwnerRefundReviewStatus.APPROVED) {
             return null
         }
 

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -63,6 +63,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     OWNER_WITHDRAWAL_REASON_DETAIL_REQUIRED(400_112, "기타 탈퇴 사유를 입력해주세요.", 400),
     OWNER_WITHDRAWAL_BLOCKED_OPEN_GROUPBUY(409_105, "개설된 공구가 있어 탈퇴할 수 없어요.", 409),
     OWNER_WITHDRAWAL_BLOCKED_PENDING_CUSTOMER_PICKUP(409_106, "달성 완료 공구의 픽업이 모두 완료된 후 탈퇴할 수 있어요.", 409),
+    OWNER_REFUND_REVIEW_ALREADY_PROCESSED(409_107, "이미 처리된 환불 요청입니다.", 409),
     EMAIL_VERIFICATION_DAILY_LIMIT_EXCEEDED(429_101, "내일 다시 시도해주세요.", 429),
     INVALID_SIGNUP_TOKEN(401_107, "회원가입 인증정보가 유효하지 않습니다. 이메일 인증을 다시 진행해주세요.", 401),
     KAKAO_TOKEN_REQUEST_INVALID(401_101, "카카오 토큰 요청 파라미터가 올바르지 않습니다.", 401),

--- a/src/main/resources/db/migration/V33__alter_participation_add_owner_refund_review_fields.sql
+++ b/src/main/resources/db/migration/V33__alter_participation_add_owner_refund_review_fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE participation
+    ADD COLUMN owner_refund_review_status VARCHAR(30) NULL AFTER refunded_at,
+    ADD COLUMN owner_refund_dispute_reason VARCHAR(500) NULL AFTER owner_refund_review_status,
+    ADD COLUMN owner_refund_reviewed_at DATETIME NULL AFTER owner_refund_dispute_reason;
+

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2034,6 +2034,40 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/v1/owner/settlements/refund-requests/{participationId}/review-submissions:
+    post:
+      tags: [Owner]
+      summary: 사장님 환불 요청 검토 제출
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: participationId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnerRefundReviewSubmitRequest'
+      responses:
+        '200':
+          description: 제출 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerRefundReviewSubmit'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/v1/owner/group-buy-requests:
     get:
@@ -4720,6 +4754,39 @@ components:
         status:
           type: string
           enum: [PENDING, COMPLETED]
+
+    OwnerRefundReviewActionType:
+      type: string
+      enum: [APPROVE, DISPUTE]
+
+    OwnerRefundReviewSubmitRequest:
+      type: object
+      required: [action]
+      properties:
+        action:
+          $ref: '#/components/schemas/OwnerRefundReviewActionType'
+        disputeReason:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: action이 DISPUTE일 때 입력
+          example: "픽업 요청 시간 변경이 선행되어야 합니다."
+
+    ApiResponseOwnerRefundReviewSubmit:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/OwnerRefundReviewSubmitResponse'
+        error: { nullable: true, example: null }
+
+    OwnerRefundReviewSubmitResponse:
+      type: object
+      required: [participationId, processed]
+      properties:
+        participationId: { type: integer, format: int64, example: 1001 }
+        processed: { type: boolean, example: true }
 
     OwnerGroupBuyRequestCreate:
       type: object

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1929,6 +1929,112 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/owner/settlements/monthly-summary:
+    get:
+      tags: [Owner]
+      summary: 사장님 월별 정산 예정 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            example: 2026
+        - name: month
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+            example: 5
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerSettlementMonthlySummary'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/owner/settlements/month-chips:
+    get:
+      tags: [Owner]
+      summary: 사장님 정산 월 칩 조회
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerSettlementMonthChipList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/owner/settlements/refund-requests:
+    get:
+      tags: [Owner]
+      summary: 사장님 환불 요청 목록 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: tab
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [ALL, PENDING, COMPLETED]
+            default: ALL
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerRefundRequestList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/owner/settlements/refund-requests/{participationId}:
+    get:
+      tags: [Owner]
+      summary: 사장님 환불 요청 상세 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: participationId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerRefundRequestDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/owner/group-buy-requests:
     get:
       tags: [Owner]
@@ -4502,6 +4608,118 @@ components:
           maxLength: 100
           description: reason이 OTHER일 때 필수
           example: 재고 수급 이슈로 조기 마감합니다.
+
+    ApiResponseOwnerSettlementMonthlySummary:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/OwnerSettlementMonthlySummary'
+        error: { nullable: true, example: null }
+
+    OwnerSettlementMonthlySummary:
+      type: object
+      required: [year, month, settlementExpectedAmount, grossRevenueAmount, refundFeeAmount]
+      properties:
+        year: { type: integer, example: 2026 }
+        month: { type: integer, example: 5 }
+        settlementExpectedAmount: { type: integer, format: int64, example: 216000 }
+        grossRevenueAmount: { type: integer, format: int64, example: 240000 }
+        refundFeeAmount: { type: integer, format: int64, example: 24000 }
+
+    ApiResponseOwnerSettlementMonthChipList:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/OwnerSettlementMonthChipList'
+        error: { nullable: true, example: null }
+
+    OwnerSettlementMonthChipList:
+      type: object
+      required: [chips]
+      properties:
+        chips:
+          type: array
+          items:
+            $ref: '#/components/schemas/OwnerSettlementMonthChip'
+
+    OwnerSettlementMonthChip:
+      type: object
+      required: [year, month, label]
+      properties:
+        year: { type: integer, example: 2026 }
+        month: { type: integer, example: 5 }
+        label: { type: string, example: "2026년 5월" }
+
+    ApiResponseOwnerRefundRequestList:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/OwnerRefundRequestList'
+        error: { nullable: true, example: null }
+
+    OwnerRefundRequestList:
+      type: object
+      required: [pendingCount, completedCount, hasPendingItems, items]
+      properties:
+        pendingCount: { type: integer, example: 1 }
+        completedCount: { type: integer, example: 2 }
+        hasPendingItems: { type: boolean, example: true }
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OwnerRefundRequestListItem'
+
+    OwnerRefundRequestListItem:
+      type: object
+      required: [participationId, groupBuyId, productName, paymentAmount, requesterName, requesterCode, refundReasonLabel, requestedDate, status, exceeded24Hours]
+      properties:
+        participationId: { type: integer, format: int64, example: 1001 }
+        groupBuyId: { type: integer, format: int64, example: 901001 }
+        productName: { type: string, example: "초코 크루아상&소금빵 세트" }
+        paymentAmount: { type: integer, example: 24000 }
+        requesterName: { type: string, example: "김민지" }
+        requesterCode: { type: string, example: "P001" }
+        refundReasonLabel: { type: string, example: "픽업 불가" }
+        requestedDate: { type: string, format: date, example: "2026-05-02" }
+        status:
+          type: string
+          enum: [PENDING, COMPLETED]
+        exceeded24Hours: { type: boolean, example: true }
+
+    ApiResponseOwnerRefundRequestDetail:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/OwnerRefundRequestDetail'
+        error: { nullable: true, example: null }
+
+    OwnerRefundRequestDetail:
+      type: object
+      required: [participationId, groupBuyId, productName, requesterName, requestedDate, paymentAmount, penaltyAmount, refundExpectedAmount, status]
+      properties:
+        participationId: { type: integer, format: int64, example: 1001 }
+        groupBuyId: { type: integer, format: int64, example: 901001 }
+        productName: { type: string, example: "초코 크루아상&소금빵 세트" }
+        requesterName: { type: string, example: "김민지" }
+        requestedDate: { type: string, format: date, example: "2026-04-29" }
+        paymentAmount: { type: integer, example: 24000 }
+        penaltyAmount: { type: integer, example: 2400 }
+        refundExpectedAmount: { type: integer, example: 21600 }
+        refundReasonDetail:
+          type: string
+          nullable: true
+          example: "일정 변경으로 픽업이 어려워졌어요. 환불 부탁드립니다"
+        status:
+          type: string
+          enum: [PENDING, COMPLETED]
 
     OwnerGroupBuyRequestCreate:
       type: object

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2062,6 +2062,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponseOwnerRefundReviewSubmit'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -31,6 +31,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -115,6 +116,7 @@ class OwnerSettlementServiceTest {
             participationRepository.findRefundRequestsByStoreIdsAndStatuses(
                 defaultStoreIds(),
                 listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                LocalDate.now(ZoneId.of("Asia/Seoul")).minusMonths(6).atStartOfDay(),
             )
         ).thenReturn(
             listOf(

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -3,6 +3,8 @@ package com.moongchijang.domain.owner.application
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewActionType
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitRequest
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -162,6 +164,43 @@ class OwnerSettlementServiceTest {
         verifyNoInteractions(storeStaffRepository)
     }
 
+    @Test
+    fun `환불 요청 검토 제출 성공`() {
+        val owner = seller()
+        val participation = refundParticipation(id = 1020L, status = ParticipationStatus.REFUND_PENDING)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(participationRepository.findById(1020L)).thenReturn(Optional.of(participation))
+
+        val response = service.submitRefundReview(
+            ownerId = owner.id!!,
+            participationId = 1020L,
+            request = OwnerRefundReviewSubmitRequest(action = OwnerRefundReviewActionType.APPROVE),
+        )
+
+        assertEquals(1020L, response.participationId)
+        assertTrue(response.processed)
+    }
+
+    @Test
+    fun `환불 요청 검토 제출 시 이의제기 사유 누락 예외`() {
+        val owner = seller()
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+
+        val exception = assertThrows<CustomException> {
+            service.submitRefundReview(
+                ownerId = owner.id!!,
+                participationId = 1021L,
+                request = OwnerRefundReviewSubmitRequest(
+                    action = OwnerRefundReviewActionType.DISPUTE,
+                    disputeReason = " ",
+                ),
+            )
+        }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+    }
+
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
         role = UserRole.SELLER
     }
@@ -206,4 +245,3 @@ class OwnerSettlementServiceTest {
         updatedAtField.set(entity, updatedAt)
     }
 }
-

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -81,7 +81,7 @@ class OwnerSettlementServiceTest {
         assertEquals(5, result.month)
         assertEquals(240000L, result.grossRevenueAmount)
         assertEquals(24000L, result.refundFeeAmount)
-        assertEquals(216000L, result.settlementExpectedAmount)
+        assertEquals(264000L, result.settlementExpectedAmount)
     }
 
     @Test
@@ -137,7 +137,7 @@ class OwnerSettlementServiceTest {
         val owner = seller()
         val participation = refundParticipation(id = 1010L, status = ParticipationStatus.REFUND_PENDING)
         stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
-        `when`(participationRepository.findById(1010L)).thenReturn(Optional.of(participation))
+        `when`(participationRepository.findPickupDetailById(1010L)).thenReturn(participation)
 
         val detail = service.getRefundRequestDetail(owner.id!!, 1010L)
 

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -1,0 +1,209 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class OwnerSettlementServiceTest {
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    @Mock
+    private lateinit var storeStaffRepository: StoreStaffRepository
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var participationRepository: ParticipationRepository
+
+    @InjectMocks
+    private lateinit var service: OwnerSettlementService
+
+    @Test
+    fun `월별 정산 예정 금액을 조회한다`() {
+        val owner = seller()
+        val storeIds = listOf(1L)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(storeIds)
+        `when`(
+            participationRepository.sumTotalAmountByStoreIdsAndStatusesAndYearMonth(
+                storeIds,
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+                listOf(ParticipationStatus.CONFIRMED),
+                2026,
+                5,
+            )
+        ).thenReturn(240000L)
+        `when`(
+            participationRepository.sumRefundFeeAmountByStoreIdsAndYearMonth(
+                storeIds,
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                2026,
+                5,
+            )
+        ).thenReturn(24000L)
+
+        val result = service.getMonthlySettlementSummary(owner.id!!, 2026, 5)
+
+        assertEquals(2026, result.year)
+        assertEquals(5, result.month)
+        assertEquals(240000L, result.grossRevenueAmount)
+        assertEquals(24000L, result.refundFeeAmount)
+        assertEquals(216000L, result.settlementExpectedAmount)
+    }
+
+    @Test
+    fun `정산 월 칩을 연월 기준으로 중복 없이 반환한다`() {
+        val owner = seller()
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(
+            groupBuyRepository.findDistinctPickupDatesByStoreIdsAndStatuses(
+                listOf(1L),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+            )
+        ).thenReturn(
+            listOf(
+                LocalDate.of(2026, 5, 2),
+                LocalDate.of(2026, 5, 10),
+                LocalDate.of(2026, 4, 29),
+            )
+        )
+
+        val result = service.getSettlementMonthChips(owner.id!!)
+
+        assertEquals(2, result.chips.size)
+        assertEquals("2026년 5월", result.chips[0].label)
+        assertEquals("2026년 4월", result.chips[1].label)
+    }
+
+    @Test
+    fun `환불 요청 목록 탭 필터를 적용한다`() {
+        val owner = seller()
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(
+            participationRepository.findRefundRequestsByStoreIdsAndStatuses(
+                listOf(1L),
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+            )
+        ).thenReturn(
+            listOf(
+                refundParticipation(id = 1001L, status = ParticipationStatus.REFUND_PENDING),
+                refundParticipation(id = 1002L, status = ParticipationStatus.REFUNDED),
+            )
+        )
+        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(listOf(1L), ParticipationStatus.REFUND_PENDING)).thenReturn(1L)
+        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(listOf(1L), ParticipationStatus.REFUNDED)).thenReturn(1L)
+
+        val pendingOnly = service.getRefundRequests(owner.id!!, OwnerRefundRequestTab.PENDING)
+        val all = service.getRefundRequests(owner.id!!, OwnerRefundRequestTab.ALL)
+
+        assertEquals(1, pendingOnly.items.size)
+        assertEquals(2, all.items.size)
+        assertTrue(all.hasPendingItems)
+    }
+
+    @Test
+    fun `환불 요청 상세를 조회한다`() {
+        val owner = seller()
+        val participation = refundParticipation(id = 1010L, status = ParticipationStatus.REFUND_PENDING)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(participationRepository.findById(1010L)).thenReturn(Optional.of(participation))
+
+        val detail = service.getRefundRequestDetail(owner.id!!, 1010L)
+
+        assertEquals(1010L, detail.participationId)
+        assertEquals(24000, detail.paymentAmount)
+        assertEquals(2400, detail.penaltyAmount)
+        assertEquals(21600, detail.refundExpectedAmount)
+    }
+
+    @Test
+    fun `사장님 권한이 아니면 환불 요청 조회가 불가하다`() {
+        val buyer = UserFixture.createKakaoUser(id = 99L)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(99L)).thenReturn(buyer)
+
+        val exception = assertThrows<CustomException> {
+            service.getRefundRequests(99L, OwnerRefundRequestTab.ALL)
+        }
+
+        assertEquals(ErrorCode.FORBIDDEN, exception.errorCode)
+        verifyNoInteractions(storeStaffRepository)
+    }
+
+    private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
+        role = UserRole.SELLER
+    }
+
+    private fun refundParticipation(id: Long, status: ParticipationStatus): Participation {
+        val user = UserFixture.createKakaoUser(id = 11L, nickname = "김민지")
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 901001L,
+            status = GroupBuyStatus.COMPLETED,
+            productName = "초코 크루아상&소금빵 세트",
+            price = 24000,
+        )
+        groupBuy.store.id = 1L
+
+        return Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 21600,
+            feeAmount = 2400,
+            totalAmount = 24000,
+            status = status,
+            pickupStatus = PickupStatus.NOT_READY,
+            cancelReason = ParticipationCancelReason.TIME_UNAVAILABLE,
+            cancelReasonDetail = "일정 변경으로 픽업이 어려워졌어요. 환불 부탁드립니다",
+            cancelledAt = LocalDateTime.now().minusDays(1),
+            refundedAt = if (status == ParticipationStatus.REFUNDED) LocalDateTime.now().minusHours(6) else null,
+            id = id,
+        ).also {
+            setAuditFields(it, LocalDateTime.now().minusDays(2), LocalDateTime.now().minusDays(1))
+        }
+    }
+
+    private fun setAuditFields(entity: Any, createdAt: LocalDateTime, updatedAt: LocalDateTime) {
+        val baseClass = entity.javaClass.superclass
+        val createdAtField = baseClass.getDeclaredField("createdAt")
+        createdAtField.isAccessible = true
+        createdAtField.set(entity, createdAt)
+
+        val updatedAtField = baseClass.getDeclaredField("updatedAt")
+        updatedAtField.isAccessible = true
+        updatedAtField.set(entity, updatedAt)
+    }
+}
+

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewActionType
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitRequest
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -121,9 +122,6 @@ class OwnerSettlementServiceTest {
                 refundParticipation(id = 1002L, status = ParticipationStatus.REFUNDED),
             )
         )
-        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(defaultStoreIds(), ParticipationStatus.REFUND_PENDING)).thenReturn(1L)
-        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(defaultStoreIds(), ParticipationStatus.REFUNDED)).thenReturn(1L)
-
         val pendingOnly = service.getRefundRequests(owner.id!!, OwnerRefundRequestTab.PENDING)
         val all = service.getRefundRequests(owner.id!!, OwnerRefundRequestTab.ALL)
 
@@ -165,7 +163,7 @@ class OwnerSettlementServiceTest {
         val owner = seller()
         val participation = refundParticipation(id = 1020L, status = ParticipationStatus.REFUND_PENDING)
         stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
-        `when`(participationRepository.findById(1020L)).thenReturn(Optional.of(participation))
+        `when`(participationRepository.findByIdForUpdate(1020L)).thenReturn(Optional.of(participation))
 
         val response = service.submitRefundReview(
             ownerId = owner.id!!,
@@ -194,6 +192,27 @@ class OwnerSettlementServiceTest {
         }
 
         assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+    }
+
+    @Test
+    fun `이미 처리된 환불 요청은 재처리할 수 없다`() {
+        val owner = seller()
+        val participation = refundParticipation(id = 1022L, status = ParticipationStatus.REFUND_PENDING).apply {
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.APPROVED
+            ownerRefundReviewedAt = LocalDateTime.now().minusMinutes(3)
+        }
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
+        `when`(participationRepository.findByIdForUpdate(1022L)).thenReturn(Optional.of(participation))
+
+        val exception = assertThrows<CustomException> {
+            service.submitRefundReview(
+                ownerId = owner.id!!,
+                participationId = 1022L,
+                request = OwnerRefundReviewSubmitRequest(action = OwnerRefundReviewActionType.APPROVE),
+            )
+        }
+
+        assertEquals(ErrorCode.OWNER_REFUND_REVIEW_ALREADY_PROCESSED, exception.errorCode)
     }
 
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -53,9 +53,8 @@ class OwnerSettlementServiceTest {
     @Test
     fun `월별 정산 예정 금액을 조회한다`() {
         val owner = seller()
-        val storeIds = listOf(1L)
-        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
-        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(storeIds)
+        val storeIds = defaultStoreIds()
+        stubSellerAndStoreIds(owner.id!!, owner, storeIds)
         `when`(
             participationRepository.sumTotalAmountByStoreIdsAndStatusesAndYearMonth(
                 storeIds,
@@ -86,11 +85,10 @@ class OwnerSettlementServiceTest {
     @Test
     fun `정산 월 칩을 연월 기준으로 중복 없이 반환한다`() {
         val owner = seller()
-        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
-        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
         `when`(
             groupBuyRepository.findDistinctPickupDatesByStoreIdsAndStatuses(
-                listOf(1L),
+                defaultStoreIds(),
                 listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
             )
         ).thenReturn(
@@ -111,11 +109,10 @@ class OwnerSettlementServiceTest {
     @Test
     fun `환불 요청 목록 탭 필터를 적용한다`() {
         val owner = seller()
-        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
-        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
         `when`(
             participationRepository.findRefundRequestsByStoreIdsAndStatuses(
-                listOf(1L),
+                defaultStoreIds(),
                 listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
             )
         ).thenReturn(
@@ -124,8 +121,8 @@ class OwnerSettlementServiceTest {
                 refundParticipation(id = 1002L, status = ParticipationStatus.REFUNDED),
             )
         )
-        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(listOf(1L), ParticipationStatus.REFUND_PENDING)).thenReturn(1L)
-        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(listOf(1L), ParticipationStatus.REFUNDED)).thenReturn(1L)
+        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(defaultStoreIds(), ParticipationStatus.REFUND_PENDING)).thenReturn(1L)
+        `when`(participationRepository.countRefundRequestsByStoreIdsAndStatus(defaultStoreIds(), ParticipationStatus.REFUNDED)).thenReturn(1L)
 
         val pendingOnly = service.getRefundRequests(owner.id!!, OwnerRefundRequestTab.PENDING)
         val all = service.getRefundRequests(owner.id!!, OwnerRefundRequestTab.ALL)
@@ -139,8 +136,7 @@ class OwnerSettlementServiceTest {
     fun `환불 요청 상세를 조회한다`() {
         val owner = seller()
         val participation = refundParticipation(id = 1010L, status = ParticipationStatus.REFUND_PENDING)
-        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
-        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
         `when`(participationRepository.findById(1010L)).thenReturn(Optional.of(participation))
 
         val detail = service.getRefundRequestDetail(owner.id!!, 1010L)
@@ -168,8 +164,7 @@ class OwnerSettlementServiceTest {
     fun `환불 요청 검토 제출 성공`() {
         val owner = seller()
         val participation = refundParticipation(id = 1020L, status = ParticipationStatus.REFUND_PENDING)
-        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
-        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
         `when`(participationRepository.findById(1020L)).thenReturn(Optional.of(participation))
 
         val response = service.submitRefundReview(
@@ -203,6 +198,17 @@ class OwnerSettlementServiceTest {
 
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {
         role = UserRole.SELLER
+    }
+
+    private fun defaultStoreIds(): List<Long> = listOf(1L)
+
+    private fun stubSellerAndStoreIds(
+        ownerId: Long,
+        owner: com.moongchijang.domain.user.domain.entity.User,
+        storeIds: List<Long>,
+    ) {
+        `when`(userRepository.findByIdAndDeletedAtIsNull(ownerId)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(ownerId)).thenReturn(storeIds)
     }
 
     private fun refundParticipation(id: Long, status: ParticipationStatus): Participation {


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 정산/환불 확인 기능을 위한 DTO 및 enum을 추가했습니다.
- 정산/환불 조회용 리포지토리 쿼리를 추가했습니다.
- 사장님 정산/환불 확인 서비스(`OwnerSettlementService`)를 추가했습니다.
  - 월별 정산 예정 조회
  - 년/월 칩 조회
  - 환불 요청 목록(탭 필터: 전체/검토대기/처리완료)
  - 환불 요청 상세 조회
- 사장님 정산/환불 확인 컨트롤러 API를 추가했습니다.
  - `GET /api/v1/owner/settlements/monthly-summary`
  - `GET /api/v1/owner/settlements/month-chips`
  - `GET /api/v1/owner/settlements/refund-requests`
  - `GET /api/v1/owner/settlements/refund-requests/{participationId}`
- 환불 요청 검토 제출 API를 추가했습니다.
  - `POST /api/v1/owner/settlements/refund-requests/{participationId}/review-submissions`
  - 액션: `APPROVE` / `DISPUTE`
- 환불 검토 처리 정합성 강화를 위해 참여 테이블에 검토 상태 컬럼을 추가했습니다.
  - `owner_refund_review_status`
  - `owner_refund_dispute_reason`
  - `owner_refund_reviewed_at`
- 처리 검증 로직을 추가했습니다.
  - `REFUND_PENDING` 상태에서만 검토 제출 허용
  - 이미 처리된 건 재처리 차단(409)
  - `DISPUTE` 시 사유 필수
- 스케줄러 환불 처리 가드를 추가했습니다.
  - 사용자 환불 요청 건(`cancelReason` 존재)은 `APPROVED` 검토 완료 후에만 실제 환불 처리 대상
- 테스트 및 OpenAPI 명세를 업데이트했습니다.

## ✨ 코드리뷰 반영 내용
- 월별 조회 검증 기준이 서버 로컬 시간대에 의존할 수 있었습니다.
  - year-month 검증 기준을 `LocalDate.now(ZoneId.of("Asia/Seoul"))`로 고정했습니다.
  - UTC 서버 환경에서도 KST 기준 월 조회가 정상 동작하도록 수정했습니다.
- 환불 요청 목록 조회가 누적 데이터 증가 시 성능 저하/OOM 위험이 있었습니다.
  - 목록 조회 범위를 최근 6개월로 제한했습니다.
  - 리포지토리 쿼리에 `fromDateTime` 조건을 추가해 DB 레벨에서 조회량을 줄였습니다.
- 환불 상세 조회에서 불필요한 지연 로딩 쿼리 발생 가능성이 있었습니다.
  - `findById` 대신 fetch join 기반 `findPickupDetailById`로 조회하도록 변경했습니다.
  - `Participation + User + GroupBuy + Store`를 한 번에 로딩하도록 최적화했습니다.
- 환불 검토 사유 필드 정합성 이슈가 있었습니다.
  - `DISPUTE`가 아닌 `APPROVE` 제출 시 `owner_refund_dispute_reason`을 `null`로 초기화하도록 수정했습니다.
  - 이전 이의제기 사유가 승인 케이스에 잔존하지 않도록 처리했습니다.
- null 단언(`!!`) 사용으로 NPE 위험이 있었습니다.
  - 환불 요청 목록/상세의 `requestedDate` 계산에서 `createdAt!!`를 제거했습니다.
  - `cancelledAt ?: createdAt ?: LocalDateTime.now()` 방식으로 null-safe 처리했습니다.
- 미사용 리포지토리 메서드가 남아 있었습니다.
  - `countRefundRequestsByStoreIdsAndStatus` 메서드를 제거해 코드 정리를 수행했습니다.
- 정산 공식이 정책과 불일치했습니다.
  - 사장님이 위약금을 가져가는 정책으로 `settlementExpectedAmount = grossRevenueAmount + refundFeeAmount`로 수정했습니다.
  - 서비스 계산식과 테스트 기대값을 함께 정합화했습니다.
- 환불 처리 상태 전이/재처리 방지 정합성이 부족했습니다.
  - `owner_refund_review_status / owner_refund_dispute_reason / owner_refund_reviewed_at` 컬럼을 추가했습니다.
  - `REFUND_PENDING` 상태에서만 검토 제출 허용, 이미 처리된 건은 `409`으로 차단하도록 반영했습니다.
  - 스케줄러 환불 처리도 `APPROVED` 검토 완료 건만 진행되도록 가드를 추가했습니다.

## 🔍 참고 사항
- 현재 `DISPUTE` 제출 시에는 **CS 티켓 시스템으로 자동 전환/생성하지 않고**, DB에 이의제기 상태와 사유를 저장하는 단계까지 구현했습니다.
- 즉, CS 티켓 생성/외부 CS 연동은 후속 작업에서 구현 예정입니다.
- 이번 PR은 환불 검토 처리의 상태 전이 및 재처리 방지 정합성 확보에 초점을 맞췄습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #242 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인