### PR TITLE
[MCJ-1545] FEAT: 어드민 대시보드 운영 요약 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
@@ -62,12 +62,12 @@ class AdminDashboardSummaryService(
             ),
             unconfirmedOrderCount = 0,
             unconfirmedOrderOver48hCount = 0,
-            todayCompletedRefundCount = participationRepository.countByStatusAndRefundedAtBetween(
+            todayCompletedRefundCount = participationRepository.countByStatusAndRefundedAtFromUntil(
                 status = ParticipationStatus.REFUNDED,
                 from = todayRange.start,
                 to = todayRange.end
             ),
-            todayCompletedApprovalCount = groupBuyRequestStatusHistoryRepository.countByStatusInAndChangedAtBetween(
+            todayCompletedApprovalCount = groupBuyRequestStatusHistoryRepository.countByStatusInAndChangedAtFromUntil(
                 statuses = completedApprovalStatuses,
                 from = todayRange.start,
                 to = todayRange.end

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
@@ -1,0 +1,108 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class AdminDashboardSummaryService(
+    private val groupBuyRequestRepository: GroupBuyRequestRepository,
+    private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository,
+    private val participationRepository: ParticipationRepository,
+    private val clock: Clock,
+) {
+
+    fun getSummary(): AdminDashboardSummaryResponse {
+        val now = LocalDateTime.now(clock)
+        val today = LocalDate.now(clock)
+        val todayRange = today.toRange()
+        val yesterdayRange = today.minusDays(1).toRange()
+        val pendingApprovalStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
+        val completedApprovalStatuses = listOf(GroupBuyRequestStatus.OPENED, GroupBuyRequestStatus.REJECTED)
+
+        val pendingRefundAmount = participationRepository.sumPaymentOrderAmountByStatus(ParticipationStatus.REFUND_PENDING)
+        val todayPendingRefundAmount = participationRepository.sumPaymentOrderAmountByStatusAndCancelledAtBetween(
+            status = ParticipationStatus.REFUND_PENDING,
+            from = todayRange.start,
+            to = todayRange.end
+        )
+        val yesterdayPendingRefundAmount = participationRepository.sumPaymentOrderAmountByStatusAndCancelledAtBetween(
+            status = ParticipationStatus.REFUND_PENDING,
+            from = yesterdayRange.start,
+            to = yesterdayRange.end
+        )
+        val pendingCreatedAts = groupBuyRequestRepository.findCreatedAtByStatusIn(pendingApprovalStatuses)
+
+        return AdminDashboardSummaryResponse(
+            pendingRefundAmount = pendingRefundAmount,
+            pendingRefundAmountChangeRate = changeRate(todayPendingRefundAmount, yesterdayPendingRefundAmount),
+            pendingApprovalCount = groupBuyRequestRepository.countByStatusIn(pendingApprovalStatuses),
+            averageReviewMinutes = averageReviewMinutes(pendingCreatedAts, now),
+            pendingApprovalChangeRate = changeRate(
+                current = groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(
+                    statuses = pendingApprovalStatuses,
+                    from = todayRange.start,
+                    to = todayRange.end
+                ),
+                previous = groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(
+                    statuses = pendingApprovalStatuses,
+                    from = yesterdayRange.start,
+                    to = yesterdayRange.end
+                )
+            ),
+            unconfirmedOrderCount = 0,
+            unconfirmedOrderOver48hCount = 0,
+            todayCompletedRefundCount = participationRepository.countByStatusAndRefundedAtBetween(
+                status = ParticipationStatus.REFUNDED,
+                from = todayRange.start,
+                to = todayRange.end
+            ),
+            todayCompletedApprovalCount = groupBuyRequestStatusHistoryRepository.countByStatusInAndChangedAtBetween(
+                statuses = completedApprovalStatuses,
+                from = todayRange.start,
+                to = todayRange.end
+            ),
+            hasOrderOver48h = false
+        )
+    }
+
+    private fun averageReviewMinutes(createdAts: List<LocalDateTime>, now: LocalDateTime): Long {
+        if (createdAts.isEmpty()) {
+            return 0L
+        }
+
+        return createdAts
+            .map { Duration.between(it, now).toMinutes().coerceAtLeast(0) }
+            .average()
+            .toLong()
+    }
+
+    private fun changeRate(current: Long, previous: Long): Double {
+        if (previous == 0L) {
+            return if (current == 0L) 0.0 else 100.0
+        }
+
+        return (current - previous) * 100.0 / previous
+    }
+
+    private fun LocalDate.toRange(): DateTimeRange =
+        DateTimeRange(
+            start = atStartOfDay(),
+            end = plusDays(1).atStartOfDay()
+        )
+
+    private data class DateTimeRange(
+        val start: LocalDateTime,
+        val end: LocalDateTime,
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardSummaryResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardSummaryResponse.kt
@@ -1,0 +1,14 @@
+package com.moongchijang.domain.admin.application.dto
+
+data class AdminDashboardSummaryResponse(
+    val pendingRefundAmount: Long,
+    val pendingRefundAmountChangeRate: Double,
+    val pendingApprovalCount: Long,
+    val averageReviewMinutes: Long,
+    val pendingApprovalChangeRate: Double,
+    val unconfirmedOrderCount: Long,
+    val unconfirmedOrderOver48hCount: Long,
+    val todayCompletedRefundCount: Long,
+    val todayCompletedApprovalCount: Long,
+    val hasOrderOver48h: Boolean,
+)

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
@@ -1,0 +1,24 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminDashboardSummaryService
+import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@Tag(name = "Admin", description = "운영자 관리")
+class AdminDashboardController(
+    private val adminDashboardSummaryService: AdminDashboardSummaryService,
+) {
+
+    @GetMapping("/summary")
+    @Operation(summary = "운영자 대시보드 운영 관리 요약")
+    fun getSummary(): ResponseEntity<ApiResponse<AdminDashboardSummaryResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminDashboardSummaryService.getSummary()))
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.Optional
 
 interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
@@ -63,6 +64,24 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
     ): Page<GroupBuyRequest>
 
     fun countByUserId(userId: Long): Long
+
+    fun countByStatusIn(statuses: Collection<GroupBuyRequestStatus>): Long
+
+    fun countByStatusInAndCreatedAtBetween(
+        statuses: Collection<GroupBuyRequestStatus>,
+        from: LocalDateTime,
+        to: LocalDateTime
+    ): Long
+
+    @Query(
+        """
+        select request.createdAt
+        from GroupBuyRequest request
+        where request.status in :statuses
+          and request.createdAt is not null
+        """
+    )
+    fun findCreatedAtByStatusIn(@Param("statuses") statuses: Collection<GroupBuyRequestStatus>): List<LocalDateTime>
 
     fun findByStatusInAndDesiredPickupDate(
         statuses: Collection<GroupBuyRequestStatus>,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -67,10 +67,19 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
 
     fun countByStatusIn(statuses: Collection<GroupBuyRequestStatus>): Long
 
+    @Query(
+        """
+        select count(request)
+        from GroupBuyRequest request
+        where request.status in :statuses
+          and request.createdAt >= :from
+          and request.createdAt < :to
+        """
+    )
     fun countByStatusInAndCreatedAtBetween(
-        statuses: Collection<GroupBuyRequestStatus>,
-        from: LocalDateTime,
-        to: LocalDateTime
+        @Param("statuses") statuses: Collection<GroupBuyRequestStatus>,
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime
     ): Long
 
     @Query(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
@@ -3,14 +3,25 @@ package com.moongchijang.domain.groupbuy.domain.repository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 interface GroupBuyRequestStatusHistoryRepository : JpaRepository<GroupBuyRequestStatusHistory, Long> {
     fun findByGroupBuyRequestIdOrderByChangedAtAsc(groupBuyRequestId: Long): List<GroupBuyRequestStatusHistory>
     fun findByGroupBuyRequestIdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory>
-    fun countByStatusInAndChangedAtBetween(
-        statuses: Collection<GroupBuyRequestStatus>,
-        from: LocalDateTime,
-        to: LocalDateTime
+    @Query(
+        """
+        select count(history)
+        from GroupBuyRequestStatusHistory history
+        where history.status in :statuses
+          and history.changedAt >= :from
+          and history.changedAt < :to
+        """
+    )
+    fun countByStatusInAndChangedAtFromUntil(
+        @Param("statuses") statuses: Collection<GroupBuyRequestStatus>,
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime
     ): Long
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
@@ -1,9 +1,16 @@
 package com.moongchijang.domain.groupbuy.domain.repository
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHistory
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
 
 interface GroupBuyRequestStatusHistoryRepository : JpaRepository<GroupBuyRequestStatusHistory, Long> {
     fun findByGroupBuyRequestIdOrderByChangedAtAsc(groupBuyRequestId: Long): List<GroupBuyRequestStatusHistory>
     fun findByGroupBuyRequestIdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory>
+    fun countByStatusInAndChangedAtBetween(
+        statuses: Collection<GroupBuyRequestStatus>,
+        from: LocalDateTime,
+        to: LocalDateTime
+    ): Long
 }

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -271,10 +271,19 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     fun countByUserIdAndStatus(userId: Long, status: ParticipationStatus): Long
 
-    fun countByStatusAndRefundedAtBetween(
-        status: ParticipationStatus,
-        from: LocalDateTime,
-        to: LocalDateTime
+    @Query(
+        """
+        select count(p)
+        from Participation p
+        where p.status = :status
+          and p.refundedAt >= :from
+          and p.refundedAt < :to
+        """
+    )
+    fun countByStatusAndRefundedAtFromUntil(
+        @Param("status") status: ParticipationStatus,
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime
     ): Long
 
     @Query(

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -271,6 +271,38 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     fun countByUserIdAndStatus(userId: Long, status: ParticipationStatus): Long
 
+    fun countByStatusAndRefundedAtBetween(
+        status: ParticipationStatus,
+        from: LocalDateTime,
+        to: LocalDateTime
+    ): Long
+
+    @Query(
+        """
+        select coalesce(sum(po.totalAmount), 0)
+        from Participation p
+        join PaymentOrder po on po.user = p.user and po.groupBuy = p.groupBuy
+        where p.status = :status
+        """
+    )
+    fun sumPaymentOrderAmountByStatus(@Param("status") status: ParticipationStatus): Long
+
+    @Query(
+        """
+        select coalesce(sum(po.totalAmount), 0)
+        from Participation p
+        join PaymentOrder po on po.user = p.user and po.groupBuy = p.groupBuy
+        where p.status = :status
+          and p.cancelledAt >= :from
+          and p.cancelledAt < :to
+        """
+    )
+    fun sumPaymentOrderAmountByStatusAndCancelledAtBetween(
+        @Param("status") status: ParticipationStatus,
+        @Param("from") from: LocalDateTime,
+        @Param("to") to: LocalDateTime
+    ): Long
+
     fun countByUserIdAndStatusIn(userId: Long, statuses: Collection<ParticipationStatus>): Long
 
     fun countByGroupBuyIdAndStatusIn(groupBuyId: Long, statuses: Collection<ParticipationStatus>): Long

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1123,7 +1123,7 @@ paths:
     get:
       tags: [Admin]
       summary: 운영자 대시보드 요약 정보
-      description: 헤더에 항상 노출되는 대기중 요청 / 진행 중 공구 / 달성률 / 대기 환불 요약을 반환한다.
+      description: 운영 관리 요약 영역에 노출되는 환불 금액, 개설승인 대기, 발주 미확정, 오늘 처리 완료 요약을 반환한다.
       security:
         - bearerAuth: []
       responses:
@@ -4552,21 +4552,47 @@ components:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [pendingRequestCount, activeGroupBuyCount, achievementRate, pendingRefundCount]
+          required: [pendingRefundAmount, pendingRefundAmountChangeRate, pendingApprovalCount, averageReviewMinutes, pendingApprovalChangeRate, unconfirmedOrderCount, unconfirmedOrderOver48hCount, todayCompletedRefundCount, todayCompletedApprovalCount, hasOrderOver48h]
           properties:
-            pendingRequestCount:
+            pendingRefundAmount:
               type: integer
-              description: 대기중 요청 건수 (처리 필요)
-            activeGroupBuyCount:
-              type: integer
-              description: 진행 중 공구 개수
-            achievementRate:
+              format: int64
+              description: 검토 대기 환불 총 금액. 현재는 REFUND_PENDING 참여의 결제 주문 총액 기준
+            pendingRefundAmountChangeRate:
               type: number
               format: double
-              description: 최근 30일 공구 달성률 (%). 달성완료 / 마감된 전체 공구 기준
-            pendingRefundCount:
+              description: 전일 대비 검토 대기 환불 금액 증감률(%)
+            pendingApprovalCount:
               type: integer
-              description: 대기 환불 건수 (처리 필요)
+              format: int64
+              description: 개설승인 대기 건수
+            averageReviewMinutes:
+              type: integer
+              format: int64
+              description: 개설승인 대기 요청의 평균 검토 시간(분)
+            pendingApprovalChangeRate:
+              type: number
+              format: double
+              description: 전일 대비 개설승인 대기 요청 생성 건수 증감률(%)
+            unconfirmedOrderCount:
+              type: integer
+              format: int64
+              description: 발주 미확정 건수. 발주 도메인 구현 전까지 0 반환
+            unconfirmedOrderOver48hCount:
+              type: integer
+              format: int64
+              description: 발주 미확정 48시간 초과 건수. 발주 도메인 구현 전까지 0 반환
+            todayCompletedRefundCount:
+              type: integer
+              format: int64
+              description: 오늘 환불 처리 완료 건수
+            todayCompletedApprovalCount:
+              type: integer
+              format: int64
+              description: 오늘 개설 승인/반려 처리 완료 건수
+            hasOrderOver48h:
+              type: boolean
+              description: 48시간 초과 발주 미확정 경고 노출 여부
         error: { nullable: true, example: null }
 
     ApiResponseAdminRequestPage:

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
@@ -1,0 +1,135 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class AdminDashboardSummaryServiceTest {
+
+    private val groupBuyRequestRepository: GroupBuyRequestRepository = mock(GroupBuyRequestRepository::class.java)
+    private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository =
+        mock(GroupBuyRequestStatusHistoryRepository::class.java)
+    private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val service = AdminDashboardSummaryService(
+        groupBuyRequestRepository = groupBuyRequestRepository,
+        groupBuyRequestStatusHistoryRepository = groupBuyRequestStatusHistoryRepository,
+        participationRepository = participationRepository,
+        clock = clock
+    )
+
+    @Test
+    fun `운영 관리 요약을 현재 도메인 기준으로 집계한다`() {
+        val todayStart = LocalDateTime.of(2026, 5, 27, 0, 0)
+        val tomorrowStart = LocalDateTime.of(2026, 5, 28, 0, 0)
+        val yesterdayStart = LocalDateTime.of(2026, 5, 26, 0, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val pendingStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
+        val completedStatuses = listOf(GroupBuyRequestStatus.OPENED, GroupBuyRequestStatus.REJECTED)
+
+        `when`(participationRepository.sumPaymentOrderAmountByStatus(ParticipationStatus.REFUND_PENDING))
+            .thenReturn(30_000L)
+        `when`(
+            participationRepository.sumPaymentOrderAmountByStatusAndCancelledAtBetween(
+                ParticipationStatus.REFUND_PENDING,
+                todayStart,
+                tomorrowStart
+            )
+        ).thenReturn(15_000L)
+        `when`(
+            participationRepository.sumPaymentOrderAmountByStatusAndCancelledAtBetween(
+                ParticipationStatus.REFUND_PENDING,
+                yesterdayStart,
+                todayStart
+            )
+        ).thenReturn(10_000L)
+        `when`(groupBuyRequestRepository.findCreatedAtByStatusIn(pendingStatuses))
+            .thenReturn(listOf(now.minusMinutes(30), now.minusMinutes(90)))
+        `when`(groupBuyRequestRepository.countByStatusIn(pendingStatuses)).thenReturn(4L)
+        `when`(groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(pendingStatuses, todayStart, tomorrowStart))
+            .thenReturn(3L)
+        `when`(groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(pendingStatuses, yesterdayStart, todayStart))
+            .thenReturn(2L)
+        `when`(
+            participationRepository.countByStatusAndRefundedAtBetween(
+                ParticipationStatus.REFUNDED,
+                todayStart,
+                tomorrowStart
+            )
+        ).thenReturn(5L)
+        `when`(
+            groupBuyRequestStatusHistoryRepository.countByStatusInAndChangedAtBetween(
+                completedStatuses,
+                todayStart,
+                tomorrowStart
+            )
+        ).thenReturn(6L)
+
+        val result = service.getSummary()
+
+        assertEquals(30_000L, result.pendingRefundAmount)
+        assertEquals(50.0, result.pendingRefundAmountChangeRate)
+        assertEquals(4L, result.pendingApprovalCount)
+        assertEquals(60L, result.averageReviewMinutes)
+        assertEquals(50.0, result.pendingApprovalChangeRate)
+        assertEquals(0L, result.unconfirmedOrderCount)
+        assertEquals(0L, result.unconfirmedOrderOver48hCount)
+        assertEquals(5L, result.todayCompletedRefundCount)
+        assertEquals(6L, result.todayCompletedApprovalCount)
+        assertFalse(result.hasOrderOver48h)
+    }
+
+    @Test
+    fun `전일 값이 없으면 현재 값 존재 여부에 따라 증감률을 반환한다`() {
+        val todayStart = LocalDateTime.of(2026, 5, 27, 0, 0)
+        val tomorrowStart = LocalDateTime.of(2026, 5, 28, 0, 0)
+        val yesterdayStart = LocalDateTime.of(2026, 5, 26, 0, 0)
+        val pendingStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
+
+        `when`(participationRepository.sumPaymentOrderAmountByStatus(ParticipationStatus.REFUND_PENDING))
+            .thenReturn(0L)
+        `when`(
+            participationRepository.sumPaymentOrderAmountByStatusAndCancelledAtBetween(
+                ParticipationStatus.REFUND_PENDING,
+                todayStart,
+                tomorrowStart
+            )
+        ).thenReturn(1_000L)
+        `when`(
+            participationRepository.sumPaymentOrderAmountByStatusAndCancelledAtBetween(
+                ParticipationStatus.REFUND_PENDING,
+                yesterdayStart,
+                todayStart
+            )
+        ).thenReturn(0L)
+        `when`(groupBuyRequestRepository.findCreatedAtByStatusIn(pendingStatuses)).thenReturn(emptyList())
+        `when`(groupBuyRequestRepository.countByStatusIn(pendingStatuses)).thenReturn(0L)
+        `when`(groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(pendingStatuses, todayStart, tomorrowStart))
+            .thenReturn(0L)
+        `when`(groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(pendingStatuses, yesterdayStart, todayStart))
+            .thenReturn(0L)
+
+        val result = service.getSummary()
+
+        assertEquals(100.0, result.pendingRefundAmountChangeRate)
+        assertEquals(0.0, result.pendingApprovalChangeRate)
+        assertEquals(0L, result.averageReviewMinutes)
+        verify(participationRepository).countByStatusAndRefundedAtBetween(
+            ParticipationStatus.REFUNDED,
+            todayStart,
+            tomorrowStart
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
@@ -63,14 +63,14 @@ class AdminDashboardSummaryServiceTest {
         `when`(groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(pendingStatuses, yesterdayStart, todayStart))
             .thenReturn(2L)
         `when`(
-            participationRepository.countByStatusAndRefundedAtBetween(
+            participationRepository.countByStatusAndRefundedAtFromUntil(
                 ParticipationStatus.REFUNDED,
                 todayStart,
                 tomorrowStart
             )
         ).thenReturn(5L)
         `when`(
-            groupBuyRequestStatusHistoryRepository.countByStatusInAndChangedAtBetween(
+            groupBuyRequestStatusHistoryRepository.countByStatusInAndChangedAtFromUntil(
                 completedStatuses,
                 todayStart,
                 tomorrowStart
@@ -126,7 +126,7 @@ class AdminDashboardSummaryServiceTest {
         assertEquals(100.0, result.pendingRefundAmountChangeRate)
         assertEquals(0.0, result.pendingApprovalChangeRate)
         assertEquals(0L, result.averageReviewMinutes)
-        verify(participationRepository).countByStatusAndRefundedAtBetween(
+        verify(participationRepository).countByStatusAndRefundedAtFromUntil(
             ParticipationStatus.REFUNDED,
             todayStart,
             tomorrowStart

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardControllerTest.kt
@@ -1,0 +1,37 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminDashboardSummaryService
+import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class AdminDashboardControllerTest {
+
+    private val adminDashboardSummaryService: AdminDashboardSummaryService = mock(AdminDashboardSummaryService::class.java)
+    private val controller = AdminDashboardController(adminDashboardSummaryService)
+
+    @Test
+    fun `운영자 대시보드 요약 조회는 서비스 결과를 반환한다`() {
+        val response = AdminDashboardSummaryResponse(
+            pendingRefundAmount = 10_000L,
+            pendingRefundAmountChangeRate = 10.0,
+            pendingApprovalCount = 3L,
+            averageReviewMinutes = 45L,
+            pendingApprovalChangeRate = -20.0,
+            unconfirmedOrderCount = 0L,
+            unconfirmedOrderOver48hCount = 0L,
+            todayCompletedRefundCount = 2L,
+            todayCompletedApprovalCount = 4L,
+            hasOrderOver48h = false
+        )
+        `when`(adminDashboardSummaryService.getSummary()).thenReturn(response)
+
+        val result = controller.getSummary()
+
+        assertEquals(response, result.body?.data)
+        verify(adminDashboardSummaryService).getSummary()
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- `GET /api/v1/admin/summary` 운영자 대시보드 운영 관리 요약 API를 추가했습니다.
- 검토 대기 환불 금액과 전일 대비 증감률을 `REFUND_PENDING` 참여 및 결제 주문 금액 기준으로 집계합니다.
- 개설승인 대기 건수, 평균 검토 시간, 전일 대비 증감률을 공구 개설 요청 상태/생성일 기준으로 집계합니다.
- 오늘 환불 처리 완료 건수와 오늘 개설 승인/반려 처리 완료 건수를 집계합니다.
- 발주 미확정 항목은 발주 도메인 구현 전까지 `0`/`false`로 반환하도록 명시했습니다.
- 서비스/컨트롤러 테스트를 추가하고 OpenAPI 스펙을 명세서 기준으로 갱신했습니다.

## 🔍 참고 사항
- 현재 코드에는 발주 확정 상태, 사장님 컨택 기록 도메인이 없어 발주 미확정/48시간 초과는 후속 발주 관리 PR에서 실제 집계로 전환할 예정입니다.
- 환불 요청 전용 도메인이 없어 환불 요청 시각은 `Participation.cancelledAt`, 환불 금액은 `PaymentOrder.totalAmount` 기준으로 산출합니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- Closes #239

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인