### PR TITLE
[MCJ-1549] FEAT: 어드민 발주 관리 상태 기반 목록 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
@@ -2,6 +2,9 @@ package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -18,6 +21,7 @@ import java.time.LocalDateTime
 class AdminDashboardSummaryService(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
     private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository,
+    private val groupBuyRepository: GroupBuyRepository,
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
@@ -29,6 +33,12 @@ class AdminDashboardSummaryService(
         val yesterdayRange = today.minusDays(1).toRange()
         val pendingApprovalStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
         val completedApprovalStatuses = listOf(GroupBuyRequestStatus.OPENED, GroupBuyRequestStatus.REJECTED)
+        val orderOverdueBefore = now.minusHours(48)
+        val unconfirmedOrderOver48hCount = groupBuyRepository.countOverdueAdminOrders(
+            status = GroupBuyStatus.ACHIEVED,
+            orderStatus = GroupBuyOrderStatus.PENDING,
+            overdueBefore = orderOverdueBefore
+        )
 
         val pendingRefundAmount = participationRepository.sumPaymentOrderAmountByStatus(ParticipationStatus.REFUND_PENDING)
         val todayPendingRefundAmount = participationRepository.sumPaymentOrderAmountByStatusAndCancelledAtBetween(
@@ -60,8 +70,11 @@ class AdminDashboardSummaryService(
                     to = yesterdayRange.end
                 )
             ),
-            unconfirmedOrderCount = 0,
-            unconfirmedOrderOver48hCount = 0,
+            unconfirmedOrderCount = groupBuyRepository.countByStatusAndOrderStatus(
+                status = GroupBuyStatus.ACHIEVED,
+                orderStatus = GroupBuyOrderStatus.PENDING
+            ),
+            unconfirmedOrderOver48hCount = unconfirmedOrderOver48hCount,
             todayCompletedRefundCount = participationRepository.countByStatusAndRefundedAtFromUntil(
                 status = ParticipationStatus.REFUNDED,
                 from = todayRange.start,
@@ -72,7 +85,7 @@ class AdminDashboardSummaryService(
                 from = todayRange.start,
                 to = todayRange.end
             ),
-            hasOrderOver48h = false
+            hasOrderOver48h = unconfirmedOrderOver48hCount > 0
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -1,0 +1,60 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.AdminOrderPageResponse
+import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class AdminOrderService(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val participationRepository: ParticipationRepository,
+    private val clock: Clock,
+) {
+
+    fun getOrders(
+        status: AdminOrderStatusFilter,
+        pageable: Pageable
+    ): AdminOrderPageResponse {
+        val now = LocalDateTime.now(clock)
+        val page = groupBuyRepository.findAdminOrderPage(
+            groupBuyStatus = GroupBuyStatus.ACHIEVED,
+            orderStatuses = status.toOrderStatuses(),
+            overdueBefore = status.overdueBefore(now),
+            pageable = pageable
+        )
+        val groupBuyIds = page.content.map { it.id }
+        val pendingRefundCountsByGroupBuyId = if (groupBuyIds.isEmpty()) {
+            emptyMap()
+        } else {
+            participationRepository.countPendingRefundsByGroupBuyIdIn(groupBuyIds)
+                .associate { it.groupBuyId to it.pendingRefundCount }
+        }
+
+        return AdminOrderPageResponse.from(page, pendingRefundCountsByGroupBuyId, now)
+    }
+
+    private fun AdminOrderStatusFilter.toOrderStatuses(): List<GroupBuyOrderStatus> =
+        when (this) {
+            AdminOrderStatusFilter.OVERDUE_48H,
+            AdminOrderStatusFilter.PENDING -> listOf(GroupBuyOrderStatus.PENDING)
+            AdminOrderStatusFilter.CONFIRMED -> listOf(GroupBuyOrderStatus.CONFIRMED)
+            AdminOrderStatusFilter.ALL -> GroupBuyOrderStatus.entries
+        }
+
+    private fun AdminOrderStatusFilter.overdueBefore(now: LocalDateTime): LocalDateTime? =
+        when (this) {
+            AdminOrderStatusFilter.OVERDUE_48H -> now.minusHours(48)
+            AdminOrderStatusFilter.PENDING,
+            AdminOrderStatusFilter.CONFIRMED,
+            AdminOrderStatusFilter.ALL -> null
+        }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
@@ -1,0 +1,98 @@
+package com.moongchijang.domain.admin.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import org.springframework.data.domain.Page
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+enum class AdminOrderStatusFilter {
+    OVERDUE_48H,
+    PENDING,
+    CONFIRMED,
+    ALL
+}
+
+data class AdminOrderPageResponse(
+    val content: List<AdminOrderListItemResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int,
+) {
+    companion object {
+        fun from(
+            page: Page<GroupBuy>,
+            pendingRefundCountsByGroupBuyId: Map<Long, Long>,
+            now: LocalDateTime,
+        ): AdminOrderPageResponse =
+            AdminOrderPageResponse(
+                content = page.content.map {
+                    AdminOrderListItemResponse.from(
+                        groupBuy = it,
+                        pendingRefundCount = pendingRefundCountsByGroupBuyId[it.id] ?: 0L,
+                        now = now
+                    )
+                },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                number = page.number,
+                size = page.size
+            )
+    }
+}
+
+data class AdminOrderListItemResponse(
+    val orderId: Long,
+    val groupBuyId: Long,
+    val productName: String,
+    val storeName: String,
+    val achievedAt: LocalDateTime?,
+    val finalQuantity: Int,
+    val pendingRefundCount: Long,
+    val pickupDate: LocalDate,
+    val elapsedHours: Long,
+    val progressRate: Int,
+    val orderStatus: GroupBuyOrderStatus,
+    val ownerContactedAt: LocalDateTime?,
+    val orderConfirmedAt: LocalDateTime?,
+    val actionable: Boolean,
+) {
+    companion object {
+        fun from(
+            groupBuy: GroupBuy,
+            pendingRefundCount: Long,
+            now: LocalDateTime
+        ): AdminOrderListItemResponse {
+            val achievedAt = groupBuy.orderAchievedAt()
+            return AdminOrderListItemResponse(
+                orderId = groupBuy.id,
+                groupBuyId = groupBuy.id,
+                productName = groupBuy.productName,
+                storeName = groupBuy.store.name,
+                achievedAt = achievedAt,
+                finalQuantity = groupBuy.currentQuantity,
+                pendingRefundCount = pendingRefundCount,
+                pickupDate = groupBuy.pickupDate,
+                elapsedHours = achievedAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
+                progressRate = achievementRate(groupBuy),
+                orderStatus = groupBuy.orderStatus,
+                ownerContactedAt = groupBuy.orderOwnerContactedAt,
+                orderConfirmedAt = groupBuy.orderConfirmedAt,
+                actionable = groupBuy.orderStatus == GroupBuyOrderStatus.PENDING
+            )
+        }
+
+        private fun achievementRate(groupBuy: GroupBuy): Int {
+            if (groupBuy.targetQuantity <= 0) {
+                return 0
+            }
+
+            return groupBuy.currentQuantity * 100 / groupBuy.targetQuantity
+        }
+    }
+}
+
+fun GroupBuy.orderAchievedAt(): LocalDateTime? =
+    achievedAt ?: updatedAt ?: createdAt

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
@@ -1,0 +1,30 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminOrderService
+import com.moongchijang.domain.admin.application.dto.AdminOrderPageResponse
+import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Pageable
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/orders")
+@Tag(name = "Admin", description = "운영자 관리")
+class AdminOrderController(
+    private val adminOrderService: AdminOrderService,
+) {
+
+    @GetMapping
+    @Operation(summary = "운영자 발주 관리 목록 조회")
+    fun getOrders(
+        @RequestParam(defaultValue = "ALL") status: AdminOrderStatusFilter,
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<AdminOrderPageResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrders(status, pageable)))
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -88,15 +88,51 @@ class GroupBuy(
     @Column(name = "closed_by_type", length = 20)
     var closedByType: GroupBuyClosedByType? = null,
 
+    @Column(name = "achieved_at")
+    var achievedAt: LocalDateTime? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status", nullable = false, length = 30)
+    var orderStatus: GroupBuyOrderStatus = GroupBuyOrderStatus.PENDING,
+
+    @Column(name = "order_owner_contacted_at")
+    var orderOwnerContactedAt: LocalDateTime? = null,
+
+    @Column(name = "order_confirmed_at")
+    var orderConfirmedAt: LocalDateTime? = null,
+
+    @Column(name = "order_cancelled_at")
+    var orderCancelledAt: LocalDateTime? = null,
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 
 ) : BaseEntity()
 {
-    fun transitionToAchieved() {
+    fun transitionToAchieved(achievedAt: LocalDateTime = LocalDateTime.now()) {
         requireStatus(GroupBuyStatus.IN_PROGRESS)
         status = GroupBuyStatus.ACHIEVED
+        this.achievedAt = achievedAt
+    }
+
+    fun markOrderOwnerContacted(contactedAt: LocalDateTime = LocalDateTime.now()) {
+        requireStatus(GroupBuyStatus.ACHIEVED)
+        orderOwnerContactedAt = contactedAt
+    }
+
+    fun confirmOrder(confirmedAt: LocalDateTime = LocalDateTime.now()) {
+        requireStatus(GroupBuyStatus.ACHIEVED)
+        orderStatus = GroupBuyOrderStatus.CONFIRMED
+        orderConfirmedAt = confirmedAt
+        orderCancelledAt = null
+    }
+
+    fun cancelOrder(cancelledAt: LocalDateTime = LocalDateTime.now()) {
+        requireStatus(GroupBuyStatus.ACHIEVED)
+        orderStatus = GroupBuyOrderStatus.CANCELLED
+        orderCancelledAt = cancelledAt
+        orderConfirmedAt = null
     }
 
     fun transitionToCompletedByDeadline(now: LocalDateTime) {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOrderStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOrderStatus.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.groupbuy.domain.entity
+
+enum class GroupBuyOrderStatus {
+    PENDING,
+    CONFIRMED,
+    CANCELLED
+}

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -1,7 +1,9 @@
 package com.moongchijang.domain.groupbuy.domain.repository
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import org.springframework.data.domain.Page
 import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
@@ -27,6 +29,51 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
         deadlineFrom: LocalDateTime,
         deadlineTo: LocalDateTime
     ): List<GroupBuy>
+
+    @Query(
+        value = """
+            select gb
+            from GroupBuy gb
+            join fetch gb.store
+            where gb.status = :groupBuyStatus
+              and gb.orderStatus in :orderStatuses
+              and (:overdueBefore is null or coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) < :overdueBefore)
+            order by coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) asc, gb.id asc
+        """,
+        countQuery = """
+            select count(gb)
+            from GroupBuy gb
+            where gb.status = :groupBuyStatus
+              and gb.orderStatus in :orderStatuses
+              and (:overdueBefore is null or coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) < :overdueBefore)
+        """
+    )
+    fun findAdminOrderPage(
+        @Param("groupBuyStatus") groupBuyStatus: GroupBuyStatus,
+        @Param("orderStatuses") orderStatuses: Collection<GroupBuyOrderStatus>,
+        @Param("overdueBefore") overdueBefore: LocalDateTime?,
+        pageable: Pageable
+    ): Page<GroupBuy>
+
+    fun countByStatusAndOrderStatus(
+        status: GroupBuyStatus,
+        orderStatus: GroupBuyOrderStatus
+    ): Long
+
+    @Query(
+        """
+        select count(gb)
+        from GroupBuy gb
+        where gb.status = :status
+          and gb.orderStatus = :orderStatus
+          and coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) < :overdueBefore
+        """
+    )
+    fun countOverdueAdminOrders(
+        @Param("status") status: GroupBuyStatus,
+        @Param("orderStatus") orderStatus: GroupBuyOrderStatus,
+        @Param("overdueBefore") overdueBefore: LocalDateTime
+    ): Long
 
     @EntityGraph(attributePaths = ["store"])
     fun findWithStoreById(id: Long): Optional<GroupBuy>

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -37,15 +37,15 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
             join fetch gb.store
             where gb.status = :groupBuyStatus
               and gb.orderStatus in :orderStatuses
-              and (:overdueBefore is null or coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) < :overdueBefore)
-            order by coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) asc, gb.id asc
+              and (:overdueBefore is null or gb.achievedAt < :overdueBefore)
+            order by gb.achievedAt asc, gb.id asc
         """,
         countQuery = """
             select count(gb)
             from GroupBuy gb
             where gb.status = :groupBuyStatus
               and gb.orderStatus in :orderStatuses
-              and (:overdueBefore is null or coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) < :overdueBefore)
+              and (:overdueBefore is null or gb.achievedAt < :overdueBefore)
         """
     )
     fun findAdminOrderPage(
@@ -66,7 +66,7 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
         from GroupBuy gb
         where gb.status = :status
           and gb.orderStatus = :orderStatus
-          and coalesce(gb.achievedAt, gb.updatedAt, gb.createdAt) < :overdueBefore
+          and gb.achievedAt < :overdueBefore
         """
     )
     fun countOverdueAdminOrders(

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -320,6 +320,21 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 
     @Query(
         """
+        select p.groupBuy.id as groupBuyId,
+               count(p) as pendingRefundCount
+        from Participation p
+        where p.groupBuy.id in :groupBuyIds
+          and p.status = :status
+        group by p.groupBuy.id
+        """
+    )
+    fun countPendingRefundsByGroupBuyIdIn(
+        @Param("groupBuyIds") groupBuyIds: Collection<Long>,
+        @Param("status") status: ParticipationStatus = ParticipationStatus.REFUND_PENDING
+    ): List<GroupBuyPendingRefundCount>
+
+    @Query(
+        """
         select coalesce(sum(p.totalAmount), 0)
         from Participation p
         join p.groupBuy gb
@@ -409,4 +424,9 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Participation p join fetch p.groupBuy where p.id = :id")
     fun findByIdForUpdate(@Param("id") id: Long): Optional<Participation>
+}
+
+interface GroupBuyPendingRefundCount {
+    val groupBuyId: Long
+    val pendingRefundCount: Long
 }

--- a/src/main/resources/db/migration/V34__alter_group_buys_add_order_management_fields.sql
+++ b/src/main/resources/db/migration/V34__alter_group_buys_add_order_management_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE group_buys
+    ADD COLUMN achieved_at DATETIME NULL AFTER closed_by_type,
+    ADD COLUMN order_status VARCHAR(30) NOT NULL DEFAULT 'PENDING' AFTER achieved_at,
+    ADD COLUMN order_owner_contacted_at DATETIME NULL AFTER order_status,
+    ADD COLUMN order_confirmed_at DATETIME NULL AFTER order_owner_contacted_at,
+    ADD COLUMN order_cancelled_at DATETIME NULL AFTER order_confirmed_at;

--- a/src/main/resources/db/migration/V34__alter_group_buys_add_order_management_fields.sql
+++ b/src/main/resources/db/migration/V34__alter_group_buys_add_order_management_fields.sql
@@ -4,3 +4,11 @@ ALTER TABLE group_buys
     ADD COLUMN order_owner_contacted_at DATETIME NULL AFTER order_status,
     ADD COLUMN order_confirmed_at DATETIME NULL AFTER order_owner_contacted_at,
     ADD COLUMN order_cancelled_at DATETIME NULL AFTER order_confirmed_at;
+
+UPDATE group_buys
+SET achieved_at = COALESCE(updated_at, created_at)
+WHERE status = 'ACHIEVED'
+  AND achieved_at IS NULL;
+
+CREATE INDEX idx_group_buys_order_lookup
+    ON group_buys (status, order_status, achieved_at);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1256,6 +1256,33 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/admin/orders:
+    get:
+      tags: [Admin]
+      summary: 발주 관리 목록 조회 (운영자)
+      description: 달성된 공구의 발주 확정 대기, 48시간 초과, 확정 완료, 전체 목록을 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [OVERDUE_48H, PENDING, CONFIRMED, ALL]
+            default: ALL
+          description: OVERDUE_48H=48시간 초과, PENDING=확정 대기, CONFIRMED=확정 완료, ALL=전체
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 발주 관리 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOrderPage'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/group-buys/{groupBuyId}/checkout:
     get:
       tags: [Participation]
@@ -5061,11 +5088,11 @@ components:
             unconfirmedOrderCount:
               type: integer
               format: int64
-              description: 발주 미확정 건수. 발주 도메인 구현 전까지 0 반환
+              description: 달성된 공구 중 발주 확정 대기 건수
             unconfirmedOrderOver48hCount:
               type: integer
               format: int64
-              description: 발주 미확정 48시간 초과 건수. 발주 도메인 구현 전까지 0 반환
+              description: 달성 후 48시간을 초과한 발주 확정 대기 건수
             todayCompletedRefundCount:
               type: integer
               format: int64
@@ -5078,6 +5105,71 @@ components:
               type: boolean
               description: 48시간 초과 발주 미확정 경고 노출 여부
         error: { nullable: true, example: null }
+
+    ApiResponseAdminOrderPage:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [content, totalElements, totalPages, number, size]
+          properties:
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/AdminOrderListItem'
+            totalElements: { type: integer, format: int64 }
+            totalPages: { type: integer }
+            number: { type: integer }
+            size: { type: integer }
+        error: { nullable: true, example: null }
+
+    AdminOrderListItem:
+      type: object
+      required: [orderId, groupBuyId, productName, storeName, finalQuantity, pendingRefundCount, pickupDate, elapsedHours, progressRate, orderStatus, actionable]
+      properties:
+        orderId:
+          type: integer
+          format: int64
+          description: 발주 관리 식별자. 현재는 groupBuyId와 동일
+        groupBuyId: { type: integer, format: int64 }
+        productName: { type: string }
+        storeName: { type: string }
+        achievedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: 공구 달성 일시
+        finalQuantity:
+          type: integer
+          description: 최종 참여 수량
+        pendingRefundCount:
+          type: integer
+          format: int64
+          description: 해당 공구의 환불 대기 건수
+        pickupDate: { type: string, format: date }
+        elapsedHours:
+          type: integer
+          format: int64
+          description: 달성 후 경과 시간
+        progressRate:
+          type: integer
+          description: 목표 수량 대비 달성률(%)
+        orderStatus:
+          type: string
+          enum: [PENDING, CONFIRMED, CANCELLED]
+        ownerContactedAt:
+          type: string
+          format: date-time
+          nullable: true
+        orderConfirmedAt:
+          type: string
+          format: date-time
+          nullable: true
+        actionable:
+          type: boolean
+          description: 발주 확정/연락 등 운영 작업 가능 여부
 
     ApiResponseAdminRequestPage:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
@@ -1,12 +1,15 @@
 package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
@@ -21,11 +24,13 @@ class AdminDashboardSummaryServiceTest {
     private val groupBuyRequestRepository: GroupBuyRequestRepository = mock(GroupBuyRequestRepository::class.java)
     private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository =
         mock(GroupBuyRequestStatusHistoryRepository::class.java)
+    private val groupBuyRepository: GroupBuyRepository = mock(GroupBuyRepository::class.java)
     private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
     private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneId.of("Asia/Seoul"))
     private val service = AdminDashboardSummaryService(
         groupBuyRequestRepository = groupBuyRequestRepository,
         groupBuyRequestStatusHistoryRepository = groupBuyRequestStatusHistoryRepository,
+        groupBuyRepository = groupBuyRepository,
         participationRepository = participationRepository,
         clock = clock
     )
@@ -38,7 +43,15 @@ class AdminDashboardSummaryServiceTest {
         val now = LocalDateTime.of(2026, 5, 27, 13, 0)
         val pendingStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
         val completedStatuses = listOf(GroupBuyRequestStatus.OPENED, GroupBuyRequestStatus.REJECTED)
+        val orderOverdueBefore = LocalDateTime.of(2026, 5, 25, 13, 0)
 
+        `when`(
+            groupBuyRepository.countOverdueAdminOrders(
+                GroupBuyStatus.ACHIEVED,
+                GroupBuyOrderStatus.PENDING,
+                orderOverdueBefore
+            )
+        ).thenReturn(2L)
         `when`(participationRepository.sumPaymentOrderAmountByStatus(ParticipationStatus.REFUND_PENDING))
             .thenReturn(30_000L)
         `when`(
@@ -58,6 +71,8 @@ class AdminDashboardSummaryServiceTest {
         `when`(groupBuyRequestRepository.findCreatedAtByStatusIn(pendingStatuses))
             .thenReturn(listOf(now.minusMinutes(30), now.minusMinutes(90)))
         `when`(groupBuyRequestRepository.countByStatusIn(pendingStatuses)).thenReturn(4L)
+        `when`(groupBuyRepository.countByStatusAndOrderStatus(GroupBuyStatus.ACHIEVED, GroupBuyOrderStatus.PENDING))
+            .thenReturn(7L)
         `when`(groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(pendingStatuses, todayStart, tomorrowStart))
             .thenReturn(3L)
         `when`(groupBuyRequestRepository.countByStatusInAndCreatedAtBetween(pendingStatuses, yesterdayStart, todayStart))
@@ -84,11 +99,11 @@ class AdminDashboardSummaryServiceTest {
         assertEquals(4L, result.pendingApprovalCount)
         assertEquals(60L, result.averageReviewMinutes)
         assertEquals(50.0, result.pendingApprovalChangeRate)
-        assertEquals(0L, result.unconfirmedOrderCount)
-        assertEquals(0L, result.unconfirmedOrderOver48hCount)
+        assertEquals(7L, result.unconfirmedOrderCount)
+        assertEquals(2L, result.unconfirmedOrderOver48hCount)
         assertEquals(5L, result.todayCompletedRefundCount)
         assertEquals(6L, result.todayCompletedApprovalCount)
-        assertFalse(result.hasOrderOver48h)
+        assertTrue(result.hasOrderOver48h)
     }
 
     @Test
@@ -97,7 +112,15 @@ class AdminDashboardSummaryServiceTest {
         val tomorrowStart = LocalDateTime.of(2026, 5, 28, 0, 0)
         val yesterdayStart = LocalDateTime.of(2026, 5, 26, 0, 0)
         val pendingStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
+        val orderOverdueBefore = LocalDateTime.of(2026, 5, 25, 13, 0)
 
+        `when`(
+            groupBuyRepository.countOverdueAdminOrders(
+                GroupBuyStatus.ACHIEVED,
+                GroupBuyOrderStatus.PENDING,
+                orderOverdueBefore
+            )
+        ).thenReturn(0L)
         `when`(participationRepository.sumPaymentOrderAmountByStatus(ParticipationStatus.REFUND_PENDING))
             .thenReturn(0L)
         `when`(

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
@@ -1,0 +1,101 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.repository.GroupBuyPendingRefundCount
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.support.GroupBuyFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class AdminOrderServiceTest {
+
+    private val groupBuyRepository: GroupBuyRepository = mock(GroupBuyRepository::class.java)
+    private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val service = AdminOrderService(
+        groupBuyRepository = groupBuyRepository,
+        participationRepository = participationRepository,
+        clock = clock
+    )
+
+    @Test
+    fun `48시간 초과 발주 목록을 조회한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val achievedAt = now.minusHours(50)
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 30L,
+            status = GroupBuyStatus.ACHIEVED,
+            targetQuantity = 20,
+            currentQuantity = 20
+        ).apply {
+            this.achievedAt = achievedAt
+            orderStatus = GroupBuyOrderStatus.PENDING
+        }
+        val pendingRefundCount = pendingRefundCount(groupBuyId = 30L, count = 2L)
+
+        `when`(
+            groupBuyRepository.findAdminOrderPage(
+                GroupBuyStatus.ACHIEVED,
+                listOf(GroupBuyOrderStatus.PENDING),
+                now.minusHours(48),
+                pageable
+            )
+        ).thenReturn(PageImpl(listOf(groupBuy), pageable, 1))
+        `when`(participationRepository.countPendingRefundsByGroupBuyIdIn(listOf(30L)))
+            .thenReturn(listOf(pendingRefundCount))
+
+        val result = service.getOrders(AdminOrderStatusFilter.OVERDUE_48H, pageable)
+
+        assertEquals(1, result.content.size)
+        assertEquals(30L, result.content[0].orderId)
+        assertEquals("두쫀쿠 1개", result.content[0].productName)
+        assertEquals(achievedAt, result.content[0].achievedAt)
+        assertEquals(20, result.content[0].finalQuantity)
+        assertEquals(2L, result.content[0].pendingRefundCount)
+        assertEquals(50L, result.content[0].elapsedHours)
+        assertEquals(100, result.content[0].progressRate)
+        assertEquals(GroupBuyOrderStatus.PENDING, result.content[0].orderStatus)
+        assertTrue(result.content[0].actionable)
+    }
+
+    @Test
+    fun `목록이 비어있으면 환불 대기 집계를 생략한다`() {
+        val pageable = PageRequest.of(0, 20)
+        `when`(
+            groupBuyRepository.findAdminOrderPage(
+                GroupBuyStatus.ACHIEVED,
+                GroupBuyOrderStatus.entries,
+                null,
+                pageable
+            )
+        ).thenReturn(PageImpl(emptyList(), pageable, 0))
+
+        val result = service.getOrders(AdminOrderStatusFilter.ALL, pageable)
+
+        assertTrue(result.content.isEmpty())
+        verifyNoInteractions(participationRepository)
+    }
+
+    private fun pendingRefundCount(
+        groupBuyId: Long,
+        count: Long
+    ): GroupBuyPendingRefundCount =
+        object : GroupBuyPendingRefundCount {
+            override val groupBuyId: Long = groupBuyId
+            override val pendingRefundCount: Long = count
+        }
+}

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderControllerTest.kt
@@ -1,0 +1,35 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminOrderService
+import com.moongchijang.domain.admin.application.dto.AdminOrderPageResponse
+import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageRequest
+
+class AdminOrderControllerTest {
+
+    private val adminOrderService: AdminOrderService = mock(AdminOrderService::class.java)
+    private val controller = AdminOrderController(adminOrderService)
+
+    @Test
+    fun `운영자 발주 목록 조회는 상태 필터와 페이징을 서비스로 전달한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val response = AdminOrderPageResponse(
+            content = emptyList(),
+            totalElements = 0,
+            totalPages = 0,
+            number = 0,
+            size = 20
+        )
+        `when`(adminOrderService.getOrders(AdminOrderStatusFilter.PENDING, pageable)).thenReturn(response)
+
+        val result = controller.getOrders(AdminOrderStatusFilter.PENDING, pageable)
+
+        assertEquals(response, result.body?.data)
+        verify(adminOrderService).getOrders(AdminOrderStatusFilter.PENDING, pageable)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 달성된 공구의 발주 상태 필드와 달성 일시를 추가했습니다.
- GET /api/v1/admin/orders 목록 조회 API를 추가했습니다.
- 발주 확정 대기/48시간 초과/확정 완료/전체 필터와 환불 대기 건수, 경과 시간, 진행률을 응답합니다.
- 대시보드 발주 미확정/48시간 초과 요약이 실제 발주 상태를 기준으로 집계되도록 연결했습니다.
- 관련 테스트와 OpenAPI 스펙을 함께 추가했습니다.

## 🔍 참고 사항
- 이번 PR은 발주 관리의 목록/상태 기반 조회까지 구현합니다. 상세 조회, 사장님 연락 기록, 발주 확정/취소 액션은 후속 PR에서 진행합니다.
- 이전 admin PR 범위도 같이 확인했습니다. 공구 개설 요청 목록/상세/액션과 대시보드 요약은 현재 openapi.yaml에 반영되어 있고, 이번 변경으로 발주 목록 API도 문서와 맞췄습니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closes #245

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인