### PR TITLE
[MCJ-1550] FEAT: 어드민 발주 관리 상세 및 처리 액션 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -51,7 +51,6 @@ class AdminOrderService(
         val now = LocalDateTime.now(clock)
         val groupBuy = groupBuyRepository.findAdminOrderDetailById(orderId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
-        validateAdminOrder(groupBuy)
 
         return AdminOrderDetailResponse.from(
             groupBuy = groupBuy,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -1,11 +1,16 @@
 package com.moongchijang.domain.admin.application
 
+import com.moongchijang.domain.admin.application.dto.AdminOrderDetailResponse
 import com.moongchijang.domain.admin.application.dto.AdminOrderPageResponse
 import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -41,6 +46,74 @@ class AdminOrderService(
 
         return AdminOrderPageResponse.from(page, pendingRefundCountsByGroupBuyId, now)
     }
+
+    fun getOrderDetail(orderId: Long): AdminOrderDetailResponse {
+        val now = LocalDateTime.now(clock)
+        val groupBuy = groupBuyRepository.findAdminOrderDetailById(orderId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+        validateAdminOrder(groupBuy)
+
+        return AdminOrderDetailResponse.from(
+            groupBuy = groupBuy,
+            pendingRefundCount = countPendingRefunds(groupBuy.id),
+            now = now
+        )
+    }
+
+    @Transactional
+    fun markOwnerContacted(orderId: Long): AdminOrderDetailResponse {
+        val now = LocalDateTime.now(clock)
+        val groupBuy = findOrderForUpdate(orderId)
+        validatePendingOrder(groupBuy)
+        groupBuy.markOrderOwnerContacted(now)
+
+        return AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+    }
+
+    @Transactional
+    fun confirmOrder(orderId: Long): AdminOrderDetailResponse {
+        val now = LocalDateTime.now(clock)
+        val groupBuy = findOrderForUpdate(orderId)
+        validatePendingOrder(groupBuy)
+        groupBuy.confirmOrder(now)
+
+        return AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+    }
+
+    @Transactional
+    fun cancelOrder(orderId: Long): AdminOrderDetailResponse {
+        val now = LocalDateTime.now(clock)
+        val groupBuy = findOrderForUpdate(orderId)
+        validatePendingOrder(groupBuy)
+        groupBuy.cancelOrder(now)
+
+        return AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+    }
+
+    private fun findOrderForUpdate(orderId: Long): GroupBuy {
+        val groupBuy = groupBuyRepository.findWithLockById(orderId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+        validateAdminOrder(groupBuy)
+        return groupBuy
+    }
+
+    private fun validateAdminOrder(groupBuy: GroupBuy) {
+        if (groupBuy.status != GroupBuyStatus.ACHIEVED) {
+            throw CustomException(ErrorCode.GROUPBUY_ORDER_INVALID_STATUS, "groupBuyStatus=${groupBuy.status}")
+        }
+    }
+
+    private fun validatePendingOrder(groupBuy: GroupBuy) {
+        if (groupBuy.orderStatus != GroupBuyOrderStatus.PENDING) {
+            throw CustomException(ErrorCode.GROUPBUY_ORDER_INVALID_STATUS, "orderStatus=${groupBuy.orderStatus}")
+        }
+    }
+
+    private fun countPendingRefunds(groupBuyId: Long): Long =
+        participationRepository.countByGroupBuyIdAndStatusIn(
+            groupBuyId = groupBuyId,
+            statuses = listOf(ParticipationStatus.REFUND_PENDING)
+        )
 
     private fun AdminOrderStatusFilter.toOrderStatuses(): List<GroupBuyOrderStatus> =
         when (this) {

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
@@ -76,23 +76,84 @@ data class AdminOrderListItemResponse(
                 pendingRefundCount = pendingRefundCount,
                 pickupDate = groupBuy.pickupDate,
                 elapsedHours = achievedAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
-                progressRate = achievementRate(groupBuy),
+                progressRate = calculateAchievementRate(groupBuy),
                 orderStatus = groupBuy.orderStatus,
                 ownerContactedAt = groupBuy.orderOwnerContactedAt,
                 orderConfirmedAt = groupBuy.orderConfirmedAt,
                 actionable = groupBuy.orderStatus == GroupBuyOrderStatus.PENDING
             )
         }
+    }
+}
 
-        private fun achievementRate(groupBuy: GroupBuy): Int {
-            if (groupBuy.targetQuantity <= 0) {
-                return 0
-            }
-
-            return groupBuy.currentQuantity * 100 / groupBuy.targetQuantity
+data class AdminOrderDetailResponse(
+    val orderId: Long,
+    val groupBuyId: Long,
+    val productName: String,
+    val productDescription: String,
+    val storeName: String,
+    val storeAddress: String,
+    val storePhoneNumber: String?,
+    val achievedAt: LocalDateTime?,
+    val finalQuantity: Int,
+    val targetQuantity: Int,
+    val pendingRefundCount: Long,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: String,
+    val pickupTimeEnd: String,
+    val pickupLocation: String,
+    val pickupContact: String?,
+    val elapsedHours: Long,
+    val progressRate: Int,
+    val orderStatus: GroupBuyOrderStatus,
+    val ownerContactedAt: LocalDateTime?,
+    val orderConfirmedAt: LocalDateTime?,
+    val orderCancelledAt: LocalDateTime?,
+    val actionable: Boolean,
+) {
+    companion object {
+        fun from(
+            groupBuy: GroupBuy,
+            pendingRefundCount: Long,
+            now: LocalDateTime,
+        ): AdminOrderDetailResponse {
+            val achievedAt = groupBuy.orderAchievedAt()
+            return AdminOrderDetailResponse(
+                orderId = groupBuy.id,
+                groupBuyId = groupBuy.id,
+                productName = groupBuy.productName,
+                productDescription = groupBuy.productDescription,
+                storeName = groupBuy.store.name,
+                storeAddress = groupBuy.store.address,
+                storePhoneNumber = groupBuy.store.phoneNumber,
+                achievedAt = achievedAt,
+                finalQuantity = groupBuy.currentQuantity,
+                targetQuantity = groupBuy.targetQuantity,
+                pendingRefundCount = pendingRefundCount,
+                pickupDate = groupBuy.pickupDate,
+                pickupTimeStart = groupBuy.pickupTimeStart.toString(),
+                pickupTimeEnd = groupBuy.pickupTimeEnd.toString(),
+                pickupLocation = groupBuy.pickupLocation,
+                pickupContact = groupBuy.pickupContact,
+                elapsedHours = achievedAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
+                progressRate = calculateAchievementRate(groupBuy),
+                orderStatus = groupBuy.orderStatus,
+                ownerContactedAt = groupBuy.orderOwnerContactedAt,
+                orderConfirmedAt = groupBuy.orderConfirmedAt,
+                orderCancelledAt = groupBuy.orderCancelledAt,
+                actionable = groupBuy.orderStatus == GroupBuyOrderStatus.PENDING
+            )
         }
     }
 }
 
 fun GroupBuy.orderAchievedAt(): LocalDateTime? =
     achievedAt ?: updatedAt ?: createdAt
+
+private fun calculateAchievementRate(groupBuy: GroupBuy): Int {
+    if (groupBuy.targetQuantity <= 0) {
+        return 0
+    }
+
+    return groupBuy.currentQuantity * 100 / groupBuy.targetQuantity
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.admin.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import org.springframework.data.domain.Page
 import java.time.Duration
 import java.time.LocalDate
@@ -80,7 +81,7 @@ data class AdminOrderListItemResponse(
                 orderStatus = groupBuy.orderStatus,
                 ownerContactedAt = groupBuy.orderOwnerContactedAt,
                 orderConfirmedAt = groupBuy.orderConfirmedAt,
-                actionable = groupBuy.orderStatus == GroupBuyOrderStatus.PENDING
+                actionable = groupBuy.isAdminOrderActionable()
             )
         }
     }
@@ -141,7 +142,7 @@ data class AdminOrderDetailResponse(
                 ownerContactedAt = groupBuy.orderOwnerContactedAt,
                 orderConfirmedAt = groupBuy.orderConfirmedAt,
                 orderCancelledAt = groupBuy.orderCancelledAt,
-                actionable = groupBuy.orderStatus == GroupBuyOrderStatus.PENDING
+                actionable = groupBuy.isAdminOrderActionable()
             )
         }
     }
@@ -157,3 +158,6 @@ private fun calculateAchievementRate(groupBuy: GroupBuy): Int {
 
     return groupBuy.currentQuantity * 100 / groupBuy.targetQuantity
 }
+
+private fun GroupBuy.isAdminOrderActionable(): Boolean =
+    status == GroupBuyStatus.ACHIEVED && orderStatus == GroupBuyOrderStatus.PENDING

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminOrderService
+import com.moongchijang.domain.admin.application.dto.AdminOrderDetailResponse
 import com.moongchijang.domain.admin.application.dto.AdminOrderPageResponse
 import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
 import com.moongchijang.global.response.ApiResponse
@@ -9,6 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -27,4 +30,32 @@ class AdminOrderController(
         pageable: Pageable
     ): ResponseEntity<ApiResponse<AdminOrderPageResponse>> =
         ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrders(status, pageable)))
