### PR TITLE
[MCJ-1551] FEAT: 어드민 대시보드 발주 미확정 모니터링 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
@@ -1,0 +1,56 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.AdminDashboardUnconfirmedOrderResponse
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class AdminDashboardOrderMonitoringService(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val participationRepository: ParticipationRepository,
+    private val clock: Clock,
+) {
+
+    fun getUnconfirmedOrders(pageable: Pageable): AdminDashboardUnconfirmedOrderResponse {
+        val now = LocalDateTime.now(clock)
+        val overdueBefore = now.minusHours(48)
+        val page = groupBuyRepository.findAdminOrderPage(
+            groupBuyStatus = GroupBuyStatus.ACHIEVED,
+            orderStatuses = listOf(GroupBuyOrderStatus.PENDING),
+            overdueBefore = null,
+            pageable = pageable
+        )
+        val groupBuyIds = page.content.map { it.id }
+        val pendingRefundCountsByGroupBuyId = if (groupBuyIds.isEmpty()) {
+            emptyMap()
+        } else {
+            participationRepository.countPendingRefundsByGroupBuyIdIn(groupBuyIds)
+                .associate { it.groupBuyId to it.pendingRefundCount }
+        }
+        val overdueCount = groupBuyRepository.countOverdueAdminOrders(
+            status = GroupBuyStatus.ACHIEVED,
+            orderStatus = GroupBuyOrderStatus.PENDING,
+            overdueBefore = overdueBefore
+        )
+
+        return AdminDashboardUnconfirmedOrderResponse.from(
+            page = page,
+            pendingRefundCountsByGroupBuyId = pendingRefundCountsByGroupBuyId,
+            totalUnconfirmedCount = groupBuyRepository.countByStatusAndOrderStatus(
+                status = GroupBuyStatus.ACHIEVED,
+                orderStatus = GroupBuyOrderStatus.PENDING
+            ),
+            overdueCount = overdueCount,
+            now = now,
+            overdueBefore = overdueBefore
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
@@ -44,10 +44,7 @@ class AdminDashboardOrderMonitoringService(
         return AdminDashboardUnconfirmedOrderResponse.from(
             page = page,
             pendingRefundCountsByGroupBuyId = pendingRefundCountsByGroupBuyId,
-            totalUnconfirmedCount = groupBuyRepository.countByStatusAndOrderStatus(
-                status = GroupBuyStatus.ACHIEVED,
-                orderStatus = GroupBuyOrderStatus.PENDING
-            ),
+            totalUnconfirmedCount = page.totalElements,
             overdueCount = overdueCount,
             now = now,
             overdueBefore = overdueBefore

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardOrderMonitoringResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardOrderMonitoringResponse.kt
@@ -1,0 +1,96 @@
+package com.moongchijang.domain.admin.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import org.springframework.data.domain.Page
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class AdminDashboardUnconfirmedOrderResponse(
+    val totalUnconfirmedCount: Long,
+    val overdueCount: Long,
+    val hasOverdue: Boolean,
+    val content: List<AdminDashboardUnconfirmedOrderItemResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int,
+) {
+    companion object {
+        fun from(
+            page: Page<GroupBuy>,
+            pendingRefundCountsByGroupBuyId: Map<Long, Long>,
+            totalUnconfirmedCount: Long,
+            overdueCount: Long,
+            now: LocalDateTime,
+            overdueBefore: LocalDateTime,
+        ): AdminDashboardUnconfirmedOrderResponse =
+            AdminDashboardUnconfirmedOrderResponse(
+                totalUnconfirmedCount = totalUnconfirmedCount,
+                overdueCount = overdueCount,
+                hasOverdue = overdueCount > 0,
+                content = page.content.map {
+                    AdminDashboardUnconfirmedOrderItemResponse.from(
+                        groupBuy = it,
+                        pendingRefundCount = pendingRefundCountsByGroupBuyId[it.id] ?: 0L,
+                        now = now,
+                        overdueBefore = overdueBefore
+                    )
+                },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                number = page.number,
+                size = page.size
+            )
+    }
+}
+
+data class AdminDashboardUnconfirmedOrderItemResponse(
+    val orderId: Long,
+    val groupBuyId: Long,
+    val productName: String,
+    val storeName: String,
+    val achievedAt: LocalDateTime?,
+    val finalQuantity: Int,
+    val pendingRefundCount: Long,
+    val pickupDate: LocalDate,
+    val elapsedHours: Long,
+    val overdue: Boolean,
+    val progressRate: Int,
+    val ownerContacted: Boolean,
+    val ownerContactedAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(
+            groupBuy: GroupBuy,
+            pendingRefundCount: Long,
+            now: LocalDateTime,
+            overdueBefore: LocalDateTime,
+        ): AdminDashboardUnconfirmedOrderItemResponse {
+            val achievedAt = groupBuy.orderAchievedAt()
+            return AdminDashboardUnconfirmedOrderItemResponse(
+                orderId = groupBuy.id,
+                groupBuyId = groupBuy.id,
+                productName = groupBuy.productName,
+                storeName = groupBuy.store.name,
+                achievedAt = achievedAt,
+                finalQuantity = groupBuy.currentQuantity,
+                pendingRefundCount = pendingRefundCount,
+                pickupDate = groupBuy.pickupDate,
+                elapsedHours = achievedAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
+                overdue = achievedAt?.isBefore(overdueBefore) == true,
+                progressRate = calculateAchievementRate(groupBuy),
+                ownerContacted = groupBuy.orderOwnerContactedAt != null,
+                ownerContactedAt = groupBuy.orderOwnerContactedAt
+            )
+        }
+
+        private fun calculateAchievementRate(groupBuy: GroupBuy): Int {
+            if (groupBuy.targetQuantity <= 0) {
+                return 0
+            }
+
+            return groupBuy.currentQuantity * 100 / groupBuy.targetQuantity
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardOrderMonitoringResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardOrderMonitoringResponse.kt
@@ -67,7 +67,7 @@ data class AdminDashboardUnconfirmedOrderItemResponse(
             now: LocalDateTime,
             overdueBefore: LocalDateTime,
         ): AdminDashboardUnconfirmedOrderItemResponse {
-            val achievedAt = groupBuy.orderAchievedAt()
+            val achievedAt = groupBuy.achievedAt
             return AdminDashboardUnconfirmedOrderItemResponse(
                 orderId = groupBuy.id,
                 groupBuyId = groupBuy.id,

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
@@ -1,10 +1,13 @@
 package com.moongchijang.domain.admin.presentation
 
+import com.moongchijang.domain.admin.application.AdminDashboardOrderMonitoringService
 import com.moongchijang.domain.admin.application.AdminDashboardSummaryService
+import com.moongchijang.domain.admin.application.dto.AdminDashboardUnconfirmedOrderResponse
 import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -15,10 +18,18 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Admin", description = "운영자 관리")
 class AdminDashboardController(
     private val adminDashboardSummaryService: AdminDashboardSummaryService,
+    private val adminDashboardOrderMonitoringService: AdminDashboardOrderMonitoringService,
 ) {
 
     @GetMapping("/summary")
     @Operation(summary = "운영자 대시보드 운영 관리 요약")
     fun getSummary(): ResponseEntity<ApiResponse<AdminDashboardSummaryResponse>> =
         ResponseEntity.ok(ApiResponse.success(adminDashboardSummaryService.getSummary()))
+
+    @GetMapping("/dashboard/unconfirmed-orders")
+    @Operation(summary = "운영자 대시보드 발주 미확정 모니터링")
+    fun getUnconfirmedOrders(
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<AdminDashboardUnconfirmedOrderResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminDashboardOrderMonitoringService.getUnconfirmedOrders(pageable)))
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1256,6 +1256,26 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/admin/dashboard/unconfirmed-orders:
+    get:
+      tags: [Admin]
+      summary: 대시보드 발주 미확정 모니터링 (운영자)
+      description: 달성됐지만 발주 확정 전인 공구와 48시간 초과 여부를 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 발주 미확정 모니터링 목록과 요약
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminDashboardUnconfirmedOrders'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/admin/orders:
     get:
       tags: [Admin]
@@ -5120,6 +5140,78 @@ components:
               type: boolean
               description: 48시간 초과 발주 미확정 경고 노출 여부
         error: { nullable: true, example: null }
+
+    ApiResponseAdminDashboardUnconfirmedOrders:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [totalUnconfirmedCount, overdueCount, hasOverdue, content, totalElements, totalPages, number, size]
+          properties:
+            totalUnconfirmedCount:
+              type: integer
+              format: int64
+              description: 달성된 공구 중 발주 확정 대기 건수
+            overdueCount:
+              type: integer
+              format: int64
+              description: 달성 후 48시간을 초과한 발주 확정 대기 건수
+            hasOverdue:
+              type: boolean
+              description: 48시간 초과 발주 미확정 경고 노출 여부
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/AdminDashboardUnconfirmedOrderItem'
+            totalElements: { type: integer, format: int64 }
+            totalPages: { type: integer }
+            number: { type: integer }
+            size: { type: integer }
+        error: { nullable: true, example: null }
+
+    AdminDashboardUnconfirmedOrderItem:
+      type: object
+      required: [orderId, groupBuyId, productName, storeName, finalQuantity, pendingRefundCount, pickupDate, elapsedHours, overdue, progressRate, ownerContacted]
+      properties:
+        orderId:
+          type: integer
+          format: int64
+          description: 발주 관리 식별자. 현재는 groupBuyId와 동일
+        groupBuyId: { type: integer, format: int64 }
+        productName: { type: string }
+        storeName: { type: string }
+        achievedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: 공구 달성 일시
+        finalQuantity:
+          type: integer
+          description: 최종 참여 수량
+        pendingRefundCount:
+          type: integer
+          format: int64
+          description: 해당 공구의 환불 대기 건수
+        pickupDate: { type: string, format: date }
+        elapsedHours:
+          type: integer
+          format: int64
+          description: 달성 후 경과 시간
+        overdue:
+          type: boolean
+          description: 달성 후 48시간 초과 여부
+        progressRate:
+          type: integer
+          description: 목표 수량 대비 달성률(%)
+        ownerContacted:
+          type: boolean
+          description: 사장님 연락 완료 여부
+        ownerContactedAt:
+          type: string
+          format: date-time
+          nullable: true
 
     ApiResponseAdminOrderPage:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringServiceTest.kt
@@ -1,0 +1,121 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.participation.domain.repository.GroupBuyPendingRefundCount
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.support.GroupBuyFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class AdminDashboardOrderMonitoringServiceTest {
+
+    private val groupBuyRepository: GroupBuyRepository = mock(GroupBuyRepository::class.java)
+    private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val service = AdminDashboardOrderMonitoringService(
+        groupBuyRepository = groupBuyRepository,
+        participationRepository = participationRepository,
+        clock = clock
+    )
+
+    @Test
+    fun `대시보드 발주 미확정 모니터링 목록과 요약을 조회한다`() {
+        val pageable = PageRequest.of(0, 5)
+        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val overdueBefore = now.minusHours(48)
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 41L,
+            status = GroupBuyStatus.ACHIEVED,
+            targetQuantity = 20,
+            currentQuantity = 20
+        ).apply {
+            achievedAt = now.minusHours(50)
+            orderStatus = GroupBuyOrderStatus.PENDING
+            markOrderOwnerContacted(now.minusHours(2))
+        }
+        `when`(
+            groupBuyRepository.findAdminOrderPage(
+                GroupBuyStatus.ACHIEVED,
+                listOf(GroupBuyOrderStatus.PENDING),
+                null,
+                pageable
+            )
+        ).thenReturn(PageImpl(listOf(groupBuy), pageable, 1))
+        `when`(participationRepository.countPendingRefundsByGroupBuyIdIn(listOf(41L)))
+            .thenReturn(listOf(pendingRefundCount(41L, 2L)))
+        `when`(
+            groupBuyRepository.countOverdueAdminOrders(
+                GroupBuyStatus.ACHIEVED,
+                GroupBuyOrderStatus.PENDING,
+                overdueBefore
+            )
+        ).thenReturn(1L)
+        `when`(groupBuyRepository.countByStatusAndOrderStatus(GroupBuyStatus.ACHIEVED, GroupBuyOrderStatus.PENDING))
+            .thenReturn(3L)
+
+        val result = service.getUnconfirmedOrders(pageable)
+
+        assertEquals(3L, result.totalUnconfirmedCount)
+        assertEquals(1L, result.overdueCount)
+        assertTrue(result.hasOverdue)
+        assertEquals(1, result.content.size)
+        assertEquals(41L, result.content[0].orderId)
+        assertEquals(2L, result.content[0].pendingRefundCount)
+        assertEquals(50L, result.content[0].elapsedHours)
+        assertTrue(result.content[0].overdue)
+        assertTrue(result.content[0].ownerContacted)
+        assertEquals(100, result.content[0].progressRate)
+    }
+
+    @Test
+    fun `목록이 비어있으면 환불 대기 집계를 생략한다`() {
+        val pageable = PageRequest.of(0, 5)
+        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val overdueBefore = now.minusHours(48)
+        `when`(
+            groupBuyRepository.findAdminOrderPage(
+                GroupBuyStatus.ACHIEVED,
+                listOf(GroupBuyOrderStatus.PENDING),
+                null,
+                pageable
+            )
+        ).thenReturn(PageImpl(emptyList(), pageable, 0))
+        `when`(
+            groupBuyRepository.countOverdueAdminOrders(
+                GroupBuyStatus.ACHIEVED,
+                GroupBuyOrderStatus.PENDING,
+                overdueBefore
+            )
+        ).thenReturn(0L)
+        `when`(groupBuyRepository.countByStatusAndOrderStatus(GroupBuyStatus.ACHIEVED, GroupBuyOrderStatus.PENDING))
+            .thenReturn(0L)
+
+        val result = service.getUnconfirmedOrders(pageable)
+
+        assertTrue(result.content.isEmpty())
+        assertFalse(result.hasOverdue)
+        verifyNoInteractions(participationRepository)
+    }
+
+    private fun pendingRefundCount(
+        groupBuyId: Long,
+        count: Long
+    ): GroupBuyPendingRefundCount =
+        object : GroupBuyPendingRefundCount {
+            override val groupBuyId: Long = groupBuyId
+            override val pendingRefundCount: Long = count
+        }
+}

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringServiceTest.kt
@@ -33,7 +33,7 @@ class AdminDashboardOrderMonitoringServiceTest {
 
     @Test
     fun `대시보드 발주 미확정 모니터링 목록과 요약을 조회한다`() {
-        val pageable = PageRequest.of(0, 5)
+        val pageable = PageRequest.of(0, 1)
         val now = LocalDateTime.of(2026, 5, 27, 13, 0)
         val overdueBefore = now.minusHours(48)
         val groupBuy = GroupBuyFixture.createGroupBuy(
@@ -53,7 +53,7 @@ class AdminDashboardOrderMonitoringServiceTest {
                 null,
                 pageable
             )
-        ).thenReturn(PageImpl(listOf(groupBuy), pageable, 1))
+        ).thenReturn(PageImpl(listOf(groupBuy), pageable, 3))
         `when`(participationRepository.countPendingRefundsByGroupBuyIdIn(listOf(41L)))
             .thenReturn(listOf(pendingRefundCount(41L, 2L)))
         `when`(
@@ -63,9 +63,6 @@ class AdminDashboardOrderMonitoringServiceTest {
                 overdueBefore
             )
         ).thenReturn(1L)
-        `when`(groupBuyRepository.countByStatusAndOrderStatus(GroupBuyStatus.ACHIEVED, GroupBuyOrderStatus.PENDING))
-            .thenReturn(3L)
-
         val result = service.getUnconfirmedOrders(pageable)
 
         assertEquals(3L, result.totalUnconfirmedCount)
@@ -100,9 +97,6 @@ class AdminDashboardOrderMonitoringServiceTest {
                 overdueBefore
             )
         ).thenReturn(0L)
-        `when`(groupBuyRepository.countByStatusAndOrderStatus(GroupBuyStatus.ACHIEVED, GroupBuyOrderStatus.PENDING))
-            .thenReturn(0L)
-
         val result = service.getUnconfirmedOrders(pageable)
 
         assertTrue(result.content.isEmpty())

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardControllerTest.kt
@@ -1,17 +1,25 @@
 package com.moongchijang.domain.admin.presentation
 
+import com.moongchijang.domain.admin.application.AdminDashboardOrderMonitoringService
 import com.moongchijang.domain.admin.application.AdminDashboardSummaryService
 import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
+import com.moongchijang.domain.admin.application.dto.AdminDashboardUnconfirmedOrderResponse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageRequest
 
 class AdminDashboardControllerTest {
 
     private val adminDashboardSummaryService: AdminDashboardSummaryService = mock(AdminDashboardSummaryService::class.java)
-    private val controller = AdminDashboardController(adminDashboardSummaryService)
+    private val adminDashboardOrderMonitoringService: AdminDashboardOrderMonitoringService =
+        mock(AdminDashboardOrderMonitoringService::class.java)
+    private val controller = AdminDashboardController(
+        adminDashboardSummaryService = adminDashboardSummaryService,
+        adminDashboardOrderMonitoringService = adminDashboardOrderMonitoringService
+    )
 
     @Test
     fun `운영자 대시보드 요약 조회는 서비스 결과를 반환한다`() {
@@ -33,5 +41,26 @@ class AdminDashboardControllerTest {
 
         assertEquals(response, result.body?.data)
         verify(adminDashboardSummaryService).getSummary()
+    }
+
+    @Test
+    fun `운영자 대시보드 발주 미확정 모니터링은 페이징을 서비스로 전달한다`() {
+        val pageable = PageRequest.of(0, 5)
+        val response = AdminDashboardUnconfirmedOrderResponse(
+            totalUnconfirmedCount = 0L,
+            overdueCount = 0L,
+            hasOverdue = false,
+            content = emptyList(),
+            totalElements = 0L,
+            totalPages = 0,
+            number = 0,
+            size = 5
+        )
+        `when`(adminDashboardOrderMonitoringService.getUnconfirmedOrders(pageable)).thenReturn(response)
+
+        val result = controller.getUnconfirmedOrders(pageable)
+
+        assertEquals(response, result.body?.data)
+        verify(adminDashboardOrderMonitoringService).getUnconfirmedOrders(pageable)
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- GET /api/v1/admin/dashboard/unconfirmed-orders API를 추가했습니다.
- 달성됐지만 발주 확정 전인 공구 목록을 조회합니다.
- 전체 미확정 건수, 48시간 초과 건수, 경고 노출 여부를 함께 응답합니다.
- 각 항목에 경과 시간, 48시간 초과 여부, 사장님 연락 완료 여부/시각, 환불 대기 건수를 포함했습니다.
- 서비스/컨트롤러 테스트를 추가했습니다.
- OpenAPI 스펙을 실제 컨트롤러와 응답 DTO에 맞춰 추가했습니다.

## 🔍 참고 사항
- 이번 PR은 기능명세서 1.3 발주 미확정 모니터링 범위입니다.
- 발주 상태/연락/확정/취소 기반은 이전 PR #246, #248에서 구현된 필드를 사용합니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closes #250

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인