### PR TITLE
[MCJ-1557] FEAT: 관리자 환불 요청 관리 API 구현 및 상태 전이/검증 로직 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -47,7 +47,22 @@ class AdminRefundRequestService(
         val statuses = tab.toParticipationStatuses()
         val reviewStatuses = tab.toOwnerReviewStatuses()
         val includeNullReviewStatus = tab == AdminRefundRequestTab.REVIEW_PENDING
-        val cancelReasons = caseFilter.toCancelReasons()
+        val caseFilterCondition = caseFilter.toCaseFilterCondition()
+        if (!caseFilterCondition.supported) {
+            log.info(
+                "[AdminRefundRequestService] 환불 요청 목록 조회 완료(미지원 케이스 필터): tab={}, caseFilter={}, keyword={}, page={}, size={}",
+                tab, caseFilter, normalizedKeyword, pageable.pageNumber, pageable.pageSize
+            )
+            return AdminRefundRequestPageResponse(
+                content = emptyList(),
+                totalElements = 0L,
+                totalPages = 0,
+                number = pageable.pageNumber,
+                size = pageable.pageSize,
+                hasSlaWarning = false,
+                slaWarningCount = 0,
+            )
+        }
         log.info(
             "[AdminRefundRequestService] 환불 요청 목록 조회 시작: tab={}, caseFilter={}, keyword={}, page={}, size={}",
             tab, caseFilter, normalizedKeyword, pageable.pageNumber, pageable.pageSize
@@ -57,8 +72,8 @@ class AdminRefundRequestService(
             useReviewStatusFilter = reviewStatuses.isNotEmpty() || includeNullReviewStatus,
             reviewStatuses = reviewStatuses.ifEmpty { listOf(OwnerRefundReviewStatus.PENDING) },
             includeNullReviewStatus = includeNullReviewStatus,
-            useCaseFilter = cancelReasons.isNotEmpty(),
-            cancelReasons = cancelReasons.ifEmpty { listOf(ParticipationCancelReason.OTHER) },
+            useCaseFilter = caseFilterCondition.reasons.isNotEmpty(),
+            cancelReasons = caseFilterCondition.reasons.ifEmpty { listOf(ParticipationCancelReason.OTHER) },
             keyword = normalizedKeyword,
             pageable = pageable,
         )
@@ -230,18 +245,33 @@ class AdminRefundRequestService(
         }
     }
 
-    private fun AdminRefundRequestCaseFilter.toCancelReasons(): List<ParticipationCancelReason> {
+    private fun AdminRefundRequestCaseFilter.toCaseFilterCondition(): CaseFilterCondition {
         return when (this) {
-            AdminRefundRequestCaseFilter.ALL -> emptyList()
-            AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL -> listOf(ParticipationCancelReason.NO_LONGER_WANTED)
-            AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL -> listOf(
-                ParticipationCancelReason.PREFER_DIRECT_VISIT,
-                ParticipationCancelReason.BOUGHT_ELSEWHERE,
+            AdminRefundRequestCaseFilter.ALL -> CaseFilterCondition(supported = true, reasons = emptyList())
+            AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL -> CaseFilterCondition(
+                supported = true,
+                reasons = listOf(ParticipationCancelReason.NO_LONGER_WANTED),
             )
-            AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW -> listOf(ParticipationCancelReason.TIME_UNAVAILABLE)
-            AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL -> emptyList()
-            AdminRefundRequestCaseFilter.TARGET_NOT_MET -> emptyList()
-            AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND -> listOf(ParticipationCancelReason.OTHER)
+            AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL -> CaseFilterCondition(
+                supported = true,
+                reasons = listOf(
+                    ParticipationCancelReason.PREFER_DIRECT_VISIT,
+                    ParticipationCancelReason.BOUGHT_ELSEWHERE,
+                ),
+            )
+            AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW -> CaseFilterCondition(
+                supported = true,
+                reasons = listOf(ParticipationCancelReason.TIME_UNAVAILABLE),
+            )
+            AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL,
+            AdminRefundRequestCaseFilter.TARGET_NOT_MET -> CaseFilterCondition(
+                supported = false,
+                reasons = emptyList(),
+            )
+            AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND -> CaseFilterCondition(
+                supported = true,
+                reasons = listOf(ParticipationCancelReason.OTHER),
+            )
         }
     }
 
@@ -256,4 +286,9 @@ class AdminRefundRequestService(
             null -> AdminRefundRequestStatus.REVIEW_PENDING
         }
     }
+
+    private data class CaseFilterCondition(
+        val supported: Boolean,
+        val reasons: List<ParticipationCancelReason>,
+    )
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestAp
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestListItemResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestRejectRequest
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestStatus
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
 import com.moongchijang.domain.admin.application.refund.AdminRefundRequestStatusTransitionPolicy
@@ -150,6 +151,59 @@ class AdminRefundRequestService(
         )
         log.info(
             "[AdminRefundRequestService] 환불 요청 승인 완료: requestId={}, status={}",
+            requestId,
+            response.status
+        )
+        return response
+    }
+
+    @Transactional
+    fun rejectRefundRequest(
+        requestId: Long,
+        request: AdminRefundRequestRejectRequest,
+    ): AdminRefundRequestDetailResponse {
+        val rejectionReason = request.rejectionReason.trim()
+        if (rejectionReason.isBlank()) {
+            throw CustomException(ErrorCode.INVALID_INPUT, "rejectionReason은 필수입니다.")
+        }
+        log.info(
+            "[AdminRefundRequestService] 환불 요청 거절 시작: requestId={}, rejectionReasonLength={}",
+            requestId,
+            rejectionReason.length
+        )
+        val now = LocalDateTime.now(clock)
+        val participation = participationRepository.findByIdForUpdate(requestId)
+            .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+
+        val currentStatus = participation.toAdminStatus()
+        AdminRefundRequestStatusTransitionPolicy.validateTransition(
+            from = currentStatus,
+            to = AdminRefundRequestStatus.REJECTED,
+        )
+
+        participation.ownerRefundReviewStatus = OwnerRefundReviewStatus.DISPUTED
+        participation.ownerRefundReviewedAt = now
+        participation.ownerRefundDisputeReason = rejectionReason
+        participation.approvedRefundAmount = null
+        refundRequestSyncService.markRejected(
+            participation = participation,
+            reason = rejectionReason,
+            at = now,
+        )
+
+        val paymentOrder = paymentOrderRepository.findByUserIdAndGroupBuyId(
+            userId = participation.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND),
+            groupBuyId = participation.groupBuy.id,
+        )
+        val payment = paymentOrder?.let { paymentRepository.findByPaymentOrderOrderId(it.orderId) }
+        val response = AdminRefundRequestDetailResponse.from(
+            participation = participation,
+            paymentOrder = paymentOrder,
+            payment = payment,
+            now = now,
+        )
+        log.info(
+            "[AdminRefundRequestService] 환불 요청 거절 완료: requestId={}, status={}",
             requestId,
             response.status
         )

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -121,9 +121,13 @@ class AdminRefundRequestService(
         if (request.refundAmount > participation.totalAmount) {
             throw CustomException(ErrorCode.INVALID_INPUT, "refundAmount는 결제 금액을 초과할 수 없습니다.")
         }
+        if (request.refundAmount > (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)) {
+            throw CustomException(ErrorCode.INVALID_INPUT, "refundAmount는 수수료 차감 후 환불 가능 금액을 초과할 수 없습니다.")
+        }
 
         participation.ownerRefundReviewStatus = OwnerRefundReviewStatus.APPROVED
         participation.ownerRefundReviewedAt = now
+        participation.approvedRefundAmount = request.refundAmount
         participation.ownerRefundDisputeReason = null
 
         val paymentOrder = paymentOrderRepository.findByUserIdAndGroupBuyId(

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -121,9 +121,6 @@ class AdminRefundRequestService(
             to = AdminRefundRequestStatus.IN_PROGRESS,
         )
 
-        if (request.refundAmount > participation.totalAmount) {
-            throw CustomException(ErrorCode.INVALID_INPUT, "refundAmount는 결제 금액을 초과할 수 없습니다.")
-        }
         val maxRefundAmount = if (participation.cancelReason == null) {
             participation.totalAmount
         } else {

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestListItemResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
@@ -8,6 +9,10 @@ import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStat
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
+import com.moongchijang.domain.payment.domain.repository.PaymentRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -19,6 +24,8 @@ import java.time.LocalDateTime
 @Transactional(readOnly = true)
 class AdminRefundRequestService(
     private val participationRepository: ParticipationRepository,
+    private val paymentOrderRepository: PaymentOrderRepository,
+    private val paymentRepository: PaymentRepository,
     private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -66,6 +73,26 @@ class AdminRefundRequestService(
             hasSlaWarning = slaWarningCount > 0,
             slaWarningCount = slaWarningCount,
         )
+    }
+
+    fun getRefundRequestDetail(requestId: Long): AdminRefundRequestDetailResponse {
+        log.info("[AdminRefundRequestService] 환불 요청 상세 조회 시작: requestId={}", requestId)
+        val now = LocalDateTime.now(clock)
+        val participation = participationRepository.findPickupDetailById(requestId)
+            ?: throw CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
+        val paymentOrder = paymentOrderRepository.findByUserIdAndGroupBuyId(
+            userId = participation.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND),
+            groupBuyId = participation.groupBuy.id,
+        )
+        val payment = paymentOrder?.let { paymentRepository.findByPaymentOrderOrderId(it.orderId) }
+        val response = AdminRefundRequestDetailResponse.from(
+            participation = participation,
+            paymentOrder = paymentOrder,
+            payment = payment,
+            now = now,
+        )
+        log.info("[AdminRefundRequestService] 환불 요청 상세 조회 완료: requestId={}, status={}", requestId, response.status)
+        return response
     }
 
     private fun AdminRefundRequestTab.toParticipationStatuses(): List<ParticipationStatus> {

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -54,12 +54,17 @@ class AdminRefundRequestService(
             tab, caseFilter, normalizedKeyword, pageable.pageNumber, pageable.pageSize, page.totalElements
         )
 
+        val items = page.content.map { AdminRefundRequestListItemResponse.from(it, now) }
+        val slaWarningCount = items.count { it.slaWarning }
+
         return AdminRefundRequestPageResponse(
-            content = page.content.map { AdminRefundRequestListItemResponse.from(it, now) },
+            content = items,
             totalElements = page.totalElements,
             totalPages = page.totalPages,
             number = page.number,
             size = page.size,
+            hasSlaWarning = slaWarningCount > 0,
+            slaWarningCount = slaWarningCount,
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -47,22 +47,7 @@ class AdminRefundRequestService(
         val statuses = tab.toParticipationStatuses()
         val reviewStatuses = tab.toOwnerReviewStatuses()
         val includeNullReviewStatus = tab == AdminRefundRequestTab.REVIEW_PENDING
-        val caseFilterCondition = caseFilter.toCaseFilterCondition()
-        if (!caseFilterCondition.supported) {
-            log.info(
-                "[AdminRefundRequestService] 환불 요청 목록 조회 완료(미지원 케이스 필터): tab={}, caseFilter={}, keyword={}, page={}, size={}",
-                tab, caseFilter, normalizedKeyword, pageable.pageNumber, pageable.pageSize
-            )
-            return AdminRefundRequestPageResponse(
-                content = emptyList(),
-                totalElements = 0L,
-                totalPages = 0,
-                number = pageable.pageNumber,
-                size = pageable.pageSize,
-                hasSlaWarning = false,
-                slaWarningCount = 0,
-            )
-        }
+        val cancelReasons = caseFilter.toCancelReasons()
         log.info(
             "[AdminRefundRequestService] 환불 요청 목록 조회 시작: tab={}, caseFilter={}, keyword={}, page={}, size={}",
             tab, caseFilter, normalizedKeyword, pageable.pageNumber, pageable.pageSize
@@ -72,8 +57,8 @@ class AdminRefundRequestService(
             useReviewStatusFilter = reviewStatuses.isNotEmpty() || includeNullReviewStatus,
             reviewStatuses = reviewStatuses.ifEmpty { listOf(OwnerRefundReviewStatus.PENDING) },
             includeNullReviewStatus = includeNullReviewStatus,
-            useCaseFilter = caseFilterCondition.reasons.isNotEmpty(),
-            cancelReasons = caseFilterCondition.reasons.ifEmpty { listOf(ParticipationCancelReason.OTHER) },
+            caseFilter = caseFilter.name,
+            cancelReasons = cancelReasons.ifEmpty { listOf(ParticipationCancelReason.OTHER) },
             keyword = normalizedKeyword,
             pageable = pageable,
         )
@@ -257,33 +242,18 @@ class AdminRefundRequestService(
         }
     }
 
-    private fun AdminRefundRequestCaseFilter.toCaseFilterCondition(): CaseFilterCondition {
+    private fun AdminRefundRequestCaseFilter.toCancelReasons(): List<ParticipationCancelReason> {
         return when (this) {
-            AdminRefundRequestCaseFilter.ALL -> CaseFilterCondition(supported = true, reasons = emptyList())
-            AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL -> CaseFilterCondition(
-                supported = true,
-                reasons = listOf(ParticipationCancelReason.NO_LONGER_WANTED),
+            AdminRefundRequestCaseFilter.ALL -> emptyList()
+            AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL -> listOf(ParticipationCancelReason.NO_LONGER_WANTED)
+            AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL -> listOf(
+                ParticipationCancelReason.PREFER_DIRECT_VISIT,
+                ParticipationCancelReason.BOUGHT_ELSEWHERE,
             )
-            AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL -> CaseFilterCondition(
-                supported = true,
-                reasons = listOf(
-                    ParticipationCancelReason.PREFER_DIRECT_VISIT,
-                    ParticipationCancelReason.BOUGHT_ELSEWHERE,
-                ),
-            )
-            AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW -> CaseFilterCondition(
-                supported = true,
-                reasons = listOf(ParticipationCancelReason.TIME_UNAVAILABLE),
-            )
+            AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW -> listOf(ParticipationCancelReason.TIME_UNAVAILABLE)
             AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL,
-            AdminRefundRequestCaseFilter.TARGET_NOT_MET -> CaseFilterCondition(
-                supported = false,
-                reasons = emptyList(),
-            )
-            AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND -> CaseFilterCondition(
-                supported = true,
-                reasons = listOf(ParticipationCancelReason.OTHER),
-            )
+            AdminRefundRequestCaseFilter.TARGET_NOT_MET -> emptyList()
+            AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND -> listOf(ParticipationCancelReason.OTHER)
         }
     }
 
@@ -299,8 +269,4 @@ class AdminRefundRequestService(
         }
     }
 
-    private data class CaseFilterCondition(
-        val supported: Boolean,
-        val reasons: List<ParticipationCancelReason>,
-    )
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -14,6 +14,7 @@ import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
 import com.moongchijang.domain.payment.domain.repository.PaymentRepository
+import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
@@ -29,6 +30,7 @@ class AdminRefundRequestService(
     private val participationRepository: ParticipationRepository,
     private val paymentOrderRepository: PaymentOrderRepository,
     private val paymentRepository: PaymentRepository,
+    private val refundRequestSyncService: RefundRequestSyncService,
     private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -129,6 +131,11 @@ class AdminRefundRequestService(
         participation.ownerRefundReviewedAt = now
         participation.approvedRefundAmount = request.refundAmount
         participation.ownerRefundDisputeReason = null
+        refundRequestSyncService.markApproved(
+            participation = participation,
+            approvedAmount = request.refundAmount,
+            at = now,
+        )
 
         val paymentOrder = paymentOrderRepository.findByUserIdAndGroupBuyId(
             userId = participation.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND),

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -28,45 +28,33 @@ class AdminRefundRequestService(
 
     fun getRefundRequests(
         tab: AdminRefundRequestTab,
+        caseFilter: AdminRefundRequestCaseFilter,
+        keyword: String?,
         pageable: Pageable,
     ): AdminRefundRequestPageResponse {
         val now = LocalDateTime.now(clock)
+        val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
+        val statuses = tab.toParticipationStatuses()
+        val reviewStatuses = tab.toOwnerReviewStatuses()
+        val includeNullReviewStatus = tab == AdminRefundRequestTab.REVIEW_PENDING
+        val cancelReasons = caseFilter.toCancelReasons()
         log.info(
-            "[AdminRefundRequestService] 환불 요청 목록 조회 시작: tab={}, page={}, size={}",
-            tab, pageable.pageNumber, pageable.pageSize
+            "[AdminRefundRequestService] 환불 요청 목록 조회 시작: tab={}, caseFilter={}, keyword={}, page={}, size={}",
+            tab, caseFilter, normalizedKeyword, pageable.pageNumber, pageable.pageSize
         )
-        val page = when (tab) {
-            AdminRefundRequestTab.ALL -> participationRepository.findAdminRefundRequestsAll(
-                statuses = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
-                pageable = pageable,
-            )
-
-            AdminRefundRequestTab.REVIEW_PENDING -> participationRepository.findAdminRefundRequestsByReviewStatusIncludingNull(
-                status = ParticipationStatus.REFUND_PENDING,
-                reviewStatus = OwnerRefundReviewStatus.PENDING,
-                pageable = pageable,
-            )
-
-            AdminRefundRequestTab.IN_PROGRESS -> participationRepository.findAdminRefundRequestsByReviewStatus(
-                status = ParticipationStatus.REFUND_PENDING,
-                reviewStatus = OwnerRefundReviewStatus.APPROVED,
-                pageable = pageable,
-            )
-
-            AdminRefundRequestTab.APPROVED -> participationRepository.findAdminRefundRequestsAll(
-                statuses = listOf(ParticipationStatus.REFUNDED),
-                pageable = pageable,
-            )
-
-            AdminRefundRequestTab.REJECTED -> participationRepository.findAdminRefundRequestsByReviewStatus(
-                status = ParticipationStatus.REFUND_PENDING,
-                reviewStatus = OwnerRefundReviewStatus.DISPUTED,
-                pageable = pageable,
-            )
-        }
+        val page = participationRepository.findAdminRefundRequests(
+            statuses = statuses,
+            useReviewStatusFilter = reviewStatuses.isNotEmpty() || includeNullReviewStatus,
+            reviewStatuses = reviewStatuses.ifEmpty { listOf(OwnerRefundReviewStatus.PENDING) },
+            includeNullReviewStatus = includeNullReviewStatus,
+            useCaseFilter = cancelReasons.isNotEmpty(),
+            cancelReasons = cancelReasons.ifEmpty { listOf(ParticipationCancelReason.OTHER) },
+            keyword = normalizedKeyword,
+            pageable = pageable,
+        )
         log.info(
-            "[AdminRefundRequestService] 환불 요청 목록 조회 완료: tab={}, page={}, size={}, totalElements={}",
-            tab, pageable.pageNumber, pageable.pageSize, page.totalElements
+            "[AdminRefundRequestService] 환불 요청 목록 조회 완료: tab={}, caseFilter={}, keyword={}, page={}, size={}, totalElements={}",
+            tab, caseFilter, normalizedKeyword, pageable.pageNumber, pageable.pageSize, page.totalElements
         )
 
         return AdminRefundRequestPageResponse(
@@ -116,6 +104,41 @@ class AdminRefundRequestService(
             ParticipationCancelReason.BOUGHT_ELSEWHERE -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
             ParticipationCancelReason.OTHER -> AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND
             null -> AdminRefundRequestCaseFilter.ALL
+        }
+    }
+
+    private fun AdminRefundRequestTab.toParticipationStatuses(): List<ParticipationStatus> {
+        return when (this) {
+            AdminRefundRequestTab.ALL -> listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
+            AdminRefundRequestTab.REVIEW_PENDING,
+            AdminRefundRequestTab.IN_PROGRESS,
+            AdminRefundRequestTab.REJECTED -> listOf(ParticipationStatus.REFUND_PENDING)
+            AdminRefundRequestTab.APPROVED -> listOf(ParticipationStatus.REFUNDED)
+        }
+    }
+
+    private fun AdminRefundRequestTab.toOwnerReviewStatuses(): List<OwnerRefundReviewStatus> {
+        return when (this) {
+            AdminRefundRequestTab.ALL,
+            AdminRefundRequestTab.APPROVED -> emptyList()
+            AdminRefundRequestTab.REVIEW_PENDING -> listOf(OwnerRefundReviewStatus.PENDING)
+            AdminRefundRequestTab.IN_PROGRESS -> listOf(OwnerRefundReviewStatus.APPROVED)
+            AdminRefundRequestTab.REJECTED -> listOf(OwnerRefundReviewStatus.DISPUTED)
+        }
+    }
+
+    private fun AdminRefundRequestCaseFilter.toCancelReasons(): List<ParticipationCancelReason> {
+        return when (this) {
+            AdminRefundRequestCaseFilter.ALL -> emptyList()
+            AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL -> listOf(ParticipationCancelReason.NO_LONGER_WANTED)
+            AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL -> listOf(
+                ParticipationCancelReason.PREFER_DIRECT_VISIT,
+                ParticipationCancelReason.BOUGHT_ELSEWHERE,
+            )
+            AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW -> listOf(ParticipationCancelReason.TIME_UNAVAILABLE)
+            AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL -> emptyList()
+            AdminRefundRequestCaseFilter.TARGET_NOT_MET -> emptyList()
+            AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND -> listOf(ParticipationCancelReason.OTHER)
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -3,11 +3,8 @@ package com.moongchijang.domain.admin.application
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestListItemResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
-import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestStatus
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
-import com.moongchijang.domain.admin.application.dto.refund.calculateSlaRemainingHours
 import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
-import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
@@ -58,53 +55,12 @@ class AdminRefundRequestService(
         )
 
         return AdminRefundRequestPageResponse(
-            content = page.content.map { it.toListItem(now) },
+            content = page.content.map { AdminRefundRequestListItemResponse.from(it, now) },
             totalElements = page.totalElements,
             totalPages = page.totalPages,
             number = page.number,
             size = page.size,
         )
-    }
-
-    private fun Participation.toListItem(now: LocalDateTime): AdminRefundRequestListItemResponse {
-        val requestedAt = cancelledAt ?: createdAt ?: now
-        return AdminRefundRequestListItemResponse(
-            requestId = id,
-            caseFilter = cancelReason.toAdminCaseFilter(),
-            consumerName = user.nickname ?: "알 수 없음",
-            groupBuyName = groupBuy.productName,
-            storeName = groupBuy.store.name,
-            paymentAmount = totalAmount,
-            refundAmount = if (status == ParticipationStatus.REFUNDED) totalAmount else 0,
-            ownerOpinion = ownerRefundDisputeReason,
-            requestedAt = requestedAt,
-            slaRemainingHours = calculateSlaRemainingHours(requestedAt, now),
-            status = toAdminStatus(),
-        )
-    }
-
-    private fun Participation.toAdminStatus(): AdminRefundRequestStatus {
-        if (status == ParticipationStatus.REFUNDED) {
-            return AdminRefundRequestStatus.APPROVED
-        }
-
-        return when (ownerRefundReviewStatus) {
-            OwnerRefundReviewStatus.APPROVED -> AdminRefundRequestStatus.IN_PROGRESS
-            OwnerRefundReviewStatus.DISPUTED -> AdminRefundRequestStatus.REJECTED
-            OwnerRefundReviewStatus.PENDING,
-            null -> AdminRefundRequestStatus.REVIEW_PENDING
-        }
-    }
-
-    private fun ParticipationCancelReason?.toAdminCaseFilter(): AdminRefundRequestCaseFilter {
-        return when (this) {
-            ParticipationCancelReason.TIME_UNAVAILABLE -> AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW
-            ParticipationCancelReason.NO_LONGER_WANTED -> AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL
-            ParticipationCancelReason.PREFER_DIRECT_VISIT -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
-            ParticipationCancelReason.BOUGHT_ELSEWHERE -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
-            ParticipationCancelReason.OTHER -> AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND
-            null -> AdminRefundRequestCaseFilter.ALL
-        }
     }
 
     private fun AdminRefundRequestTab.toParticipationStatuses(): List<ParticipationStatus> {

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -1,10 +1,13 @@
 package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestApproveRequest
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestListItemResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestStatus
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
+import com.moongchijang.domain.admin.application.refund.AdminRefundRequestStatusTransitionPolicy
 import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
@@ -95,6 +98,53 @@ class AdminRefundRequestService(
         return response
     }
 
+    @Transactional
+    fun approveRefundRequest(
+        requestId: Long,
+        request: AdminRefundRequestApproveRequest,
+    ): AdminRefundRequestDetailResponse {
+        log.info(
+            "[AdminRefundRequestService] 환불 요청 승인 시작: requestId={}, refundAmount={}",
+            requestId,
+            request.refundAmount
+        )
+        val now = LocalDateTime.now(clock)
+        val participation = participationRepository.findByIdForUpdate(requestId)
+            .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
+
+        val currentStatus = participation.toAdminStatus()
+        AdminRefundRequestStatusTransitionPolicy.validateTransition(
+            from = currentStatus,
+            to = AdminRefundRequestStatus.IN_PROGRESS,
+        )
+
+        if (request.refundAmount > participation.totalAmount) {
+            throw CustomException(ErrorCode.INVALID_INPUT, "refundAmount는 결제 금액을 초과할 수 없습니다.")
+        }
+
+        participation.ownerRefundReviewStatus = OwnerRefundReviewStatus.APPROVED
+        participation.ownerRefundReviewedAt = now
+        participation.ownerRefundDisputeReason = null
+
+        val paymentOrder = paymentOrderRepository.findByUserIdAndGroupBuyId(
+            userId = participation.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND),
+            groupBuyId = participation.groupBuy.id,
+        )
+        val payment = paymentOrder?.let { paymentRepository.findByPaymentOrderOrderId(it.orderId) }
+        val response = AdminRefundRequestDetailResponse.from(
+            participation = participation,
+            paymentOrder = paymentOrder,
+            payment = payment,
+            now = now,
+        )
+        log.info(
+            "[AdminRefundRequestService] 환불 요청 승인 완료: requestId={}, status={}",
+            requestId,
+            response.status
+        )
+        return response
+    }
+
     private fun AdminRefundRequestTab.toParticipationStatuses(): List<ParticipationStatus> {
         return when (this) {
             AdminRefundRequestTab.ALL -> listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
@@ -127,6 +177,18 @@ class AdminRefundRequestService(
             AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL -> emptyList()
             AdminRefundRequestCaseFilter.TARGET_NOT_MET -> emptyList()
             AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND -> listOf(ParticipationCancelReason.OTHER)
+        }
+    }
+
+    private fun com.moongchijang.domain.participation.domain.entity.Participation.toAdminStatus(): AdminRefundRequestStatus {
+        if (status == ParticipationStatus.REFUNDED) {
+            return AdminRefundRequestStatus.APPROVED
+        }
+        return when (ownerRefundReviewStatus) {
+            OwnerRefundReviewStatus.APPROVED -> AdminRefundRequestStatus.IN_PROGRESS
+            OwnerRefundReviewStatus.DISPUTED -> AdminRefundRequestStatus.REJECTED
+            OwnerRefundReviewStatus.PENDING,
+            null -> AdminRefundRequestStatus.REVIEW_PENDING
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -139,8 +139,20 @@ class AdminRefundRequestService(
         if (request.refundAmount > participation.totalAmount) {
             throw CustomException(ErrorCode.INVALID_INPUT, "refundAmount는 결제 금액을 초과할 수 없습니다.")
         }
-        if (request.refundAmount > (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)) {
-            throw CustomException(ErrorCode.INVALID_INPUT, "refundAmount는 수수료 차감 후 환불 가능 금액을 초과할 수 없습니다.")
+        val maxRefundAmount = if (participation.cancelReason == null) {
+            participation.totalAmount
+        } else {
+            (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+        }
+        if (request.refundAmount > maxRefundAmount) {
+            throw CustomException(
+                ErrorCode.INVALID_INPUT,
+                if (participation.cancelReason == null) {
+                    "refundAmount는 결제 금액을 초과할 수 없습니다."
+                } else {
+                    "refundAmount는 수수료 차감 후 환불 가능 금액을 초과할 수 없습니다."
+                }
+            )
         }
 
         participation.ownerRefundReviewStatus = OwnerRefundReviewStatus.APPROVED

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -1,0 +1,121 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestListItemResponse
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestStatus
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
+import com.moongchijang.domain.admin.application.dto.refund.calculateSlaRemainingHours
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class AdminRefundRequestService(
+    private val participationRepository: ParticipationRepository,
+    private val clock: Clock,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun getRefundRequests(
+        tab: AdminRefundRequestTab,
+        pageable: Pageable,
+    ): AdminRefundRequestPageResponse {
+        val now = LocalDateTime.now(clock)
+        log.info(
+            "[AdminRefundRequestService] 환불 요청 목록 조회 시작: tab={}, page={}, size={}",
+            tab, pageable.pageNumber, pageable.pageSize
+        )
+        val page = when (tab) {
+            AdminRefundRequestTab.ALL -> participationRepository.findAdminRefundRequestsAll(
+                statuses = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                pageable = pageable,
+            )
+
+            AdminRefundRequestTab.REVIEW_PENDING -> participationRepository.findAdminRefundRequestsByReviewStatusIncludingNull(
+                status = ParticipationStatus.REFUND_PENDING,
+                reviewStatus = OwnerRefundReviewStatus.PENDING,
+                pageable = pageable,
+            )
+
+            AdminRefundRequestTab.IN_PROGRESS -> participationRepository.findAdminRefundRequestsByReviewStatus(
+                status = ParticipationStatus.REFUND_PENDING,
+                reviewStatus = OwnerRefundReviewStatus.APPROVED,
+                pageable = pageable,
+            )
+
+            AdminRefundRequestTab.APPROVED -> participationRepository.findAdminRefundRequestsAll(
+                statuses = listOf(ParticipationStatus.REFUNDED),
+                pageable = pageable,
+            )
+
+            AdminRefundRequestTab.REJECTED -> participationRepository.findAdminRefundRequestsByReviewStatus(
+                status = ParticipationStatus.REFUND_PENDING,
+                reviewStatus = OwnerRefundReviewStatus.DISPUTED,
+                pageable = pageable,
+            )
+        }
+        log.info(
+            "[AdminRefundRequestService] 환불 요청 목록 조회 완료: tab={}, page={}, size={}, totalElements={}",
+            tab, pageable.pageNumber, pageable.pageSize, page.totalElements
+        )
+
+        return AdminRefundRequestPageResponse(
+            content = page.content.map { it.toListItem(now) },
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            number = page.number,
+            size = page.size,
+        )
+    }
+
+    private fun Participation.toListItem(now: LocalDateTime): AdminRefundRequestListItemResponse {
+        val requestedAt = cancelledAt ?: createdAt ?: now
+        return AdminRefundRequestListItemResponse(
+            requestId = id,
+            caseFilter = cancelReason.toAdminCaseFilter(),
+            consumerName = user.nickname ?: "알 수 없음",
+            groupBuyName = groupBuy.productName,
+            storeName = groupBuy.store.name,
+            paymentAmount = totalAmount,
+            refundAmount = if (status == ParticipationStatus.REFUNDED) totalAmount else 0,
+            ownerOpinion = ownerRefundDisputeReason,
+            requestedAt = requestedAt,
+            slaRemainingHours = calculateSlaRemainingHours(requestedAt, now),
+            status = toAdminStatus(),
+        )
+    }
+
+    private fun Participation.toAdminStatus(): AdminRefundRequestStatus {
+        if (status == ParticipationStatus.REFUNDED) {
+            return AdminRefundRequestStatus.APPROVED
+        }
+
+        return when (ownerRefundReviewStatus) {
+            OwnerRefundReviewStatus.APPROVED -> AdminRefundRequestStatus.IN_PROGRESS
+            OwnerRefundReviewStatus.DISPUTED -> AdminRefundRequestStatus.REJECTED
+            OwnerRefundReviewStatus.PENDING,
+            null -> AdminRefundRequestStatus.REVIEW_PENDING
+        }
+    }
+
+    private fun ParticipationCancelReason?.toAdminCaseFilter(): AdminRefundRequestCaseFilter {
+        return when (this) {
+            ParticipationCancelReason.TIME_UNAVAILABLE -> AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW
+            ParticipationCancelReason.NO_LONGER_WANTED -> AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL
+            ParticipationCancelReason.PREFER_DIRECT_VISIT -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
+            ParticipationCancelReason.BOUGHT_ELSEWHERE -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
+            ParticipationCancelReason.OTHER -> AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND
+            null -> AdminRefundRequestCaseFilter.ALL
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestApproveRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestApproveRequest.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Min
+
+@Schema(description = "어드민 환불 요청 승인 요청")
+data class AdminRefundRequestApproveRequest(
+    @field:Schema(description = "환불 승인 금액", example = "12000")
+    @field:Min(0)
+    val refundAmount: Int,
+)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestCaseFilter.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestCaseFilter.kt
@@ -1,0 +1,14 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "어드민 환불 요청 케이스 필터")
+enum class AdminRefundRequestCaseFilter {
+    ALL,
+    PRE_ACHIEVEMENT_FREE_CANCEL,
+    POST_ACHIEVEMENT_CANCEL,
+    PICKUP_PERIOD_NO_SHOW,
+    OWNER_FAULT_CANCEL,
+    TARGET_NOT_MET,
+    DISPUTE_OR_DROPOUT_REFUND,
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestDetailResponse.kt
@@ -1,0 +1,180 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.payment.domain.entity.Payment
+import com.moongchijang.domain.payment.domain.entity.PaymentOrder
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Schema(description = "어드민 환불 요청 상세 응답")
+data class AdminRefundRequestDetailResponse(
+
+    @Schema(description = "환불 요청 ID(참여 ID)")
+    val requestId: Long,
+
+    @Schema(description = "처리 상태")
+    val status: AdminRefundRequestStatus,
+
+    @Schema(description = "SLA 남은 시간(시간)")
+    val slaRemainingHours: Long,
+
+    @Schema(description = "요청 후 1시간 초과 여부")
+    val slaWarning: Boolean,
+
+    @Schema(description = "소비자 닉네임")
+    val consumerNickname: String?,
+
+    @Schema(description = "소비자 전화번호")
+    val consumerPhoneNumber: String?,
+
+    @Schema(description = "소비자 이메일")
+    val consumerEmail: String?,
+
+    @Schema(description = "가입 방식")
+    val signupProvider: String,
+
+    @Schema(description = "공구명")
+    val groupBuyName: String,
+
+    @Schema(description = "매장명")
+    val storeName: String,
+
+    @Schema(description = "달성 여부")
+    val achieved: Boolean,
+
+    @Schema(description = "픽업일(YYYY-MM-DD)")
+    val pickupDate: String,
+
+    @Schema(description = "픽업 장소")
+    val pickupLocation: String,
+
+    @Schema(description = "결제 금액")
+    val paymentAmount: Int,
+
+    @Schema(description = "환불 예정 금액")
+    val refundExpectedAmount: Int,
+
+    @Schema(description = "결제 수단")
+    val paymentMethod: String?,
+
+    @Schema(description = "승인 번호")
+    val approvalNumber: String?,
+
+    @Schema(description = "결제 일시")
+    val paidAt: LocalDateTime?,
+
+    @Schema(description = "환불 사유")
+    val refundReason: String,
+
+    @Schema(description = "환불 상세 설명")
+    val refundReasonDetail: String?,
+
+    @Schema(description = "요청 일시")
+    val requestedAt: LocalDateTime,
+
+    @Schema(description = "사장님 의견 제출 일시")
+    val ownerOpinionSubmittedAt: LocalDateTime?,
+
+    @Schema(description = "사장님 의견 내용")
+    val ownerOpinion: String?,
+
+    @Schema(description = "처리 이력")
+    val histories: List<AdminRefundRequestHistoryItemResponse>,
+) {
+    companion object {
+        fun from(
+            participation: Participation,
+            paymentOrder: PaymentOrder?,
+            payment: Payment?,
+            now: LocalDateTime,
+        ): AdminRefundRequestDetailResponse {
+            val requestedAt = participation.cancelledAt ?: participation.createdAt ?: now
+            return AdminRefundRequestDetailResponse(
+                requestId = participation.id,
+                status = participation.toAdminStatus(),
+                slaRemainingHours = calculateSlaRemainingHours(requestedAt, now),
+                slaWarning = isSlaWarning(requestedAt, now),
+                consumerNickname = participation.user.nickname,
+                consumerPhoneNumber = participation.user.phoneNumber,
+                consumerEmail = participation.user.email,
+                signupProvider = participation.user.provider.name,
+                groupBuyName = participation.groupBuy.productName,
+                storeName = participation.groupBuy.store.name,
+                achieved = participation.groupBuy.status == GroupBuyStatus.ACHIEVED,
+                pickupDate = participation.groupBuy.pickupDate.format(PICKUP_DATE_FORMATTER),
+                pickupLocation = participation.groupBuy.pickupLocation,
+                paymentAmount = participation.totalAmount,
+                refundExpectedAmount = (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0),
+                paymentMethod = payment?.method,
+                approvalNumber = payment?.pgPaymentId,
+                paidAt = payment?.approvedAt ?: paymentOrder?.approvedAt,
+                refundReason = participation.cancelReason.toRefundReasonLabel(),
+                refundReasonDetail = participation.cancelReasonDetail,
+                requestedAt = requestedAt,
+                ownerOpinionSubmittedAt = participation.ownerRefundReviewedAt,
+                ownerOpinion = participation.ownerRefundDisputeReason,
+                histories = participation.toHistories(now),
+            )
+        }
+    }
+}
+
+private fun Participation.toHistories(now: LocalDateTime): List<AdminRefundRequestHistoryItemResponse> {
+    val requestedAt = cancelledAt ?: createdAt ?: now
+    val items = mutableListOf(
+        AdminRefundRequestHistoryItemResponse(
+            type = "REQUESTED",
+            occurredAt = requestedAt,
+            memo = cancelReasonDetail,
+        )
+    )
+    ownerRefundReviewedAt?.let {
+        items.add(
+            AdminRefundRequestHistoryItemResponse(
+                type = "OWNER_REVIEWED",
+                occurredAt = it,
+                memo = ownerRefundDisputeReason,
+            )
+        )
+    }
+    refundedAt?.let {
+        items.add(
+            AdminRefundRequestHistoryItemResponse(
+                type = "REFUNDED",
+                occurredAt = it,
+                memo = null,
+            )
+        )
+    }
+    return items.sortedBy { it.occurredAt }
+}
+
+private fun Participation.toAdminStatus(): AdminRefundRequestStatus {
+    if (status == ParticipationStatus.REFUNDED) {
+        return AdminRefundRequestStatus.APPROVED
+    }
+    return when (ownerRefundReviewStatus) {
+        OwnerRefundReviewStatus.APPROVED -> AdminRefundRequestStatus.IN_PROGRESS
+        OwnerRefundReviewStatus.DISPUTED -> AdminRefundRequestStatus.REJECTED
+        OwnerRefundReviewStatus.PENDING,
+        null -> AdminRefundRequestStatus.REVIEW_PENDING
+    }
+}
+
+private fun ParticipationCancelReason?.toRefundReasonLabel(): String {
+    return when (this) {
+        ParticipationCancelReason.TIME_UNAVAILABLE -> "픽업 불가"
+        ParticipationCancelReason.NO_LONGER_WANTED -> "구매 의사 없음"
+        ParticipationCancelReason.PREFER_DIRECT_VISIT -> "매장 직접 구매"
+        ParticipationCancelReason.BOUGHT_ELSEWHERE -> "타 채널 구매"
+        ParticipationCancelReason.OTHER -> "기타"
+        null -> "기타"
+    }
+}
+
+private val PICKUP_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestDetailResponse.kt
@@ -109,7 +109,8 @@ data class AdminRefundRequestDetailResponse(
                 pickupDate = participation.groupBuy.pickupDate.format(PICKUP_DATE_FORMATTER),
                 pickupLocation = participation.groupBuy.pickupLocation,
                 paymentAmount = participation.totalAmount,
-                refundExpectedAmount = (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0),
+                refundExpectedAmount = participation.approvedRefundAmount
+                    ?: (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0),
                 paymentMethod = payment?.method,
                 approvalNumber = payment?.pgPaymentId,
                 paidAt = payment?.approvedAt ?: paymentOrder?.approvedAt,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestHistoryItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestHistoryItemResponse.kt
@@ -1,0 +1,17 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "어드민 환불 요청 처리 이력 아이템")
+data class AdminRefundRequestHistoryItemResponse(
+
+    @Schema(description = "이력 타입")
+    val type: String,
+
+    @Schema(description = "이력 시각")
+    val occurredAt: LocalDateTime,
+
+    @Schema(description = "이력 메모")
+    val memo: String?,
+)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
@@ -60,7 +60,11 @@ data class AdminRefundRequestListItemResponse(
                 groupBuyName = participation.groupBuy.productName,
                 storeName = participation.groupBuy.store.name,
                 paymentAmount = participation.totalAmount,
-                refundAmount = if (participation.status == ParticipationStatus.REFUNDED) participation.totalAmount else 0,
+                refundAmount = when (participation.status) {
+                    ParticipationStatus.REFUNDED -> participation.approvedRefundAmount ?: participation.totalAmount
+                    ParticipationStatus.REFUND_PENDING -> participation.approvedRefundAmount ?: 0
+                    else -> 0
+                },
                 ownerOpinion = participation.ownerRefundDisputeReason,
                 requestedAt = requestedAt,
                 slaRemainingHours = calculateSlaRemainingHours(requestedAt, now),

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
@@ -1,5 +1,9 @@
 package com.moongchijang.domain.admin.application.dto.refund
 
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Duration
 import java.time.LocalDateTime
@@ -39,7 +43,53 @@ data class AdminRefundRequestListItemResponse(
 
     @Schema(description = "처리 상태")
     val status: AdminRefundRequestStatus,
-)
+){
+    companion object {
+        fun from(
+            participation: Participation,
+            now: LocalDateTime,
+        ): AdminRefundRequestListItemResponse {
+            val requestedAt = participation.cancelledAt ?: participation.createdAt ?: now
+            return AdminRefundRequestListItemResponse(
+                requestId = participation.id,
+                caseFilter = participation.cancelReason.toAdminCaseFilter(),
+                consumerName = participation.user.nickname ?: "알 수 없음",
+                groupBuyName = participation.groupBuy.productName,
+                storeName = participation.groupBuy.store.name,
+                paymentAmount = participation.totalAmount,
+                refundAmount = if (participation.status == ParticipationStatus.REFUNDED) participation.totalAmount else 0,
+                ownerOpinion = participation.ownerRefundDisputeReason,
+                requestedAt = requestedAt,
+                slaRemainingHours = calculateSlaRemainingHours(requestedAt, now),
+                status = participation.toAdminStatus(),
+            )
+        }
+    }
+}
+
+private fun Participation.toAdminStatus(): AdminRefundRequestStatus {
+    if (status == ParticipationStatus.REFUNDED) {
+        return AdminRefundRequestStatus.APPROVED
+    }
+
+    return when (ownerRefundReviewStatus) {
+        OwnerRefundReviewStatus.APPROVED -> AdminRefundRequestStatus.IN_PROGRESS
+        OwnerRefundReviewStatus.DISPUTED -> AdminRefundRequestStatus.REJECTED
+        OwnerRefundReviewStatus.PENDING,
+        null -> AdminRefundRequestStatus.REVIEW_PENDING
+    }
+}
+
+private fun ParticipationCancelReason?.toAdminCaseFilter(): AdminRefundRequestCaseFilter {
+    return when (this) {
+        ParticipationCancelReason.TIME_UNAVAILABLE -> AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW
+        ParticipationCancelReason.NO_LONGER_WANTED -> AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL
+        ParticipationCancelReason.PREFER_DIRECT_VISIT -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
+        ParticipationCancelReason.BOUGHT_ELSEWHERE -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
+        ParticipationCancelReason.OTHER -> AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND
+        null -> AdminRefundRequestCaseFilter.ALL
+    }
+}
 
 internal fun calculateSlaRemainingHours(
     requestedAt: LocalDateTime,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
@@ -41,6 +41,9 @@ data class AdminRefundRequestListItemResponse(
     @Schema(description = "SLA 남은 시간(시간)")
     val slaRemainingHours: Long,
 
+    @Schema(description = "요청 후 1시간 초과 여부")
+    val slaWarning: Boolean,
+
     @Schema(description = "처리 상태")
     val status: AdminRefundRequestStatus,
 ){
@@ -61,6 +64,7 @@ data class AdminRefundRequestListItemResponse(
                 ownerOpinion = participation.ownerRefundDisputeReason,
                 requestedAt = requestedAt,
                 slaRemainingHours = calculateSlaRemainingHours(requestedAt, now),
+                slaWarning = isSlaWarning(requestedAt, now),
                 status = participation.toAdminStatus(),
             )
         }
@@ -97,4 +101,11 @@ internal fun calculateSlaRemainingHours(
 ): Long {
     val deadline = requestedAt.plusHours(24)
     return Duration.between(now, deadline).toHours()
+}
+
+internal fun isSlaWarning(
+    requestedAt: LocalDateTime,
+    now: LocalDateTime,
+): Boolean {
+    return Duration.between(requestedAt, now).toHours() >= 1
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStat
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Duration
 import java.time.LocalDateTime
@@ -55,7 +56,7 @@ data class AdminRefundRequestListItemResponse(
             val requestedAt = participation.cancelledAt ?: participation.createdAt ?: now
             return AdminRefundRequestListItemResponse(
                 requestId = participation.id,
-                caseFilter = participation.cancelReason.toAdminCaseFilter(),
+                caseFilter = participation.toAdminCaseFilter(),
                 consumerName = participation.user.nickname ?: "알 수 없음",
                 groupBuyName = participation.groupBuy.productName,
                 storeName = participation.groupBuy.store.name,
@@ -88,8 +89,16 @@ private fun Participation.toAdminStatus(): AdminRefundRequestStatus {
     }
 }
 
-private fun ParticipationCancelReason?.toAdminCaseFilter(): AdminRefundRequestCaseFilter {
-    return when (this) {
+private fun Participation.toAdminCaseFilter(): AdminRefundRequestCaseFilter {
+    if (cancelReason == null) {
+        return if (groupBuy.status == GroupBuyStatus.FAILED) {
+            AdminRefundRequestCaseFilter.TARGET_NOT_MET
+        } else {
+            AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL
+        }
+    }
+
+    return when (cancelReason) {
         ParticipationCancelReason.TIME_UNAVAILABLE -> AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW
         ParticipationCancelReason.NO_LONGER_WANTED -> AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL
         ParticipationCancelReason.PREFER_DIRECT_VISIT -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestListItemResponse.kt
@@ -1,0 +1,50 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Duration
+import java.time.LocalDateTime
+
+@Schema(description = "어드민 환불 요청 목록 아이템")
+data class AdminRefundRequestListItemResponse(
+
+    @Schema(description = "환불 요청 ID(참여 ID)")
+    val requestId: Long,
+
+    @Schema(description = "환불 케이스")
+    val caseFilter: AdminRefundRequestCaseFilter,
+
+    @Schema(description = "소비자명")
+    val consumerName: String,
+
+    @Schema(description = "공구명")
+    val groupBuyName: String,
+
+    @Schema(description = "매장명")
+    val storeName: String,
+
+    @Schema(description = "결제 금액")
+    val paymentAmount: Int,
+
+    @Schema(description = "환불 금액")
+    val refundAmount: Int,
+
+    @Schema(description = "사장님 의견")
+    val ownerOpinion: String?,
+
+    @Schema(description = "요청 일시")
+    val requestedAt: LocalDateTime,
+
+    @Schema(description = "SLA 남은 시간(시간)")
+    val slaRemainingHours: Long,
+
+    @Schema(description = "처리 상태")
+    val status: AdminRefundRequestStatus,
+)
+
+internal fun calculateSlaRemainingHours(
+    requestedAt: LocalDateTime,
+    now: LocalDateTime,
+): Long {
+    val deadline = requestedAt.plusHours(24)
+    return Duration.between(now, deadline).toHours()
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestPageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestPageResponse.kt
@@ -19,4 +19,10 @@ data class AdminRefundRequestPageResponse(
 
     @Schema(description = "페이지 크기")
     val size: Int,
+
+    @Schema(description = "요청 후 1시간 초과 SLA 경고 건 존재 여부")
+    val hasSlaWarning: Boolean,
+
+    @Schema(description = "요청 후 1시간 초과 SLA 경고 건수")
+    val slaWarningCount: Int,
 )

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestPageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestPageResponse.kt
@@ -1,0 +1,22 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "어드민 환불 요청 목록 페이지 응답")
+data class AdminRefundRequestPageResponse(
+
+    @Schema(description = "목록")
+    val content: List<AdminRefundRequestListItemResponse>,
+
+    @Schema(description = "전체 건수")
+    val totalElements: Long,
+
+    @Schema(description = "전체 페이지 수")
+    val totalPages: Int,
+
+    @Schema(description = "현재 페이지 번호(0-base)")
+    val number: Int,
+
+    @Schema(description = "페이지 크기")
+    val size: Int,
+)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestRejectRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestRejectRequest.kt
@@ -1,0 +1,14 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "운영자 환불 요청 거절 처리 요청 DTO")
+data class AdminRefundRequestRejectRequest(
+
+    @field:NotBlank(message = "rejectionReason은 필수입니다.")
+    @field:Size(max = 200, message = "rejectionReason은 200자를 초과할 수 없습니다.")
+    @Schema(description = "환불 요청 거절 사유 (최대 200자)", example = "증빙 자료 불충분으로 환불이 어렵습니다.")
+    val rejectionReason: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestStatus.kt
@@ -1,0 +1,11 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "어드민 환불 요청 처리 상태")
+enum class AdminRefundRequestStatus {
+    REVIEW_PENDING,
+    IN_PROGRESS,
+    APPROVED,
+    REJECTED,
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestTab.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/refund/AdminRefundRequestTab.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.domain.admin.application.dto.refund
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "어드민 환불 요청 탭 필터")
+enum class AdminRefundRequestTab {
+    ALL,
+    REVIEW_PENDING,
+    IN_PROGRESS,
+    APPROVED,
+    REJECTED,
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/refund/AdminRefundRequestStatusTransitionPolicy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/refund/AdminRefundRequestStatusTransitionPolicy.kt
@@ -1,0 +1,36 @@
+package com.moongchijang.domain.admin.application.refund
+
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestStatus
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+
+object AdminRefundRequestStatusTransitionPolicy {
+    private val allowedTransitions = mapOf(
+        AdminRefundRequestStatus.REVIEW_PENDING to setOf(
+            AdminRefundRequestStatus.IN_PROGRESS,
+            AdminRefundRequestStatus.APPROVED,
+            AdminRefundRequestStatus.REJECTED,
+        ),
+        AdminRefundRequestStatus.IN_PROGRESS to setOf(
+            AdminRefundRequestStatus.APPROVED,
+            AdminRefundRequestStatus.REJECTED,
+        ),
+        AdminRefundRequestStatus.APPROVED to emptySet(),
+        AdminRefundRequestStatus.REJECTED to emptySet(),
+    )
+
+    fun validateTransition(from: AdminRefundRequestStatus, to: AdminRefundRequestStatus) {
+        if (from == to) {
+            return
+        }
+
+        if (from == AdminRefundRequestStatus.APPROVED || from == AdminRefundRequestStatus.REJECTED) {
+            throw CustomException(ErrorCode.ADMIN_REFUND_REQUEST_ALREADY_PROCESSED)
+        }
+
+        val allowed = allowedTransitions[from].orEmpty()
+        if (to !in allowed) {
+            throw CustomException(ErrorCode.ADMIN_REFUND_REQUEST_INVALID_STATUS_TRANSITION)
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminRefundRequestService
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
 import com.moongchijang.global.response.ApiResponse
@@ -13,6 +14,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -55,5 +57,22 @@ class AdminRefundRequestController(
                 )
             )
         )
+    }
+
+    @GetMapping("/{requestId}")
+    @Operation(summary = "운영자 환불 요청 상세 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "환불 요청 상세 조회 성공"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요"),
+            SwaggerApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            SwaggerApiResponse(responseCode = "404", description = "환불 요청을 찾을 수 없음"),
+        ]
+    )
+    fun getRefundRequestDetail(
+        @PathVariable requestId: Long,
+    ): ResponseEntity<ApiResponse<AdminRefundRequestDetailResponse>> {
+        log.info("[AdminRefundRequestController] 환불 요청 상세 조회 요청: requestId={}", requestId)
+        return ResponseEntity.ok(ApiResponse.success(adminRefundRequestService.getRefundRequestDetail(requestId)))
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminRefundRequestService
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
 import com.moongchijang.global.response.ApiResponse
@@ -36,12 +37,23 @@ class AdminRefundRequestController(
     )
     fun getRefundRequests(
         @RequestParam(defaultValue = "ALL") tab: AdminRefundRequestTab,
+        @RequestParam(defaultValue = "ALL") caseFilter: AdminRefundRequestCaseFilter,
+        @RequestParam(required = false) keyword: String?,
         pageable: Pageable,
     ): ResponseEntity<ApiResponse<AdminRefundRequestPageResponse>> {
         log.info(
-            "[AdminRefundRequestController] 환불 요청 목록 조회 요청: tab={}, page={}, size={}",
-            tab, pageable.pageNumber, pageable.pageSize
+            "[AdminRefundRequestController] 환불 요청 목록 조회 요청: tab={}, caseFilter={}, keyword={}, page={}, size={}",
+            tab, caseFilter, keyword, pageable.pageNumber, pageable.pageSize
         )
-        return ResponseEntity.ok(ApiResponse.success(adminRefundRequestService.getRefundRequests(tab, pageable)))
+        return ResponseEntity.ok(
+            ApiResponse.success(
+                adminRefundRequestService.getRefundRequests(
+                    tab = tab,
+                    caseFilter = caseFilter,
+                    keyword = keyword,
+                    pageable = pageable,
+                )
+            )
+        )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminRefundRequestService
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestApproveRequest
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
@@ -10,11 +11,14 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -74,5 +78,29 @@ class AdminRefundRequestController(
     ): ResponseEntity<ApiResponse<AdminRefundRequestDetailResponse>> {
         log.info("[AdminRefundRequestController] 환불 요청 상세 조회 요청: requestId={}", requestId)
         return ResponseEntity.ok(ApiResponse.success(adminRefundRequestService.getRefundRequestDetail(requestId)))
+    }
+
+    @PatchMapping("/{requestId}/approve")
+    @Operation(summary = "운영자 환불 요청 승인 처리")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "환불 요청 승인 처리 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "잘못된 환불 금액 또는 상태 전이"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요"),
+            SwaggerApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            SwaggerApiResponse(responseCode = "404", description = "환불 요청을 찾을 수 없음"),
+            SwaggerApiResponse(responseCode = "409", description = "이미 처리된 환불 요청"),
+        ]
+    )
+    fun approveRefundRequest(
+        @PathVariable requestId: Long,
+        @Valid @RequestBody request: AdminRefundRequestApproveRequest,
+    ): ResponseEntity<ApiResponse<AdminRefundRequestDetailResponse>> {
+        log.info(
+            "[AdminRefundRequestController] 환불 요청 승인 처리 요청: requestId={}, refundAmount={}",
+            requestId,
+            request.refundAmount
+        )
+        return ResponseEntity.ok(ApiResponse.success(adminRefundRequestService.approveRefundRequest(requestId, request)))
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestAp
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestRejectRequest
 import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -102,5 +103,29 @@ class AdminRefundRequestController(
             request.refundAmount
         )
         return ResponseEntity.ok(ApiResponse.success(adminRefundRequestService.approveRefundRequest(requestId, request)))
+    }
+
+    @PatchMapping("/{requestId}/reject")
+    @Operation(summary = "운영자 환불 요청 거절 처리")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "환불 요청 거절 처리 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "잘못된 거절 사유 또는 상태 전이"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요"),
+            SwaggerApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            SwaggerApiResponse(responseCode = "404", description = "환불 요청을 찾을 수 없음"),
+            SwaggerApiResponse(responseCode = "409", description = "이미 처리된 환불 요청"),
+        ]
+    )
+    fun rejectRefundRequest(
+        @PathVariable requestId: Long,
+        @Valid @RequestBody request: AdminRefundRequestRejectRequest,
+    ): ResponseEntity<ApiResponse<AdminRefundRequestDetailResponse>> {
+        log.info(
+            "[AdminRefundRequestController] 환불 요청 거절 처리 요청: requestId={}, rejectionReasonLength={}",
+            requestId,
+            request.rejectionReason.trim().length
+        )
+        return ResponseEntity.ok(ApiResponse.success(adminRefundRequestService.rejectRefundRequest(requestId, request)))
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminRefundRequestController.kt
@@ -1,0 +1,47 @@
+package com.moongchijang.domain.admin.presentation
+
+import com.moongchijang.domain.admin.application.AdminRefundRequestService
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestPageResponse
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/refund-requests")
+@Tag(name = "Admin", description = "운영자 관리")
+class AdminRefundRequestController(
+    private val adminRefundRequestService: AdminRefundRequestService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping
+    @Operation(summary = "운영자 환불 요청 목록 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "환불 요청 목록 조회 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요"),
+            SwaggerApiResponse(responseCode = "403", description = "접근 권한 없음"),
+        ]
+    )
+    fun getRefundRequests(
+        @RequestParam(defaultValue = "ALL") tab: AdminRefundRequestTab,
+        pageable: Pageable,
+    ): ResponseEntity<ApiResponse<AdminRefundRequestPageResponse>> {
+        log.info(
+            "[AdminRefundRequestController] 환불 요청 목록 조회 요청: tab={}, page={}, size={}",
+            tab, pageable.pageNumber, pageable.pageSize
+        )
+        return ResponseEntity.ok(ApiResponse.success(adminRefundRequestService.getRefundRequests(tab, pageable)))
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -215,7 +215,11 @@ class OwnerSettlementService(
             OwnerRefundReviewActionType.DISPUTE -> OwnerRefundReviewStatus.DISPUTED
         }
         participation.approvedRefundAmount = if (request.action == OwnerRefundReviewActionType.APPROVE) {
-            (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+            if (participation.cancelReason == null) {
+                participation.totalAmount
+            } else {
+                (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+            }
         } else {
             null
         }
@@ -229,7 +233,11 @@ class OwnerSettlementService(
             refundRequestSyncService.markApproved(
                 participation = participation,
                 approvedAmount = participation.approvedRefundAmount
-                    ?: (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0),
+                    ?: if (participation.cancelReason == null) {
+                        participation.totalAmount
+                    } else {
+                        (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+                    },
                 at = participation.ownerRefundReviewedAt ?: java.time.LocalDateTime.now(),
             )
         } else {

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -18,6 +18,7 @@ import com.moongchijang.domain.participation.domain.entity.ParticipationCancelRe
 import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
@@ -37,6 +38,7 @@ class OwnerSettlementService(
     private val storeStaffRepository: StoreStaffRepository,
     private val groupBuyRepository: GroupBuyRepository,
     private val participationRepository: ParticipationRepository,
+    private val refundRequestSyncService: RefundRequestSyncService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -223,6 +225,20 @@ class OwnerSettlementService(
             null
         }
         participation.ownerRefundReviewedAt = java.time.LocalDateTime.now()
+        if (request.action == OwnerRefundReviewActionType.APPROVE) {
+            refundRequestSyncService.markApproved(
+                participation = participation,
+                approvedAmount = participation.approvedRefundAmount
+                    ?: (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0),
+                at = participation.ownerRefundReviewedAt ?: java.time.LocalDateTime.now(),
+            )
+        } else {
+            refundRequestSyncService.markRejected(
+                participation = participation,
+                reason = participation.ownerRefundDisputeReason,
+                at = participation.ownerRefundReviewedAt ?: java.time.LocalDateTime.now(),
+            )
+        }
 
         log.info(
             "[OwnerSettlementService] 환불 요청 검토 제출 완료: ownerId={}, participationId={}, action={}",

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -210,42 +210,36 @@ class OwnerSettlementService(
             throw CustomException(ErrorCode.OWNER_REFUND_REVIEW_ALREADY_PROCESSED)
         }
 
-        participation.ownerRefundReviewStatus = when (request.action) {
-            OwnerRefundReviewActionType.APPROVE -> OwnerRefundReviewStatus.APPROVED
-            OwnerRefundReviewActionType.DISPUTE -> OwnerRefundReviewStatus.DISPUTED
-        }
-        participation.approvedRefundAmount = if (request.action == OwnerRefundReviewActionType.APPROVE) {
-            if (participation.cancelReason == null) {
-                participation.totalAmount
-            } else {
-                (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+        val now = java.time.LocalDateTime.now()
+        participation.ownerRefundReviewedAt = now
+
+        when (request.action) {
+            OwnerRefundReviewActionType.APPROVE -> {
+                val approvedAmount = if (participation.cancelReason == null) {
+                    participation.totalAmount
+                } else {
+                    (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+                }
+                participation.ownerRefundReviewStatus = OwnerRefundReviewStatus.APPROVED
+                participation.approvedRefundAmount = approvedAmount
+                participation.ownerRefundDisputeReason = null
+                refundRequestSyncService.markApproved(
+                    participation = participation,
+                    approvedAmount = approvedAmount,
+                    at = now,
+                )
             }
-        } else {
-            null
-        }
-        participation.ownerRefundDisputeReason = if (request.action == OwnerRefundReviewActionType.DISPUTE) {
-            request.disputeReason?.trim()?.takeIf { it.isNotBlank() }
-        } else {
-            null
-        }
-        participation.ownerRefundReviewedAt = java.time.LocalDateTime.now()
-        if (request.action == OwnerRefundReviewActionType.APPROVE) {
-            refundRequestSyncService.markApproved(
-                participation = participation,
-                approvedAmount = participation.approvedRefundAmount
-                    ?: if (participation.cancelReason == null) {
-                        participation.totalAmount
-                    } else {
-                        (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
-                    },
-                at = participation.ownerRefundReviewedAt ?: java.time.LocalDateTime.now(),
-            )
-        } else {
-            refundRequestSyncService.markRejected(
-                participation = participation,
-                reason = participation.ownerRefundDisputeReason,
-                at = participation.ownerRefundReviewedAt ?: java.time.LocalDateTime.now(),
-            )
+            OwnerRefundReviewActionType.DISPUTE -> {
+                val disputeReason = request.disputeReason?.trim()?.takeIf { it.isNotBlank() }
+                participation.ownerRefundReviewStatus = OwnerRefundReviewStatus.DISPUTED
+                participation.approvedRefundAmount = null
+                participation.ownerRefundDisputeReason = disputeReason
+                refundRequestSyncService.markRejected(
+                    participation = participation,
+                    reason = disputeReason,
+                    at = now,
+                )
+            }
         }
 
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -212,6 +212,11 @@ class OwnerSettlementService(
             OwnerRefundReviewActionType.APPROVE -> OwnerRefundReviewStatus.APPROVED
             OwnerRefundReviewActionType.DISPUTE -> OwnerRefundReviewStatus.DISPUTED
         }
+        participation.approvedRefundAmount = if (request.action == OwnerRefundReviewActionType.APPROVE) {
+            (participation.totalAmount - participation.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+        } else {
+            null
+        }
         participation.ownerRefundDisputeReason = if (request.action == OwnerRefundReviewActionType.DISPUTE) {
             request.disputeReason?.trim()?.takeIf { it.isNotBlank() }
         } else {

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
@@ -85,6 +85,9 @@ class Participation(
     @Column(name = "refunded_at")
     var refundedAt: LocalDateTime? = null,
 
+    @Column(name = "approved_refund_amount")
+    var approvedRefundAmount: Int? = null,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "owner_refund_review_status", length = 30)
     var ownerRefundReviewStatus: OwnerRefundReviewStatus? = null,

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -524,16 +524,28 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         join fetch p.user u
         join fetch p.groupBuy gb
         join fetch gb.store
-        where p.cancelReason is not null
-          and p.status in :statuses
+        where p.status in :statuses
           and (
             :useReviewStatusFilter = false
             or p.ownerRefundReviewStatus in :reviewStatuses
             or (:includeNullReviewStatus = true and p.ownerRefundReviewStatus is null)
           )
           and (
-            :useCaseFilter = false
-            or p.cancelReason in :cancelReasons
+            :caseFilter = 'ALL'
+            or (
+              :caseFilter = 'TARGET_NOT_MET'
+              and p.cancelReason is null
+              and gb.status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.FAILED
+            )
+            or (
+              :caseFilter = 'OWNER_FAULT_CANCEL'
+              and p.cancelReason is null
+              and gb.status <> com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.FAILED
+            )
+            or (
+              :caseFilter not in ('ALL', 'TARGET_NOT_MET', 'OWNER_FAULT_CANCEL')
+              and p.cancelReason in :cancelReasons
+            )
           )
           and (
             :keyword is null
@@ -548,16 +560,28 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         from Participation p
         join p.user u
         join p.groupBuy gb
-        where p.cancelReason is not null
-          and p.status in :statuses
+        where p.status in :statuses
           and (
             :useReviewStatusFilter = false
             or p.ownerRefundReviewStatus in :reviewStatuses
             or (:includeNullReviewStatus = true and p.ownerRefundReviewStatus is null)
           )
           and (
-            :useCaseFilter = false
-            or p.cancelReason in :cancelReasons
+            :caseFilter = 'ALL'
+            or (
+              :caseFilter = 'TARGET_NOT_MET'
+              and p.cancelReason is null
+              and gb.status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.FAILED
+            )
+            or (
+              :caseFilter = 'OWNER_FAULT_CANCEL'
+              and p.cancelReason is null
+              and gb.status <> com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.FAILED
+            )
+            or (
+              :caseFilter not in ('ALL', 'TARGET_NOT_MET', 'OWNER_FAULT_CANCEL')
+              and p.cancelReason in :cancelReasons
+            )
           )
           and (
             :keyword is null
@@ -572,7 +596,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         @Param("useReviewStatusFilter") useReviewStatusFilter: Boolean,
         @Param("reviewStatuses") reviewStatuses: Collection<OwnerRefundReviewStatus>,
         @Param("includeNullReviewStatus") includeNullReviewStatus: Boolean,
-        @Param("useCaseFilter") useCaseFilter: Boolean,
+        @Param("caseFilter") caseFilter: String,
         @Param("cancelReasons") cancelReasons: Collection<ParticipationCancelReason>,
         @Param("keyword") keyword: String?,
         pageable: Pageable,

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.participation.domain.repository
 
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
@@ -514,6 +515,81 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Participation p join fetch p.groupBuy where p.id = :id")
     fun findByIdForUpdate(@Param("id") id: Long): Optional<Participation>
+
+    @Query(
+        value = """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.cancelReason is not null
+          and p.status in :statuses
+        order by p.cancelledAt desc, p.createdAt desc
+        """,
+        countQuery = """
+        select count(p)
+        from Participation p
+        where p.cancelReason is not null
+          and p.status in :statuses
+        """
+    )
+    fun findAdminRefundRequestsAll(
+        @Param("statuses") statuses: Collection<ParticipationStatus>,
+        pageable: Pageable,
+    ): Page<Participation>
+
+    @Query(
+        value = """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.cancelReason is not null
+          and p.status = :status
+          and p.ownerRefundReviewStatus = :reviewStatus
+        order by p.cancelledAt desc, p.createdAt desc
+        """,
+        countQuery = """
+        select count(p)
+        from Participation p
+        where p.cancelReason is not null
+          and p.status = :status
+          and p.ownerRefundReviewStatus = :reviewStatus
+        """
+    )
+    fun findAdminRefundRequestsByReviewStatus(
+        @Param("status") status: ParticipationStatus,
+        @Param("reviewStatus") reviewStatus: OwnerRefundReviewStatus,
+        pageable: Pageable,
+    ): Page<Participation>
+
+    @Query(
+        value = """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.cancelReason is not null
+          and p.status = :status
+          and (p.ownerRefundReviewStatus is null or p.ownerRefundReviewStatus = :reviewStatus)
+        order by p.cancelledAt desc, p.createdAt desc
+        """,
+        countQuery = """
+        select count(p)
+        from Participation p
+        where p.cancelReason is not null
+          and p.status = :status
+          and (p.ownerRefundReviewStatus is null or p.ownerRefundReviewStatus = :reviewStatus)
+        """
+    )
+    fun findAdminRefundRequestsByReviewStatusIncludingNull(
+        @Param("status") status: ParticipationStatus,
+        @Param("reviewStatus") reviewStatus: OwnerRefundReviewStatus,
+        pageable: Pageable,
+    ): Page<Participation>
 
     @Query(
         """

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.participation.domain.repository
 
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
@@ -520,74 +521,60 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         value = """
         select p
         from Participation p
-        join fetch p.user
+        join fetch p.user u
         join fetch p.groupBuy gb
         join fetch gb.store
         where p.cancelReason is not null
           and p.status in :statuses
+          and (
+            :useReviewStatusFilter = false
+            or p.ownerRefundReviewStatus in :reviewStatuses
+            or (:includeNullReviewStatus = true and p.ownerRefundReviewStatus is null)
+          )
+          and (
+            :useCaseFilter = false
+            or p.cancelReason in :cancelReasons
+          )
+          and (
+            :keyword is null
+            or str(p.id) = :keyword
+            or lower(u.nickname) like lower(concat('%', :keyword, '%'))
+            or lower(gb.productName) like lower(concat('%', :keyword, '%'))
+          )
         order by p.cancelledAt desc, p.createdAt desc
         """,
         countQuery = """
         select count(p)
         from Participation p
+        join p.user u
+        join p.groupBuy gb
         where p.cancelReason is not null
           and p.status in :statuses
+          and (
+            :useReviewStatusFilter = false
+            or p.ownerRefundReviewStatus in :reviewStatuses
+            or (:includeNullReviewStatus = true and p.ownerRefundReviewStatus is null)
+          )
+          and (
+            :useCaseFilter = false
+            or p.cancelReason in :cancelReasons
+          )
+          and (
+            :keyword is null
+            or str(p.id) = :keyword
+            or lower(u.nickname) like lower(concat('%', :keyword, '%'))
+            or lower(gb.productName) like lower(concat('%', :keyword, '%'))
+          )
         """
     )
-    fun findAdminRefundRequestsAll(
+    fun findAdminRefundRequests(
         @Param("statuses") statuses: Collection<ParticipationStatus>,
-        pageable: Pageable,
-    ): Page<Participation>
-
-    @Query(
-        value = """
-        select p
-        from Participation p
-        join fetch p.user
-        join fetch p.groupBuy gb
-        join fetch gb.store
-        where p.cancelReason is not null
-          and p.status = :status
-          and p.ownerRefundReviewStatus = :reviewStatus
-        order by p.cancelledAt desc, p.createdAt desc
-        """,
-        countQuery = """
-        select count(p)
-        from Participation p
-        where p.cancelReason is not null
-          and p.status = :status
-          and p.ownerRefundReviewStatus = :reviewStatus
-        """
-    )
-    fun findAdminRefundRequestsByReviewStatus(
-        @Param("status") status: ParticipationStatus,
-        @Param("reviewStatus") reviewStatus: OwnerRefundReviewStatus,
-        pageable: Pageable,
-    ): Page<Participation>
-
-    @Query(
-        value = """
-        select p
-        from Participation p
-        join fetch p.user
-        join fetch p.groupBuy gb
-        join fetch gb.store
-        where p.cancelReason is not null
-          and p.status = :status
-          and (p.ownerRefundReviewStatus is null or p.ownerRefundReviewStatus = :reviewStatus)
-        order by p.cancelledAt desc, p.createdAt desc
-        """,
-        countQuery = """
-        select count(p)
-        from Participation p
-        where p.cancelReason is not null
-          and p.status = :status
-          and (p.ownerRefundReviewStatus is null or p.ownerRefundReviewStatus = :reviewStatus)
-        """
-    )
-    fun findAdminRefundRequestsByReviewStatusIncludingNull(
-        @Param("status") status: ParticipationStatus,
-        @Param("reviewStatus") reviewStatus: OwnerRefundReviewStatus,
+        @Param("useReviewStatusFilter") useReviewStatusFilter: Boolean,
+        @Param("reviewStatuses") reviewStatuses: Collection<OwnerRefundReviewStatus>,
+        @Param("includeNullReviewStatus") includeNullReviewStatus: Boolean,
+        @Param("useCaseFilter") useCaseFilter: Boolean,
+        @Param("cancelReasons") cancelReasons: Collection<ParticipationCancelReason>,
+        @Param("keyword") keyword: String?,
         pageable: Pageable,
     ): Page<Participation>
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -682,8 +682,12 @@ class PaymentService(
             participationId = participation.id,
             orderId = order.orderId,
             pgPaymentId = payment.pgPaymentId,
-            refundAmount = participation.approvedRefundAmount
-                ?: (order.totalAmount - order.feeAmount.coerceAtLeast(0)).coerceAtLeast(0),
+            refundAmount = when {
+                participation.approvedRefundAmount != null -> participation.approvedRefundAmount!!
+                // 자동 실패(목표 미달), 사장님 귀책 등 사용자 요청 사유가 없는 환불은 전액 환불
+                participation.cancelReason == null -> order.totalAmount
+                else -> (order.totalAmount - order.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+            },
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -625,7 +625,11 @@ class PaymentService(
         } ?: return false
 
         val paymentResult = try {
-            portOnePaymentPort.cancelPayment(target.pgPaymentId, PENDING_REFUND_CANCEL_REASON)
+            portOnePaymentPort.cancelPayment(
+                paymentId = target.pgPaymentId,
+                reason = PENDING_REFUND_CANCEL_REASON,
+                cancelAmount = target.refundAmount,
+            )
         } catch (e: CustomException) {
             log.warn(
                 "[PaymentService] 환불대기 PG 취소 실패: participationId={}, orderId={}, errorCode={}",
@@ -635,7 +639,7 @@ class PaymentService(
             )
             return false
         }
-        if (paymentResult.status != PORTONE_STATUS_CANCELLED) {
+        if (paymentResult.status != PORTONE_STATUS_CANCELLED && paymentResult.status != PORTONE_STATUS_PARTIAL_CANCELLED) {
             log.warn(
                 "[PaymentService] 환불대기 PG 취소 미완료 상태: participationId={}, orderId={}, portOneStatus={}",
                 target.participationId,
@@ -676,6 +680,8 @@ class PaymentService(
             participationId = participation.id,
             orderId = order.orderId,
             pgPaymentId = payment.pgPaymentId,
+            refundAmount = participation.approvedRefundAmount
+                ?: (order.totalAmount - order.feeAmount.coerceAtLeast(0)).coerceAtLeast(0),
         )
     }
 
@@ -691,8 +697,14 @@ class PaymentService(
         val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
             ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
 
-        order.cancel(refundedAt)
-        payment.cancel(refundedAt)
+        val partial = target.refundAmount < order.totalAmount
+        if (partial) {
+            order.partialCancel(refundedAt)
+            payment.partialCancel(refundedAt)
+        } else {
+            order.cancel(refundedAt)
+            payment.cancel(refundedAt)
+        }
         participation.status = ParticipationStatus.REFUNDED
         participation.refundedAt = refundedAt
     }
@@ -853,6 +865,7 @@ class PaymentService(
         val participationId: Long,
         val orderId: String,
         val pgPaymentId: String,
+        val refundAmount: Int,
     )
 
     companion object {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -27,6 +27,7 @@ import com.moongchijang.domain.payment.domain.entity.PaymentOrder
 import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
 import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
 import com.moongchijang.domain.payment.domain.repository.PaymentRepository
+import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
@@ -55,6 +56,7 @@ class PaymentService(
     private val transactionManager: PlatformTransactionManager,
     private val redisLockUtil: RedisLockUtil,
     private val notificationEventPublisher: NotificationEventPublisher,
+    private val refundRequestSyncService: RefundRequestSyncService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -707,6 +709,7 @@ class PaymentService(
         }
         participation.status = ParticipationStatus.REFUNDED
         participation.refundedAt = refundedAt
+        refundRequestSyncService.markCompleted(participation = participation, at = refundedAt)
     }
 
     private fun validateParticipationOwner(participation: Participation, userId: Long) {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -682,12 +682,13 @@ class PaymentService(
             participationId = participation.id,
             orderId = order.orderId,
             pgPaymentId = payment.pgPaymentId,
-            refundAmount = when {
-                participation.approvedRefundAmount != null -> participation.approvedRefundAmount!!
-                // 자동 실패(목표 미달), 사장님 귀책 등 사용자 요청 사유가 없는 환불은 전액 환불
-                participation.cancelReason == null -> order.totalAmount
-                else -> (order.totalAmount - order.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
-            },
+            refundAmount = participation.approvedRefundAmount
+                ?: if (participation.cancelReason == null) {
+                    // 자동 실패(목표 미달), 사장님 귀책 등 사용자 요청 사유가 없는 환불은 전액 환불
+                    order.totalAmount
+                } else {
+                    (order.totalAmount - order.feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+                },
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/port/PortOnePaymentPort.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/port/PortOnePaymentPort.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 interface PortOnePaymentPort {
     fun getPayment(paymentId: String): PortOnePaymentResult
 
-    fun cancelPayment(paymentId: String, reason: String): PortOnePaymentResult
+    fun cancelPayment(paymentId: String, reason: String, cancelAmount: Int? = null): PortOnePaymentResult
 }
 
 data class PortOnePaymentResult(

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -40,12 +40,17 @@ class PortOnePaymentClient(
         }
     }
 
-    override fun cancelPayment(paymentId: String, reason: String): PortOnePaymentResult {
+    override fun cancelPayment(paymentId: String, reason: String, cancelAmount: Int?): PortOnePaymentResult {
+        val requestBody = mutableMapOf<String, Any>("reason" to reason).apply {
+            if (cancelAmount != null) {
+                this["amount"] = cancelAmount
+            }
+        }
         val response = try {
             restClient.post()
                 .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}/cancel", paymentId)
                 .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
-                .body(mapOf("reason" to reason))
+                .body(requestBody)
                 .retrieve()
                 .body(Map::class.java)
                 ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)

--- a/src/main/kotlin/com/moongchijang/domain/refund/application/RefundRequestSyncService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/refund/application/RefundRequestSyncService.kt
@@ -1,0 +1,81 @@
+package com.moongchijang.domain.refund.application
+
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.refund.domain.entity.RefundRequest
+import com.moongchijang.domain.refund.domain.repository.RefundRequestRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class RefundRequestSyncService(
+    private val refundRequestRepository: RefundRequestRepository,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun markApproved(participation: Participation, approvedAmount: Int, at: LocalDateTime) {
+        log.info(
+            "[RefundRequestSyncService] 환불 요청 승인 동기화 시작: participationId={}, approvedAmount={}",
+            participation.id,
+            approvedAmount
+        )
+        val refundRequest = refundRequestRepository.findByParticipationId(participation.id)
+            ?: RefundRequest(
+                participation = participation,
+                requestedAmount = participation.totalAmount,
+                requestedAt = participation.cancelledAt ?: participation.createdAt ?: at,
+            )
+        refundRequest.markApproved(approvedRefundAmount = approvedAmount, at = at)
+        refundRequestRepository.save(refundRequest)
+        log.info(
+            "[RefundRequestSyncService] 환불 요청 승인 동기화 완료: participationId={}, refundRequestId={}, status={}",
+            participation.id,
+            refundRequest.id,
+            refundRequest.status
+        )
+    }
+
+    fun markRejected(participation: Participation, reason: String?, at: LocalDateTime) {
+        log.info(
+            "[RefundRequestSyncService] 환불 요청 거절 동기화 시작: participationId={}, reasonPresent={}",
+            participation.id,
+            !reason.isNullOrBlank()
+        )
+        val refundRequest = refundRequestRepository.findByParticipationId(participation.id)
+            ?: RefundRequest(
+                participation = participation,
+                requestedAmount = participation.totalAmount,
+                requestedAt = participation.cancelledAt ?: participation.createdAt ?: at,
+            )
+        refundRequest.markRejected(reason = reason, at = at)
+        refundRequestRepository.save(refundRequest)
+        log.info(
+            "[RefundRequestSyncService] 환불 요청 거절 동기화 완료: participationId={}, refundRequestId={}, status={}",
+            participation.id,
+            refundRequest.id,
+            refundRequest.status
+        )
+    }
+
+    fun markCompleted(participation: Participation, at: LocalDateTime) {
+        log.info(
+            "[RefundRequestSyncService] 환불 요청 완료 동기화 시작: participationId={}, refundedAt={}",
+            participation.id,
+            at
+        )
+        val refundRequest = refundRequestRepository.findByParticipationId(participation.id)
+            ?: RefundRequest(
+                participation = participation,
+                requestedAmount = participation.totalAmount,
+                requestedAt = participation.cancelledAt ?: participation.createdAt ?: at,
+            )
+        refundRequest.markCompleted(at = at)
+        refundRequestRepository.save(refundRequest)
+        log.info(
+            "[RefundRequestSyncService] 환불 요청 완료 동기화 완료: participationId={}, refundRequestId={}, status={}",
+            participation.id,
+            refundRequest.id,
+            refundRequest.status
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/refund/domain/entity/RefundRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/refund/domain/entity/RefundRequest.kt
@@ -1,0 +1,72 @@
+package com.moongchijang.domain.refund.domain.entity
+
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "refund_requests")
+class RefundRequest(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participation_id", nullable = false)
+    var participation: Participation,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    var status: RefundRequestStatus = RefundRequestStatus.REQUESTED,
+
+    @Column(name = "requested_amount", nullable = false)
+    var requestedAmount: Int,
+
+    @Column(name = "approved_refund_amount")
+    var approvedRefundAmount: Int? = null,
+
+    @Column(name = "rejected_reason", length = 200)
+    var rejectedReason: String? = null,
+
+    @Column(name = "requested_at", nullable = false)
+    var requestedAt: LocalDateTime,
+
+    @Column(name = "approved_at")
+    var approvedAt: LocalDateTime? = null,
+
+    @Column(name = "rejected_at")
+    var rejectedAt: LocalDateTime? = null,
+
+    @Column(name = "refunded_at")
+    var refundedAt: LocalDateTime? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L,
+) : BaseEntity() {
+    fun markApproved(approvedRefundAmount: Int, at: LocalDateTime) {
+        status = RefundRequestStatus.APPROVED
+        this.approvedRefundAmount = approvedRefundAmount
+        approvedAt = at
+        rejectedReason = null
+        rejectedAt = null
+    }
+
+    fun markRejected(reason: String?, at: LocalDateTime) {
+        status = RefundRequestStatus.REJECTED
+        rejectedReason = reason
+        rejectedAt = at
+    }
+
+    fun markCompleted(at: LocalDateTime) {
+        status = RefundRequestStatus.COMPLETED
+        refundedAt = at
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/refund/domain/entity/RefundRequestStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/refund/domain/entity/RefundRequestStatus.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.refund.domain.entity
+
+enum class RefundRequestStatus {
+    REQUESTED,
+    APPROVED,
+    REJECTED,
+    COMPLETED,
+}

--- a/src/main/kotlin/com/moongchijang/domain/refund/domain/repository/RefundRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/refund/domain/repository/RefundRequestRepository.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.refund.domain.repository
+
+import com.moongchijang.domain.refund.domain.entity.RefundRequest
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefundRequestRepository : JpaRepository<RefundRequest, Long> {
+    fun findByParticipationId(participationId: Long): RefundRequest?
+}

--- a/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/moongchijang/global/exception/ErrorCode.kt
@@ -64,6 +64,8 @@ enum class ErrorCode(val code: Int, val message: String, val httpStatus: Int) {
     OWNER_WITHDRAWAL_BLOCKED_OPEN_GROUPBUY(409_105, "개설된 공구가 있어 탈퇴할 수 없어요.", 409),
     OWNER_WITHDRAWAL_BLOCKED_PENDING_CUSTOMER_PICKUP(409_106, "달성 완료 공구의 픽업이 모두 완료된 후 탈퇴할 수 있어요.", 409),
     OWNER_REFUND_REVIEW_ALREADY_PROCESSED(409_107, "이미 처리된 환불 요청입니다.", 409),
+    ADMIN_REFUND_REQUEST_ALREADY_PROCESSED(409_108, "이미 처리된 환불 요청입니다.", 409),
+    ADMIN_REFUND_REQUEST_INVALID_STATUS_TRANSITION(400_113, "허용되지 않는 환불 요청 상태 전이입니다.", 400),
     EMAIL_VERIFICATION_DAILY_LIMIT_EXCEEDED(429_101, "내일 다시 시도해주세요.", 429),
     INVALID_SIGNUP_TOKEN(401_107, "회원가입 인증정보가 유효하지 않습니다. 이메일 인증을 다시 진행해주세요.", 401),
     KAKAO_TOKEN_REQUEST_INVALID(401_101, "카카오 토큰 요청 파라미터가 올바르지 않습니다.", 401),

--- a/src/main/resources/db/migration/V36__alter_participation_add_approved_refund_amount.sql
+++ b/src/main/resources/db/migration/V36__alter_participation_add_approved_refund_amount.sql
@@ -1,0 +1,2 @@
+ALTER TABLE participation
+    ADD COLUMN approved_refund_amount INT NULL COMMENT '승인된 환불 금액(부분환불용)';

--- a/src/main/resources/db/migration/V37__create_refund_requests_table.sql
+++ b/src/main/resources/db/migration/V37__create_refund_requests_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE refund_requests
+(
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    participation_id BIGINT NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    requested_amount INT NOT NULL,
+    approved_refund_amount INT NULL,
+    rejected_reason VARCHAR(200) NULL,
+    requested_at DATETIME NOT NULL,
+    approved_at DATETIME NULL,
+    rejected_at DATETIME NULL,
+    refunded_at DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_refund_requests_participation_id (participation_id),
+    CONSTRAINT fk_refund_requests_participation
+        FOREIGN KEY (participation_id) REFERENCES participation (id)
+);

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestServiceTest.kt
@@ -26,7 +26,6 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
@@ -53,8 +52,20 @@ class AdminRefundRequestServiceTest {
     )
 
     @Test
-    fun `미지원 케이스 필터는 빈 목록을 반환한다`() {
+    fun `사장님 귀책 케이스 필터는 조건에 맞는 목록을 조회한다`() {
         val pageable = PageRequest.of(0, 20)
+        `when`(
+            participationRepository.findAdminRefundRequests(
+                statuses = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                useReviewStatusFilter = false,
+                reviewStatuses = listOf(OwnerRefundReviewStatus.PENDING),
+                includeNullReviewStatus = false,
+                caseFilter = "OWNER_FAULT_CANCEL",
+                cancelReasons = listOf(com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason.OTHER),
+                keyword = "테스트",
+                pageable = pageable,
+            )
+        ).thenReturn(PageImpl(emptyList(), pageable, 0))
 
         val result = service.getRefundRequests(
             tab = AdminRefundRequestTab.ALL,
@@ -65,7 +76,6 @@ class AdminRefundRequestServiceTest {
 
         assertTrue(result.content.isEmpty())
         assertEquals(0L, result.totalElements)
-        verifyNoInteractions(participationRepository)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestServiceTest.kt
@@ -1,0 +1,200 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestApproveRequest
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestRejectRequest
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestStatus
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestTab
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
+import com.moongchijang.domain.payment.domain.repository.PaymentRepository
+import com.moongchijang.domain.refund.application.RefundRequestSyncService
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Optional
+
+class AdminRefundRequestServiceTest {
+
+    private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
+    private val paymentOrderRepository: PaymentOrderRepository = mock(PaymentOrderRepository::class.java)
+    private val paymentRepository: PaymentRepository = mock(PaymentRepository::class.java)
+    private val refundRequestSyncService: RefundRequestSyncService = mock(RefundRequestSyncService::class.java)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T01:00:00Z"), ZoneId.of("Asia/Seoul"))
+
+    private val service = AdminRefundRequestService(
+        participationRepository = participationRepository,
+        paymentOrderRepository = paymentOrderRepository,
+        paymentRepository = paymentRepository,
+        refundRequestSyncService = refundRequestSyncService,
+        clock = clock,
+    )
+
+    @Test
+    fun `미지원 케이스 필터는 빈 목록을 반환한다`() {
+        val pageable = PageRequest.of(0, 20)
+
+        val result = service.getRefundRequests(
+            tab = AdminRefundRequestTab.ALL,
+            caseFilter = AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL,
+            keyword = "테스트",
+            pageable = pageable,
+        )
+
+        assertTrue(result.content.isEmpty())
+        assertEquals(0L, result.totalElements)
+        verifyNoInteractions(participationRepository)
+    }
+
+    @Test
+    fun `환불 요청 승인 시 상태를 처리중으로 전이하고 승인 금액을 저장한다`() {
+        val participation = refundParticipation(id = 101L).apply {
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.PENDING
+            status = ParticipationStatus.REFUND_PENDING
+        }
+        `when`(participationRepository.findByIdForUpdate(101L)).thenReturn(Optional.of(participation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyId(anyLong(), anyLong())).thenReturn(null)
+
+        val result = service.approveRefundRequest(
+            requestId = 101L,
+            request = AdminRefundRequestApproveRequest(refundAmount = 21_600),
+        )
+
+        assertEquals(AdminRefundRequestStatus.IN_PROGRESS, result.status)
+        assertEquals(21_600, participation.approvedRefundAmount)
+        assertEquals(OwnerRefundReviewStatus.APPROVED, participation.ownerRefundReviewStatus)
+        verify(refundRequestSyncService).markApproved(participation, 21_600, LocalDateTime.now(clock))
+    }
+
+    @Test
+    fun `환불 가능 금액을 초과한 승인 금액은 실패한다`() {
+        val participation = refundParticipation(id = 102L).apply {
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.PENDING
+        }
+        `when`(participationRepository.findByIdForUpdate(102L)).thenReturn(Optional.of(participation))
+
+        val exception = assertThrows<CustomException> {
+            service.approveRefundRequest(
+                requestId = 102L,
+                request = AdminRefundRequestApproveRequest(refundAmount = 30_000),
+            )
+        }
+
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+    }
+
+    @Test
+    fun `이미 승인 완료된 요청을 재승인하면 실패한다`() {
+        val participation = refundParticipation(id = 103L).apply {
+            status = ParticipationStatus.REFUNDED
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.APPROVED
+            refundedAt = LocalDateTime.now(clock).minusMinutes(3)
+        }
+        `when`(participationRepository.findByIdForUpdate(103L)).thenReturn(Optional.of(participation))
+
+        val exception = assertThrows<CustomException> {
+            service.approveRefundRequest(
+                requestId = 103L,
+                request = AdminRefundRequestApproveRequest(refundAmount = 21_600),
+            )
+        }
+
+        assertEquals(ErrorCode.ADMIN_REFUND_REQUEST_ALREADY_PROCESSED, exception.errorCode)
+    }
+
+    @Test
+    fun `환불 요청 거절 시 상태를 거절로 전이하고 사유를 저장한다`() {
+        val participation = refundParticipation(id = 104L).apply {
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.PENDING
+            approvedRefundAmount = 12_000
+        }
+        `when`(participationRepository.findByIdForUpdate(104L)).thenReturn(Optional.of(participation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyId(anyLong(), anyLong())).thenReturn(null)
+
+        val result = service.rejectRefundRequest(
+            requestId = 104L,
+            request = AdminRefundRequestRejectRequest(rejectionReason = " 증빙 자료 불충분 "),
+        )
+
+        assertEquals(AdminRefundRequestStatus.REJECTED, result.status)
+        assertEquals(OwnerRefundReviewStatus.DISPUTED, participation.ownerRefundReviewStatus)
+        assertEquals("증빙 자료 불충분", participation.ownerRefundDisputeReason)
+        assertNull(participation.approvedRefundAmount)
+        verify(refundRequestSyncService).markRejected(participation, "증빙 자료 불충분", LocalDateTime.now(clock))
+    }
+
+    @Test
+    fun `환불 요청 거절 시 사유가 공백이면 실패한다`() {
+        val exception = assertThrows<CustomException> {
+            service.rejectRefundRequest(
+                requestId = 105L,
+                request = AdminRefundRequestRejectRequest(rejectionReason = "   "),
+            )
+        }
+        assertEquals(ErrorCode.INVALID_INPUT, exception.errorCode)
+    }
+
+    @Test
+    fun `거절 사유는 200자까지 저장 가능하다`() {
+        val reason200 = "a".repeat(200)
+        val participation = refundParticipation(id = 106L).apply {
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.PENDING
+        }
+        `when`(participationRepository.findByIdForUpdate(106L)).thenReturn(Optional.of(participation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyId(anyLong(), anyLong())).thenReturn(null)
+
+        val result = service.rejectRefundRequest(
+            requestId = 106L,
+            request = AdminRefundRequestRejectRequest(rejectionReason = reason200),
+        )
+
+        assertEquals(AdminRefundRequestStatus.REJECTED, result.status)
+        assertEquals(reason200, participation.ownerRefundDisputeReason)
+    }
+
+    private fun refundParticipation(id: Long): Participation {
+        val user = UserFixture.createKakaoUser(id = 7L, nickname = "환불유저")
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 3001L,
+            status = GroupBuyStatus.ACHIEVED,
+            productName = "초코 크루아상",
+            price = 24_000,
+        )
+        groupBuy.store.id = 11L
+
+        return Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 21_600,
+            feeAmount = 2_400,
+            totalAmount = 24_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelReasonDetail = "환불 요청",
+            cancelledAt = LocalDateTime.now(clock).minusHours(2),
+            id = id,
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -11,6 +11,7 @@ import com.moongchijang.domain.participation.domain.entity.ParticipationCancelRe
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
@@ -48,6 +49,9 @@ class OwnerSettlementServiceTest {
 
     @Mock
     private lateinit var participationRepository: ParticipationRepository
+
+    @Mock
+    private lateinit var refundRequestSyncService: RefundRequestSyncService
 
     @InjectMocks
     private lateinit var service: OwnerSettlementService

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -23,6 +23,7 @@ import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
 import com.moongchijang.domain.payment.domain.entity.PaymentStatus
 import com.moongchijang.domain.payment.domain.repository.PaymentOrderRepository
 import com.moongchijang.domain.payment.domain.repository.PaymentRepository
+import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
 import com.moongchijang.domain.store.domain.entity.Store
@@ -92,6 +93,9 @@ class PaymentServiceTest {
     @Mock
     private lateinit var notificationEventPublisher: NotificationEventPublisher
 
+    @Mock
+    private lateinit var refundRequestSyncService: RefundRequestSyncService
+
     private val portOneProperties = PortOneProperties(
         storeId = "store-test",
         channelKey = "channel-test",
@@ -111,6 +115,7 @@ class PaymentServiceTest {
             transactionManager = transactionManager,
             redisLockUtil = redisLockUtil,
             notificationEventPublisher = notificationEventPublisher,
+            refundRequestSyncService = refundRequestSyncService
         )
     }
 
@@ -680,7 +685,7 @@ class PaymentServiceTest {
         `when`(paymentOrderRepository.findByUserIdAndGroupBuyIdForUpdate(1L, 10L)).thenReturn(order)
         `when`(paymentOrderRepository.findByOrderIdForUpdate(order.orderId)).thenReturn(order)
         `when`(paymentRepository.findByPaymentOrderOrderId(order.orderId)).thenReturn(payment)
-        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "MINIMUM_QUANTITY_NOT_MET"))
+        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "MINIMUM_QUANTITY_NOT_MET", 12_000))
             .thenReturn(
                 PortOnePaymentResult(
                     paymentId = "portone-payment-id",
@@ -739,7 +744,7 @@ class PaymentServiceTest {
         `when`(participationRepository.findByIdForUpdate(89L)).thenReturn(Optional.of(participation))
         `when`(paymentOrderRepository.findByUserIdAndGroupBuyIdForUpdate(1L, 10L)).thenReturn(order)
         `when`(paymentRepository.findByPaymentOrderOrderId(order.orderId)).thenReturn(payment)
-        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "MINIMUM_QUANTITY_NOT_MET"))
+        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "MINIMUM_QUANTITY_NOT_MET", 12_000))
             .thenReturn(
                 PortOnePaymentResult(
                     paymentId = "portone-payment-id",
@@ -811,7 +816,7 @@ class PaymentServiceTest {
         `when`(paymentOrderRepository.findByUserIdAndGroupBuyIdForUpdate(2L, 10L)).thenReturn(secondOrder)
         `when`(paymentOrderRepository.findByOrderIdForUpdate(secondOrder.orderId)).thenReturn(secondOrder)
         `when`(paymentRepository.findByPaymentOrderOrderId(secondOrder.orderId)).thenReturn(secondPayment)
-        `when`(portOnePaymentPort.cancelPayment("second-portone-payment-id", "MINIMUM_QUANTITY_NOT_MET"))
+        `when`(portOnePaymentPort.cancelPayment("second-portone-payment-id", "MINIMUM_QUANTITY_NOT_MET", 6_000))
             .thenReturn(
                 PortOnePaymentResult(
                     paymentId = "second-portone-payment-id",


### PR DESCRIPTION
## 📌 작업한 내용
- 관리자 환불 요청 목록/상세/승인/거절 API를 구현했습니다.
  - `GET /api/v1/admin/refund-requests`
  - `GET /api/v1/admin/refund-requests/{requestId}`
  - `PATCH /api/v1/admin/refund-requests/{requestId}/approve`
  - `PATCH /api/v1/admin/refund-requests/{requestId}/reject`
- 환불 요청 상태 전이 정책을 적용했습니다.
  - `검토대기 -> 처리중/승인/거절`
  - `처리중 -> 승인/거절`
  - `승인완료/거절` 상태 재처리 차단
- 승인/거절 처리 시 환불 동기화 로직을 연동했습니다.
  - 승인: `approvedRefundAmount` 저장 + `RefundRequestSyncService.markApproved`
  - 거절: `rejectionReason` 저장 + `approvedRefundAmount` 초기화 + `RefundRequestSyncService.markRejected`
- 환불 금액 계산/표시 정합성을 보강했습니다.
  - 목록/상세 응답에서 `approvedRefundAmount` 우선 반영
  - 미설정 시 정책 기반 fallback 적용
    - 사용자 취소 요청: 수수료 차감 금액
    - 목표 미달 자동 실패/사장님 귀책: 전액 환불
- 목록 조회 필터/검색/SLA 응답을 보강했습니다.
  - 탭/케이스 필터/키워드 검색
  - SLA 남은 시간, 1시간 초과 경고 플래그/카운트
- 케이스 필터 매핑을 구체화했습니다.
  - `TARGET_NOT_MET`: `cancelReason is null` + `groupBuy.status == FAILED`
  - `OWNER_FAULT_CANCEL`: `cancelReason is null` + `groupBuy.status != FAILED`
  - 기존 취소 사유 기반 케이스는 기존 매핑 유지
- 관리자 환불 서비스 단위 테스트를 추가했습니다.
  - 승인/거절 상태 전이
  - 재처리 방지
  - 검증 실패 케이스
  - 필터 동작

## 🔍 참고 사항
- 이번 변경은 백엔드 API/도메인 로직 중심이며, OpenAPI 상세 문서화는 후속 작업으로 진행합니다.
- 인덱스/쿼리 성능 보강은 별도 작업으로 분리했습니다.
- 거절 사유 길이 제한은 요청 DTO에서 `최대 200자`로 검증됩니다.
- 환불 정책 반영:
  - 목표 미달 자동 실패(`TARGET_NOT_MET`)는 전액 환불
  - 사장님 귀책 취소(`OWNER_FAULT_CANCEL`)는 전액 환불
  - 달성 전 사용자 취소 API는 기존 전액 환불 흐름 유지

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #260 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인