### PR TITLE
[MCJ-1558] CHORE: IAM 최소권한 전환 및 모니터링 메트릭 접근 정책 정비

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -98,10 +98,41 @@ resource "aws_iam_role" "ec2_role" {
   })
 }
 
-// EC2 S3 접근 권한 연결
-resource "aws_iam_role_policy_attachment" "ec2_s3_access" {
+// EC2 S3 최소 권한 정책 문서
+data "aws_iam_policy_document" "ec2_s3_least_privilege" {
+  statement {
+    sid    = "S3ObjectReadWriteDeleteForAppBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:AbortMultipartUpload",
+    ]
+    resources = ["${aws_s3_bucket.terraform_test_bucket.arn}/*"]
+  }
+
+  statement {
+    sid    = "S3ListBucketForAppBucket"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [aws_s3_bucket.terraform_test_bucket.arn]
+  }
+}
+
+// EC2 S3 최소 권한 정책
+resource "aws_iam_policy" "ec2_s3_least_privilege" {
+  name        = "${var.project_name}-ec2-s3-least-privilege"
+  description = "Least-privilege S3 access for ${var.project_name} EC2 application role"
+  policy      = data.aws_iam_policy_document.ec2_s3_least_privilege.json
+}
+
+// EC2 S3 최소 권한 정책 연결
+resource "aws_iam_role_policy_attachment" "ec2_s3_least_privilege" {
   role       = aws_iam_role.ec2_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  policy_arn = aws_iam_policy.ec2_s3_least_privilege.arn
 }
 
 // EC2 인스턴스 프로파일 설정

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -34,6 +34,7 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.requestMatchers(
                     "/health",
+                    "/metrics",
                     "/api/v1/auth/kakao",
                     "/api/v1/auth/refresh",
                     "/api/v1/auth/email/**",


### PR DESCRIPTION
## 📌 작업한 내용
- Terraform에서 EC2 IAM S3 권한을 최소권한으로 전환했습니다.
  - 기존 `AmazonS3FullAccess` attachment 제거
  - 앱 버킷 한정 커스텀 정책 추가
    - `s3:ListBucket` (bucket)
    - `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:AbortMultipartUpload` (object)
- Terraform 검증을 수행했습니다.
  - `terraform validate` 성공
  - `terraform plan` 확인
    - `aws_iam_role_policy_attachment.ec2_s3_access` 삭제
    - `aws_iam_policy.ec2_s3_least_privilege` 생성
    - `aws_iam_role_policy_attachment.ec2_s3_least_privilege` 생성
- 모니터링 메트릭 수집 이슈를 수정했습니다.
  - Spring Security에서 `/metrics` 엔드포인트 `permitAll` 허용
  - Prometheus의 `app-prod:8081/metrics` 수집 시 403 발생하던 문제 해소

## 🔍 참고 사항
- 메트릭 수집 정상 기준:
  - `http://app-prod:8081/metrics` 응답 200
  - Prometheus targets에서 `job="app"` 상태 `UP`
- `terraform apply` 전 최종 정책 범위(대상 버킷/권한) 운영 기준 재확인 권장

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #263 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인