### PR TITLE
[MCJ-1556] FEAT: 어드민 정산 현황 기본 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
@@ -1,0 +1,136 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.settlement.ADMIN_SETTLEMENT_DELAY_DAYS
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDashboardResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDetailResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementPageResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatus
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatusFilter
+import com.moongchijang.domain.admin.application.dto.settlement.scheduledSettlementDate
+import com.moongchijang.domain.admin.application.dto.settlement.settlementAmount
+import com.moongchijang.domain.admin.application.dto.settlement.toSettlementStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Service
+@Transactional(readOnly = true)
+class AdminSettlementService(
+    private val participationRepository: ParticipationRepository,
+    private val clock: Clock,
+) {
+
+    fun getDashboard(
+        year: Int,
+        month: Int,
+    ): AdminSettlementDashboardResponse {
+        val yearMonth = validateYearMonth(year, month)
+        val today = LocalDate.now(clock)
+        val range = yearMonth.toDateRange()
+        val aggregations = participationRepository.findAdminSettlementAggregations(
+            groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,
+            transactionStatuses = TRANSACTION_STATUSES,
+            revenueStatuses = REVENUE_STATUSES,
+            refundStatuses = REFUND_STATUSES,
+            pickupDateFrom = range.from,
+            pickupDateTo = range.to
+        )
+
+        return AdminSettlementDashboardResponse(
+            year = year,
+            month = month,
+            completedSettlementAmount = aggregations
+                .filter { it.scheduledSettlementDate().toSettlementStatus(today) == AdminSettlementStatus.COMPLETED }
+                .sumOf { it.settlementAmount() },
+            scheduledSettlementAmount = aggregations
+                .filter { it.scheduledSettlementDate().toSettlementStatus(today) == AdminSettlementStatus.SCHEDULED }
+                .sumOf { it.settlementAmount() },
+            platformFeeAmount = aggregations.sumOf { it.platformFeeAmount },
+            totalTransactionAmount = aggregations.sumOf { it.totalPaymentAmount }
+        )
+    }
+
+    fun getSettlements(
+        year: Int,
+        month: Int,
+        status: AdminSettlementStatusFilter,
+        pageable: Pageable,
+    ): AdminSettlementPageResponse {
+        val yearMonth = validateYearMonth(year, month)
+        val today = LocalDate.now(clock)
+        val range = yearMonth.toDateRange().filterByStatus(status, today)
+        val page = participationRepository.findAdminSettlementPage(
+            groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,
+            transactionStatuses = TRANSACTION_STATUSES,
+            revenueStatuses = REVENUE_STATUSES,
+            refundStatuses = REFUND_STATUSES,
+            pickupDateFrom = range.from,
+            pickupDateTo = range.to,
+            pageable = pageable
+        )
+
+        return AdminSettlementPageResponse.from(page, today)
+    }
+
+    fun getSettlementDetail(settlementId: Long): AdminSettlementDetailResponse {
+        val today = LocalDate.now(clock)
+        val aggregation = participationRepository.findAdminSettlementDetail(
+            groupBuyId = settlementId,
+            groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,
+            transactionStatuses = TRANSACTION_STATUSES,
+            revenueStatuses = REVENUE_STATUSES,
+            refundStatuses = REFUND_STATUSES,
+        ) ?: throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
+
+        return AdminSettlementDetailResponse.from(aggregation, today)
+    }
+
+    private fun validateYearMonth(year: Int, month: Int): YearMonth {
+        if (year !in 2000..2100 || month !in 1..12) {
+            throw CustomException(ErrorCode.INVALID_INPUT)
+        }
+
+        return YearMonth.of(year, month)
+    }
+
+    private fun YearMonth.toDateRange(): DateRange =
+        DateRange(atDay(1), plusMonths(1).atDay(1))
+
+    private fun DateRange.filterByStatus(
+        status: AdminSettlementStatusFilter,
+        today: LocalDate,
+    ): DateRange {
+        val completedToExclusive = today.minusDays(ADMIN_SETTLEMENT_DELAY_DAYS).plusDays(1)
+        return when (status) {
+            AdminSettlementStatusFilter.SCHEDULED -> DateRange(
+                from = maxOf(from, completedToExclusive),
+                to = to
+            )
+            AdminSettlementStatusFilter.COMPLETED -> DateRange(
+                from = from,
+                to = minOf(to, completedToExclusive)
+            )
+            AdminSettlementStatusFilter.ALL -> this
+        }
+    }
+
+    private data class DateRange(
+        val from: LocalDate,
+        val to: LocalDate,
+    )
+
+    private companion object {
+        val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val REVENUE_STATUSES = listOf(ParticipationStatus.CONFIRMED)
+        val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+        val TRANSACTION_STATUSES = REVENUE_STATUSES + REFUND_STATUSES
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.admin.application
 import com.moongchijang.domain.admin.application.dto.settlement.ADMIN_SETTLEMENT_DELAY_DAYS
 import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDashboardResponse
 import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDetailResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementListItemResponse
 import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementPageResponse
 import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatus
 import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatusFilter
@@ -53,7 +54,7 @@ class AdminSettlementService(
             scheduledSettlementAmount = aggregations
                 .filter { it.scheduledSettlementDate().toSettlementStatus(today) == AdminSettlementStatus.SCHEDULED }
                 .sumOf { it.settlementAmount() },
-            platformFeeAmount = aggregations.sumOf { it.platformFeeAmount },
+            platformFeeAmount = 0L,
             totalTransactionAmount = aggregations.sumOf { it.totalPaymentAmount }
         )
     }
@@ -90,7 +91,7 @@ class AdminSettlementService(
             refundStatuses = REFUND_STATUSES,
         ) ?: throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
 
-        return AdminSettlementDetailResponse.from(aggregation, today)
+        return AdminSettlementListItemResponse.from(aggregation, today)
     }
 
     private fun validateYearMonth(year: Int, month: Int): YearMonth {

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/settlement/AdminSettlementResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/settlement/AdminSettlementResponse.kt
@@ -1,0 +1,140 @@
+package com.moongchijang.domain.admin.application.dto.settlement
+
+import com.moongchijang.domain.participation.domain.repository.AdminSettlementAggregation
+import org.springframework.data.domain.Page
+import java.time.LocalDate
+
+enum class AdminSettlementStatusFilter {
+    SCHEDULED,
+    COMPLETED,
+    ALL
+}
+
+enum class AdminSettlementStatus {
+    SCHEDULED,
+    COMPLETED
+}
+
+data class AdminSettlementDashboardResponse(
+    val year: Int,
+    val month: Int,
+    val completedSettlementAmount: Long,
+    val scheduledSettlementAmount: Long,
+    val platformFeeAmount: Long,
+    val totalTransactionAmount: Long,
+)
+
+data class AdminSettlementPageResponse(
+    val content: List<AdminSettlementListItemResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int,
+) {
+    companion object {
+        fun from(
+            page: Page<AdminSettlementAggregation>,
+            today: LocalDate,
+        ): AdminSettlementPageResponse =
+            AdminSettlementPageResponse(
+                content = page.content.map { AdminSettlementListItemResponse.from(it, today) },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                number = page.number,
+                size = page.size
+            )
+    }
+}
+
+data class AdminSettlementListItemResponse(
+    val settlementId: Long,
+    val groupBuyId: Long,
+    val storeName: String,
+    val productName: String,
+    val pickupCompletedDate: LocalDate,
+    val participantCount: Long,
+    val totalPaymentAmount: Long,
+    val refundDeductionAmount: Long,
+    val platformFeeAmount: Long,
+    val settlementAmount: Long,
+    val scheduledSettlementDate: LocalDate,
+    val status: AdminSettlementStatus,
+    val actionable: Boolean,
+) {
+    companion object {
+        fun from(
+            aggregation: AdminSettlementAggregation,
+            today: LocalDate,
+        ): AdminSettlementListItemResponse {
+            val scheduledSettlementDate = aggregation.scheduledSettlementDate()
+            val status = scheduledSettlementDate.toSettlementStatus(today)
+            return AdminSettlementListItemResponse(
+                settlementId = aggregation.groupBuyId,
+                groupBuyId = aggregation.groupBuyId,
+                storeName = aggregation.storeName,
+                productName = aggregation.productName,
+                pickupCompletedDate = aggregation.pickupCompletedDate,
+                participantCount = aggregation.participantCount,
+                totalPaymentAmount = aggregation.totalPaymentAmount,
+                refundDeductionAmount = aggregation.refundDeductionAmount,
+                platformFeeAmount = aggregation.platformFeeAmount,
+                settlementAmount = aggregation.settlementAmount(),
+                scheduledSettlementDate = scheduledSettlementDate,
+                status = status,
+                actionable = status == AdminSettlementStatus.SCHEDULED
+            )
+        }
+    }
+}
+
+data class AdminSettlementDetailResponse(
+    val settlementId: Long,
+    val groupBuyId: Long,
+    val storeName: String,
+    val productName: String,
+    val pickupCompletedDate: LocalDate,
+    val participantCount: Long,
+    val totalPaymentAmount: Long,
+    val refundDeductionAmount: Long,
+    val platformFeeAmount: Long,
+    val settlementAmount: Long,
+    val scheduledSettlementDate: LocalDate,
+    val status: AdminSettlementStatus,
+    val actionable: Boolean,
+) {
+    companion object {
+        fun from(
+            aggregation: AdminSettlementAggregation,
+            today: LocalDate,
+        ): AdminSettlementDetailResponse {
+            val scheduledSettlementDate = aggregation.scheduledSettlementDate()
+            val status = scheduledSettlementDate.toSettlementStatus(today)
+            return AdminSettlementDetailResponse(
+                settlementId = aggregation.groupBuyId,
+                groupBuyId = aggregation.groupBuyId,
+                storeName = aggregation.storeName,
+                productName = aggregation.productName,
+                pickupCompletedDate = aggregation.pickupCompletedDate,
+                participantCount = aggregation.participantCount,
+                totalPaymentAmount = aggregation.totalPaymentAmount,
+                refundDeductionAmount = aggregation.refundDeductionAmount,
+                platformFeeAmount = aggregation.platformFeeAmount,
+                settlementAmount = aggregation.settlementAmount(),
+                scheduledSettlementDate = scheduledSettlementDate,
+                status = status,
+                actionable = status == AdminSettlementStatus.SCHEDULED
+            )
+        }
+    }
+}
+
+fun AdminSettlementAggregation.settlementAmount(): Long =
+    (totalPaymentAmount - refundDeductionAmount - platformFeeAmount).coerceAtLeast(0L)
+
+fun AdminSettlementAggregation.scheduledSettlementDate(): LocalDate =
+    pickupCompletedDate.plusDays(ADMIN_SETTLEMENT_DELAY_DAYS)
+
+fun LocalDate.toSettlementStatus(today: LocalDate): AdminSettlementStatus =
+    if (isAfter(today)) AdminSettlementStatus.SCHEDULED else AdminSettlementStatus.COMPLETED
+
+const val ADMIN_SETTLEMENT_DELAY_DAYS: Long = 3

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/settlement/AdminSettlementResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/settlement/AdminSettlementResponse.kt
@@ -77,7 +77,7 @@ data class AdminSettlementListItemResponse(
                 participantCount = aggregation.participantCount,
                 totalPaymentAmount = aggregation.totalPaymentAmount,
                 refundDeductionAmount = aggregation.refundDeductionAmount,
-                platformFeeAmount = aggregation.platformFeeAmount,
+                platformFeeAmount = 0L,
                 settlementAmount = aggregation.settlementAmount(),
                 scheduledSettlementDate = scheduledSettlementDate,
                 status = status,
@@ -87,49 +87,10 @@ data class AdminSettlementListItemResponse(
     }
 }
 
-data class AdminSettlementDetailResponse(
-    val settlementId: Long,
-    val groupBuyId: Long,
-    val storeName: String,
-    val productName: String,
-    val pickupCompletedDate: LocalDate,
-    val participantCount: Long,
-    val totalPaymentAmount: Long,
-    val refundDeductionAmount: Long,
-    val platformFeeAmount: Long,
-    val settlementAmount: Long,
-    val scheduledSettlementDate: LocalDate,
-    val status: AdminSettlementStatus,
-    val actionable: Boolean,
-) {
-    companion object {
-        fun from(
-            aggregation: AdminSettlementAggregation,
-            today: LocalDate,
-        ): AdminSettlementDetailResponse {
-            val scheduledSettlementDate = aggregation.scheduledSettlementDate()
-            val status = scheduledSettlementDate.toSettlementStatus(today)
-            return AdminSettlementDetailResponse(
-                settlementId = aggregation.groupBuyId,
-                groupBuyId = aggregation.groupBuyId,
-                storeName = aggregation.storeName,
-                productName = aggregation.productName,
-                pickupCompletedDate = aggregation.pickupCompletedDate,
-                participantCount = aggregation.participantCount,
-                totalPaymentAmount = aggregation.totalPaymentAmount,
-                refundDeductionAmount = aggregation.refundDeductionAmount,
-                platformFeeAmount = aggregation.platformFeeAmount,
-                settlementAmount = aggregation.settlementAmount(),
-                scheduledSettlementDate = scheduledSettlementDate,
-                status = status,
-                actionable = status == AdminSettlementStatus.SCHEDULED
-            )
-        }
-    }
-}
+typealias AdminSettlementDetailResponse = AdminSettlementListItemResponse
 
 fun AdminSettlementAggregation.settlementAmount(): Long =
-    (totalPaymentAmount - refundDeductionAmount - platformFeeAmount).coerceAtLeast(0L)
+    (totalPaymentAmount - refundDeductionAmount).coerceAtLeast(0L)
 
 fun AdminSettlementAggregation.scheduledSettlementDate(): LocalDate =
     pickupCompletedDate.plusDays(ADMIN_SETTLEMENT_DELAY_DAYS)

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
@@ -1,0 +1,50 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminSettlementService
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDashboardResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDetailResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementPageResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatusFilter
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Pageable
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/settlements")
+@Tag(name = "Admin", description = "운영자 관리")
+class AdminSettlementController(
+    private val adminSettlementService: AdminSettlementService,
+) {
+
+    @GetMapping("/dashboard")
+    @Operation(summary = "운영자 정산 현황 대시보드 조회")
+    fun getDashboard(
+        @RequestParam year: Int,
+        @RequestParam month: Int,
+    ): ResponseEntity<ApiResponse<AdminSettlementDashboardResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminSettlementService.getDashboard(year, month)))
+
+    @GetMapping
+    @Operation(summary = "운영자 정산 현황 목록 조회")
+    fun getSettlements(
+        @RequestParam year: Int,
+        @RequestParam month: Int,
+        @RequestParam(defaultValue = "ALL") status: AdminSettlementStatusFilter,
+        pageable: Pageable,
+    ): ResponseEntity<ApiResponse<AdminSettlementPageResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlements(year, month, status, pageable)))
+
+    @GetMapping("/{settlementId}")
+    @Operation(summary = "운영자 정산 현황 상세 조회")
+    fun getSettlementDetail(
+        @PathVariable settlementId: Long,
+    ): ResponseEntity<ApiResponse<AdminSettlementDetailResponse>> =
+        ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlementDetail(settlementId)))
+}

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -399,7 +399,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
                coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
                coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
