### PR TITLE
[MCJ-1553] FEAT: 어드민 CS 티켓 관리 기본 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
@@ -49,7 +49,7 @@ class AdminCsTicketService(
         request: AdminCsTicketUpdateRequest,
     ): AdminCsTicketDetailResponse {
         val now = LocalDateTime.now(clock)
-        val ticket = csTicketRepository.findWithLockById(ticketId)
+        val ticket = csTicketRepository.findAdminDetailById(ticketId)
             .orElseThrow { CustomException(ErrorCode.CS_TICKET_NOT_FOUND) }
 
         ticket.updateProcessing(

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
@@ -1,0 +1,64 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketDetailResponse
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketPageResponse
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketStatusFilter
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketUpdateRequest
+import com.moongchijang.domain.csticket.domain.repository.CsTicketRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class AdminCsTicketService(
+    private val csTicketRepository: CsTicketRepository,
+    private val clock: Clock,
+) {
+
+    fun getTickets(
+        status: AdminCsTicketStatusFilter,
+        keyword: String?,
+        pageable: Pageable,
+    ): AdminCsTicketPageResponse {
+        val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
+        val page = csTicketRepository.findAdminPage(
+            status = status.toStatus(),
+            keyword = normalizedKeyword,
+            ticketId = normalizedKeyword?.toLongOrNull(),
+            pageable = pageable
+        )
+
+        return AdminCsTicketPageResponse.from(page, LocalDateTime.now(clock))
+    }
+
+    fun getTicketDetail(ticketId: Long): AdminCsTicketDetailResponse {
+        val ticket = csTicketRepository.findAdminDetailById(ticketId)
+            .orElseThrow { CustomException(ErrorCode.CS_TICKET_NOT_FOUND) }
+
+        return AdminCsTicketDetailResponse.from(ticket, LocalDateTime.now(clock))
+    }
+
+    @Transactional
+    fun updateTicket(
+        ticketId: Long,
+        request: AdminCsTicketUpdateRequest,
+    ): AdminCsTicketDetailResponse {
+        val now = LocalDateTime.now(clock)
+        val ticket = csTicketRepository.findWithLockById(ticketId)
+            .orElseThrow { CustomException(ErrorCode.CS_TICKET_NOT_FOUND) }
+
+        ticket.updateProcessing(
+            status = request.status,
+            assigneeName = request.assigneeName,
+            processingMemo = request.processingMemo,
+            now = now
+        )
+
+        return AdminCsTicketDetailResponse.from(ticket, now)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/csticket/AdminCsTicketResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/csticket/AdminCsTicketResponse.kt
@@ -1,0 +1,170 @@
+package com.moongchijang.domain.admin.application.dto.csticket
+
+import com.moongchijang.domain.csticket.domain.entity.CsTicket
+import com.moongchijang.domain.csticket.domain.entity.CsTicketPriority
+import com.moongchijang.domain.csticket.domain.entity.CsTicketStatus
+import com.moongchijang.domain.csticket.domain.entity.CsTicketType
+import jakarta.validation.constraints.Size
+import org.springframework.data.domain.Page
+import java.time.Duration
+import java.time.LocalDateTime
+
+enum class AdminCsTicketStatusFilter {
+    RECEIVED,
+    IN_PROGRESS,
+    COMPLETED,
+    ALL;
+
+    fun toStatus(): CsTicketStatus? =
+        when (this) {
+            RECEIVED -> CsTicketStatus.RECEIVED
+            IN_PROGRESS -> CsTicketStatus.IN_PROGRESS
+            COMPLETED -> CsTicketStatus.COMPLETED
+            ALL -> null
+        }
+}
+
+data class AdminCsTicketPageResponse(
+    val content: List<AdminCsTicketListItemResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int,
+) {
+    companion object {
+        fun from(page: Page<CsTicket>, now: LocalDateTime): AdminCsTicketPageResponse =
+            AdminCsTicketPageResponse(
+                content = page.content.map { AdminCsTicketListItemResponse.from(it, now) },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                number = page.number,
+                size = page.size
+            )
+    }
+}
+
+data class AdminCsTicketListItemResponse(
+    val ticketId: Long,
+    val type: CsTicketType,
+    val title: String,
+    val consumerId: Long?,
+    val consumerName: String?,
+    val groupBuyId: Long?,
+    val groupBuyName: String?,
+    val priority: CsTicketPriority,
+    val assigneeName: String?,
+    val createdAt: LocalDateTime?,
+    val slaHours: Long,
+    val status: CsTicketStatus,
+    val actionable: Boolean,
+) {
+    companion object {
+        fun from(ticket: CsTicket, now: LocalDateTime): AdminCsTicketListItemResponse =
+            AdminCsTicketListItemResponse(
+                ticketId = ticket.id,
+                type = ticket.type,
+                title = ticket.title,
+                consumerId = ticket.consumer?.id,
+                consumerName = ticket.consumer?.nickname,
+                groupBuyId = ticket.groupBuy?.id,
+                groupBuyName = ticket.groupBuy?.productName,
+                priority = ticket.priority,
+                assigneeName = ticket.assigneeName,
+                createdAt = ticket.createdAt,
+                slaHours = ticket.createdAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
+                status = ticket.status,
+                actionable = ticket.status != CsTicketStatus.COMPLETED
+            )
+    }
+}
+
+data class AdminCsTicketDetailResponse(
+    val ticketId: Long,
+    val type: CsTicketType,
+    val title: String,
+    val description: String,
+    val priority: CsTicketPriority,
+    val status: CsTicketStatus,
+    val createdAt: LocalDateTime?,
+    val updatedAt: LocalDateTime?,
+    val slaHours: Long,
+    val consumer: AdminCsTicketUserResponse?,
+    val owner: AdminCsTicketOwnerResponse?,
+    val groupBuy: AdminCsTicketGroupBuyResponse?,
+    val refundParticipationId: Long?,
+    val assigneeName: String?,
+    val processingMemo: String?,
+    val resolvedAt: LocalDateTime?,
+    val actionable: Boolean,
+) {
+    companion object {
+        fun from(ticket: CsTicket, now: LocalDateTime): AdminCsTicketDetailResponse =
+            AdminCsTicketDetailResponse(
+                ticketId = ticket.id,
+                type = ticket.type,
+                title = ticket.title,
+                description = ticket.description,
+                priority = ticket.priority,
+                status = ticket.status,
+                createdAt = ticket.createdAt,
+                updatedAt = ticket.updatedAt,
+                slaHours = ticket.createdAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
+                consumer = ticket.consumer?.let { user ->
+                    AdminCsTicketUserResponse(
+                        userId = user.id,
+                        nickname = user.nickname,
+                        email = user.email,
+                        phoneNumber = user.phoneNumber
+                    )
+                },
+                owner = ticket.groupBuy?.store?.let { store ->
+                    AdminCsTicketOwnerResponse(
+                        storeId = store.id,
+                        storeName = store.name,
+                        storePhoneNumber = store.phoneNumber
+                    )
+                },
+                groupBuy = ticket.groupBuy?.let { groupBuy ->
+                    AdminCsTicketGroupBuyResponse(
+                        groupBuyId = groupBuy.id,
+                        productName = groupBuy.productName,
+                        storeName = groupBuy.store.name
+                    )
+                },
+                refundParticipationId = ticket.refundParticipationId,
+                assigneeName = ticket.assigneeName,
+                processingMemo = ticket.processingMemo,
+                resolvedAt = ticket.resolvedAt,
+                actionable = ticket.status != CsTicketStatus.COMPLETED
+            )
+    }
+}
+
+data class AdminCsTicketUserResponse(
+    val userId: Long?,
+    val nickname: String?,
+    val email: String?,
+    val phoneNumber: String?,
+)
+
+data class AdminCsTicketOwnerResponse(
+    val storeId: Long,
+    val storeName: String,
+    val storePhoneNumber: String?,
+)
+
+data class AdminCsTicketGroupBuyResponse(
+    val groupBuyId: Long,
+    val productName: String,
+    val storeName: String,
+)
+
+data class AdminCsTicketUpdateRequest(
+    val status: CsTicketStatus? = null,
+
+    @field:Size(max = 50)
+    val assigneeName: String? = null,
+
+    @field:Size(max = 1000)
+    val processingMemo: String? = null,
+)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/csticket/AdminCsTicketResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/csticket/AdminCsTicketResponse.kt
@@ -71,7 +71,7 @@ data class AdminCsTicketListItemResponse(
                 priority = ticket.priority,
                 assigneeName = ticket.assigneeName,
                 createdAt = ticket.createdAt,
-                slaHours = ticket.createdAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
+                slaHours = ticket.calculateSlaHours(now),
                 status = ticket.status,
                 actionable = ticket.status != CsTicketStatus.COMPLETED
             )
@@ -108,7 +108,7 @@ data class AdminCsTicketDetailResponse(
                 status = ticket.status,
                 createdAt = ticket.createdAt,
                 updatedAt = ticket.updatedAt,
-                slaHours = ticket.createdAt?.let { Duration.between(it, now).toHours().coerceAtLeast(0) } ?: 0L,
+                slaHours = ticket.calculateSlaHours(now),
                 consumer = ticket.consumer?.let { user ->
                     AdminCsTicketUserResponse(
                         userId = user.id,
@@ -168,3 +168,14 @@ data class AdminCsTicketUpdateRequest(
     @field:Size(max = 1000)
     val processingMemo: String? = null,
 )
+
+private fun CsTicket.calculateSlaHours(now: LocalDateTime): Long {
+    val startedAt = createdAt ?: return 0L
+    val endedAt = if (status == CsTicketStatus.COMPLETED) {
+        resolvedAt ?: now
+    } else {
+        now
+    }
+
+    return Duration.between(startedAt, endedAt).toHours().coerceAtLeast(0)
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
@@ -1,0 +1,52 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminCsTicketService
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketDetailResponse
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketPageResponse
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketStatusFilter
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketUpdateRequest
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/cs-tickets")
+@Tag(name = "Admin", description = "운영자 관리")
+class AdminCsTicketController(
+    private val adminCsTicketService: AdminCsTicketService,
+) {
+
+    @GetMapping
+    @Operation(summary = "운영자 CS 티켓 목록 조회")
+    fun getTickets(
+        @RequestParam(defaultValue = "ALL") status: AdminCsTicketStatusFilter,
+        @RequestParam(required = false) keyword: String?,
+        pageable: Pageable,
+    ): ResponseEntity<ApiResponse<AdminCsTicketPageResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTickets(status, keyword, pageable)))
+
+    @GetMapping("/{ticketId}")
+    @Operation(summary = "운영자 CS 티켓 상세 조회")
+    fun getTicketDetail(
+        @PathVariable ticketId: Long,
+    ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTicketDetail(ticketId)))
+
+    @PatchMapping("/{ticketId}")
+    @Operation(summary = "운영자 CS 티켓 처리 정보 변경")
+    fun updateTicket(
+        @PathVariable ticketId: Long,
+        @Valid @RequestBody request: AdminCsTicketUpdateRequest,
+    ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminCsTicketService.updateTicket(ticketId, request)))
+}

--- a/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicket.kt
+++ b/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicket.kt
@@ -1,0 +1,79 @@
+package com.moongchijang.domain.csticket.domain.entity
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.user.domain.entity.User
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "cs_tickets")
+class CsTicket(
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    var type: CsTicketType,
+
+    @Column(nullable = false, length = 100)
+    var title: String,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var description: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var priority: CsTicketPriority = CsTicketPriority.MEDIUM,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: CsTicketStatus = CsTicketStatus.RECEIVED,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consumer_id")
+    var consumer: User? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_buy_id")
+    var groupBuy: GroupBuy? = null,
+
+    @Column(name = "refund_participation_id")
+    var refundParticipationId: Long? = null,
+
+    @Column(name = "assignee_name", length = 50)
+    var assigneeName: String? = null,
+
+    @Column(name = "processing_memo", length = 1000)
+    var processingMemo: String? = null,
+
+    @Column(name = "resolved_at")
+    var resolvedAt: LocalDateTime? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L,
+) : BaseEntity() {
+
+    fun updateProcessing(
+        status: CsTicketStatus?,
+        assigneeName: String?,
+        processingMemo: String?,
+        now: LocalDateTime,
+    ) {
+        status?.let {
+            this.status = it
+            resolvedAt = if (it == CsTicketStatus.COMPLETED) now else null
+        }
+        assigneeName?.let { this.assigneeName = it.takeIf { value -> value.isNotBlank() } }
+        processingMemo?.let { this.processingMemo = it.takeIf { value -> value.isNotBlank() } }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicketPriority.kt
+++ b/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicketPriority.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.csticket.domain.entity
+
+enum class CsTicketPriority {
+    LOW,
+    MEDIUM,
+    HIGH,
+    URGENT
+}

--- a/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicketStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicketStatus.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.csticket.domain.entity
+
+enum class CsTicketStatus {
+    RECEIVED,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicketType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/csticket/domain/entity/CsTicketType.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.domain.csticket.domain.entity
+
+enum class CsTicketType {
+    REFUND,
+    ORDER,
+    PICKUP,
+    ACCOUNT,
+    ETC
+}

--- a/src/main/kotlin/com/moongchijang/domain/csticket/domain/repository/CsTicketRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/csticket/domain/repository/CsTicketRepository.kt
@@ -2,11 +2,9 @@ package com.moongchijang.domain.csticket.domain.repository
 
 import com.moongchijang.domain.csticket.domain.entity.CsTicket
 import com.moongchijang.domain.csticket.domain.entity.CsTicketStatus
-import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.util.Optional
@@ -24,11 +22,11 @@ interface CsTicketRepository : JpaRepository<CsTicket, Long> {
               and (
                 :keyword is null
                 or ticket.id = :ticketId
-                or lower(coalesce(ticket.title, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(consumer.nickname, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(consumer.email, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(consumer.phoneNumber, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(groupBuy.productName, '')) like lower(concat('%', :keyword, '%'))
+                or lower(ticket.title) like lower(concat('%', :keyword, '%'))
+                or lower(consumer.nickname) like lower(concat('%', :keyword, '%'))
+                or lower(consumer.email) like lower(concat('%', :keyword, '%'))
+                or lower(consumer.phoneNumber) like lower(concat('%', :keyword, '%'))
+                or lower(groupBuy.productName) like lower(concat('%', :keyword, '%'))
               )
             order by ticket.createdAt desc, ticket.id desc
         """,
@@ -41,11 +39,11 @@ interface CsTicketRepository : JpaRepository<CsTicket, Long> {
               and (
                 :keyword is null
                 or ticket.id = :ticketId
-                or lower(coalesce(ticket.title, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(consumer.nickname, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(consumer.email, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(consumer.phoneNumber, '')) like lower(concat('%', :keyword, '%'))
-                or lower(coalesce(groupBuy.productName, '')) like lower(concat('%', :keyword, '%'))
+                or lower(ticket.title) like lower(concat('%', :keyword, '%'))
+                or lower(consumer.nickname) like lower(concat('%', :keyword, '%'))
+                or lower(consumer.email) like lower(concat('%', :keyword, '%'))
+                or lower(consumer.phoneNumber) like lower(concat('%', :keyword, '%'))
+                or lower(groupBuy.productName) like lower(concat('%', :keyword, '%'))
               )
         """
     )
@@ -68,7 +66,4 @@ interface CsTicketRepository : JpaRepository<CsTicket, Long> {
     )
     fun findAdminDetailById(@Param("id") id: Long): Optional<CsTicket>
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select ticket from CsTicket ticket where ticket.id = :id")
-    fun findWithLockById(@Param("id") id: Long): Optional<CsTicket>
 }

--- a/src/main/kotlin/com/moongchijang/domain/csticket/domain/repository/CsTicketRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/csticket/domain/repository/CsTicketRepository.kt
@@ -1,0 +1,74 @@
+package com.moongchijang.domain.csticket.domain.repository
+
+import com.moongchijang.domain.csticket.domain.entity.CsTicket
+import com.moongchijang.domain.csticket.domain.entity.CsTicketStatus
+import jakarta.persistence.LockModeType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.Optional
+
+interface CsTicketRepository : JpaRepository<CsTicket, Long> {
+
+    @Query(
+        value = """
+            select ticket
+            from CsTicket ticket
+            left join fetch ticket.consumer consumer
+            left join fetch ticket.groupBuy groupBuy
+            left join fetch groupBuy.store store
+            where (:status is null or ticket.status = :status)
+              and (
+                :keyword is null
+                or ticket.id = :ticketId
+                or lower(coalesce(ticket.title, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(consumer.nickname, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(consumer.email, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(consumer.phoneNumber, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(groupBuy.productName, '')) like lower(concat('%', :keyword, '%'))
+              )
+            order by ticket.createdAt desc, ticket.id desc
+        """,
+        countQuery = """
+            select count(ticket)
+            from CsTicket ticket
+            left join ticket.consumer consumer
+            left join ticket.groupBuy groupBuy
+            where (:status is null or ticket.status = :status)
+              and (
+                :keyword is null
+                or ticket.id = :ticketId
+                or lower(coalesce(ticket.title, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(consumer.nickname, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(consumer.email, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(consumer.phoneNumber, '')) like lower(concat('%', :keyword, '%'))
+                or lower(coalesce(groupBuy.productName, '')) like lower(concat('%', :keyword, '%'))
+              )
+        """
+    )
+    fun findAdminPage(
+        @Param("status") status: CsTicketStatus?,
+        @Param("keyword") keyword: String?,
+        @Param("ticketId") ticketId: Long?,
+        pageable: Pageable,
+    ): Page<CsTicket>
+
+    @Query(
+        """
+            select ticket
+            from CsTicket ticket
+            left join fetch ticket.consumer
+            left join fetch ticket.groupBuy groupBuy
+            left join fetch groupBuy.store
+            where ticket.id = :id
+        """
+    )
+    fun findAdminDetailById(@Param("id") id: Long): Optional<CsTicket>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select ticket from CsTicket ticket where ticket.id = :id")
+    fun findWithLockById(@Param("id") id: Long): Optional<CsTicket>
+}

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -149,6 +149,9 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_DATE(400_453, "픽업일은 공구 마감일 이후여야 합니다.", 400),
     OWNER_GROUPBUY_REQUEST_NOT_FOUND(404_450, "사장님 공구 개설 요청을 찾을 수 없습니다.", 404),
 
+    // CsTicket(500~549)
+    CS_TICKET_NOT_FOUND(404_500, "CS 티켓을 찾을 수 없습니다.", 404),
+
     // Notification(360~369)
     NOTIFICATION_NOT_FOUND(404_360, "알림을 찾을 수 없습니다.", 404),
     NOTIFICATION_FORBIDDEN(403_360, "본인 알림만 처리할 수 있습니다.", 403),

--- a/src/main/resources/db/migration/V35__create_cs_tickets_table.sql
+++ b/src/main/resources/db/migration/V35__create_cs_tickets_table.sql
@@ -1,0 +1,24 @@
+CREATE TABLE cs_tickets (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    type VARCHAR(30) NOT NULL,
+    title VARCHAR(100) NOT NULL,
+    description TEXT NOT NULL,
+    priority VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    consumer_id BIGINT NULL,
+    group_buy_id BIGINT NULL,
+    refund_participation_id BIGINT NULL,
+    assignee_name VARCHAR(50) NULL,
+    processing_memo VARCHAR(1000) NULL,
+    resolved_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_cs_tickets_consumer_id FOREIGN KEY (consumer_id) REFERENCES users (id),
+    CONSTRAINT fk_cs_tickets_group_buy_id FOREIGN KEY (group_buy_id) REFERENCES group_buys (id),
+    CONSTRAINT fk_cs_tickets_refund_participation_id FOREIGN KEY (refund_participation_id) REFERENCES participation (id)
+);
+
+CREATE INDEX idx_cs_tickets_status_created_at ON cs_tickets (status, created_at);
+CREATE INDEX idx_cs_tickets_consumer_id ON cs_tickets (consumer_id);
+CREATE INDEX idx_cs_tickets_group_buy_id ON cs_tickets (group_buy_id);

--- a/src/main/resources/db/migration/V35__create_cs_tickets_table.sql
+++ b/src/main/resources/db/migration/V35__create_cs_tickets_table.sql
@@ -22,3 +22,4 @@ CREATE TABLE cs_tickets (
 CREATE INDEX idx_cs_tickets_status_created_at ON cs_tickets (status, created_at);
 CREATE INDEX idx_cs_tickets_consumer_id ON cs_tickets (consumer_id);
 CREATE INDEX idx_cs_tickets_group_buy_id ON cs_tickets (group_buy_id);
+CREATE INDEX idx_cs_tickets_refund_participation_id ON cs_tickets (refund_participation_id);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1416,6 +1416,97 @@ paths:
         '409':
           $ref: '#/components/responses/Conflict'
 
+  /api/v1/admin/cs-tickets:
+    get:
+      tags: [Admin]
+      summary: CS 티켓 목록 조회 (운영자)
+      description: 접수, 처리중, 완료, 전체 CS 티켓을 상태와 키워드로 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [RECEIVED, IN_PROGRESS, COMPLETED, ALL]
+            default: ALL
+          description: RECEIVED=접수, IN_PROGRESS=처리중, COMPLETED=완료, ALL=전체
+        - name: keyword
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 티켓 ID, 제목, 소비자 닉네임/이메일/전화번호, 공구명 검색어
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: CS 티켓 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminCsTicketPage'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/admin/cs-tickets/{ticketId}:
+    get:
+      tags: [Admin]
+      summary: CS 티켓 상세 조회 (운영자)
+      description: 선택한 CS 티켓의 문제 설명, 관련 사용자/공구/환불, 처리 정보를 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: CS 티켓 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminCsTicketDetail'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags: [Admin]
+      summary: CS 티켓 처리 정보 변경 (운영자)
+      description: CS 티켓의 상태, 담당자, 처리 메모를 변경한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: ticketId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCsTicketUpdateRequest'
+      responses:
+        '200':
+          description: 변경 후 CS 티켓 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminCsTicketDetail'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/group-buys/{groupBuyId}/checkout:
     get:
       tags: [Participation]
@@ -5350,6 +5441,188 @@ components:
         actionable:
           type: boolean
           description: 발주 확정/연락 등 운영 작업 가능 여부
+
+    ApiResponseAdminCsTicketPage:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [content, totalElements, totalPages, number, size]
+          properties:
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/AdminCsTicketListItem'
+            totalElements: { type: integer, format: int64 }
+            totalPages: { type: integer }
+            number: { type: integer }
+            size: { type: integer }
+        error: { nullable: true, example: null }
+
+    AdminCsTicketListItem:
+      type: object
+      required: [ticketId, type, title, priority, slaHours, status, actionable]
+      properties:
+        ticketId: { type: integer, format: int64 }
+        type:
+          type: string
+          enum: [REFUND, ORDER, PICKUP, ACCOUNT, ETC]
+          description: 티켓 유형
+        title: { type: string }
+        consumerId:
+          type: integer
+          format: int64
+          nullable: true
+        consumerName:
+          type: string
+          nullable: true
+        groupBuyId:
+          type: integer
+          format: int64
+          nullable: true
+        groupBuyName:
+          type: string
+          nullable: true
+        priority:
+          type: string
+          enum: [LOW, MEDIUM, HIGH, URGENT]
+        assigneeName:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        slaHours:
+          type: integer
+          format: int64
+          description: 티켓 생성 후 경과 시간
+        status:
+          type: string
+          enum: [RECEIVED, IN_PROGRESS, COMPLETED]
+        actionable:
+          type: boolean
+          description: 운영 처리 가능 여부
+
+    ApiResponseAdminCsTicketDetail:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/AdminCsTicketDetail'
+        error: { nullable: true, example: null }
+
+    AdminCsTicketDetail:
+      type: object
+      required: [ticketId, type, title, description, priority, status, slaHours, actionable]
+      properties:
+        ticketId: { type: integer, format: int64 }
+        type:
+          type: string
+          enum: [REFUND, ORDER, PICKUP, ACCOUNT, ETC]
+        title: { type: string }
+        description: { type: string }
+        priority:
+          type: string
+          enum: [LOW, MEDIUM, HIGH, URGENT]
+        status:
+          type: string
+          enum: [RECEIVED, IN_PROGRESS, COMPLETED]
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        slaHours:
+          type: integer
+          format: int64
+          description: 티켓 생성 후 경과 시간
+        consumer:
+          allOf:
+            - $ref: '#/components/schemas/AdminCsTicketUser'
+          nullable: true
+        owner:
+          allOf:
+            - $ref: '#/components/schemas/AdminCsTicketOwner'
+          nullable: true
+        groupBuy:
+          allOf:
+            - $ref: '#/components/schemas/AdminCsTicketGroupBuy'
+          nullable: true
+        refundParticipationId:
+          type: integer
+          format: int64
+          nullable: true
+        assigneeName:
+          type: string
+          nullable: true
+        processingMemo:
+          type: string
+          nullable: true
+        resolvedAt:
+          type: string
+          format: date-time
+          nullable: true
+        actionable:
+          type: boolean
+          description: 운영 처리 가능 여부
+
+    AdminCsTicketUser:
+      type: object
+      properties:
+        userId:
+          type: integer
+          format: int64
+          nullable: true
+        nickname:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        phoneNumber:
+          type: string
+          nullable: true
+
+    AdminCsTicketOwner:
+      type: object
+      required: [storeId, storeName]
+      properties:
+        storeId: { type: integer, format: int64 }
+        storeName: { type: string }
+        storePhoneNumber:
+          type: string
+          nullable: true
+
+    AdminCsTicketGroupBuy:
+      type: object
+      required: [groupBuyId, productName, storeName]
+      properties:
+        groupBuyId: { type: integer, format: int64 }
+        productName: { type: string }
+        storeName: { type: string }
+
+    AdminCsTicketUpdateRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [RECEIVED, IN_PROGRESS, COMPLETED]
+          nullable: true
+        assigneeName:
+          type: string
+          maxLength: 50
+          nullable: true
+        processingMemo:
+          type: string
+          maxLength: 1000
+          nullable: true
 
     ApiResponseAdminRequestPage:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketServiceTest.kt
@@ -104,8 +104,10 @@ class AdminCsTicketServiceTest {
 
     @Test
     fun `CS 티켓 처리 상태 담당자 메모를 변경한다`() {
-        val ticket = createTicket(id = 12L, status = CsTicketStatus.RECEIVED)
-        `when`(csTicketRepository.findWithLockById(12L)).thenReturn(Optional.of(ticket))
+        val ticket = createTicket(id = 12L, status = CsTicketStatus.RECEIVED).apply {
+            setAuditTime(LocalDateTime.of(2026, 5, 28, 10, 0))
+        }
+        `when`(csTicketRepository.findAdminDetailById(12L)).thenReturn(Optional.of(ticket))
 
         val result = service.updateTicket(
             ticketId = 12L,
@@ -120,8 +122,24 @@ class AdminCsTicketServiceTest {
         assertEquals("김은서", result.assigneeName)
         assertEquals("안내 완료", result.processingMemo)
         assertEquals(LocalDateTime.of(2026, 5, 28, 13, 0), result.resolvedAt)
+        assertEquals(3L, result.slaHours)
         assertFalse(result.actionable)
         assertNotNull(ticket.resolvedAt)
+    }
+
+    @Test
+    fun `완료된 CS 티켓 SLA는 해결 시각 기준으로 계산한다`() {
+        val ticket = createTicket(id = 13L, status = CsTicketStatus.COMPLETED).apply {
+            setAuditTime(LocalDateTime.of(2026, 5, 28, 9, 0))
+            resolvedAt = LocalDateTime.of(2026, 5, 28, 10, 30)
+        }
+        `when`(csTicketRepository.findAdminDetailById(13L)).thenReturn(Optional.of(ticket))
+
+        val result = service.getTicketDetail(13L)
+
+        assertEquals(CsTicketStatus.COMPLETED, result.status)
+        assertEquals(1L, result.slaHours)
+        assertFalse(result.actionable)
     }
 
     private fun createTicket(

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketServiceTest.kt
@@ -1,0 +1,153 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketStatusFilter
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketUpdateRequest
+import com.moongchijang.domain.csticket.domain.entity.CsTicket
+import com.moongchijang.domain.csticket.domain.entity.CsTicketPriority
+import com.moongchijang.domain.csticket.domain.entity.CsTicketStatus
+import com.moongchijang.domain.csticket.domain.entity.CsTicketType
+import com.moongchijang.domain.csticket.domain.repository.CsTicketRepository
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.global.entity.BaseEntity
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Optional
+
+class AdminCsTicketServiceTest {
+
+    private val csTicketRepository: CsTicketRepository = mock(CsTicketRepository::class.java)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val service = AdminCsTicketService(csTicketRepository, clock)
+
+    @Test
+    fun `CS 티켓 목록을 상태와 검색어로 조회한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val ticket = createTicket(id = 10L, status = CsTicketStatus.RECEIVED).apply {
+            setAuditTime(LocalDateTime.of(2026, 5, 28, 10, 0))
+        }
+        `when`(
+            csTicketRepository.findAdminPage(
+                CsTicketStatus.RECEIVED,
+                "10",
+                10L,
+                pageable
+            )
+        ).thenReturn(PageImpl(listOf(ticket), pageable, 1))
+
+        val result = service.getTickets(AdminCsTicketStatusFilter.RECEIVED, " 10 ", pageable)
+
+        assertEquals(1, result.content.size)
+        assertEquals(10L, result.content[0].ticketId)
+        assertEquals("픽업 일정 문의", result.content[0].title)
+        assertEquals("테스트유저", result.content[0].consumerName)
+        assertEquals("두쫀쿠 1개", result.content[0].groupBuyName)
+        assertEquals(3L, result.content[0].slaHours)
+        assertTrue(result.content[0].actionable)
+    }
+
+    @Test
+    fun `빈 검색어는 검색 조건 없이 전체 상태로 조회한다`() {
+        val pageable = PageRequest.of(0, 20)
+        `when`(csTicketRepository.findAdminPage(null, null, null, pageable))
+            .thenReturn(PageImpl(emptyList(), pageable, 0))
+
+        val result = service.getTickets(AdminCsTicketStatusFilter.ALL, "   ", pageable)
+
+        assertTrue(result.content.isEmpty())
+        verify(csTicketRepository).findAdminPage(null, null, null, pageable)
+    }
+
+    @Test
+    fun `CS 티켓 상세를 조회한다`() {
+        val ticket = createTicket(id = 11L, status = CsTicketStatus.IN_PROGRESS).apply {
+            assigneeName = "김은서"
+            processingMemo = "사장님 확인 대기"
+            setAuditTime(LocalDateTime.of(2026, 5, 28, 9, 0))
+        }
+        `when`(csTicketRepository.findAdminDetailById(11L)).thenReturn(Optional.of(ticket))
+
+        val result = service.getTicketDetail(11L)
+
+        assertEquals(11L, result.ticketId)
+        assertEquals(CsTicketStatus.IN_PROGRESS, result.status)
+        assertEquals("김은서", result.assigneeName)
+        assertEquals("사장님 확인 대기", result.processingMemo)
+        assertEquals("뭉치장 베이커리", result.owner?.storeName)
+        assertEquals(4L, result.slaHours)
+        assertTrue(result.actionable)
+    }
+
+    @Test
+    fun `존재하지 않는 CS 티켓 상세는 예외를 던진다`() {
+        `when`(csTicketRepository.findAdminDetailById(404L)).thenReturn(Optional.empty())
+
+        assertThrows(CustomException::class.java) {
+            service.getTicketDetail(404L)
+        }
+    }
+
+    @Test
+    fun `CS 티켓 처리 상태 담당자 메모를 변경한다`() {
+        val ticket = createTicket(id = 12L, status = CsTicketStatus.RECEIVED)
+        `when`(csTicketRepository.findWithLockById(12L)).thenReturn(Optional.of(ticket))
+
+        val result = service.updateTicket(
+            ticketId = 12L,
+            request = AdminCsTicketUpdateRequest(
+                status = CsTicketStatus.COMPLETED,
+                assigneeName = "김은서",
+                processingMemo = "안내 완료"
+            )
+        )
+
+        assertEquals(CsTicketStatus.COMPLETED, result.status)
+        assertEquals("김은서", result.assigneeName)
+        assertEquals("안내 완료", result.processingMemo)
+        assertEquals(LocalDateTime.of(2026, 5, 28, 13, 0), result.resolvedAt)
+        assertFalse(result.actionable)
+        assertNotNull(ticket.resolvedAt)
+    }
+
+    private fun createTicket(
+        id: Long,
+        status: CsTicketStatus,
+    ): CsTicket =
+        CsTicket(
+            type = CsTicketType.PICKUP,
+            title = "픽업 일정 문의",
+            description = "픽업 시간을 바꿀 수 있나요?",
+            priority = CsTicketPriority.MEDIUM,
+            status = status,
+            consumer = UserFixture.createKakaoUser(id = 3L),
+            groupBuy = GroupBuyFixture.createGroupBuy(id = 30L, status = GroupBuyStatus.IN_PROGRESS),
+            refundParticipationId = null,
+            id = id
+        )
+
+    private fun BaseEntity.setAuditTime(value: LocalDateTime) {
+        BaseEntity::class.java.getDeclaredField("createdAt").apply {
+            isAccessible = true
+            set(this@setAuditTime, value)
+        }
+        BaseEntity::class.java.getDeclaredField("updatedAt").apply {
+            isAccessible = true
+            set(this@setAuditTime, value)
+        }
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketControllerTest.kt
@@ -1,0 +1,98 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminCsTicketService
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketDetailResponse
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketPageResponse
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketStatusFilter
+import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketUpdateRequest
+import com.moongchijang.domain.csticket.domain.entity.CsTicketPriority
+import com.moongchijang.domain.csticket.domain.entity.CsTicketStatus
+import com.moongchijang.domain.csticket.domain.entity.CsTicketType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDateTime
+
+class AdminCsTicketControllerTest {
+
+    private val adminCsTicketService: AdminCsTicketService = mock(AdminCsTicketService::class.java)
+    private val controller = AdminCsTicketController(adminCsTicketService)
+
+    @Test
+    fun `운영자 CS 티켓 목록 조회는 상태 검색어 페이징을 서비스로 전달한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val response = AdminCsTicketPageResponse(
+            content = emptyList(),
+            totalElements = 0,
+            totalPages = 0,
+            number = 0,
+            size = 20
+        )
+        `when`(
+            adminCsTicketService.getTickets(
+                AdminCsTicketStatusFilter.IN_PROGRESS,
+                "소비자",
+                pageable
+            )
+        ).thenReturn(response)
+
+        val result = controller.getTickets(AdminCsTicketStatusFilter.IN_PROGRESS, "소비자", pageable)
+
+        assertEquals(response, result.body?.data)
+        verify(adminCsTicketService).getTickets(AdminCsTicketStatusFilter.IN_PROGRESS, "소비자", pageable)
+    }
+
+    @Test
+    fun `운영자 CS 티켓 상세 조회는 티켓 ID를 서비스로 전달한다`() {
+        val response = detailResponse(ticketId = 10L)
+        `when`(adminCsTicketService.getTicketDetail(10L)).thenReturn(response)
+
+        val result = controller.getTicketDetail(10L)
+
+        assertEquals(response, result.body?.data)
+        verify(adminCsTicketService).getTicketDetail(10L)
+    }
+
+    @Test
+    fun `운영자 CS 티켓 변경은 티켓 ID와 요청을 서비스로 전달한다`() {
+        val request = AdminCsTicketUpdateRequest(
+            status = CsTicketStatus.COMPLETED,
+            assigneeName = "김은서",
+            processingMemo = "처리 완료"
+        )
+        val response = detailResponse(ticketId = 11L, status = CsTicketStatus.COMPLETED)
+        `when`(adminCsTicketService.updateTicket(11L, request)).thenReturn(response)
+
+        val result = controller.updateTicket(11L, request)
+
+        assertEquals(response, result.body?.data)
+        verify(adminCsTicketService).updateTicket(11L, request)
+    }
+
+    private fun detailResponse(
+        ticketId: Long,
+        status: CsTicketStatus = CsTicketStatus.RECEIVED,
+    ): AdminCsTicketDetailResponse =
+        AdminCsTicketDetailResponse(
+            ticketId = ticketId,
+            type = CsTicketType.PICKUP,
+            title = "픽업 일정 문의",
+            description = "픽업 시간을 바꿀 수 있나요?",
+            priority = CsTicketPriority.MEDIUM,
+            status = status,
+            createdAt = LocalDateTime.of(2026, 5, 28, 10, 0),
+            updatedAt = LocalDateTime.of(2026, 5, 28, 10, 0),
+            slaHours = 3,
+            consumer = null,
+            owner = null,
+            groupBuy = null,
+            refundParticipationId = null,
+            assigneeName = "김은서",
+            processingMemo = "처리 완료",
+            resolvedAt = null,
+            actionable = status != CsTicketStatus.COMPLETED
+        )
+}


### PR DESCRIPTION
## 📌 작업한 내용
- CS 티켓 엔티티/상태/우선순위/유형과 테이블 마이그레이션을 추가했습니다.
- 운영자 CS 티켓 목록, 상세, 처리 정보 변경 API를 구현했습니다.
- 상태 필터와 키워드 검색(티켓 ID, 제목, 소비자 정보, 공구명)을 지원합니다.
- 서비스/컨트롤러 테스트와 OpenAPI 스펙을 추가했습니다.

## 🔍 참고 사항
- 관련 환불은 현재 환불 도메인 연동 전이라 `refundParticipationId`로 연결 가능하게 열어두었습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- closes #254


## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인