+
+    @GetMapping("/{orderId}")
+    @Operation(summary = "운영자 발주 관리 상세 조회")
+    fun getOrderDetail(
+        @PathVariable orderId: Long
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrderDetail(orderId)))
+
+    @PostMapping("/{orderId}/owner-contact")
+    @Operation(summary = "운영자 발주 사장님 연락 완료 기록")
+    fun markOwnerContacted(
+        @PathVariable orderId: Long
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminOrderService.markOwnerContacted(orderId)))
+
+    @PostMapping("/{orderId}/confirm")
+    @Operation(summary = "운영자 발주 확정 처리")
+    fun confirmOrder(
+        @PathVariable orderId: Long
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminOrderService.confirmOrder(orderId)))
+
+    @PostMapping("/{orderId}/cancel")
+    @Operation(summary = "운영자 발주 취소 처리")
+    fun cancelOrder(
+        @PathVariable orderId: Long
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminOrderService.cancelOrder(orderId)))
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -78,6 +78,9 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
     @EntityGraph(attributePaths = ["store"])
     fun findWithStoreById(id: Long): Optional<GroupBuy>
 
+    @Query("select gb from GroupBuy gb join fetch gb.store where gb.id = :id")
+    fun findAdminOrderDetailById(@Param("id") id: Long): Optional<GroupBuy>
+
     fun findByStoreIdInAndStatusInOrderByDeadlineAsc(
         storeIds: Collection<Long>,
         statuses: Collection<GroupBuyStatus>

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -115,6 +115,7 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     GROUPBUY_ALREADY_PARTICIPATED(409_306, "이미 참여한 공구예요.", 409),
     GROUPBUY_LOCK_ACQUISITION_FAILED(409_300, "요청이 많아 잠시 처리 지연 중입니다. 잠시 후 다시 시도해주세요.", 409),
     GROUPBUY_LOCK_INTERRUPTED(500_300, "요청 처리 중 일시적인 오류가 발생했습니다.", 500),
+    GROUPBUY_ORDER_INVALID_STATUS(409_307, "처리할 수 없는 발주 상태입니다.", 409),
 
     // Payment(350~399)
     PAYMENT_INVALID_QUANTITY(400_350, "참여 수량이 올바르지 않습니다.", 400),

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1283,6 +1283,119 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/admin/orders/{orderId}:
+    get:
+      tags: [Admin]
+      summary: 발주 관리 상세 조회 (운영자)
+      description: 발주 관리 목록에서 선택한 달성 공구의 상세 정보와 처리 상태를 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: 발주 관리 식별자. 현재는 groupBuyId와 동일
+      responses:
+        '200':
+          description: 발주 관리 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOrderDetail'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /api/v1/admin/orders/{orderId}/owner-contact:
+    post:
+      tags: [Admin]
+      summary: 발주 사장님 연락 완료 기록 (운영자)
+      description: 확정 대기 발주 건에 사장님 연락 완료 시각을 기록한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: 사장님 연락 완료 기록 후 발주 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOrderDetail'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /api/v1/admin/orders/{orderId}/confirm:
+    post:
+      tags: [Admin]
+      summary: 발주 확정 처리 (운영자)
+      description: 확정 대기 발주 건을 확정 완료 상태로 변경한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: 발주 확정 처리 후 발주 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOrderDetail'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
+  /api/v1/admin/orders/{orderId}/cancel:
+    post:
+      tags: [Admin]
+      summary: 발주 취소 처리 (운영자)
+      description: 확정 대기 발주 건을 취소 상태로 변경한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: 발주 취소 처리 후 발주 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOrderDetail'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+
   /api/v1/group-buys/{groupBuyId}/checkout:
     get:
       tags: [Participation]
@@ -2343,104 +2456,6 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '404':
           $ref: '#/components/responses/NotFound'
-
-  /api/v1/admin/group-buys:
-    get:
-      tags: [Admin]
-      summary: 진행 중인 공구 현황 목록 (운영자)
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: status
-          in: query
-          schema:
-            type: string
-            enum: [ALL, IN_PROGRESS, ACHIEVED]
-            default: ALL
-      responses:
-        '200':
-          description: 공구 현황 목록
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseAdminGroupBuyList'
-    post:
-      tags: [Admin]
-      summary: 공구 개설 (운영자)
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AdminGroupBuyCreate'
-      responses:
-        '201':
-          description: 공구 개설 완료
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseGroupBuyId'
-
-  /api/v1/admin/group-buys/{groupBuyId}:
-    get:
-      tags: [Admin]
-      summary: 공구 상세 조회 (운영자)
-      security:
-        - bearerAuth: []
-      parameters:
-        - $ref: '#/components/parameters/GroupBuyId'
-      responses:
-        '200':
-          description: 공구 상세
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseAdminGroupBuyDetail'
-    patch:
-      tags: [Admin]
-      summary: 공구 정보 수정 (운영자)
-      security:
-        - bearerAuth: []
-      parameters:
-        - $ref: '#/components/parameters/GroupBuyId'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AdminGroupBuyUpdate'
-      responses:
-        '200':
-          $ref: '#/components/responses/SuccessNoData'
-
-  /api/v1/admin/group-buys/{groupBuyId}/order-confirm:
-    post:
-      tags: [Admin]
-      summary: 발주 확정 처리
-      description: ACHIEVED 상태 공구에 대해 발주를 확정한다.
-      security:
-        - bearerAuth: []
-      parameters:
-        - $ref: '#/components/parameters/GroupBuyId'
-      responses:
-        '200':
-          $ref: '#/components/responses/SuccessNoData'
-        '409':
-          $ref: '#/components/responses/Conflict'
-
-  /api/v1/admin/group-buys/{groupBuyId}/order-sheet:
-    post:
-      tags: [Admin]
-      summary: 발주서 발송
-      security:
-        - bearerAuth: []
-      parameters:
-        - $ref: '#/components/parameters/GroupBuyId'
-      responses:
-        '200':
-          $ref: '#/components/responses/SuccessNoData'
 
   /api/v1/admin/refunds:
     get:
@@ -5001,7 +5016,7 @@ components:
             targetQuantity: { type: integer, example: 20 }
             maxQuantity: { type: integer, example: 50 }
             perUserLimit: { type: integer, nullable: true, example: 2 }
-            thumbnailUrl: { type: string, example: https://cdn.example.com/owner-requests/1.jpg }
+            thumbnailUrl: { type: string, example: "https://cdn.example.com/owner-requests/1.jpg" }
             imageUrls:
               type: array
               items:
@@ -5164,6 +5179,79 @@ components:
           format: date-time
           nullable: true
         orderConfirmedAt:
+          type: string
+          format: date-time
+          nullable: true
+        actionable:
+          type: boolean
+          description: 발주 확정/연락 등 운영 작업 가능 여부
+
+    ApiResponseAdminOrderDetail:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/AdminOrderDetail'
+        error: { nullable: true, example: null }
+
+    AdminOrderDetail:
+      type: object
+      required: [orderId, groupBuyId, productName, productDescription, storeName, storeAddress, finalQuantity, targetQuantity, pendingRefundCount, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, elapsedHours, progressRate, orderStatus, actionable]
+      properties:
+        orderId:
+          type: integer
+          format: int64
+          description: 발주 관리 식별자. 현재는 groupBuyId와 동일
+        groupBuyId: { type: integer, format: int64 }
+        productName: { type: string }
+        productDescription: { type: string }
+        storeName: { type: string }
+        storeAddress: { type: string }
+        storePhoneNumber:
+          type: string
+          nullable: true
+        achievedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: 공구 달성 일시
+        finalQuantity:
+          type: integer
+          description: 최종 참여 수량
+        targetQuantity:
+          type: integer
+          description: 목표 수량
+        pendingRefundCount:
+          type: integer
+          format: int64
+          description: 해당 공구의 환불 대기 건수
+        pickupDate: { type: string, format: date }
+        pickupTimeStart: { type: string, format: time }
+        pickupTimeEnd: { type: string, format: time }
+        pickupLocation: { type: string }
+        pickupContact:
+          type: string
+          nullable: true
+        elapsedHours:
+          type: integer
+          format: int64
+          description: 달성 후 경과 시간
+        progressRate:
+          type: integer
+          description: 목표 수량 대비 달성률(%)
+        orderStatus:
+          type: string
+          enum: [PENDING, CONFIRMED, CANCELLED]
+        ownerContactedAt:
+          type: string
+          format: date-time
+          nullable: true
+        orderConfirmedAt:
+          type: string
+          format: date-time
+          nullable: true
+        orderCancelledAt:
           type: string
           format: date-time
           nullable: true
@@ -5356,114 +5444,6 @@ components:
               type: integer
               format: int64
               nullable: true
-        error: { nullable: true, example: null }
-
-    ApiResponseAdminGroupBuyList:
-      type: object
-      required: [success, data, error]
-      properties:
-        success: { type: boolean, example: true }
-        data:
-          type: array
-          items:
-            type: object
-            required: [groupBuyId, storeName, productName, status, deadline, achievementRate, currentQuantity, targetQuantity, remainingQuantity, isOrderConfirmed, isOrderSheetSent]
-            properties:
-              groupBuyId: { type: integer, format: int64 }
-              storeName: { type: string }
-              productName: { type: string }
-              status:
-                type: string
-                enum: [IN_PROGRESS, ACHIEVED]
-              deadline: { type: string, format: date }
-              achievementRate: { type: integer }
-              currentQuantity: { type: integer }
-              targetQuantity: { type: integer }
-              remainingQuantity: { type: integer }
-              isOrderConfirmed: { type: boolean }
-              isOrderSheetSent: { type: boolean }
-        error: { nullable: true, example: null }
-
-    AdminGroupBuyCreate:
-      type: object
-      required: [ storeId, productName, productDescription, price, targetQuantity, maxQuantity, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation ]
-      properties:
-        requestId: { type: integer, format: int64, nullable: true }
-        storeId: { type: integer, format: int64 }
-        productName: { type: string, maxLength: 100 }
-        productDescription: { type: string }
-        price: { type: integer, minimum: 1 }
-        targetQuantity: { type: integer, minimum: 1, description: 목표 수량 }
-        maxQuantity: { type: integer, minimum: 1, description: 최대 수량 (선착순 마감 기준) }
-        notice: { type: string, nullable: true, description: 유의사항 }
-        deadline: { type: string, format: date-time }
-        pickupDate: { type: string, format: date }
-        pickupTimeStart: { type: string, format: time }
-        pickupTimeEnd: { type: string, format: time }
-        pickupLocation: { type: string }
-        pickupAddress: { type: string, nullable: true, description: "픽업 장소 주소 (매장 주소와 다를 경우 입력)" }
-
-    AdminGroupBuyUpdate:
-      type: object
-      properties:
-        productName: { type: string }
-        productDescription: { type: string }
-        price: { type: integer, minimum: 1 }
-        targetQuantity: { type: integer, minimum: 1 }
-        maxQuantity: { type: integer, minimum: 1 }
-        deadline: { type: string, format: date-time }
-        pickupDate: { type: string, format: date }
-        pickupTimeStart: { type: string, format: time }
-        pickupTimeEnd: { type: string, format: time }
-        pickupLocation: { type: string }
-        
-    AdminGroupBuyDetail:
-      type: object
-      required: [groupBuyId, requestId, storeId, storeName, productName, productDescription, price, targetQuantity, maxQuantity, currentQuantity, remainingQuantity, achievementRate, notice, status, deadline, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, isOrderConfirmed, isOrderSheetSent]
-      properties:
-        groupBuyId: { type: integer, format: int64 }
-        requestId: { type: integer, format: int64, nullable: true }
-        storeId: { type: integer, format: int64 }
-        storeName: { type: string }
-        productName: { type: string }
-        productDescription: { type: string }
-        price: { type: integer }
-        targetQuantity: { type: integer }
-        maxQuantity: { type: integer, nullable: true }
-        currentQuantity: { type: integer }
-        remainingQuantity: { type: integer }
-        achievementRate: { type: integer }
-        notice: { type: string, nullable: true }
-        status:
-          type: string
-          enum: [IN_PROGRESS, ACHIEVED, FAILED]
-        deadline: { type: string, format: date-time }
-        pickupDate: { type: string, format: date }
-        pickupTimeStart: { type: string, format: time }
-        pickupTimeEnd: { type: string, format: time }
-        pickupLocation: { type: string }
-        isOrderConfirmed: { type: boolean }
-        isOrderSheetSent: { type: boolean }
-
-    ApiResponseGroupBuyId:
-      type: object
-      required: [success, data, error]
-      properties:
-        success: { type: boolean, example: true }
-        data:
-          type: object
-          required: [groupBuyId]
-          properties:
-            groupBuyId: { type: integer, format: int64 }
-        error: { nullable: true, example: null }
-
-    ApiResponseAdminGroupBuyDetail:
-      type: object
-      required: [success, data, error]
-      properties:
-        success: { type: boolean, example: true }
-        data:
-          $ref: '#/components/schemas/AdminGroupBuyDetail'
         error: { nullable: true, example: null }
 
     ApiResponseAdminRefundPage:

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
@@ -4,11 +4,15 @@ import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.GroupBuyPendingRefundCount
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.exception.CustomException
 import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verifyNoInteractions
@@ -19,6 +23,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.util.Optional
 
 class AdminOrderServiceTest {
 
@@ -88,6 +93,101 @@ class AdminOrderServiceTest {
 
         assertTrue(result.content.isEmpty())
         verifyNoInteractions(participationRepository)
+    }
+
+    @Test
+    fun `발주 상세를 조회한다`() {
+        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val achievedAt = now.minusHours(3)
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 31L,
+            status = GroupBuyStatus.ACHIEVED,
+            targetQuantity = 10,
+            currentQuantity = 8
+        ).apply {
+            this.achievedAt = achievedAt
+        }
+        `when`(groupBuyRepository.findAdminOrderDetailById(31L)).thenReturn(Optional.of(groupBuy))
+        `when`(
+            participationRepository.countByGroupBuyIdAndStatusIn(
+                31L,
+                listOf(ParticipationStatus.REFUND_PENDING)
+            )
+        ).thenReturn(1L)
+
+        val result = service.getOrderDetail(31L)
+
+        assertEquals(31L, result.orderId)
+        assertEquals("뭉치장 베이커리", result.storeName)
+        assertEquals(1L, result.pendingRefundCount)
+        assertEquals(3L, result.elapsedHours)
+        assertEquals(80, result.progressRate)
+        assertTrue(result.actionable)
+    }
+
+    @Test
+    fun `사장님 연락 완료를 기록한다`() {
+        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 32L,
+            status = GroupBuyStatus.ACHIEVED
+        ).apply {
+            achievedAt = now.minusHours(1)
+            orderStatus = GroupBuyOrderStatus.PENDING
+        }
+        `when`(groupBuyRepository.findWithLockById(32L)).thenReturn(Optional.of(groupBuy))
+        `when`(
+            participationRepository.countByGroupBuyIdAndStatusIn(
+                32L,
+                listOf(ParticipationStatus.REFUND_PENDING)
+            )
+        ).thenReturn(0L)
+
+        val result = service.markOwnerContacted(32L)
+
+        assertEquals(now, result.ownerContactedAt)
+        assertEquals(GroupBuyOrderStatus.PENDING, result.orderStatus)
+        assertTrue(result.actionable)
+    }
+
+    @Test
+    fun `발주를 확정 처리한다`() {
+        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 33L,
+            status = GroupBuyStatus.ACHIEVED
+        ).apply {
+            achievedAt = now.minusHours(1)
+            orderStatus = GroupBuyOrderStatus.PENDING
+        }
+        `when`(groupBuyRepository.findWithLockById(33L)).thenReturn(Optional.of(groupBuy))
+        `when`(
+            participationRepository.countByGroupBuyIdAndStatusIn(
+                33L,
+                listOf(ParticipationStatus.REFUND_PENDING)
+            )
+        ).thenReturn(0L)
+
+        val result = service.confirmOrder(33L)
+
+        assertEquals(GroupBuyOrderStatus.CONFIRMED, result.orderStatus)
+        assertEquals(now, result.orderConfirmedAt)
+        assertFalse(result.actionable)
+    }
+
+    @Test
+    fun `확정된 발주는 다시 취소 처리할 수 없다`() {
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 34L,
+            status = GroupBuyStatus.ACHIEVED
+        ).apply {
+            orderStatus = GroupBuyOrderStatus.CONFIRMED
+        }
+        `when`(groupBuyRepository.findWithLockById(34L)).thenReturn(Optional.of(groupBuy))
+
+        assertThrows(CustomException::class.java) {
+            service.cancelOrder(34L)
+        }
     }
 
     private fun pendingRefundCount(

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
@@ -126,6 +126,30 @@ class AdminOrderServiceTest {
     }
 
     @Test
+    fun `완료된 공구도 발주 상세를 조회할 수 있고 작업은 비활성화된다`() {
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 35L,
+            status = GroupBuyStatus.COMPLETED,
+            targetQuantity = 10,
+            currentQuantity = 10
+        ).apply {
+            orderStatus = GroupBuyOrderStatus.PENDING
+        }
+        `when`(groupBuyRepository.findAdminOrderDetailById(35L)).thenReturn(Optional.of(groupBuy))
+        `when`(
+            participationRepository.countByGroupBuyIdAndStatusIn(
+                35L,
+                listOf(ParticipationStatus.REFUND_PENDING)
+            )
+        ).thenReturn(0L)
+
+        val result = service.getOrderDetail(35L)
+
+        assertEquals(35L, result.orderId)
+        assertFalse(result.actionable)
+    }
+
+    @Test
     fun `사장님 연락 완료를 기록한다`() {
         val now = LocalDateTime.of(2026, 5, 27, 13, 0)
         val groupBuy = GroupBuyFixture.createGroupBuy(

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderControllerTest.kt
@@ -1,14 +1,18 @@
 package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminOrderService
+import com.moongchijang.domain.admin.application.dto.AdminOrderDetailResponse
 import com.moongchijang.domain.admin.application.dto.AdminOrderPageResponse
 import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 class AdminOrderControllerTest {
 
@@ -32,4 +36,56 @@ class AdminOrderControllerTest {
         assertEquals(response, result.body?.data)
         verify(adminOrderService).getOrders(AdminOrderStatusFilter.PENDING, pageable)
     }
+
+    @Test
+    fun `운영자 발주 상세 조회는 주문 ID를 서비스로 전달한다`() {
+        val response = detailResponse(orderId = 30L)
+        `when`(adminOrderService.getOrderDetail(30L)).thenReturn(response)
+
+        val result = controller.getOrderDetail(30L)
+
+        assertEquals(response, result.body?.data)
+        verify(adminOrderService).getOrderDetail(30L)
+    }
+
+    @Test
+    fun `운영자 발주 확정 처리는 주문 ID를 서비스로 전달한다`() {
+        val response = detailResponse(orderId = 31L, orderStatus = GroupBuyOrderStatus.CONFIRMED)
+        `when`(adminOrderService.confirmOrder(31L)).thenReturn(response)
+
+        val result = controller.confirmOrder(31L)
+
+        assertEquals(response, result.body?.data)
+        verify(adminOrderService).confirmOrder(31L)
+    }
+
+    private fun detailResponse(
+        orderId: Long,
+        orderStatus: GroupBuyOrderStatus = GroupBuyOrderStatus.PENDING,
+    ): AdminOrderDetailResponse =
+        AdminOrderDetailResponse(
+            orderId = orderId,
+            groupBuyId = orderId,
+            productName = "두쫀쿠 1개",
+            productDescription = "설명",
+            storeName = "뭉치장 베이커리",
+            storeAddress = "서울 성동구",
+            storePhoneNumber = null,
+            achievedAt = LocalDateTime.of(2026, 5, 27, 10, 0),
+            finalQuantity = 20,
+            targetQuantity = 20,
+            pendingRefundCount = 0,
+            pickupDate = LocalDate.of(2026, 6, 1),
+            pickupTimeStart = "14:00",
+            pickupTimeEnd = "18:00",
+            pickupLocation = "서울 성동구 성수동",
+            pickupContact = null,
+            elapsedHours = 3,
+            progressRate = 100,
+            orderStatus = orderStatus,
+            ownerContactedAt = null,
+            orderConfirmedAt = null,
+            orderCancelledAt = null,
+            actionable = orderStatus == GroupBuyOrderStatus.PENDING
+        )
 }


### PR DESCRIPTION
## 📌 작업한 내용
- GET /api/v1/admin/orders/{orderId} 발주 상세 조회 API를 추가했습니다.
- POST /api/v1/admin/orders/{orderId}/owner-contact 사장님 연락 완료 기록 API를 추가했습니다.
- POST /api/v1/admin/orders/{orderId}/confirm 발주 확정 처리 API를 추가했습니다.
- POST /api/v1/admin/orders/{orderId}/cancel 발주 취소 처리 API를 추가했습니다.
- 확정 대기 상태에서만 처리 액션이 가능하도록 상태 검증을 추가했습니다.
- 서비스/컨트롤러 테스트를 추가했습니다.

## 🔍 참고 사항
- 이번 PR은 기능명세서 6. 발주 관리 중 상세 조회와 연락/확정/취소 처리 액션을 다룹니다.
- OpenAPI에는 새 발주 처리 API 스펙을 추가했고, 실제 컨트롤러가 없는 기존 /api/v1/admin/group-buys 계열 문서는 제거했습니다.
- Gemini 피드백에 따라 완료/종료된 발주도 상세 조회 가능하게 하고, 작업 가능 여부는 ACHIEVED + PENDING에서만 true가 되도록 조정했습니다.
- OpenAPI YAML 파싱을 확인했습니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closes #247

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인