-               coalesce(sum(case when p.status in :transactionStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
+               0 as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
         where gb.status in :groupBuyStatuses
@@ -435,7 +435,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
                coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
                coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
-               coalesce(sum(case when p.status in :transactionStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
+               0 as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
         where gb.status in :groupBuyStatuses
@@ -462,7 +462,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
                coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
                coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
-               coalesce(sum(case when p.status in :transactionStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
+               0 as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
         where gb.id = :groupBuyId

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -391,6 +391,94 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     ): List<Participation>
 
     @Query(
+        value = """
+        select gb.id as groupBuyId,
+               gb.store.name as storeName,
+               gb.productName as productName,
+               gb.pickupDate as pickupCompletedDate,
+               coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
+               coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
+               coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
+               coalesce(sum(case when p.status in :transactionStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
+        from GroupBuy gb
+        left join Participation p on p.groupBuy = gb
+        where gb.status in :groupBuyStatuses
+          and gb.pickupDate >= :pickupDateFrom
+          and gb.pickupDate < :pickupDateTo
+        group by gb.id, gb.store.name, gb.productName, gb.pickupDate
+        order by gb.pickupDate desc, gb.id desc
+        """,
+        countQuery = """
+        select count(gb)
+        from GroupBuy gb
+        where gb.status in :groupBuyStatuses
+          and gb.pickupDate >= :pickupDateFrom
+          and gb.pickupDate < :pickupDateTo
+        """
+    )
+    fun findAdminSettlementPage(
+        @Param("groupBuyStatuses") groupBuyStatuses: Collection<GroupBuyStatus>,
+        @Param("transactionStatuses") transactionStatuses: Collection<ParticipationStatus>,
+        @Param("revenueStatuses") revenueStatuses: Collection<ParticipationStatus>,
+        @Param("refundStatuses") refundStatuses: Collection<ParticipationStatus>,
+        @Param("pickupDateFrom") pickupDateFrom: LocalDate,
+        @Param("pickupDateTo") pickupDateTo: LocalDate,
+        pageable: Pageable,
+    ): Page<AdminSettlementAggregation>
+
+    @Query(
+        """
+        select gb.id as groupBuyId,
+               gb.store.name as storeName,
+               gb.productName as productName,
+               gb.pickupDate as pickupCompletedDate,
+               coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
+               coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
+               coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
+               coalesce(sum(case when p.status in :transactionStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
+        from GroupBuy gb
+        left join Participation p on p.groupBuy = gb
+        where gb.status in :groupBuyStatuses
+          and gb.pickupDate >= :pickupDateFrom
+          and gb.pickupDate < :pickupDateTo
+        group by gb.id, gb.store.name, gb.productName, gb.pickupDate
+        """
+    )
+    fun findAdminSettlementAggregations(
+        @Param("groupBuyStatuses") groupBuyStatuses: Collection<GroupBuyStatus>,
+        @Param("transactionStatuses") transactionStatuses: Collection<ParticipationStatus>,
+        @Param("revenueStatuses") revenueStatuses: Collection<ParticipationStatus>,
+        @Param("refundStatuses") refundStatuses: Collection<ParticipationStatus>,
+        @Param("pickupDateFrom") pickupDateFrom: LocalDate,
+        @Param("pickupDateTo") pickupDateTo: LocalDate,
+    ): List<AdminSettlementAggregation>
+
+    @Query(
+        """
+        select gb.id as groupBuyId,
+               gb.store.name as storeName,
+               gb.productName as productName,
+               gb.pickupDate as pickupCompletedDate,
+               coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
+               coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
+               coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
+               coalesce(sum(case when p.status in :transactionStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
+        from GroupBuy gb
+        left join Participation p on p.groupBuy = gb
+        where gb.id = :groupBuyId
+          and gb.status in :groupBuyStatuses
+        group by gb.id, gb.store.name, gb.productName, gb.pickupDate
+        """
+    )
+    fun findAdminSettlementDetail(
+        @Param("groupBuyId") groupBuyId: Long,
+        @Param("groupBuyStatuses") groupBuyStatuses: Collection<GroupBuyStatus>,
+        @Param("transactionStatuses") transactionStatuses: Collection<ParticipationStatus>,
+        @Param("revenueStatuses") revenueStatuses: Collection<ParticipationStatus>,
+        @Param("refundStatuses") refundStatuses: Collection<ParticipationStatus>,
+    ): AdminSettlementAggregation?
+
+    @Query(
         """
         select p
         from Participation p
@@ -429,4 +517,15 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
 interface GroupBuyPendingRefundCount {
     val groupBuyId: Long
     val pendingRefundCount: Long
+}
+
+interface AdminSettlementAggregation {
+    val groupBuyId: Long
+    val storeName: String
+    val productName: String
+    val pickupCompletedDate: LocalDate
+    val participantCount: Long
+    val totalPaymentAmount: Long
+    val refundDeductionAmount: Long
+    val platformFeeAmount: Long
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2615,7 +2615,7 @@ paths:
     get:
       tags: [Admin]
       summary: 정산 현황 대시보드 조회 (운영자)
-      description: 선택한 연월의 정산 완료 금액, 정산 예정 금액, 플랫폼 수수료, 총 거래액을 조회한다.
+      description: 선택한 연월의 정산 완료 금액, 정산 예정 금액, 서비스 수수료, 총 거래액을 조회한다. 현재 서비스 수수료 정책은 0원이다.
       security:
         - bearerAuth: []
       parameters:
@@ -5915,7 +5915,7 @@ components:
             platformFeeAmount:
               type: integer
               format: int64
-              description: 플랫폼 수수료 합계
+              description: 서비스 수수료 합계. 현재 정책은 0원
             totalTransactionAmount:
               type: integer
               format: int64
@@ -5971,11 +5971,11 @@ components:
         platformFeeAmount:
           type: integer
           format: int64
-          description: 플랫폼 수수료
+          description: 서비스 수수료. 현재 정책은 0원
         settlementAmount:
           type: integer
           format: int64
-          description: 총 결제액 - 환불 차감액 - 플랫폼 수수료
+          description: 총 결제액 - 환불 차감액
         scheduledSettlementDate:
           type: string
           format: date

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2611,53 +2611,88 @@ paths:
         '409':
           $ref: '#/components/responses/Conflict'
 
-  /api/v1/admin/settlements:
+  /api/v1/admin/settlements/dashboard:
     get:
       tags: [Admin]
-      summary: 정산 내역 목록 (운영자)
+      summary: 정산 현황 대시보드 조회 (운영자)
+      description: 선택한 연월의 정산 완료 금액, 정산 예정 금액, 플랫폼 수수료, 총 거래액을 조회한다.
       security:
         - bearerAuth: []
       parameters:
-        - name: escrowStatus
+        - name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            example: 2026
+        - name: month
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+            example: 5
+      responses:
+        '200':
+          description: 정산 대시보드
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminSettlementDashboard'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/admin/settlements:
+    get:
+      tags: [Admin]
+      summary: 정산 현황 목록 조회 (운영자)
+      description: 선택한 연월의 정산 예정, 정산 완료, 전체 목록을 조회한다. 현재 settlementId는 groupBuyId와 동일하다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            example: 2026
+        - name: month
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+            example: 5
+        - name: status
           in: query
           schema:
             type: string
-            enum: [ALL, HOLDING, RELEASED]
+            enum: [SCHEDULED, COMPLETED, ALL]
             default: ALL
+          description: SCHEDULED=정산 예정, COMPLETED=정산 완료, ALL=전체
         - $ref: '#/components/parameters/Page'
         - $ref: '#/components/parameters/Size'
       responses:
         '200':
-          description: 정산 목록
+          description: 정산 현황 목록
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiResponseSettlementPage'
-    post:
-      tags: [Admin]
-      summary: 정산 생성 및 처리
-      security:
-        - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AdminSettlementCreate'
-      responses:
-        '201':
-          description: 정산 생성 완료
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiResponseSettlementId'
-        '409':
-          $ref: '#/components/responses/Conflict'
+                $ref: '#/components/schemas/ApiResponseAdminSettlementPage'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
-  /api/v1/admin/settlements/{settlementId}/release:
-    post:
+  /api/v1/admin/settlements/{settlementId}:
+    get:
       tags: [Admin]
-      summary: 에스크로 해제
+      summary: 정산 현황 상세 조회 (운영자)
+      description: 목록에서 선택한 정산 건의 상세 팝업용 정보를 조회한다. 현재 settlementId는 groupBuyId와 동일하다.
       security:
         - bearerAuth: []
       parameters:
@@ -2669,9 +2704,15 @@ paths:
             format: int64
       responses:
         '200':
-          $ref: '#/components/responses/SuccessNoData'
-        '409':
-          $ref: '#/components/responses/Conflict'
+          description: 정산 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminSettlementDetail'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 # ─────────────────────────────────────────────────────────────────
 # Components
@@ -5852,61 +5893,112 @@ components:
           maxLength: 100
           nullable: true
 
-    ApiResponseSettlementPage:
+    ApiResponseAdminSettlementDashboard:
       type: object
       required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
           type: object
-          required: [content, totalElements, totalPages]
+          required: [year, month, completedSettlementAmount, scheduledSettlementAmount, platformFeeAmount, totalTransactionAmount]
+          properties:
+            year: { type: integer, example: 2026 }
+            month: { type: integer, example: 5 }
+            completedSettlementAmount:
+              type: integer
+              format: int64
+              description: 정산 완료 금액 합계
+            scheduledSettlementAmount:
+              type: integer
+              format: int64
+              description: 정산 예정 금액 합계
+            platformFeeAmount:
+              type: integer
+              format: int64
+              description: 플랫폼 수수료 합계
+            totalTransactionAmount:
+              type: integer
+              format: int64
+              description: 총 거래액 합계
+        error: { nullable: true, example: null }
+
+    ApiResponseAdminSettlementPage:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [content, totalElements, totalPages, number, size]
           properties:
             content:
               type: array
               items:
-                type: object
-                required: [settlementId, storeName, productName, totalAmount, escrowStatus, scheduledPaymentDate, settlementMethod, memo, createdAt]
-                properties:
-                  settlementId: { type: integer, format: int64 }
-                  storeName: { type: string }
-                  productName: { type: string }
-                  totalAmount: { type: integer }
-                  escrowStatus:
-                    type: string
-                    enum: [HOLDING, RELEASED]
-                  scheduledPaymentDate: { type: string, format: date, nullable: true }
-                  settlementMethod: { type: string, nullable: true }
-                  memo: { type: string, nullable: true }
-                  createdAt: { type: string, format: date-time }
-            totalElements: { type: integer }
+                $ref: '#/components/schemas/AdminSettlementListItem'
+            totalElements: { type: integer, format: int64 }
             totalPages: { type: integer }
+            number: { type: integer }
+            size: { type: integer }
         error: { nullable: true, example: null }
 
-    AdminSettlementCreate:
+    AdminSettlementListItem:
       type: object
-      required: [groupBuyId, scheduledPaymentDate, settlementMethod]
+      required: [settlementId, groupBuyId, storeName, productName, pickupCompletedDate, participantCount, totalPaymentAmount, refundDeductionAmount, platformFeeAmount, settlementAmount, scheduledSettlementDate, status, actionable]
       properties:
+        settlementId:
+          type: integer
+          format: int64
+          description: 정산 식별자. 현재는 groupBuyId와 동일
         groupBuyId: { type: integer, format: int64 }
-        scheduledPaymentDate: { type: string, format: date }
-        settlementMethod:
+        storeName: { type: string }
+        productName: { type: string }
+        pickupCompletedDate:
           type: string
-          enum: [BANK_TRANSFER, ESCROW_AUTO]
-        memo:
+          format: date
+          description: 픽업 완료 기준일. 현재는 공구 pickupDate 기준
+        participantCount:
+          type: integer
+          format: int64
+          description: 정산 대상 참여 인원
+        totalPaymentAmount:
+          type: integer
+          format: int64
+          description: 총 결제액
+        refundDeductionAmount:
+          type: integer
+          format: int64
+          description: 환불 차감액
+        platformFeeAmount:
+          type: integer
+          format: int64
+          description: 플랫폼 수수료
+        settlementAmount:
+          type: integer
+          format: int64
+          description: 총 결제액 - 환불 차감액 - 플랫폼 수수료
+        scheduledSettlementDate:
           type: string
-          maxLength: 100
-          nullable: true
+          format: date
+          description: 정산 예정일. 현재 정책은 pickupCompletedDate + 3일
+        status:
+          type: string
+          enum: [SCHEDULED, COMPLETED]
+        actionable:
+          type: boolean
+          description: 운영 작업 가능 여부
 
-    ApiResponseSettlementId:
+    ApiResponseAdminSettlementDetail:
       type: object
       required: [success, data, error]
       properties:
         success: { type: boolean, example: true }
         data:
-          type: object
-          required: [settlementId]
-          properties:
-            settlementId: { type: integer, format: int64 }
+          $ref: '#/components/schemas/AdminSettlementDetail'
         error: { nullable: true, example: null }
+
+    AdminSettlementDetail:
+      allOf:
+        - $ref: '#/components/schemas/AdminSettlementListItem'
 
     ApiResponseSearchAnalysis:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminSettlementServiceTest.kt
@@ -1,0 +1,204 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatus
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatusFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.AdminSettlementAggregation
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.exception.CustomException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+class AdminSettlementServiceTest {
+
+    private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val service = AdminSettlementService(participationRepository, clock)
+
+    @Test
+    fun `월별 정산 대시보드를 조회한다`() {
+        val completed = aggregation(
+            groupBuyId = 10L,
+            pickupCompletedDate = LocalDate.of(2026, 5, 20),
+            totalPaymentAmount = 120_000L,
+            refundDeductionAmount = 20_000L,
+            platformFeeAmount = 5_000L
+        )
+        val scheduled = aggregation(
+            groupBuyId = 11L,
+            pickupCompletedDate = LocalDate.of(2026, 5, 27),
+            totalPaymentAmount = 80_000L,
+            refundDeductionAmount = 0L,
+            platformFeeAmount = 3_000L
+        )
+        `when`(
+            participationRepository.findAdminSettlementAggregations(
+                SETTLEMENT_GROUP_BUY_STATUSES,
+                TRANSACTION_STATUSES,
+                REVENUE_STATUSES,
+                REFUND_STATUSES,
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 6, 1)
+            )
+        ).thenReturn(listOf(completed, scheduled))
+
+        val result = service.getDashboard(2026, 5)
+
+        assertEquals(2026, result.year)
+        assertEquals(5, result.month)
+        assertEquals(95_000L, result.completedSettlementAmount)
+        assertEquals(77_000L, result.scheduledSettlementAmount)
+        assertEquals(8_000L, result.platformFeeAmount)
+        assertEquals(200_000L, result.totalTransactionAmount)
+    }
+
+    @Test
+    fun `정산 예정 목록은 예정 상태 pickupDate 범위로 조회한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val scheduled = aggregation(
+            groupBuyId = 12L,
+            pickupCompletedDate = LocalDate.of(2026, 5, 27),
+            totalPaymentAmount = 50_000L,
+            refundDeductionAmount = 10_000L,
+            platformFeeAmount = 1_000L
+        )
+        `when`(
+            participationRepository.findAdminSettlementPage(
+                SETTLEMENT_GROUP_BUY_STATUSES,
+                TRANSACTION_STATUSES,
+                REVENUE_STATUSES,
+                REFUND_STATUSES,
+                LocalDate.of(2026, 5, 26),
+                LocalDate.of(2026, 6, 1),
+                pageable
+            )
+        ).thenReturn(PageImpl(listOf(scheduled), pageable, 1))
+
+        val result = service.getSettlements(2026, 5, AdminSettlementStatusFilter.SCHEDULED, pageable)
+
+        assertEquals(1, result.content.size)
+        assertEquals(12L, result.content[0].settlementId)
+        assertEquals(LocalDate.of(2026, 5, 30), result.content[0].scheduledSettlementDate)
+        assertEquals(AdminSettlementStatus.SCHEDULED, result.content[0].status)
+        assertEquals(39_000L, result.content[0].settlementAmount)
+        assertTrue(result.content[0].actionable)
+    }
+
+    @Test
+    fun `정산 상세를 조회한다`() {
+        val aggregation = aggregation(
+            groupBuyId = 13L,
+            pickupCompletedDate = LocalDate.of(2026, 5, 23),
+            totalPaymentAmount = 100_000L,
+            refundDeductionAmount = 20_000L,
+            platformFeeAmount = 2_000L
+        )
+        `when`(
+            participationRepository.findAdminSettlementDetail(
+                13L,
+                SETTLEMENT_GROUP_BUY_STATUSES,
+                TRANSACTION_STATUSES,
+                REVENUE_STATUSES,
+                REFUND_STATUSES
+            )
+        ).thenReturn(aggregation)
+
+        val result = service.getSettlementDetail(13L)
+
+        assertEquals(13L, result.settlementId)
+        assertEquals("뭉치장 베이커리", result.storeName)
+        assertEquals(AdminSettlementStatus.COMPLETED, result.status)
+        assertEquals(78_000L, result.settlementAmount)
+        assertFalse(result.status == AdminSettlementStatus.SCHEDULED)
+    }
+
+    @Test
+    fun `존재하지 않는 정산 상세는 예외를 던진다`() {
+        `when`(
+            participationRepository.findAdminSettlementDetail(
+                404L,
+                SETTLEMENT_GROUP_BUY_STATUSES,
+                TRANSACTION_STATUSES,
+                REVENUE_STATUSES,
+                REFUND_STATUSES
+            )
+        ).thenReturn(null)
+
+        assertThrows(CustomException::class.java) {
+            service.getSettlementDetail(404L)
+        }
+    }
+
+    @Test
+    fun `잘못된 월은 예외를 던진다`() {
+        assertThrows(CustomException::class.java) {
+            service.getDashboard(2026, 13)
+        }
+    }
+
+    @Test
+    fun `전체 목록은 월 전체 pickupDate 범위로 조회한다`() {
+        val pageable = PageRequest.of(0, 20)
+        `when`(
+            participationRepository.findAdminSettlementPage(
+                SETTLEMENT_GROUP_BUY_STATUSES,
+                TRANSACTION_STATUSES,
+                REVENUE_STATUSES,
+                REFUND_STATUSES,
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 6, 1),
+                pageable
+            )
+        ).thenReturn(PageImpl(emptyList(), pageable, 0))
+
+        service.getSettlements(2026, 5, AdminSettlementStatusFilter.ALL, pageable)
+
+        verify(participationRepository).findAdminSettlementPage(
+            SETTLEMENT_GROUP_BUY_STATUSES,
+            TRANSACTION_STATUSES,
+            REVENUE_STATUSES,
+            REFUND_STATUSES,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 6, 1),
+            pageable
+        )
+    }
+
+    private fun aggregation(
+        groupBuyId: Long,
+        pickupCompletedDate: LocalDate,
+        totalPaymentAmount: Long,
+        refundDeductionAmount: Long,
+        platformFeeAmount: Long,
+    ): AdminSettlementAggregation =
+        object : AdminSettlementAggregation {
+            override val groupBuyId: Long = groupBuyId
+            override val storeName: String = "뭉치장 베이커리"
+            override val productName: String = "두쫀쿠 1개"
+            override val pickupCompletedDate: LocalDate = pickupCompletedDate
+            override val participantCount: Long = 10L
+            override val totalPaymentAmount: Long = totalPaymentAmount
+            override val refundDeductionAmount: Long = refundDeductionAmount
+            override val platformFeeAmount: Long = platformFeeAmount
+        }
+
+    private companion object {
+        val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
+        val REVENUE_STATUSES = listOf(ParticipationStatus.CONFIRMED)
+        val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+        val TRANSACTION_STATUSES = REVENUE_STATUSES + REFUND_STATUSES
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminSettlementServiceTest.kt
@@ -35,14 +35,14 @@ class AdminSettlementServiceTest {
             pickupCompletedDate = LocalDate.of(2026, 5, 20),
             totalPaymentAmount = 120_000L,
             refundDeductionAmount = 20_000L,
-            platformFeeAmount = 5_000L
+            platformFeeAmount = 0L
         )
         val scheduled = aggregation(
             groupBuyId = 11L,
             pickupCompletedDate = LocalDate.of(2026, 5, 27),
             totalPaymentAmount = 80_000L,
             refundDeductionAmount = 0L,
-            platformFeeAmount = 3_000L
+            platformFeeAmount = 0L
         )
         `when`(
             participationRepository.findAdminSettlementAggregations(
@@ -59,9 +59,9 @@ class AdminSettlementServiceTest {
 
         assertEquals(2026, result.year)
         assertEquals(5, result.month)
-        assertEquals(95_000L, result.completedSettlementAmount)
-        assertEquals(77_000L, result.scheduledSettlementAmount)
-        assertEquals(8_000L, result.platformFeeAmount)
+        assertEquals(100_000L, result.completedSettlementAmount)
+        assertEquals(80_000L, result.scheduledSettlementAmount)
+        assertEquals(0L, result.platformFeeAmount)
         assertEquals(200_000L, result.totalTransactionAmount)
     }
 
@@ -73,7 +73,7 @@ class AdminSettlementServiceTest {
             pickupCompletedDate = LocalDate.of(2026, 5, 27),
             totalPaymentAmount = 50_000L,
             refundDeductionAmount = 10_000L,
-            platformFeeAmount = 1_000L
+            platformFeeAmount = 0L
         )
         `when`(
             participationRepository.findAdminSettlementPage(
@@ -93,7 +93,7 @@ class AdminSettlementServiceTest {
         assertEquals(12L, result.content[0].settlementId)
         assertEquals(LocalDate.of(2026, 5, 30), result.content[0].scheduledSettlementDate)
         assertEquals(AdminSettlementStatus.SCHEDULED, result.content[0].status)
-        assertEquals(39_000L, result.content[0].settlementAmount)
+        assertEquals(40_000L, result.content[0].settlementAmount)
         assertTrue(result.content[0].actionable)
     }
 
@@ -104,7 +104,7 @@ class AdminSettlementServiceTest {
             pickupCompletedDate = LocalDate.of(2026, 5, 23),
             totalPaymentAmount = 100_000L,
             refundDeductionAmount = 20_000L,
-            platformFeeAmount = 2_000L
+            platformFeeAmount = 0L
         )
         `when`(
             participationRepository.findAdminSettlementDetail(
@@ -121,7 +121,7 @@ class AdminSettlementServiceTest {
         assertEquals(13L, result.settlementId)
         assertEquals("뭉치장 베이커리", result.storeName)
         assertEquals(AdminSettlementStatus.COMPLETED, result.status)
-        assertEquals(78_000L, result.settlementAmount)
+        assertEquals(80_000L, result.settlementAmount)
         assertFalse(result.status == AdminSettlementStatus.SCHEDULED)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementControllerTest.kt
@@ -26,7 +26,7 @@ class AdminSettlementControllerTest {
             month = 5,
             completedSettlementAmount = 100_000,
             scheduledSettlementAmount = 50_000,
-            platformFeeAmount = 5_000,
+            platformFeeAmount = 0,
             totalTransactionAmount = 180_000
         )
         `when`(adminSettlementService.getDashboard(2026, 5)).thenReturn(response)
@@ -73,8 +73,8 @@ class AdminSettlementControllerTest {
             participantCount = 10,
             totalPaymentAmount = 100_000,
             refundDeductionAmount = 20_000,
-            platformFeeAmount = 5_000,
-            settlementAmount = 75_000,
+            platformFeeAmount = 0,
+            settlementAmount = 80_000,
             scheduledSettlementDate = LocalDate.of(2026, 5, 23),
             status = AdminSettlementStatus.COMPLETED,
             actionable = false

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementControllerTest.kt
@@ -1,0 +1,89 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminSettlementService
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDashboardResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementDetailResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementPageResponse
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatus
+import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementStatusFilter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageRequest
+import java.time.LocalDate
+
+class AdminSettlementControllerTest {
+
+    private val adminSettlementService: AdminSettlementService = mock(AdminSettlementService::class.java)
+    private val controller = AdminSettlementController(adminSettlementService)
+
+    @Test
+    fun `운영자 정산 대시보드 조회는 년월을 서비스로 전달한다`() {
+        val response = AdminSettlementDashboardResponse(
+            year = 2026,
+            month = 5,
+            completedSettlementAmount = 100_000,
+            scheduledSettlementAmount = 50_000,
+            platformFeeAmount = 5_000,
+            totalTransactionAmount = 180_000
+        )
+        `when`(adminSettlementService.getDashboard(2026, 5)).thenReturn(response)
+
+        val result = controller.getDashboard(2026, 5)
+
+        assertEquals(response, result.body?.data)
+        verify(adminSettlementService).getDashboard(2026, 5)
+    }
+
+    @Test
+    fun `운영자 정산 목록 조회는 년월 상태 페이징을 서비스로 전달한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val response = AdminSettlementPageResponse(
+            content = emptyList(),
+            totalElements = 0,
+            totalPages = 0,
+            number = 0,
+            size = 20
+        )
+        `when`(
+            adminSettlementService.getSettlements(
+                year = 2026,
+                month = 5,
+                status = AdminSettlementStatusFilter.COMPLETED,
+                pageable = pageable
+            )
+        ).thenReturn(response)
+
+        val result = controller.getSettlements(2026, 5, AdminSettlementStatusFilter.COMPLETED, pageable)
+
+        assertEquals(response, result.body?.data)
+        verify(adminSettlementService).getSettlements(2026, 5, AdminSettlementStatusFilter.COMPLETED, pageable)
+    }
+
+    @Test
+    fun `운영자 정산 상세 조회는 정산 ID를 서비스로 전달한다`() {
+        val response = AdminSettlementDetailResponse(
+            settlementId = 10L,
+            groupBuyId = 10L,
+            storeName = "뭉치장 베이커리",
+            productName = "두쫀쿠 1개",
+            pickupCompletedDate = LocalDate.of(2026, 5, 20),
+            participantCount = 10,
+            totalPaymentAmount = 100_000,
+            refundDeductionAmount = 20_000,
+            platformFeeAmount = 5_000,
+            settlementAmount = 75_000,
+            scheduledSettlementDate = LocalDate.of(2026, 5, 23),
+            status = AdminSettlementStatus.COMPLETED,
+            actionable = false
+        )
+        `when`(adminSettlementService.getSettlementDetail(10L)).thenReturn(response)
+
+        val result = controller.getSettlementDetail(10L)
+
+        assertEquals(response, result.body?.data)
+        verify(adminSettlementService).getSettlementDetail(10L)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 어드민 정산 현황 대시보드 API를 추가했습니다.
- 어드민 정산 예정/완료/전체 목록 API를 추가했습니다.
- 어드민 정산 상세 팝업용 조회 API를 추가했습니다.
- 정산 금액 산출에 필요한 참여/환불 집계 쿼리를 추가했습니다.
- 실제 구현 API 기준으로 OpenAPI 정산 문서를 동기화했습니다.

## 🔍 참고 사항
- 현재 별도 정산 테이블이 없어서 settlementId는 groupBuyId와 동일하게 응답합니다.
- 정산 예정일은 현재 정책 기준으로 pickupCompletedDate + 3일로 계산합니다.
- 현재 서비스 수수료 정책은 0원이며, 정산금액은 총 결제액 - 환불 차감액 기준입니다.

## 🖼️ 스크린샷
- 없음 (백엔드 API 변경)

## 🔗 관련 이슈
- closes #257
- MCJ-1556

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
