### PR TITLE
[MCJ-1552] HOTFIX: api/grafana 521 장애 대응 및 Nginx 라우팅/인증서 경로 안정화

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -66,11 +66,12 @@ http {
     listen 443 ssl;
     server_name grafana.moongchijang.com;
 
-    ssl_certificate /etc/letsencrypt/live/grafana.moongchijang.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/grafana.moongchijang.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/api.moongchijang.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.moongchijang.com/privkey.pem;
 
     location / {
-      proxy_pass http://grafana:3000;
+      set $grafana http://grafana:3000;
+      proxy_pass $grafana;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 📌 작업한 내용
- Cloudflare 521 장애 원인 분석 반영
  - Nginx 기동 실패 원인(`grafana` upstream 해석 실패, 인증서 경로 불일치) 대응
- Grafana 프록시 라우팅 안정화
  - Nginx에서 Grafana upstream을 런타임 해석 방식으로 처리하도록 조정
- SSL 인증서 경로 수정
  - Grafana 도메인 443 블록에서 실제 발급된 인증서 경로(`/etc/letsencrypt/live/api.moongchijang.com/...`)로 정합성 맞춤
- 운영 가이드와의 정합성 점검
  - 배포 후 확인해야 할 운영 체크 항목(기동/응답/Cloudflare 상태) 기준 정리

## 🔍 참고 사항
- 이번 변경은 Nginx 기동 안정화가 핵심이며, 최종 정상화 확인은 운영 서버에서 필요합니다.
- 배포 후 아래 항목을 반드시 확인해야 합니다.
  - Nginx 정상 기동 여부
  - `https://api.moongchijang.com`, `https://grafana.moongchijang.com` 응답 코드(200/302)
  - Cloudflare 521 해소 여부
- 인증서는 SAN 포함 단일 인증서(`api.moongchijang.com` 경로) 기준으로 참조합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #251 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인