### PR TITLE
[MCJ-1562] CHORE: 서비스/컨트롤러 운영 로그 공백 구간 보강 및 로깅 표준화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
@@ -7,6 +7,7 @@ import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketUpdat
 import com.moongchijang.domain.csticket.domain.repository.CsTicketRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,12 +20,19 @@ class AdminCsTicketService(
     private val csTicketRepository: CsTicketRepository,
     private val clock: Clock,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun getTickets(
         status: AdminCsTicketStatusFilter,
         keyword: String?,
         pageable: Pageable,
     ): AdminCsTicketPageResponse {
+        log.info(
+            "[AdminCsTicketService] CS 티켓 목록 조회 시작: status={}, page={}, size={}",
+            status,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
         val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
         val page = csTicketRepository.findAdminPage(
             status = status.toStatus(),
@@ -33,14 +41,19 @@ class AdminCsTicketService(
             pageable = pageable
         )
 
-        return AdminCsTicketPageResponse.from(page, LocalDateTime.now(clock))
+        val response = AdminCsTicketPageResponse.from(page, LocalDateTime.now(clock))
+        log.info("[AdminCsTicketService] CS 티켓 목록 조회 완료: status={}, totalElements={}", status, response.totalElements)
+        return response
     }
 
     fun getTicketDetail(ticketId: Long): AdminCsTicketDetailResponse {
+        log.info("[AdminCsTicketService] CS 티켓 상세 조회 시작: ticketId={}", ticketId)
         val ticket = csTicketRepository.findAdminDetailById(ticketId)
             .orElseThrow { CustomException(ErrorCode.CS_TICKET_NOT_FOUND) }
 
-        return AdminCsTicketDetailResponse.from(ticket, LocalDateTime.now(clock))
+        val response = AdminCsTicketDetailResponse.from(ticket, LocalDateTime.now(clock))
+        log.info("[AdminCsTicketService] CS 티켓 상세 조회 완료: ticketId={}", ticketId)
+        return response
     }
 
     @Transactional
@@ -48,6 +61,7 @@ class AdminCsTicketService(
         ticketId: Long,
         request: AdminCsTicketUpdateRequest,
     ): AdminCsTicketDetailResponse {
+        log.info("[AdminCsTicketService] CS 티켓 수정 시작: ticketId={}, status={}", ticketId, request.status)
         val now = LocalDateTime.now(clock)
         val ticket = csTicketRepository.findAdminDetailById(ticketId)
             .orElseThrow { CustomException(ErrorCode.CS_TICKET_NOT_FOUND) }
@@ -59,6 +73,8 @@ class AdminCsTicketService(
             now = now
         )
 
-        return AdminCsTicketDetailResponse.from(ticket, now)
+        val response = AdminCsTicketDetailResponse.from(ticket, now)
+        log.info("[AdminCsTicketService] CS 티켓 수정 완료: ticketId={}, status={}", ticketId, response.status)
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
@@ -20,7 +20,7 @@ class AdminCsTicketService(
     private val csTicketRepository: CsTicketRepository,
     private val clock: Clock,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminCsTicketService::class.java)
 
     fun getTickets(
         status: AdminCsTicketStatusFilter,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
@@ -19,7 +19,7 @@ class AdminDashboardOrderMonitoringService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminDashboardOrderMonitoringService::class.java)
 
     fun getUnconfirmedOrders(pageable: Pageable): AdminDashboardUnconfirmedOrderResponse {
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -18,8 +19,14 @@ class AdminDashboardOrderMonitoringService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun getUnconfirmedOrders(pageable: Pageable): AdminDashboardUnconfirmedOrderResponse {
+        log.info(
+            "[AdminDashboardOrderMonitoringService] 미확정 주문 조회 시작: page={}, size={}",
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
         val now = LocalDateTime.now(clock)
         val overdueBefore = now.minusHours(48)
         val page = groupBuyRepository.findAdminOrderPage(
@@ -41,7 +48,7 @@ class AdminDashboardOrderMonitoringService(
             overdueBefore = overdueBefore
         )
 
-        return AdminDashboardUnconfirmedOrderResponse.from(
+        val response = AdminDashboardUnconfirmedOrderResponse.from(
             page = page,
             pendingRefundCountsByGroupBuyId = pendingRefundCountsByGroupBuyId,
             totalUnconfirmedCount = page.totalElements,
@@ -49,5 +56,11 @@ class AdminDashboardOrderMonitoringService(
             now = now,
             overdueBefore = overdueBefore
         )
+        log.info(
+            "[AdminDashboardOrderMonitoringService] 미확정 주문 조회 완료: totalUnconfirmedCount={}, overdueCount={}",
+            response.totalUnconfirmedCount,
+            response.overdueCount,
+        )
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
@@ -26,7 +26,7 @@ class AdminDashboardSummaryService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminDashboardSummaryService::class.java)
 
     fun getSummary(): AdminDashboardSummaryResponse {
         log.info("[AdminDashboardSummaryService] 관리자 대시보드 요약 조회 시작")

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
@@ -9,6 +9,7 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestReposit
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -25,8 +26,10 @@ class AdminDashboardSummaryService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun getSummary(): AdminDashboardSummaryResponse {
+        log.info("[AdminDashboardSummaryService] 관리자 대시보드 요약 조회 시작")
         val now = LocalDateTime.now(clock)
         val today = LocalDate.now(clock)
         val todayRange = today.toRange()
@@ -53,7 +56,7 @@ class AdminDashboardSummaryService(
         )
         val pendingCreatedAts = groupBuyRequestRepository.findCreatedAtByStatusIn(pendingApprovalStatuses)
 
-        return AdminDashboardSummaryResponse(
+        val response = AdminDashboardSummaryResponse(
             pendingRefundAmount = pendingRefundAmount,
             pendingRefundAmountChangeRate = changeRate(todayPendingRefundAmount, yesterdayPendingRefundAmount),
             pendingApprovalCount = groupBuyRequestRepository.countByStatusIn(pendingApprovalStatuses),
@@ -87,6 +90,12 @@ class AdminDashboardSummaryService(
             ),
             hasOrderOver48h = unconfirmedOrderOver48hCount > 0
         )
+        log.info(
+            "[AdminDashboardSummaryService] 관리자 대시보드 요약 조회 완료: pendingApprovalCount={}, unconfirmedOrderCount={}",
+            response.pendingApprovalCount,
+            response.unconfirmedOrderCount,
+        )
+        return response
     }
 
     private fun averageReviewMinutes(createdAts: List<LocalDateTime>, now: LocalDateTime): Long {

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -25,7 +25,7 @@ class AdminOrderService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminOrderService::class.java)
 
     fun getOrders(
         status: AdminOrderStatusFilter,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -11,6 +11,7 @@ import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -24,11 +25,18 @@ class AdminOrderService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun getOrders(
         status: AdminOrderStatusFilter,
         pageable: Pageable
     ): AdminOrderPageResponse {
+        log.info(
+            "[AdminOrderService] 주문 목록 조회 시작: status={}, page={}, size={}",
+            status,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
         val now = LocalDateTime.now(clock)
         val page = groupBuyRepository.findAdminOrderPage(
             groupBuyStatus = GroupBuyStatus.ACHIEVED,
@@ -44,49 +52,63 @@ class AdminOrderService(
                 .associate { it.groupBuyId to it.pendingRefundCount }
         }
 
-        return AdminOrderPageResponse.from(page, pendingRefundCountsByGroupBuyId, now)
+        val response = AdminOrderPageResponse.from(page, pendingRefundCountsByGroupBuyId, now)
+        log.info("[AdminOrderService] 주문 목록 조회 완료: status={}, totalElements={}", status, response.totalElements)
+        return response
     }
 
     fun getOrderDetail(orderId: Long): AdminOrderDetailResponse {
+        log.info("[AdminOrderService] 주문 상세 조회 시작: orderId={}", orderId)
         val now = LocalDateTime.now(clock)
         val groupBuy = groupBuyRepository.findAdminOrderDetailById(orderId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
 
-        return AdminOrderDetailResponse.from(
+        val response = AdminOrderDetailResponse.from(
             groupBuy = groupBuy,
             pendingRefundCount = countPendingRefunds(groupBuy.id),
             now = now
         )
+        log.info("[AdminOrderService] 주문 상세 조회 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
+        return response
     }
 
     @Transactional
     fun markOwnerContacted(orderId: Long): AdminOrderDetailResponse {
+        log.info("[AdminOrderService] 주문 사장님연락 상태 변경 시작: orderId={}", orderId)
         val now = LocalDateTime.now(clock)
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.markOrderOwnerContacted(now)
 
-        return AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        val response = AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        log.info("[AdminOrderService] 주문 사장님연락 상태 변경 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
+        return response
     }
 
     @Transactional
     fun confirmOrder(orderId: Long): AdminOrderDetailResponse {
+        log.info("[AdminOrderService] 주문 확정 시작: orderId={}", orderId)
         val now = LocalDateTime.now(clock)
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.confirmOrder(now)
 
-        return AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        val response = AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        log.info("[AdminOrderService] 주문 확정 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
+        return response
     }
 
     @Transactional
     fun cancelOrder(orderId: Long): AdminOrderDetailResponse {
+        log.info("[AdminOrderService] 주문 취소 시작: orderId={}", orderId)
         val now = LocalDateTime.now(clock)
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.cancelOrder(now)
 
-        return AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        val response = AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        log.info("[AdminOrderService] 주문 취소 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
+        return response
     }
 
     private fun findOrderForUpdate(orderId: Long): GroupBuy {

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
@@ -29,7 +29,7 @@ class AdminSettlementService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminSettlementService::class.java)
 
     fun getDashboard(
         year: Int,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
@@ -15,6 +15,7 @@ import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,11 +29,13 @@ class AdminSettlementService(
     private val participationRepository: ParticipationRepository,
     private val clock: Clock,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun getDashboard(
         year: Int,
         month: Int,
     ): AdminSettlementDashboardResponse {
+        log.info("[AdminSettlementService] 정산 대시보드 조회 시작: year={}, month={}", year, month)
         val yearMonth = validateYearMonth(year, month)
         val today = LocalDate.now(clock)
         val range = yearMonth.toDateRange()
@@ -45,7 +48,7 @@ class AdminSettlementService(
             pickupDateTo = range.to
         )
 
-        return AdminSettlementDashboardResponse(
+        val response = AdminSettlementDashboardResponse(
             year = year,
             month = month,
             completedSettlementAmount = aggregations
@@ -57,6 +60,8 @@ class AdminSettlementService(
             platformFeeAmount = 0L,
             totalTransactionAmount = aggregations.sumOf { it.totalPaymentAmount }
         )
+        log.info("[AdminSettlementService] 정산 대시보드 조회 완료: year={}, month={}", year, month)
+        return response
     }
 
     fun getSettlements(
@@ -65,6 +70,14 @@ class AdminSettlementService(
         status: AdminSettlementStatusFilter,
         pageable: Pageable,
     ): AdminSettlementPageResponse {
+        log.info(
+            "[AdminSettlementService] 정산 목록 조회 시작: year={}, month={}, status={}, page={}, size={}",
+            year,
+            month,
+            status,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
         val yearMonth = validateYearMonth(year, month)
         val today = LocalDate.now(clock)
         val range = yearMonth.toDateRange().filterByStatus(status, today)
@@ -78,10 +91,19 @@ class AdminSettlementService(
             pageable = pageable
         )
 
-        return AdminSettlementPageResponse.from(page, today)
+        val response = AdminSettlementPageResponse.from(page, today)
+        log.info(
+            "[AdminSettlementService] 정산 목록 조회 완료: year={}, month={}, status={}, totalElements={}",
+            year,
+            month,
+            status,
+            response.totalElements,
+        )
+        return response
     }
 
     fun getSettlementDetail(settlementId: Long): AdminSettlementDetailResponse {
+        log.info("[AdminSettlementService] 정산 상세 조회 시작: settlementId={}", settlementId)
         val today = LocalDate.now(clock)
         val aggregation = participationRepository.findAdminSettlementDetail(
             groupBuyId = settlementId,
@@ -91,7 +113,9 @@ class AdminSettlementService(
             refundStatuses = REFUND_STATUSES,
         ) ?: throw CustomException(ErrorCode.GROUPBUY_NOT_FOUND)
 
-        return AdminSettlementListItemResponse.from(aggregation, today)
+        val response = AdminSettlementListItemResponse.from(aggregation, today)
+        log.info("[AdminSettlementService] 정산 상세 조회 완료: settlementId={}", settlementId)
+        return response
     }
 
     private fun validateYearMonth(year: Int, month: Int): YearMonth {

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminCsTicketController(
     private val adminCsTicketService: AdminCsTicketService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminCsTicketController::class.java)
 
     @GetMapping
     @Operation(summary = "운영자 CS 티켓 목록 조회")

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
@@ -9,7 +9,6 @@ import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController
 class AdminCsTicketController(
     private val adminCsTicketService: AdminCsTicketService,
 ) {
-    private val log = LoggerFactory.getLogger(AdminCsTicketController::class.java)
 
     @GetMapping
     @Operation(summary = "운영자 CS 티켓 목록 조회")
@@ -35,9 +33,7 @@ class AdminCsTicketController(
         @RequestParam(required = false) keyword: String?,
         pageable: Pageable,
     ): ResponseEntity<ApiResponse<AdminCsTicketPageResponse>> {
-        log.info("[AdminCsTicketController] CS 티켓 목록 조회 요청: status={}, page={}, size={}", status, pageable.pageNumber, pageable.pageSize)
         val response = ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTickets(status, keyword, pageable)))
-        log.info("[AdminCsTicketController] CS 티켓 목록 조회 응답 완료: status={}", status)
         return response
     }
 
@@ -46,9 +42,7 @@ class AdminCsTicketController(
     fun getTicketDetail(
         @PathVariable ticketId: Long,
     ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> {
-        log.info("[AdminCsTicketController] CS 티켓 상세 조회 요청: ticketId={}", ticketId)
         val response = ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTicketDetail(ticketId)))
-        log.info("[AdminCsTicketController] CS 티켓 상세 조회 응답 완료: ticketId={}", ticketId)
         return response
     }
 
@@ -58,9 +52,7 @@ class AdminCsTicketController(
         @PathVariable ticketId: Long,
         @Valid @RequestBody request: AdminCsTicketUpdateRequest,
     ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> {
-        log.info("[AdminCsTicketController] CS 티켓 수정 요청: ticketId={}, status={}", ticketId, request.status)
         val response = ResponseEntity.ok(ApiResponse.success(adminCsTicketService.updateTicket(ticketId, request)))
-        log.info("[AdminCsTicketController] CS 티켓 수정 응답 완료: ticketId={}", ticketId)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminCsTicketController.kt
@@ -9,6 +9,7 @@ import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminCsTicketController(
     private val adminCsTicketService: AdminCsTicketService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping
     @Operation(summary = "운영자 CS 티켓 목록 조회")
@@ -32,21 +34,33 @@ class AdminCsTicketController(
         @RequestParam(defaultValue = "ALL") status: AdminCsTicketStatusFilter,
         @RequestParam(required = false) keyword: String?,
         pageable: Pageable,
-    ): ResponseEntity<ApiResponse<AdminCsTicketPageResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTickets(status, keyword, pageable)))
+    ): ResponseEntity<ApiResponse<AdminCsTicketPageResponse>> {
+        log.info("[AdminCsTicketController] CS 티켓 목록 조회 요청: status={}, page={}, size={}", status, pageable.pageNumber, pageable.pageSize)
+        val response = ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTickets(status, keyword, pageable)))
+        log.info("[AdminCsTicketController] CS 티켓 목록 조회 응답 완료: status={}", status)
+        return response
+    }
 
     @GetMapping("/{ticketId}")
     @Operation(summary = "운영자 CS 티켓 상세 조회")
     fun getTicketDetail(
         @PathVariable ticketId: Long,
-    ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTicketDetail(ticketId)))
+    ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> {
+        log.info("[AdminCsTicketController] CS 티켓 상세 조회 요청: ticketId={}", ticketId)
+        val response = ResponseEntity.ok(ApiResponse.success(adminCsTicketService.getTicketDetail(ticketId)))
+        log.info("[AdminCsTicketController] CS 티켓 상세 조회 응답 완료: ticketId={}", ticketId)
+        return response
+    }
 
     @PatchMapping("/{ticketId}")
     @Operation(summary = "운영자 CS 티켓 처리 정보 변경")
     fun updateTicket(
         @PathVariable ticketId: Long,
         @Valid @RequestBody request: AdminCsTicketUpdateRequest,
-    ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminCsTicketService.updateTicket(ticketId, request)))
+    ): ResponseEntity<ApiResponse<AdminCsTicketDetailResponse>> {
+        log.info("[AdminCsTicketController] CS 티켓 수정 요청: ticketId={}, status={}", ticketId, request.status)
+        val response = ResponseEntity.ok(ApiResponse.success(adminCsTicketService.updateTicket(ticketId, request)))
+        log.info("[AdminCsTicketController] CS 티켓 수정 응답 완료: ticketId={}", ticketId)
+        return response
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
@@ -7,6 +7,7 @@ import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryRespon
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,16 +21,25 @@ class AdminDashboardController(
     private val adminDashboardSummaryService: AdminDashboardSummaryService,
     private val adminDashboardOrderMonitoringService: AdminDashboardOrderMonitoringService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/summary")
     @Operation(summary = "운영자 대시보드 운영 관리 요약")
-    fun getSummary(): ResponseEntity<ApiResponse<AdminDashboardSummaryResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminDashboardSummaryService.getSummary()))
+    fun getSummary(): ResponseEntity<ApiResponse<AdminDashboardSummaryResponse>> {
+        log.info("[AdminDashboardController] 운영자 대시보드 요약 조회 요청")
+        val response = ResponseEntity.ok(ApiResponse.success(adminDashboardSummaryService.getSummary()))
+        log.info("[AdminDashboardController] 운영자 대시보드 요약 조회 응답 완료")
+        return response
+    }
 
     @GetMapping("/dashboard/unconfirmed-orders")
     @Operation(summary = "운영자 대시보드 발주 미확정 모니터링")
     fun getUnconfirmedOrders(
         pageable: Pageable
-    ): ResponseEntity<ApiResponse<AdminDashboardUnconfirmedOrderResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminDashboardOrderMonitoringService.getUnconfirmedOrders(pageable)))
+    ): ResponseEntity<ApiResponse<AdminDashboardUnconfirmedOrderResponse>> {
+        log.info("[AdminDashboardController] 미확정 발주 모니터링 조회 요청: page={}, size={}", pageable.pageNumber, pageable.pageSize)
+        val response = ResponseEntity.ok(ApiResponse.success(adminDashboardOrderMonitoringService.getUnconfirmedOrders(pageable)))
+        log.info("[AdminDashboardController] 미확정 발주 모니터링 조회 응답 완료")
+        return response
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
@@ -21,7 +21,7 @@ class AdminDashboardController(
     private val adminDashboardSummaryService: AdminDashboardSummaryService,
     private val adminDashboardOrderMonitoringService: AdminDashboardOrderMonitoringService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminDashboardController::class.java)
 
     @GetMapping("/summary")
     @Operation(summary = "운영자 대시보드 운영 관리 요약")

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
@@ -7,7 +7,6 @@ import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryRespon
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,14 +20,11 @@ class AdminDashboardController(
     private val adminDashboardSummaryService: AdminDashboardSummaryService,
     private val adminDashboardOrderMonitoringService: AdminDashboardOrderMonitoringService,
 ) {
-    private val log = LoggerFactory.getLogger(AdminDashboardController::class.java)
 
     @GetMapping("/summary")
     @Operation(summary = "운영자 대시보드 운영 관리 요약")
     fun getSummary(): ResponseEntity<ApiResponse<AdminDashboardSummaryResponse>> {
-        log.info("[AdminDashboardController] 운영자 대시보드 요약 조회 요청")
         val response = ResponseEntity.ok(ApiResponse.success(adminDashboardSummaryService.getSummary()))
-        log.info("[AdminDashboardController] 운영자 대시보드 요약 조회 응답 완료")
         return response
     }
 
@@ -37,9 +33,7 @@ class AdminDashboardController(
     fun getUnconfirmedOrders(
         pageable: Pageable
     ): ResponseEntity<ApiResponse<AdminDashboardUnconfirmedOrderResponse>> {
-        log.info("[AdminDashboardController] 미확정 발주 모니터링 조회 요청: page={}, size={}", pageable.pageNumber, pageable.pageSize)
         val response = ResponseEntity.ok(ApiResponse.success(adminDashboardOrderMonitoringService.getUnconfirmedOrders(pageable)))
-        log.info("[AdminDashboardController] 미확정 발주 모니터링 조회 응답 완료")
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
@@ -7,7 +7,6 @@ import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController
 class AdminOrderController(
     private val adminOrderService: AdminOrderService,
 ) {
-    private val log = LoggerFactory.getLogger(AdminOrderController::class.java)
 
     @GetMapping
     @Operation(summary = "운영자 발주 관리 목록 조회")
@@ -31,9 +29,7 @@ class AdminOrderController(
         @RequestParam(defaultValue = "ALL") status: AdminOrderStatusFilter,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<AdminOrderPageResponse>> {
-        log.info("[AdminOrderController] 운영자 발주 목록 조회 요청: status={}, page={}, size={}", status, pageable.pageNumber, pageable.pageSize)
         val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrders(status, pageable)))
-        log.info("[AdminOrderController] 운영자 발주 목록 조회 응답 완료: status={}", status)
         return response
     }
 
@@ -42,9 +38,7 @@ class AdminOrderController(
     fun getOrderDetail(
         @PathVariable orderId: Long
     ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
-        log.info("[AdminOrderController] 운영자 발주 상세 조회 요청: orderId={}", orderId)
         val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrderDetail(orderId)))
-        log.info("[AdminOrderController] 운영자 발주 상세 조회 응답 완료: orderId={}", orderId)
         return response
     }
 
@@ -53,9 +47,7 @@ class AdminOrderController(
     fun markOwnerContacted(
         @PathVariable orderId: Long
     ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
-        log.info("[AdminOrderController] 운영자 발주 사장님 연락 완료 처리 요청: orderId={}", orderId)
         val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.markOwnerContacted(orderId)))
-        log.info("[AdminOrderController] 운영자 발주 사장님 연락 완료 처리 응답 완료: orderId={}", orderId)
         return response
     }
 
@@ -64,9 +56,7 @@ class AdminOrderController(
     fun confirmOrder(
         @PathVariable orderId: Long
     ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
-        log.info("[AdminOrderController] 운영자 발주 확정 처리 요청: orderId={}", orderId)
         val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.confirmOrder(orderId)))
-        log.info("[AdminOrderController] 운영자 발주 확정 처리 응답 완료: orderId={}", orderId)
         return response
     }
 
@@ -75,9 +65,7 @@ class AdminOrderController(
     fun cancelOrder(
         @PathVariable orderId: Long
     ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
-        log.info("[AdminOrderController] 운영자 발주 취소 처리 요청: orderId={}", orderId)
         val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.cancelOrder(orderId)))
-        log.info("[AdminOrderController] 운영자 발주 취소 처리 응답 완료: orderId={}", orderId)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminOrderController(
     private val adminOrderService: AdminOrderService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminOrderController::class.java)
 
     @GetMapping
     @Operation(summary = "운영자 발주 관리 목록 조회")

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderController.kt
@@ -7,6 +7,7 @@ import com.moongchijang.domain.admin.application.dto.AdminOrderStatusFilter
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,40 +23,61 @@ import org.springframework.web.bind.annotation.RestController
 class AdminOrderController(
     private val adminOrderService: AdminOrderService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping
     @Operation(summary = "운영자 발주 관리 목록 조회")
     fun getOrders(
         @RequestParam(defaultValue = "ALL") status: AdminOrderStatusFilter,
         pageable: Pageable
-    ): ResponseEntity<ApiResponse<AdminOrderPageResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrders(status, pageable)))
+    ): ResponseEntity<ApiResponse<AdminOrderPageResponse>> {
+        log.info("[AdminOrderController] 운영자 발주 목록 조회 요청: status={}, page={}, size={}", status, pageable.pageNumber, pageable.pageSize)
+        val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrders(status, pageable)))
+        log.info("[AdminOrderController] 운영자 발주 목록 조회 응답 완료: status={}", status)
+        return response
+    }
 
     @GetMapping("/{orderId}")
     @Operation(summary = "운영자 발주 관리 상세 조회")
     fun getOrderDetail(
         @PathVariable orderId: Long
-    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrderDetail(orderId)))
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
+        log.info("[AdminOrderController] 운영자 발주 상세 조회 요청: orderId={}", orderId)
+        val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.getOrderDetail(orderId)))
+        log.info("[AdminOrderController] 운영자 발주 상세 조회 응답 완료: orderId={}", orderId)
+        return response
+    }
 
     @PostMapping("/{orderId}/owner-contact")
     @Operation(summary = "운영자 발주 사장님 연락 완료 기록")
     fun markOwnerContacted(
         @PathVariable orderId: Long
-    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminOrderService.markOwnerContacted(orderId)))
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
+        log.info("[AdminOrderController] 운영자 발주 사장님 연락 완료 처리 요청: orderId={}", orderId)
+        val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.markOwnerContacted(orderId)))
+        log.info("[AdminOrderController] 운영자 발주 사장님 연락 완료 처리 응답 완료: orderId={}", orderId)
+        return response
+    }
 
     @PostMapping("/{orderId}/confirm")
     @Operation(summary = "운영자 발주 확정 처리")
     fun confirmOrder(
         @PathVariable orderId: Long
-    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminOrderService.confirmOrder(orderId)))
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
+        log.info("[AdminOrderController] 운영자 발주 확정 처리 요청: orderId={}", orderId)
+        val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.confirmOrder(orderId)))
+        log.info("[AdminOrderController] 운영자 발주 확정 처리 응답 완료: orderId={}", orderId)
+        return response
+    }
 
     @PostMapping("/{orderId}/cancel")
     @Operation(summary = "운영자 발주 취소 처리")
     fun cancelOrder(
         @PathVariable orderId: Long
-    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminOrderService.cancelOrder(orderId)))
+    ): ResponseEntity<ApiResponse<AdminOrderDetailResponse>> {
+        log.info("[AdminOrderController] 운영자 발주 취소 처리 요청: orderId={}", orderId)
+        val response = ResponseEntity.ok(ApiResponse.success(adminOrderService.cancelOrder(orderId)))
+        log.info("[AdminOrderController] 운영자 발주 취소 처리 응답 완료: orderId={}", orderId)
+        return response
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
@@ -8,6 +8,7 @@ import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementS
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,14 +23,19 @@ import org.springframework.web.bind.annotation.RestController
 class AdminSettlementController(
     private val adminSettlementService: AdminSettlementService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/dashboard")
     @Operation(summary = "운영자 정산 현황 대시보드 조회")
     fun getDashboard(
         @RequestParam year: Int,
         @RequestParam month: Int,
-    ): ResponseEntity<ApiResponse<AdminSettlementDashboardResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminSettlementService.getDashboard(year, month)))
+    ): ResponseEntity<ApiResponse<AdminSettlementDashboardResponse>> {
+        log.info("[AdminSettlementController] 정산 대시보드 조회 요청: year={}, month={}", year, month)
+        val response = ResponseEntity.ok(ApiResponse.success(adminSettlementService.getDashboard(year, month)))
+        log.info("[AdminSettlementController] 정산 대시보드 조회 응답 완료: year={}, month={}", year, month)
+        return response
+    }
 
     @GetMapping
     @Operation(summary = "운영자 정산 현황 목록 조회")
@@ -38,13 +44,28 @@ class AdminSettlementController(
         @RequestParam month: Int,
         @RequestParam(defaultValue = "ALL") status: AdminSettlementStatusFilter,
         pageable: Pageable,
-    ): ResponseEntity<ApiResponse<AdminSettlementPageResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlements(year, month, status, pageable)))
+    ): ResponseEntity<ApiResponse<AdminSettlementPageResponse>> {
+        log.info(
+            "[AdminSettlementController] 정산 목록 조회 요청: year={}, month={}, status={}, page={}, size={}",
+            year,
+            month,
+            status,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
+        val response = ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlements(year, month, status, pageable)))
+        log.info("[AdminSettlementController] 정산 목록 조회 응답 완료: year={}, month={}, status={}", year, month, status)
+        return response
+    }
 
     @GetMapping("/{settlementId}")
     @Operation(summary = "운영자 정산 현황 상세 조회")
     fun getSettlementDetail(
         @PathVariable settlementId: Long,
-    ): ResponseEntity<ApiResponse<AdminSettlementDetailResponse>> =
-        ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlementDetail(settlementId)))
+    ): ResponseEntity<ApiResponse<AdminSettlementDetailResponse>> {
+        log.info("[AdminSettlementController] 정산 상세 조회 요청: settlementId={}", settlementId)
+        val response = ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlementDetail(settlementId)))
+        log.info("[AdminSettlementController] 정산 상세 조회 응답 완료: settlementId={}", settlementId)
+        return response
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminSettlementController(
     private val adminSettlementService: AdminSettlementService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminSettlementController::class.java)
 
     @GetMapping("/dashboard")
     @Operation(summary = "운영자 정산 현황 대시보드 조회")

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementController.kt
@@ -8,7 +8,6 @@ import com.moongchijang.domain.admin.application.dto.settlement.AdminSettlementS
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController
 class AdminSettlementController(
     private val adminSettlementService: AdminSettlementService,
 ) {
-    private val log = LoggerFactory.getLogger(AdminSettlementController::class.java)
 
     @GetMapping("/dashboard")
     @Operation(summary = "운영자 정산 현황 대시보드 조회")
@@ -31,9 +29,7 @@ class AdminSettlementController(
         @RequestParam year: Int,
         @RequestParam month: Int,
     ): ResponseEntity<ApiResponse<AdminSettlementDashboardResponse>> {
-        log.info("[AdminSettlementController] 정산 대시보드 조회 요청: year={}, month={}", year, month)
         val response = ResponseEntity.ok(ApiResponse.success(adminSettlementService.getDashboard(year, month)))
-        log.info("[AdminSettlementController] 정산 대시보드 조회 응답 완료: year={}, month={}", year, month)
         return response
     }
 
@@ -45,16 +41,7 @@ class AdminSettlementController(
         @RequestParam(defaultValue = "ALL") status: AdminSettlementStatusFilter,
         pageable: Pageable,
     ): ResponseEntity<ApiResponse<AdminSettlementPageResponse>> {
-        log.info(
-            "[AdminSettlementController] 정산 목록 조회 요청: year={}, month={}, status={}, page={}, size={}",
-            year,
-            month,
-            status,
-            pageable.pageNumber,
-            pageable.pageSize,
-        )
         val response = ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlements(year, month, status, pageable)))
-        log.info("[AdminSettlementController] 정산 목록 조회 응답 완료: year={}, month={}, status={}", year, month, status)
         return response
     }
 
@@ -63,9 +50,7 @@ class AdminSettlementController(
     fun getSettlementDetail(
         @PathVariable settlementId: Long,
     ): ResponseEntity<ApiResponse<AdminSettlementDetailResponse>> {
-        log.info("[AdminSettlementController] 정산 상세 조회 요청: settlementId={}", settlementId)
         val response = ResponseEntity.ok(ApiResponse.success(adminSettlementService.getSettlementDetail(settlementId)))
-        log.info("[AdminSettlementController] 정산 상세 조회 응답 완료: settlementId={}", settlementId)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
@@ -33,7 +33,7 @@ class AdminGroupBuyRequestActionService(
     private val storeRepository: StoreRepository,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminGroupBuyRequestActionService::class.java)
 
     fun approve(requestId: Long, request: AdminGroupBuyRequestApproveRequest): AdminGroupBuyRequestActionResponse {
         log.info("[AdminGroupBuyRequestActionService] 공구요청 승인 시작: requestId={}", requestId)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
@@ -17,6 +17,7 @@ import com.moongchijang.domain.store.domain.entity.Store
 import com.moongchijang.domain.store.domain.repository.StoreRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,8 +33,10 @@ class AdminGroupBuyRequestActionService(
     private val storeRepository: StoreRepository,
     private val eventPublisher: ApplicationEventPublisher,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun approve(requestId: Long, request: AdminGroupBuyRequestApproveRequest): AdminGroupBuyRequestActionResponse {
+        log.info("[AdminGroupBuyRequestActionService] 공구요청 승인 시작: requestId={}", requestId)
         val groupBuyRequest = findRequest(requestId)
         validateActionable(groupBuyRequest)
         val maxQuantity = request.maxQuantity ?: request.targetQuantity
@@ -70,14 +73,21 @@ class AdminGroupBuyRequestActionService(
         markRequest(groupBuyRequest, GroupBuyRequestStatus.OPENED, openedGroupBuyId = groupBuy.id)
         eventPublisher.publishEvent(AdminGroupBuyOpenedEvent(groupBuy.id))
 
-        return AdminGroupBuyRequestActionResponse(
+        val response = AdminGroupBuyRequestActionResponse(
             requestId = groupBuyRequest.id,
             status = GroupBuyRequestStatus.OPENED,
             groupBuyId = groupBuy.id
         )
+        log.info(
+            "[AdminGroupBuyRequestActionService] 공구요청 승인 완료: requestId={}, groupBuyId={}",
+            requestId,
+            groupBuy.id,
+        )
+        return response
     }
 
     fun reject(requestId: Long, request: AdminGroupBuyRequestRejectRequest): AdminGroupBuyRequestActionResponse {
+        log.info("[AdminGroupBuyRequestActionService] 공구요청 반려 시작: requestId={}", requestId)
         val groupBuyRequest = findRequest(requestId)
         validateActionable(groupBuyRequest)
 
@@ -87,11 +97,13 @@ class AdminGroupBuyRequestActionService(
         }
 
         markRequest(groupBuyRequest, GroupBuyRequestStatus.REJECTED, rejectionReason = reason)
-        return AdminGroupBuyRequestActionResponse(
+        val response = AdminGroupBuyRequestActionResponse(
             requestId = groupBuyRequest.id,
             status = GroupBuyRequestStatus.REJECTED,
             groupBuyId = null
         )
+        log.info("[AdminGroupBuyRequestActionService] 공구요청 반려 완료: requestId={}", requestId)
+        return response
     }
 
     private fun findRequest(requestId: Long): GroupBuyRequest {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -17,6 +17,7 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusH
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionSynchronization
@@ -36,8 +37,10 @@ class GroupBuyRequestService(
     private val userRepository: UserRepository,
     private val clock: Clock,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun create(userId: Long, request: GroupBuyRequestCreateRequest): GroupBuyRequestIdResponse {
+        log.info("[GroupBuyRequestService] 공구요청 생성 시작: userId={}", userId)
         if (!request.desiredPickupDate.isAfter(LocalDate.now())) {
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_INVALID_DATE)
         }
@@ -74,11 +77,14 @@ class GroupBuyRequestService(
             )
         )
 
-        return GroupBuyRequestIdResponse(saved.id)
+        val response = GroupBuyRequestIdResponse(saved.id)
+        log.info("[GroupBuyRequestService] 공구요청 생성 완료: userId={}, requestId={}", userId, saved.id)
+        return response
     }
 
     @Transactional(readOnly = true)
     fun getMyRequests(userId: Long): List<GroupBuyRequestResponse> {
+        log.info("[GroupBuyRequestService] 내 공구요청 목록 조회 시작: userId={}", userId)
         val requests = groupBuyRequestRepository.findByUserIdOrderByCreatedAtDesc(userId)
         if (requests.isEmpty()) return emptyList()
 
@@ -86,11 +92,14 @@ class GroupBuyRequestService(
             .findByGroupBuyRequestIdInOrderByChangedAtAsc(requests.map { it.id })
             .groupBy { it.groupBuyRequestId }
 
-        return requests.map { GroupBuyRequestResponse.from(it, historyMap[it.id] ?: emptyList()) }
+        val responses = requests.map { GroupBuyRequestResponse.from(it, historyMap[it.id] ?: emptyList()) }
+        log.info("[GroupBuyRequestService] 내 공구요청 목록 조회 완료: userId={}, count={}", userId, responses.size)
+        return responses
     }
 
     @Transactional(readOnly = true)
     fun getDetail(userId: Long, requestId: Long): GroupBuyRequestResponse {
+        log.info("[GroupBuyRequestService] 공구요청 상세 조회 시작: userId={}, requestId={}", userId, requestId)
         val request = groupBuyRequestRepository.findById(requestId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
 
@@ -101,7 +110,9 @@ class GroupBuyRequestService(
         val history = groupBuyRequestStatusHistoryRepository
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
 
-        return GroupBuyRequestResponse.from(request, history)
+        val response = GroupBuyRequestResponse.from(request, history)
+        log.info("[GroupBuyRequestService] 공구요청 상세 조회 완료: userId={}, requestId={}", userId, requestId)
+        return response
     }
 
     @Transactional(readOnly = true)
@@ -110,6 +121,12 @@ class GroupBuyRequestService(
         keyword: String?,
         pageable: Pageable
     ): AdminGroupBuyRequestPageResponse {
+        log.info(
+            "[GroupBuyRequestService] 관리자 공구요청 목록 조회 시작: status={}, page={}, size={}",
+            status,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
         val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
         val requestIdKeyword = normalizedKeyword?.toLongOrNull()
         val page = groupBuyRequestRepository.searchAdminRequests(
@@ -129,21 +146,35 @@ class GroupBuyRequestService(
         }
         val groupBuysById = findOpenedGroupBuys(page.content)
 
-        return AdminGroupBuyRequestPageResponse.from(page, usersById, groupBuysById, LocalDateTime.now(clock))
+        val response = AdminGroupBuyRequestPageResponse.from(page, usersById, groupBuysById, LocalDateTime.now(clock))
+        log.info(
+            "[GroupBuyRequestService] 관리자 공구요청 목록 조회 완료: status={}, totalElements={}",
+            status,
+            response.totalElements,
+        )
+        return response
     }
 
     @Transactional(readOnly = true)
     fun getAdminDetail(requestId: Long): AdminGroupBuyRequestDetailResponse {
+        log.info("[GroupBuyRequestService] 관리자 공구요청 상세 조회 시작: requestId={}", requestId)
         val request = groupBuyRequestRepository.findById(requestId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
         val requester = userRepository.findById(request.userId).orElse(null)
         val history = groupBuyRequestStatusHistoryRepository
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
 
-        return AdminGroupBuyRequestDetailResponse.from(request, requester, history)
+        val response = AdminGroupBuyRequestDetailResponse.from(request, requester, history)
+        log.info("[GroupBuyRequestService] 관리자 공구요청 상세 조회 완료: requestId={}", requestId)
+        return response
     }
 
     fun updateStatus(requestId: Long, request: GroupBuyRequestStatusUpdateRequest): GroupBuyRequestResponse {
+        log.info(
+            "[GroupBuyRequestService] 공구요청 상태 변경 시작: requestId={}, targetStatus={}",
+            requestId,
+            request.targetStatus,
+        )
         val groupBuyRequest = groupBuyRequestRepository.findById(requestId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
 
@@ -191,7 +222,13 @@ class GroupBuyRequestService(
         val history = groupBuyRequestStatusHistoryRepository
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
 
-        return GroupBuyRequestResponse.from(groupBuyRequest, history)
+        val response = GroupBuyRequestResponse.from(groupBuyRequest, history)
+        log.info(
+            "[GroupBuyRequestService] 공구요청 상태 변경 완료: requestId={}, status={}",
+            requestId,
+            response.status,
+        )
+        return response
     }
 
     private fun validateTransition(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -37,7 +37,7 @@ class GroupBuyRequestService(
     private val userRepository: UserRepository,
     private val clock: Clock,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(GroupBuyRequestService::class.java)
 
     fun create(userId: Long, request: GroupBuyRequestCreateRequest): GroupBuyRequestIdResponse {
         log.info("[GroupBuyRequestService] 공구요청 생성 시작: userId={}", userId)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/AdminGroupBuyRequestActionController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/AdminGroupBuyRequestActionController.kt
@@ -8,6 +8,7 @@ import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminGroupBuyRequestActionController(
     private val adminGroupBuyRequestActionService: AdminGroupBuyRequestActionService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @PostMapping("/{requestId}/approve")
     @Operation(summary = "소비자 공구 개설 요청 승인 및 공구 생성")
@@ -29,9 +31,12 @@ class AdminGroupBuyRequestActionController(
         @PathVariable requestId: Long,
         @Valid @RequestBody request: AdminGroupBuyRequestApproveRequest
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestActionResponse>> {
-        return ResponseEntity
+        log.info("[AdminGroupBuyRequestActionController] 공구요청 승인 요청: requestId={}", requestId)
+        val response = ResponseEntity
             .status(HttpStatus.CREATED)
             .body(ApiResponse.success(adminGroupBuyRequestActionService.approve(requestId, request)))
+        log.info("[AdminGroupBuyRequestActionController] 공구요청 승인 응답 완료: requestId={}", requestId)
+        return response
     }
 
     @PostMapping("/{requestId}/reject")
@@ -40,6 +45,9 @@ class AdminGroupBuyRequestActionController(
         @PathVariable requestId: Long,
         @Valid @RequestBody request: AdminGroupBuyRequestRejectRequest
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestActionResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(adminGroupBuyRequestActionService.reject(requestId, request)))
+        log.info("[AdminGroupBuyRequestActionController] 공구요청 반려 요청: requestId={}", requestId)
+        val response = ResponseEntity.ok(ApiResponse.success(adminGroupBuyRequestActionService.reject(requestId, request)))
+        log.info("[AdminGroupBuyRequestActionController] 공구요청 반려 응답 완료: requestId={}", requestId)
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/AdminGroupBuyRequestActionController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/AdminGroupBuyRequestActionController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminGroupBuyRequestActionController(
     private val adminGroupBuyRequestActionService: AdminGroupBuyRequestActionService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(AdminGroupBuyRequestActionController::class.java)
 
     @PostMapping("/{requestId}/approve")
     @Operation(summary = "소비자 공구 개설 요청 승인 및 공구 생성")

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/AdminGroupBuyRequestActionController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/AdminGroupBuyRequestActionController.kt
@@ -8,7 +8,6 @@ import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController
 class AdminGroupBuyRequestActionController(
     private val adminGroupBuyRequestActionService: AdminGroupBuyRequestActionService
 ) {
-    private val log = LoggerFactory.getLogger(AdminGroupBuyRequestActionController::class.java)
 
     @PostMapping("/{requestId}/approve")
     @Operation(summary = "소비자 공구 개설 요청 승인 및 공구 생성")
@@ -31,11 +29,9 @@ class AdminGroupBuyRequestActionController(
         @PathVariable requestId: Long,
         @Valid @RequestBody request: AdminGroupBuyRequestApproveRequest
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestActionResponse>> {
-        log.info("[AdminGroupBuyRequestActionController] 공구요청 승인 요청: requestId={}", requestId)
         val response = ResponseEntity
             .status(HttpStatus.CREATED)
             .body(ApiResponse.success(adminGroupBuyRequestActionService.approve(requestId, request)))
-        log.info("[AdminGroupBuyRequestActionController] 공구요청 승인 응답 완료: requestId={}", requestId)
         return response
     }
 
@@ -45,9 +41,7 @@ class AdminGroupBuyRequestActionController(
         @PathVariable requestId: Long,
         @Valid @RequestBody request: AdminGroupBuyRequestRejectRequest
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestActionResponse>> {
-        log.info("[AdminGroupBuyRequestActionController] 공구요청 반려 요청: requestId={}", requestId)
         val response = ResponseEntity.ok(ApiResponse.success(adminGroupBuyRequestActionService.reject(requestId, request)))
-        log.info("[AdminGroupBuyRequestActionController] 공구요청 반려 응답 완료: requestId={}", requestId)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
@@ -9,7 +9,6 @@ import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController
 class GroupBuyOpenRequestController(
     private val openRequestService: GroupBuyOpenRequestService
 ) {
-    private val log = LoggerFactory.getLogger(GroupBuyOpenRequestController::class.java)
 
     @PostMapping
     @Operation(summary = "공구 개설 알림 신청")
@@ -32,10 +30,8 @@ class GroupBuyOpenRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CreateGroupBuyOpenRequestRequest
     ): ResponseEntity<ApiResponse<Nothing>> {
-        log.info("[GroupBuyOpenRequestController] 공구 개설 알림 신청 요청: userId={}", principal.id)
         openRequestService.create(principal.id, request)
         val response = ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())
-        log.info("[GroupBuyOpenRequestController] 공구 개설 알림 신청 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -44,9 +40,7 @@ class GroupBuyOpenRequestController(
     fun recommendStores(
         @Valid @RequestBody request: StoreRecommendationRequest
     ): ResponseEntity<ApiResponse<StoreRecommendationResponse>> {
-        log.info("[GroupBuyOpenRequestController] 공구 개설 요청 매장 추천 요청 수신")
         val response = ResponseEntity.ok(ApiResponse.success(openRequestService.recommendStores(request)))
-        log.info("[GroupBuyOpenRequestController] 공구 개설 요청 매장 추천 응답 완료")
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
@@ -9,6 +9,7 @@ import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -23,14 +24,19 @@ import org.springframework.web.bind.annotation.RestController
 class GroupBuyOpenRequestController(
     private val openRequestService: GroupBuyOpenRequestService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     @PostMapping
     @Operation(summary = "공구 개설 알림 신청")
     fun create(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CreateGroupBuyOpenRequestRequest
     ): ResponseEntity<ApiResponse<Nothing>> {
+        log.info("[GroupBuyOpenRequestController] 공구 개설 알림 신청 요청: userId={}", principal.id)
         openRequestService.create(principal.id, request)
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())
+        val response = ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())
+        log.info("[GroupBuyOpenRequestController] 공구 개설 알림 신청 응답 완료: userId={}", principal.id)
+        return response
     }
 
     @PostMapping("/store-recommendations")
@@ -38,6 +44,9 @@ class GroupBuyOpenRequestController(
     fun recommendStores(
         @Valid @RequestBody request: StoreRecommendationRequest
     ): ResponseEntity<ApiResponse<StoreRecommendationResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(openRequestService.recommendStores(request)))
+        log.info("[GroupBuyOpenRequestController] 공구 개설 요청 매장 추천 요청 수신")
+        val response = ResponseEntity.ok(ApiResponse.success(openRequestService.recommendStores(request)))
+        log.info("[GroupBuyOpenRequestController] 공구 개설 요청 매장 추천 응답 완료")
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyOpenRequestController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 class GroupBuyOpenRequestController(
     private val openRequestService: GroupBuyOpenRequestService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(GroupBuyOpenRequestController::class.java)
 
     @PostMapping
     @Operation(summary = "공구 개설 알림 신청")

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 class GroupBuyRequestAdminController(
     private val groupBuyRequestService: GroupBuyRequestService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(GroupBuyRequestAdminController::class.java)
 
     @GetMapping
     @Operation(summary = "운영자 공구 개설 요청 목록 조회")

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
@@ -10,6 +10,7 @@ import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController
 class GroupBuyRequestAdminController(
     private val groupBuyRequestService: GroupBuyRequestService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping
     @Operation(summary = "운영자 공구 개설 요청 목록 조회")
@@ -34,7 +36,10 @@ class GroupBuyRequestAdminController(
         @RequestParam(required = false) keyword: String?,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestPageResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminRequests(status, keyword, pageable)))
+        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 목록 조회 요청: status={}, page={}, size={}", status, pageable.pageNumber, pageable.pageSize)
+        val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminRequests(status, keyword, pageable)))
+        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 목록 조회 응답 완료: status={}", status)
+        return response
     }
 
     @GetMapping("/{requestId}")
@@ -42,7 +47,10 @@ class GroupBuyRequestAdminController(
     fun getDetail(
         @PathVariable requestId: Long
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestDetailResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminDetail(requestId)))
+        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 상세 조회 요청: requestId={}", requestId)
+        val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminDetail(requestId)))
+        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 상세 조회 응답 완료: requestId={}", requestId)
+        return response
     }
 
     @PatchMapping("/{requestId}/status")
@@ -51,6 +59,13 @@ class GroupBuyRequestAdminController(
         @PathVariable requestId: Long,
         @Valid @RequestBody request: GroupBuyRequestStatusUpdateRequest
     ): ResponseEntity<ApiResponse<GroupBuyRequestResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.updateStatus(requestId, request)))
+        log.info(
+            "[GroupBuyRequestAdminController] 관리자 공구요청 상태 변경 요청: requestId={}, targetStatus={}",
+            requestId,
+            request.targetStatus,
+        )
+        val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.updateStatus(requestId, request)))
+        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 상태 변경 응답 완료: requestId={}", requestId)
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestAdminController.kt
@@ -10,7 +10,6 @@ import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -27,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController
 class GroupBuyRequestAdminController(
     private val groupBuyRequestService: GroupBuyRequestService
 ) {
-    private val log = LoggerFactory.getLogger(GroupBuyRequestAdminController::class.java)
 
     @GetMapping
     @Operation(summary = "운영자 공구 개설 요청 목록 조회")
@@ -36,9 +34,7 @@ class GroupBuyRequestAdminController(
         @RequestParam(required = false) keyword: String?,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestPageResponse>> {
-        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 목록 조회 요청: status={}, page={}, size={}", status, pageable.pageNumber, pageable.pageSize)
         val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminRequests(status, keyword, pageable)))
-        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 목록 조회 응답 완료: status={}", status)
         return response
     }
 
@@ -47,9 +43,7 @@ class GroupBuyRequestAdminController(
     fun getDetail(
         @PathVariable requestId: Long
     ): ResponseEntity<ApiResponse<AdminGroupBuyRequestDetailResponse>> {
-        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 상세 조회 요청: requestId={}", requestId)
         val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getAdminDetail(requestId)))
-        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 상세 조회 응답 완료: requestId={}", requestId)
         return response
     }
 
@@ -59,13 +53,7 @@ class GroupBuyRequestAdminController(
         @PathVariable requestId: Long,
         @Valid @RequestBody request: GroupBuyRequestStatusUpdateRequest
     ): ResponseEntity<ApiResponse<GroupBuyRequestResponse>> {
-        log.info(
-            "[GroupBuyRequestAdminController] 관리자 공구요청 상태 변경 요청: requestId={}, targetStatus={}",
-            requestId,
-            request.targetStatus,
-        )
         val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.updateStatus(requestId, request)))
-        log.info("[GroupBuyRequestAdminController] 관리자 공구요청 상태 변경 응답 완료: requestId={}", requestId)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestController.kt
@@ -9,7 +9,6 @@ import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -21,7 +20,6 @@ import org.springframework.web.bind.annotation.*
 class GroupBuyRequestController(
     private val groupBuyRequestService: GroupBuyRequestService
 ) {
-    private val log = LoggerFactory.getLogger(GroupBuyRequestController::class.java)
 
     @PostMapping
     @Operation(summary = "공구 개설 요청 제출")
@@ -29,11 +27,9 @@ class GroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: GroupBuyRequestCreateRequest
     ): ResponseEntity<ApiResponse<GroupBuyRequestIdResponse>> {
-        log.info("[GroupBuyRequestController] 공구 개설 요청 제출 요청: userId={}", principal.id)
         val response = ResponseEntity
             .status(HttpStatus.CREATED)
             .body(ApiResponse.success(groupBuyRequestService.create(principal.id, request)))
-        log.info("[GroupBuyRequestController] 공구 개설 요청 제출 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -42,9 +38,7 @@ class GroupBuyRequestController(
     fun getMyRequests(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<GroupBuyRequestResponse>>> {
-        log.info("[GroupBuyRequestController] 내 공구 요청 목록 조회 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getMyRequests(principal.id)))
-        log.info("[GroupBuyRequestController] 내 공구 요청 목록 조회 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -54,9 +48,7 @@ class GroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @PathVariable requestId: Long
     ): ResponseEntity<ApiResponse<GroupBuyRequestResponse>> {
-        log.info("[GroupBuyRequestController] 공구 요청 상세 조회 요청: userId={}, requestId={}", principal.id, requestId)
         val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getDetail(principal.id, requestId)))
-        log.info("[GroupBuyRequestController] 공구 요청 상세 조회 응답 완료: userId={}, requestId={}", principal.id, requestId)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestController.kt
@@ -9,6 +9,7 @@ import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*
 class GroupBuyRequestController(
     private val groupBuyRequestService: GroupBuyRequestService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @PostMapping
     @Operation(summary = "공구 개설 요청 제출")
@@ -27,9 +29,12 @@ class GroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: GroupBuyRequestCreateRequest
     ): ResponseEntity<ApiResponse<GroupBuyRequestIdResponse>> {
-        return ResponseEntity
+        log.info("[GroupBuyRequestController] 공구 개설 요청 제출 요청: userId={}", principal.id)
+        val response = ResponseEntity
             .status(HttpStatus.CREATED)
             .body(ApiResponse.success(groupBuyRequestService.create(principal.id, request)))
+        log.info("[GroupBuyRequestController] 공구 개설 요청 제출 응답 완료: userId={}", principal.id)
+        return response
     }
 
     @GetMapping
@@ -37,7 +42,10 @@ class GroupBuyRequestController(
     fun getMyRequests(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<GroupBuyRequestResponse>>> {
-        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getMyRequests(principal.id)))
+        log.info("[GroupBuyRequestController] 내 공구 요청 목록 조회 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getMyRequests(principal.id)))
+        log.info("[GroupBuyRequestController] 내 공구 요청 목록 조회 응답 완료: userId={}", principal.id)
+        return response
     }
 
     @GetMapping("/{requestId}")
@@ -46,6 +54,9 @@ class GroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @PathVariable requestId: Long
     ): ResponseEntity<ApiResponse<GroupBuyRequestResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getDetail(principal.id, requestId)))
+        log.info("[GroupBuyRequestController] 공구 요청 상세 조회 요청: userId={}, requestId={}", principal.id, requestId)
+        val response = ResponseEntity.ok(ApiResponse.success(groupBuyRequestService.getDetail(principal.id, requestId)))
+        log.info("[GroupBuyRequestController] 공구 요청 상세 조회 응답 완료: userId={}, requestId={}", principal.id, requestId)
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/presentation/GroupBuyRequestController.kt
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*
 class GroupBuyRequestController(
     private val groupBuyRequestService: GroupBuyRequestService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(GroupBuyRequestController::class.java)
 
     @PostMapping
     @Operation(summary = "공구 개설 요청 제출")

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -13,6 +13,7 @@ import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,9 +24,11 @@ class MypageService(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
     private val paymentOrderRepository: PaymentOrderRepository
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
-    fun getSummary(userId: Long): MypageSummaryResponse =
-        MypageSummaryResponse(
+    fun getSummary(userId: Long): MypageSummaryResponse {
+        log.info("[MypageService] 마이페이지 요약 조회 시작: userId={}", userId)
+        val response = MypageSummaryResponse(
             inProgressCount = participationRepository.countByUserIdAndStatusInAndPickupStatusIn(
                 userId = userId,
                 statuses = IN_PROGRESS_PARTICIPATION_STATUSES,
@@ -47,8 +50,12 @@ class MypageService(
             ),
             requestCount = groupBuyRequestRepository.countByUserId(userId)
         )
+        log.info("[MypageService] 마이페이지 요약 조회 완료: userId={}", userId)
+        return response
+    }
 
     fun getRefunds(userId: Long): List<MypageRefundResponse> {
+        log.info("[MypageService] 환불 목록 조회 시작: userId={}", userId)
         val participations = participationRepository.findByUserIdAndStatusInOrderByRefundedAtDescCreatedAtDesc(
             userId = userId,
             statuses = REFUND_PARTICIPATION_STATUSES,
@@ -56,24 +63,30 @@ class MypageService(
         )
         val paymentInfoByParticipationId = paymentInfoByParticipationId(participations)
 
-        return participations.map {
+        val responses = participations.map {
             MypageRefundResponse.from(
                 participation = it,
                 paymentInfo = paymentInfoByParticipationId[it.id]
             )
         }
+        log.info("[MypageService] 환불 목록 조회 완료: userId={}, count={}", userId, responses.size)
+        return responses
     }
 
     fun getParticipations(
         userId: Long,
         status: MypageParticipationStatusFilter
-    ): List<MypageParticipationResponse> =
-        when (status) {
+    ): List<MypageParticipationResponse> {
+        log.info("[MypageService] 참여 목록 조회 시작: userId={}, status={}", userId, status)
+        val responses = when (status) {
             MypageParticipationStatusFilter.IN_PROGRESS -> getInProgressParticipations(userId)
             MypageParticipationStatusFilter.PICKUP_WAITING -> getPickupWaitingParticipations(userId)
             MypageParticipationStatusFilter.PICKUP_COMPLETED -> getPickupCompletedParticipations(userId)
             MypageParticipationStatusFilter.CANCELLED_OR_REFUNDED -> getCancelledOrRefundedParticipations(userId)
         }
+        log.info("[MypageService] 참여 목록 조회 완료: userId={}, status={}, count={}", userId, status, responses.size)
+        return responses
+    }
 
     fun getInProgressParticipations(userId: Long): List<MypageParticipationResponse> {
         val participations = participationRepository.findByUserIdAndStatusInAndPickupStatusInOrderByCreatedAtDesc(
@@ -120,10 +133,14 @@ class MypageService(
             .findByUserIdAndStatusInOrderByCreatedAtDesc(userId, CANCELLED_OR_REFUNDED_PARTICIPATION_STATUSES)
             .let(::withPaymentInfo)
 
-    fun getGroupBuyRequests(userId: Long): List<MypageGroupBuyRequestResponse> =
-        groupBuyRequestRepository
+    fun getGroupBuyRequests(userId: Long): List<MypageGroupBuyRequestResponse> {
+        log.info("[MypageService] 요청공구 목록 조회 시작: userId={}", userId)
+        val responses = groupBuyRequestRepository
             .findByUserIdOrderByCreatedAtDesc(userId)
             .map(MypageGroupBuyRequestResponse::from)
+        log.info("[MypageService] 요청공구 목록 조회 완료: userId={}, count={}", userId, responses.size)
+        return responses
+    }
 
     private fun withPaymentInfo(participations: List<Participation>): List<MypageParticipationResponse> {
         val paymentInfoByParticipationId = paymentInfoByParticipationId(participations)

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -24,7 +24,7 @@ class MypageService(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
     private val paymentOrderRepository: PaymentOrderRepository
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(MypageService::class.java)
 
     fun getSummary(userId: Long): MypageSummaryResponse {
         log.info("[MypageService] 마이페이지 요약 조회 시작: userId={}", userId)

--- a/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 class MypageController(
     private val mypageService: MypageService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(MypageController::class.java)
 
     @GetMapping("/mypage/summary")
     @Operation(summary = "마이페이지 탭별 건수 조회")

--- a/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
@@ -10,6 +10,7 @@ import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,54 +24,83 @@ import org.springframework.web.bind.annotation.RestController
 class MypageController(
     private val mypageService: MypageService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/mypage/summary")
     @Operation(summary = "마이페이지 탭별 건수 조회")
     fun getSummary(
         @AuthenticationPrincipal principal: CustomUserPrincipal
-    ): ResponseEntity<ApiResponse<MypageSummaryResponse>> =
-        ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
+    ): ResponseEntity<ApiResponse<MypageSummaryResponse>> {
+        log.info("[MypageController] 마이페이지 요약 조회 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
+        log.info("[MypageController] 마이페이지 요약 조회 응답 완료: userId={}", principal.id)
+        return response
+    }
 
     @GetMapping("/users/me/tabs/counts")
     @Operation(summary = "내 탭별 건수 조회")
     fun getUserTabCounts(
         @AuthenticationPrincipal principal: CustomUserPrincipal
-    ): ResponseEntity<ApiResponse<MypageSummaryResponse>> =
-        ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
+    ): ResponseEntity<ApiResponse<MypageSummaryResponse>> {
+        log.info("[MypageController] 내 탭별 건수 조회 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
+        log.info("[MypageController] 내 탭별 건수 조회 응답 완료: userId={}", principal.id)
+        return response
+    }
 
     @GetMapping("/users/me/participations")
     @Operation(summary = "내 참여 내역 상태별 조회")
     fun getUserParticipations(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @RequestParam status: MypageParticipationStatusFilter
-    ): ResponseEntity<ApiResponse<List<MypageParticipationResponse>>> =
-        ResponseEntity.ok(ApiResponse.success(mypageService.getParticipations(principal.id, status)))
+    ): ResponseEntity<ApiResponse<List<MypageParticipationResponse>>> {
+        log.info("[MypageController] 내 참여 내역 조회 요청: userId={}, status={}", principal.id, status)
+        val response = ResponseEntity.ok(ApiResponse.success(mypageService.getParticipations(principal.id, status)))
+        log.info("[MypageController] 내 참여 내역 조회 응답 완료: userId={}, status={}", principal.id, status)
+        return response
+    }
 
     @GetMapping("/users/me/group-buy-requests")
     @Operation(summary = "내 공구 개설 요청 내역 조회")
     fun getUserGroupBuyRequests(
         @AuthenticationPrincipal principal: CustomUserPrincipal
-    ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> =
-        ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
+    ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> {
+        log.info("[MypageController] 내 공구 개설 요청 조회 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
+        log.info("[MypageController] 내 공구 개설 요청 조회 응답 완료: userId={}", principal.id)
+        return response
+    }
 
     @GetMapping("/mypage/refunds")
     @Operation(summary = "내 환불 내역 조회")
     fun getRefunds(
         @AuthenticationPrincipal principal: CustomUserPrincipal
-    ): ResponseEntity<ApiResponse<List<MypageRefundResponse>>> =
-        ResponseEntity.ok(ApiResponse.success(mypageService.getRefunds(principal.id)))
+    ): ResponseEntity<ApiResponse<List<MypageRefundResponse>>> {
+        log.info("[MypageController] 내 환불 내역 조회 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(mypageService.getRefunds(principal.id)))
+        log.info("[MypageController] 내 환불 내역 조회 응답 완료: userId={}", principal.id)
+        return response
+    }
 
     @GetMapping("/users/me/refunds")
     @Operation(summary = "내 환불 내역 조회 (마이페이지)")
     fun getUserRefunds(
         @AuthenticationPrincipal principal: CustomUserPrincipal
-    ): ResponseEntity<ApiResponse<List<MypageRefundResponse>>> =
-        ResponseEntity.ok(ApiResponse.success(mypageService.getRefunds(principal.id)))
+    ): ResponseEntity<ApiResponse<List<MypageRefundResponse>>> {
+        log.info("[MypageController] 내 환불 내역 조회(마이페이지) 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(mypageService.getRefunds(principal.id)))
+        log.info("[MypageController] 내 환불 내역 조회(마이페이지) 응답 완료: userId={}", principal.id)
+        return response
+    }
 
     @GetMapping("/mypage/group-buy-requests")
     @Operation(summary = "내 공구 개설 요청 내역 조회")
     fun getGroupBuyRequests(
         @AuthenticationPrincipal principal: CustomUserPrincipal
-    ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> =
-        ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
+    ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> {
+        log.info("[MypageController] 내 공구 개설 요청 조회(legacy) 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
+        log.info("[MypageController] 내 공구 개설 요청 조회(legacy) 응답 완료: userId={}", principal.id)
+        return response
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/presentation/MypageController.kt
@@ -10,7 +10,6 @@ import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -24,16 +23,13 @@ import org.springframework.web.bind.annotation.RestController
 class MypageController(
     private val mypageService: MypageService
 ) {
-    private val log = LoggerFactory.getLogger(MypageController::class.java)
 
     @GetMapping("/mypage/summary")
     @Operation(summary = "마이페이지 탭별 건수 조회")
     fun getSummary(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<MypageSummaryResponse>> {
-        log.info("[MypageController] 마이페이지 요약 조회 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
-        log.info("[MypageController] 마이페이지 요약 조회 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -42,9 +38,7 @@ class MypageController(
     fun getUserTabCounts(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<MypageSummaryResponse>> {
-        log.info("[MypageController] 내 탭별 건수 조회 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(mypageService.getSummary(principal.id)))
-        log.info("[MypageController] 내 탭별 건수 조회 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -54,9 +48,7 @@ class MypageController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @RequestParam status: MypageParticipationStatusFilter
     ): ResponseEntity<ApiResponse<List<MypageParticipationResponse>>> {
-        log.info("[MypageController] 내 참여 내역 조회 요청: userId={}, status={}", principal.id, status)
         val response = ResponseEntity.ok(ApiResponse.success(mypageService.getParticipations(principal.id, status)))
-        log.info("[MypageController] 내 참여 내역 조회 응답 완료: userId={}, status={}", principal.id, status)
         return response
     }
 
@@ -65,9 +57,7 @@ class MypageController(
     fun getUserGroupBuyRequests(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> {
-        log.info("[MypageController] 내 공구 개설 요청 조회 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
-        log.info("[MypageController] 내 공구 개설 요청 조회 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -76,9 +66,7 @@ class MypageController(
     fun getRefunds(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<MypageRefundResponse>>> {
-        log.info("[MypageController] 내 환불 내역 조회 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(mypageService.getRefunds(principal.id)))
-        log.info("[MypageController] 내 환불 내역 조회 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -87,9 +75,7 @@ class MypageController(
     fun getUserRefunds(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<MypageRefundResponse>>> {
-        log.info("[MypageController] 내 환불 내역 조회(마이페이지) 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(mypageService.getRefunds(principal.id)))
-        log.info("[MypageController] 내 환불 내역 조회(마이페이지) 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -98,9 +84,7 @@ class MypageController(
     fun getGroupBuyRequests(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<MypageGroupBuyRequestResponse>>> {
-        log.info("[MypageController] 내 공구 개설 요청 조회(legacy) 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(mypageService.getGroupBuyRequests(principal.id)))
-        log.info("[MypageController] 내 공구 개설 요청 조회(legacy) 응답 완료: userId={}", principal.id)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -15,6 +15,7 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -33,23 +34,39 @@ class OwnerGroupBuyRequestService(
     private val ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository,
     private val clock: Clock
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional(readOnly = true)
     fun getMyRequests(ownerId: Long, pageable: Pageable): OwnerGroupBuyRequestPageResponse {
+        log.info(
+            "[OwnerGroupBuyRequestService] 사장님 요청공구 목록 조회 시작: ownerId={}, page={}, size={}",
+            ownerId,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
         validateSeller(ownerId)
 
         val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
         if (storeIds.isEmpty()) {
-            return OwnerGroupBuyRequestPageResponse.from(PageImpl(emptyList(), pageable, 0))
+            val emptyResponse = OwnerGroupBuyRequestPageResponse.from(PageImpl(emptyList(), pageable, 0))
+            log.info("[OwnerGroupBuyRequestService] 사장님 요청공구 목록 조회 완료(소속 매장 없음): ownerId={}", ownerId)
+            return emptyResponse
         }
 
         val page: Page<OwnerGroupBuyRequest> = ownerGroupBuyRequestRepository
             .findPageByOwnerIdAndStoreIdIn(ownerId, storeIds, pageable)
-        return OwnerGroupBuyRequestPageResponse.from(page)
+        val response = OwnerGroupBuyRequestPageResponse.from(page)
+        log.info(
+            "[OwnerGroupBuyRequestService] 사장님 요청공구 목록 조회 완료: ownerId={}, totalElements={}",
+            ownerId,
+            response.totalElements,
+        )
+        return response
     }
 
     @Transactional(readOnly = true)
     fun getDetail(ownerId: Long, requestId: Long): OwnerGroupBuyRequestDetailResponse {
+        log.info("[OwnerGroupBuyRequestService] 사장님 요청공구 상세 조회 시작: ownerId={}, requestId={}", ownerId, requestId)
         validateSeller(ownerId)
 
         val request = ownerGroupBuyRequestRepository.findById(requestId)
@@ -60,10 +77,13 @@ class OwnerGroupBuyRequestService(
         }
 
         val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
-        return OwnerGroupBuyRequestDetailResponse.from(request, images)
+        val response = OwnerGroupBuyRequestDetailResponse.from(request, images)
+        log.info("[OwnerGroupBuyRequestService] 사장님 요청공구 상세 조회 완료: ownerId={}, requestId={}", ownerId, requestId)
+        return response
     }
 
     fun create(ownerId: Long, request: OwnerGroupBuyRequestCreateRequest): OwnerGroupBuyRequestCreateResponse {
+        log.info("[OwnerGroupBuyRequestService] 사장님 요청공구 생성 시작: ownerId={}, storeId={}", ownerId, request.storeId)
         val owner = validateSeller(ownerId)
 
         val store = storeRepository.findById(request.storeId)
@@ -107,10 +127,16 @@ class OwnerGroupBuyRequestService(
             }
         )
 
-        return OwnerGroupBuyRequestCreateResponse(
+        val response = OwnerGroupBuyRequestCreateResponse(
             requestId = saved.id,
             status = saved.status
         )
+        log.info(
+            "[OwnerGroupBuyRequestService] 사장님 요청공구 생성 완료: ownerId={}, requestId={}",
+            ownerId,
+            saved.id,
+        )
+        return response
     }
 
     private fun validateSeller(ownerId: Long) =

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -34,7 +34,7 @@ class OwnerGroupBuyRequestService(
     private val ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository,
     private val clock: Clock
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(OwnerGroupBuyRequestService::class.java)
 
     @Transactional(readOnly = true)
     fun getMyRequests(ownerId: Long, pageable: Pageable): OwnerGroupBuyRequestPageResponse {

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
@@ -10,7 +10,6 @@ import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -28,7 +27,6 @@ import org.springframework.web.bind.annotation.RestController
 class OwnerGroupBuyRequestController(
     private val ownerGroupBuyRequestService: OwnerGroupBuyRequestService
 ) {
-    private val log = LoggerFactory.getLogger(OwnerGroupBuyRequestController::class.java)
 
     @GetMapping
     @Operation(summary = "사장님 공구 개설 요청 목록 조회")
@@ -36,9 +34,7 @@ class OwnerGroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestPageResponse>> {
-        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 목록 조회 요청: ownerId={}, page={}, size={}", principal.id, pageable.pageNumber, pageable.pageSize)
         val response = ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getMyRequests(principal.id, pageable)))
-        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 목록 조회 응답 완료: ownerId={}", principal.id)
         return response
     }
 
@@ -48,9 +44,7 @@ class OwnerGroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @PathVariable requestId: Long
     ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestDetailResponse>> {
-        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 상세 조회 요청: ownerId={}, requestId={}", principal.id, requestId)
         val response = ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getDetail(principal.id, requestId)))
-        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 상세 조회 응답 완료: ownerId={}, requestId={}", principal.id, requestId)
         return response
     }
 
@@ -60,11 +54,9 @@ class OwnerGroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: OwnerGroupBuyRequestCreateRequest
     ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestCreateResponse>> {
-        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 생성 요청: ownerId={}", principal.id)
         val response = ResponseEntity
             .status(HttpStatus.CREATED)
             .body(ApiResponse.success(ownerGroupBuyRequestService.create(principal.id, request)))
-        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 생성 응답 완료: ownerId={}", principal.id)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 class OwnerGroupBuyRequestController(
     private val ownerGroupBuyRequestService: OwnerGroupBuyRequestService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(OwnerGroupBuyRequestController::class.java)
 
     @GetMapping
     @Operation(summary = "사장님 공구 개설 요청 목록 조회")

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyRequestController.kt
@@ -10,6 +10,7 @@ import com.moongchijang.security.principal.CustomUserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
 class OwnerGroupBuyRequestController(
     private val ownerGroupBuyRequestService: OwnerGroupBuyRequestService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping
     @Operation(summary = "사장님 공구 개설 요청 목록 조회")
@@ -34,7 +36,10 @@ class OwnerGroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         pageable: Pageable
     ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestPageResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getMyRequests(principal.id, pageable)))
+        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 목록 조회 요청: ownerId={}, page={}, size={}", principal.id, pageable.pageNumber, pageable.pageSize)
+        val response = ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getMyRequests(principal.id, pageable)))
+        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 목록 조회 응답 완료: ownerId={}", principal.id)
+        return response
     }
 
     @GetMapping("/{requestId}")
@@ -43,7 +48,10 @@ class OwnerGroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @PathVariable requestId: Long
     ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestDetailResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getDetail(principal.id, requestId)))
+        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 상세 조회 요청: ownerId={}, requestId={}", principal.id, requestId)
+        val response = ResponseEntity.ok(ApiResponse.success(ownerGroupBuyRequestService.getDetail(principal.id, requestId)))
+        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 상세 조회 응답 완료: ownerId={}, requestId={}", principal.id, requestId)
+        return response
     }
 
     @PostMapping
@@ -52,8 +60,11 @@ class OwnerGroupBuyRequestController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: OwnerGroupBuyRequestCreateRequest
     ): ResponseEntity<ApiResponse<OwnerGroupBuyRequestCreateResponse>> {
-        return ResponseEntity
+        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 생성 요청: ownerId={}", principal.id)
+        val response = ResponseEntity
             .status(HttpStatus.CREATED)
             .body(ApiResponse.success(ownerGroupBuyRequestService.create(principal.id, request)))
+        log.info("[OwnerGroupBuyRequestController] 사장님 공구요청 생성 응답 완료: ownerId={}", principal.id)
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -13,6 +13,7 @@ import com.moongchijang.domain.payment.application.dto.PortOneWebhookResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.access.prepost.PreAuthorize
@@ -29,13 +30,17 @@ import org.springframework.web.bind.annotation.RestController
 class PaymentController(
     private val paymentService: PaymentService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/group-buys/{groupBuyId}/checkout")
     fun getCheckoutInfo(
         @PathVariable groupBuyId: Long,
         @RequestParam quantity: Int,
     ): ResponseEntity<ApiResponse<CheckoutInfoResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.getCheckoutInfo(groupBuyId, quantity)))
+        log.info("[PaymentController] 결제 체크아웃 정보 조회 요청: groupBuyId={}, quantity={}", groupBuyId, quantity)
+        val response = ResponseEntity.ok(ApiResponse.success(paymentService.getCheckoutInfo(groupBuyId, quantity)))
+        log.info("[PaymentController] 결제 체크아웃 정보 조회 응답 완료: groupBuyId={}", groupBuyId)
+        return response
     }
 
     @PostMapping("/group-buys/{groupBuyId}/payment-orders")
@@ -45,7 +50,10 @@ class PaymentController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CreatePaymentOrderRequest,
     ): ResponseEntity<ApiResponse<CreatePaymentOrderResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.createPaymentOrder(groupBuyId, principal.id, request)))
+        log.info("[PaymentController] 결제 주문 생성 요청: groupBuyId={}, userId={}", groupBuyId, principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(paymentService.createPaymentOrder(groupBuyId, principal.id, request)))
+        log.info("[PaymentController] 결제 주문 생성 응답 완료: groupBuyId={}, userId={}", groupBuyId, principal.id)
+        return response
     }
 
     @PostMapping("/payments/portone/complete")
@@ -54,15 +62,21 @@ class PaymentController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CompletePortOnePaymentRequest,
     ): ResponseEntity<ApiResponse<ConfirmPaymentResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request, principal.id)))
+        log.info("[PaymentController] 결제 완료 확인 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request, principal.id)))
+        log.info("[PaymentController] 결제 완료 확인 응답 완료: userId={}", principal.id)
+        return response
     }
 
     @PostMapping("/payments/portone/webhook")
     fun handlePortOneWebhook(
         @RequestBody request: PortOneWebhookRequest,
     ): ResponseEntity<ApiResponse<PortOneWebhookResponse>> {
+        log.info("[PaymentController] PortOne 웹훅 처리 요청 수신")
         paymentService.handlePortOneWebhook(request)
-        return ResponseEntity.ok(ApiResponse.success(PortOneWebhookResponse()))
+        val response = ResponseEntity.ok(ApiResponse.success(PortOneWebhookResponse()))
+        log.info("[PaymentController] PortOne 웹훅 처리 응답 완료")
+        return response
     }
 
     @PostMapping("/participations/{participationId}/cancel")
@@ -72,6 +86,9 @@ class PaymentController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CancelParticipationRequest,
     ): ResponseEntity<ApiResponse<CancelParticipationResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(paymentService.cancelParticipation(participationId, principal.id, request)))
+        log.info("[PaymentController] 참여 취소 요청: participationId={}, userId={}", participationId, principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(paymentService.cancelParticipation(participationId, principal.id, request)))
+        log.info("[PaymentController] 참여 취소 응답 완료: participationId={}, userId={}", participationId, principal.id)
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -13,7 +13,6 @@ import com.moongchijang.domain.payment.application.dto.PortOneWebhookResponse
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.access.prepost.PreAuthorize
@@ -30,16 +29,13 @@ import org.springframework.web.bind.annotation.RestController
 class PaymentController(
     private val paymentService: PaymentService,
 ) {
-    private val log = LoggerFactory.getLogger(PaymentController::class.java)
 
     @GetMapping("/group-buys/{groupBuyId}/checkout")
     fun getCheckoutInfo(
         @PathVariable groupBuyId: Long,
         @RequestParam quantity: Int,
     ): ResponseEntity<ApiResponse<CheckoutInfoResponse>> {
-        log.info("[PaymentController] 결제 체크아웃 정보 조회 요청: groupBuyId={}, quantity={}", groupBuyId, quantity)
         val response = ResponseEntity.ok(ApiResponse.success(paymentService.getCheckoutInfo(groupBuyId, quantity)))
-        log.info("[PaymentController] 결제 체크아웃 정보 조회 응답 완료: groupBuyId={}", groupBuyId)
         return response
     }
 
@@ -50,9 +46,7 @@ class PaymentController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CreatePaymentOrderRequest,
     ): ResponseEntity<ApiResponse<CreatePaymentOrderResponse>> {
-        log.info("[PaymentController] 결제 주문 생성 요청: groupBuyId={}, userId={}", groupBuyId, principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(paymentService.createPaymentOrder(groupBuyId, principal.id, request)))
-        log.info("[PaymentController] 결제 주문 생성 응답 완료: groupBuyId={}, userId={}", groupBuyId, principal.id)
         return response
     }
 
@@ -62,9 +56,7 @@ class PaymentController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CompletePortOnePaymentRequest,
     ): ResponseEntity<ApiResponse<ConfirmPaymentResponse>> {
-        log.info("[PaymentController] 결제 완료 확인 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(paymentService.completePortOnePayment(request, principal.id)))
-        log.info("[PaymentController] 결제 완료 확인 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -72,10 +64,8 @@ class PaymentController(
     fun handlePortOneWebhook(
         @RequestBody request: PortOneWebhookRequest,
     ): ResponseEntity<ApiResponse<PortOneWebhookResponse>> {
-        log.info("[PaymentController] PortOne 웹훅 처리 요청 수신")
         paymentService.handlePortOneWebhook(request)
         val response = ResponseEntity.ok(ApiResponse.success(PortOneWebhookResponse()))
-        log.info("[PaymentController] PortOne 웹훅 처리 응답 완료")
         return response
     }
 
@@ -86,9 +76,7 @@ class PaymentController(
         @AuthenticationPrincipal principal: CustomUserPrincipal,
         @Valid @RequestBody request: CancelParticipationRequest,
     ): ResponseEntity<ApiResponse<CancelParticipationResponse>> {
-        log.info("[PaymentController] 참여 취소 요청: participationId={}, userId={}", participationId, principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(paymentService.cancelParticipation(participationId, principal.id, request)))
-        log.info("[PaymentController] 참여 취소 응답 완료: participationId={}, userId={}", participationId, principal.id)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -30,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController
 class PaymentController(
     private val paymentService: PaymentService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(PaymentController::class.java)
 
     @GetMapping("/group-buys/{groupBuyId}/checkout")
     fun getCheckoutInfo(

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -31,7 +31,7 @@ class PickupService(
     private val userRepository: UserRepository,
     private val storeStaffRepository: StoreStaffRepository,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(PickupService::class.java)
 
     @Transactional(readOnly = true)
     fun getPickupGuide(participationId: Long, userId: Long): PickupGuideResponse {

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -16,6 +16,7 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -30,14 +31,16 @@ class PickupService(
     private val userRepository: UserRepository,
     private val storeStaffRepository: StoreStaffRepository,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional(readOnly = true)
     fun getPickupGuide(participationId: Long, userId: Long): PickupGuideResponse {
+        log.info("[PickupService] 픽업 가이드 조회 시작: participationId={}, userId={}", participationId, userId)
         val participation = findOwnedParticipation(participationId, userId)
         val groupBuy = participation.groupBuy
         val store = groupBuy.store
 
-        return PickupGuideResponse(
+        val response = PickupGuideResponse(
             participationId = participation.id,
             availabilityStatus = participation.availabilityStatus(),
             pickupStatus = participation.pickupStatus,
@@ -57,16 +60,22 @@ class PickupService(
             remainingMinutes = participation.remainingPickupMinutes(),
             pickedUpAt = participation.pickedUpAt,
         )
+        log.info("[PickupService] 픽업 가이드 조회 완료: participationId={}, userId={}", participationId, userId)
+        return response
     }
 
     @Transactional
     fun getPickupQr(participationId: Long, userId: Long): PickupQrResponse {
+        log.info("[PickupService] 픽업 QR 조회 시작: participationId={}, userId={}", participationId, userId)
         val participation = findOwnedParticipation(participationId, userId)
-        return buildPickupQrResponse(participation)
+        val response = buildPickupQrResponse(participation)
+        log.info("[PickupService] 픽업 QR 조회 완료: participationId={}, userId={}", participationId, userId)
+        return response
     }
 
     @Transactional
     fun getNearestPickupQr(userId: Long): NearestPickupQrResponse {
+        log.info("[PickupService] 가장 가까운 픽업 QR 조회 시작: userId={}", userId)
         val today = todayKst()
         val candidates = participationRepository.findNearestPickupQrCandidates(
             userId = userId,
@@ -76,23 +85,31 @@ class PickupService(
         )
 
         if (candidates.isEmpty()) {
-            return NearestPickupQrResponse(
+            val response = NearestPickupQrResponse(
                 hasCandidate = false,
                 hasMultipleToday = false,
                 reason = NearestPickupQrReason.NO_AVAILABLE_PICKUP,
                 item = null,
             )
+            log.info("[PickupService] 가장 가까운 픽업 QR 조회 완료: userId={}, hasCandidate=false", userId)
+            return response
         }
 
         val todayCandidates = candidates.filter { it.groupBuy.pickupDate == today }
         val selected = todayCandidates.firstOrNull() ?: candidates.first()
 
-        return NearestPickupQrResponse(
+        val response = NearestPickupQrResponse(
             hasCandidate = true,
             hasMultipleToday = todayCandidates.size > 1,
             reason = if (todayCandidates.isEmpty()) NearestPickupQrReason.ONLY_FUTURE_PICKUP else null,
             item = buildPickupQrResponse(selected),
         )
+        log.info(
+            "[PickupService] 가장 가까운 픽업 QR 조회 완료: userId={}, hasCandidate=true, hasMultipleToday={}",
+            userId,
+            response.hasMultipleToday,
+        )
+        return response
     }
 
     private fun buildPickupQrResponse(participation: Participation): PickupQrResponse {
@@ -126,6 +143,7 @@ class PickupService(
 
     @Transactional
     fun verifyPickup(qrCode: String, processedByUserId: Long): PickupVerifyResponse {
+        log.info("[PickupService] 픽업 검증 시작: processedByUserId={}", processedByUserId)
         val participation = participationRepository.findByPickupTokenForUpdate(qrCode)
             ?: throw CustomException(ErrorCode.PICKUP_QR_NOT_FOUND)
 
@@ -146,7 +164,7 @@ class PickupService(
         val pickedUpAt = nowKst()
         participation.markPickedUp(processedBy, pickedUpAt)
 
-        return PickupVerifyResponse(
+        val response = PickupVerifyResponse(
             participationId = participation.id,
             pickupStatus = participation.pickupStatus,
             userName = participation.user.nickname,
@@ -155,6 +173,12 @@ class PickupService(
             pickedUpAt = pickedUpAt,
             pickupProcessedByUserId = processedBy.id,
         )
+        log.info(
+            "[PickupService] 픽업 검증 완료: participationId={}, processedByUserId={}",
+            participation.id,
+            processedByUserId,
+        )
+        return response
     }
 
     private fun findOwnedParticipation(participationId: Long, userId: Long): Participation {

--- a/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
@@ -9,7 +9,6 @@ import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController
 class PickupController(
     private val pickupService: PickupService,
 ) {
-    private val log = LoggerFactory.getLogger(PickupController::class.java)
 
     @GetMapping("/participations/{participationId}/pickup")
     fun getPickupGuide(
@@ -31,9 +29,7 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<PickupGuideResponse>> {
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        log.info("[PickupController] 픽업 가이드 조회 요청: participationId={}, userId={}", participationId, userId)
         val response = ResponseEntity.ok(ApiResponse.success(pickupService.getPickupGuide(participationId, userId)))
-        log.info("[PickupController] 픽업 가이드 조회 응답 완료: participationId={}, userId={}", participationId, userId)
         return response
     }
 
@@ -43,9 +39,7 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<PickupQrResponse>> {
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        log.info("[PickupController] 픽업 QR 조회 요청: participationId={}, userId={}", participationId, userId)
         val response = ResponseEntity.ok(ApiResponse.success(pickupService.getPickupQr(participationId, userId)))
-        log.info("[PickupController] 픽업 QR 조회 응답 완료: participationId={}, userId={}", participationId, userId)
         return response
     }
 
@@ -54,9 +48,7 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<NearestPickupQrResponse>> {
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        log.info("[PickupController] 가장 가까운 픽업 QR 조회 요청: userId={}", userId)
         val response = ResponseEntity.ok(ApiResponse.success(pickupService.getNearestPickupQr(userId)))
-        log.info("[PickupController] 가장 가까운 픽업 QR 조회 응답 완료: userId={}", userId)
         return response
     }
 
@@ -66,9 +58,7 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<PickupVerifyResponse>> {
         val userId = principal.requirePickupVerifierUserId()
-        log.info("[PickupController] 픽업 검증 요청: userId={}", userId)
         val response = ResponseEntity.ok(ApiResponse.success(pickupService.verifyPickup(qrCode, userId)))
-        log.info("[PickupController] 픽업 검증 응답 완료: userId={}", userId)
         return response
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
@@ -9,6 +9,7 @@ import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 class PickupController(
     private val pickupService: PickupService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/participations/{participationId}/pickup")
     fun getPickupGuide(
@@ -29,7 +31,10 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<PickupGuideResponse>> {
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        return ResponseEntity.ok(ApiResponse.success(pickupService.getPickupGuide(participationId, userId)))
+        log.info("[PickupController] 픽업 가이드 조회 요청: participationId={}, userId={}", participationId, userId)
+        val response = ResponseEntity.ok(ApiResponse.success(pickupService.getPickupGuide(participationId, userId)))
+        log.info("[PickupController] 픽업 가이드 조회 응답 완료: participationId={}, userId={}", participationId, userId)
+        return response
     }
 
     @GetMapping("/participations/{participationId}/qr")
@@ -38,7 +43,10 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<PickupQrResponse>> {
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        return ResponseEntity.ok(ApiResponse.success(pickupService.getPickupQr(participationId, userId)))
+        log.info("[PickupController] 픽업 QR 조회 요청: participationId={}, userId={}", participationId, userId)
+        val response = ResponseEntity.ok(ApiResponse.success(pickupService.getPickupQr(participationId, userId)))
+        log.info("[PickupController] 픽업 QR 조회 응답 완료: participationId={}, userId={}", participationId, userId)
+        return response
     }
 
     @GetMapping("/pickups/me/nearest-qr")
@@ -46,7 +54,10 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<NearestPickupQrResponse>> {
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
-        return ResponseEntity.ok(ApiResponse.success(pickupService.getNearestPickupQr(userId)))
+        log.info("[PickupController] 가장 가까운 픽업 QR 조회 요청: userId={}", userId)
+        val response = ResponseEntity.ok(ApiResponse.success(pickupService.getNearestPickupQr(userId)))
+        log.info("[PickupController] 가장 가까운 픽업 QR 조회 응답 완료: userId={}", userId)
+        return response
     }
 
     @PostMapping("/pickups/{qrCode}/verify")
@@ -55,7 +66,10 @@ class PickupController(
         @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ResponseEntity<ApiResponse<PickupVerifyResponse>> {
         val userId = principal.requirePickupVerifierUserId()
-        return ResponseEntity.ok(ApiResponse.success(pickupService.verifyPickup(qrCode, userId)))
+        log.info("[PickupController] 픽업 검증 요청: userId={}", userId)
+        val response = ResponseEntity.ok(ApiResponse.success(pickupService.verifyPickup(qrCode, userId)))
+        log.info("[PickupController] 픽업 검증 응답 완료: userId={}", userId)
+        return response
     }
 
     private fun CustomUserPrincipal?.requirePickupVerifierUserId(): Long {

--- a/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/presentation/PickupController.kt
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController
 class PickupController(
     private val pickupService: PickupService,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(PickupController::class.java)
 
     @GetMapping("/participations/{participationId}/pickup")
     fun getPickupGuide(

--- a/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
@@ -21,7 +20,6 @@ import org.springframework.web.bind.annotation.*
 class SearchController(
     private val searchService: SearchService
 ) {
-    private val log = LoggerFactory.getLogger(SearchController::class.java)
 
     data class SearchRequest(@field:NotBlank val keyword: String)
 
@@ -31,9 +29,7 @@ class SearchController(
         @Valid @RequestBody request: SearchRequest,
         @AuthenticationPrincipal principal: CustomUserPrincipal?
     ): ResponseEntity<ApiResponse<SearchResponse>> {
-        log.info("[SearchController] 검색 요청: userId={}, keywordLength={}", principal?.id, request.keyword.length)
         val response = ResponseEntity.ok(ApiResponse.success(searchService.search(request.keyword, principal?.id)))
-        log.info("[SearchController] 검색 응답 완료: userId={}", principal?.id)
         return response
     }
 
@@ -42,9 +38,7 @@ class SearchController(
     fun getRecentSearches(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<String>>> {
-        log.info("[SearchController] 최근 검색어 조회 요청: userId={}", principal.id)
         val response = ResponseEntity.ok(ApiResponse.success(searchService.getHistory(principal.id)))
-        log.info("[SearchController] 최근 검색어 조회 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -53,10 +47,8 @@ class SearchController(
     fun clearRecentSearches(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<Nothing>> {
-        log.info("[SearchController] 최근 검색어 전체 삭제 요청: userId={}", principal.id)
         searchService.clearHistory(principal.id)
         val response = ResponseEntity.ok(ApiResponse.success())
-        log.info("[SearchController] 최근 검색어 전체 삭제 응답 완료: userId={}", principal.id)
         return response
     }
 
@@ -66,10 +58,8 @@ class SearchController(
         @PathVariable keyword: String,
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<Nothing>> {
-        log.info("[SearchController] 최근 검색어 단건 삭제 요청: userId={}, keywordLength={}", principal.id, keyword.length)
         searchService.deleteHistory(principal.id, keyword)
         val response = ResponseEntity.ok(ApiResponse.success())
-        log.info("[SearchController] 최근 검색어 단건 삭제 응답 완료: userId={}", principal.id)
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
@@ -20,6 +21,8 @@ import org.springframework.web.bind.annotation.*
 class SearchController(
     private val searchService: SearchService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     data class SearchRequest(@field:NotBlank val keyword: String)
 
     @PostMapping
@@ -28,7 +31,10 @@ class SearchController(
         @Valid @RequestBody request: SearchRequest,
         @AuthenticationPrincipal principal: CustomUserPrincipal?
     ): ResponseEntity<ApiResponse<SearchResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(searchService.search(request.keyword, principal?.id)))
+        log.info("[SearchController] 검색 요청: userId={}, keywordLength={}", principal?.id, request.keyword.length)
+        val response = ResponseEntity.ok(ApiResponse.success(searchService.search(request.keyword, principal?.id)))
+        log.info("[SearchController] 검색 응답 완료: userId={}", principal?.id)
+        return response
     }
 
     @GetMapping("/recent")
@@ -36,7 +42,10 @@ class SearchController(
     fun getRecentSearches(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<List<String>>> {
-        return ResponseEntity.ok(ApiResponse.success(searchService.getHistory(principal.id)))
+        log.info("[SearchController] 최근 검색어 조회 요청: userId={}", principal.id)
+        val response = ResponseEntity.ok(ApiResponse.success(searchService.getHistory(principal.id)))
+        log.info("[SearchController] 최근 검색어 조회 응답 완료: userId={}", principal.id)
+        return response
     }
 
     @DeleteMapping("/recent")
@@ -44,8 +53,11 @@ class SearchController(
     fun clearRecentSearches(
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<Nothing>> {
+        log.info("[SearchController] 최근 검색어 전체 삭제 요청: userId={}", principal.id)
         searchService.clearHistory(principal.id)
-        return ResponseEntity.ok(ApiResponse.success())
+        val response = ResponseEntity.ok(ApiResponse.success())
+        log.info("[SearchController] 최근 검색어 전체 삭제 응답 완료: userId={}", principal.id)
+        return response
     }
 
     @DeleteMapping("/recent/{keyword}")
@@ -54,7 +66,10 @@ class SearchController(
         @PathVariable keyword: String,
         @AuthenticationPrincipal principal: CustomUserPrincipal
     ): ResponseEntity<ApiResponse<Nothing>> {
+        log.info("[SearchController] 최근 검색어 단건 삭제 요청: userId={}, keywordLength={}", principal.id, keyword.length)
         searchService.deleteHistory(principal.id, keyword)
-        return ResponseEntity.ok(ApiResponse.success())
+        val response = ResponseEntity.ok(ApiResponse.success())
+        log.info("[SearchController] 최근 검색어 단건 삭제 응답 완료: userId={}", principal.id)
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*
 class SearchController(
     private val searchService: SearchService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(SearchController::class.java)
 
     data class SearchRequest(@field:NotBlank val keyword: String)
 

--- a/src/main/kotlin/com/moongchijang/domain/store/application/StoreSearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/application/StoreSearchService.kt
@@ -3,12 +3,14 @@ package com.moongchijang.domain.store.application
 import com.moongchijang.domain.store.application.dto.StoreSearchResponse
 import com.moongchijang.domain.store.infrastructure.naver.NaverLocalSearchClient
 import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchItem
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class StoreSearchService(
     private val naverLocalSearchClient: NaverLocalSearchClient
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
     companion object {
         private const val NAVER_FETCH_DISPLAY = 20
 
@@ -53,8 +55,11 @@ class StoreSearchService(
     }
 
     fun search(keyword: String, display: Int = 5): StoreSearchResponse {
+        log.info("[StoreSearchService] 매장 검색 시작: keywordLength={}, display={}", keyword.length, display)
         val response = naverLocalSearchClient.search(keyword, display.coerceAtLeast(NAVER_FETCH_DISPLAY))
-        return StoreSearchResponse.from(response.items.filter { it.isBakeryDomain() }.take(display))
+        val result = StoreSearchResponse.from(response.items.filter { it.isBakeryDomain() }.take(display))
+        log.info("[StoreSearchService] 매장 검색 완료: resultCount={}", result.stores.size)
+        return result
     }
 
     private fun NaverLocalSearchItem.isBakeryDomain(): Boolean {

--- a/src/main/kotlin/com/moongchijang/domain/store/application/StoreSearchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/application/StoreSearchService.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 class StoreSearchService(
     private val naverLocalSearchClient: NaverLocalSearchClient
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(StoreSearchService::class.java)
     companion object {
         private const val NAVER_FETCH_DISPLAY = 20
 

--- a/src/main/kotlin/com/moongchijang/domain/store/presentation/StoreSearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/presentation/StoreSearchController.kt
@@ -5,7 +5,6 @@ import com.moongchijang.domain.store.application.dto.StoreSearchResponse
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -18,16 +17,13 @@ import org.springframework.web.bind.annotation.RestController
 class StoreSearchController(
     private val storeSearchService: StoreSearchService
 ) {
-    private val log = LoggerFactory.getLogger(StoreSearchController::class.java)
 
     @GetMapping("/search")
     @Operation(summary = "매장 검색 자동완성 (네이버 Local Search API)")
     fun search(
         @RequestParam keyword: String
     ): ResponseEntity<ApiResponse<StoreSearchResponse>> {
-        log.info("[StoreSearchController] 매장 검색 요청: keywordLength={}", keyword.length)
         val response = ResponseEntity.ok(ApiResponse.success(storeSearchService.search(keyword)))
-        log.info("[StoreSearchController] 매장 검색 응답 완료")
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/store/presentation/StoreSearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/presentation/StoreSearchController.kt
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
 class StoreSearchController(
     private val storeSearchService: StoreSearchService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(StoreSearchController::class.java)
 
     @GetMapping("/search")
     @Operation(summary = "매장 검색 자동완성 (네이버 Local Search API)")

--- a/src/main/kotlin/com/moongchijang/domain/store/presentation/StoreSearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/presentation/StoreSearchController.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.store.application.dto.StoreSearchResponse
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,12 +18,16 @@ import org.springframework.web.bind.annotation.RestController
 class StoreSearchController(
     private val storeSearchService: StoreSearchService
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/search")
     @Operation(summary = "매장 검색 자동완성 (네이버 Local Search API)")
     fun search(
         @RequestParam keyword: String
     ): ResponseEntity<ApiResponse<StoreSearchResponse>> {
-        return ResponseEntity.ok(ApiResponse.success(storeSearchService.search(keyword)))
+        log.info("[StoreSearchController] 매장 검색 요청: keywordLength={}", keyword.length)
+        val response = ResponseEntity.ok(ApiResponse.success(storeSearchService.search(keyword)))
+        log.info("[StoreSearchController] 매장 검색 응답 완료")
+        return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/BusinessRegistrationLookupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/BusinessRegistrationLookupService.kt
@@ -6,19 +6,26 @@ import com.moongchijang.domain.user.application.dto.BusinessRegistrationStatus
 import com.moongchijang.domain.user.application.port.BusinessRegistrationLookupPort
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class BusinessRegistrationLookupService(
     private val businessRegistrationLookupPort: BusinessRegistrationLookupPort,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     fun lookup(request: BusinessRegistrationLookupRequest): BusinessRegistrationLookupResponse {
         val businessRegistrationNumber = normalize(request.businessRegistrationNumber)
+        log.info(
+            "[BusinessRegistrationLookupService] 사업자등록 조회 시작: registrationNumberSuffix={}",
+            businessRegistrationNumber.takeLast(4),
+        )
         validateBusinessRegistrationNumberFormat(businessRegistrationNumber)
 
         val result = businessRegistrationLookupPort.lookup(businessRegistrationNumber)
 
-        return BusinessRegistrationLookupResponse(
+        val response = BusinessRegistrationLookupResponse(
             businessRegistrationNumber = format(businessRegistrationNumber),
             status = result.status,
             message = result.status.notFoundMessage(),
@@ -26,6 +33,12 @@ class BusinessRegistrationLookupService(
             ownerName = result.ownerName?.trim()?.takeIf { it.isNotBlank() },
             storeAddress = result.storeAddress?.trim()?.takeIf { it.isNotBlank() },
         )
+        log.info(
+            "[BusinessRegistrationLookupService] 사업자등록 조회 완료: registrationNumberSuffix={}, status={}",
+            businessRegistrationNumber.takeLast(4),
+            response.status,
+        )
+        return response
     }
 
     private fun normalize(raw: String): String = raw.replace(Regex("[^0-9]"), "")

--- a/src/main/kotlin/com/moongchijang/domain/user/application/BusinessRegistrationLookupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/BusinessRegistrationLookupService.kt
@@ -17,11 +17,11 @@ class BusinessRegistrationLookupService(
 
     fun lookup(request: BusinessRegistrationLookupRequest): BusinessRegistrationLookupResponse {
         val businessRegistrationNumber = normalize(request.businessRegistrationNumber)
+        validateBusinessRegistrationNumberFormat(businessRegistrationNumber)
         log.info(
             "[BusinessRegistrationLookupService] 사업자등록 조회 시작: registrationNumberSuffix={}",
             businessRegistrationNumber.takeLast(4),
         )
-        validateBusinessRegistrationNumberFormat(businessRegistrationNumber)
 
         val result = businessRegistrationLookupPort.lookup(businessRegistrationNumber)
 

--- a/src/main/kotlin/com/moongchijang/domain/user/application/BusinessRegistrationLookupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/BusinessRegistrationLookupService.kt
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service
 class BusinessRegistrationLookupService(
     private val businessRegistrationLookupPort: BusinessRegistrationLookupPort,
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
+    private val log = LoggerFactory.getLogger(BusinessRegistrationLookupService::class.java)
 
     fun lookup(request: BusinessRegistrationLookupRequest): BusinessRegistrationLookupResponse {
         val businessRegistrationNumber = normalize(request.businessRegistrationNumber)

--- a/src/main/kotlin/com/moongchijang/global/config/ApiRequestLoggingInterceptor.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/ApiRequestLoggingInterceptor.kt
@@ -1,0 +1,42 @@
+package com.moongchijang.global.config
+
+import com.moongchijang.security.principal.CustomUserPrincipal
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+@Component
+class ApiRequestLoggingInterceptor : HandlerInterceptor {
+    private val log = LoggerFactory.getLogger(ApiRequestLoggingInterceptor::class.java)
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        request.setAttribute(REQUEST_START_TIME_ATTR, System.currentTimeMillis())
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?,
+    ) {
+        val startedAt = request.getAttribute(REQUEST_START_TIME_ATTR) as? Long ?: System.currentTimeMillis()
+        val elapsedMs = System.currentTimeMillis() - startedAt
+        val userId = (request.userPrincipal as? CustomUserPrincipal)?.id
+
+        log.info(
+            "[ApiRequestLoggingInterceptor] method={}, path={}, status={}, elapsedMs={}, userId={}",
+            request.method,
+            request.requestURI,
+            response.status,
+            elapsedMs,
+            userId,
+        )
+    }
+
+    companion object {
+        private const val REQUEST_START_TIME_ATTR = "api.request.startTime"
+    }
+}

--- a/src/main/kotlin/com/moongchijang/global/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/WebMvcConfig.kt
@@ -1,0 +1,20 @@
+package com.moongchijang.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+    private val apiRequestLoggingInterceptor: ApiRequestLoggingInterceptor,
+) : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(apiRequestLoggingInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns(
+                "/health",
+                "/metrics",
+                "/api/live/ws",
+            )
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 서비스 레이어 로그 공백 구간을 보강했습니다.
  - 로그가 없던 주요 서비스에 시작/완료 로그 추가
  - 운영 추적에 필요한 식별자(`userId`, `requestId`, `orderId`, `status`, `page/size`) 중심으로 통일
- 컨트롤러 레이어 로그 공백 구간을 보강했습니다.
  - 주요 API 엔드포인트에 요청 수신/응답 완료 로그 추가
  - 조회/처리 API의 입력 컨텍스트를 로그로 남기도록 정리
- API 공통 요청/응답 로깅을 도입했습니다.
  - `ApiRequestLoggingInterceptor` 추가
  - `/api/**` 대상 공통 로그(`method`, `path`, `status`, `elapsedMs`, `userId`) 기록
  - `/health`, `/metrics`, `/api/live/ws` 제외 처리
- 컨트롤러 중복 로그를 정리했습니다.
  - 컨트롤러별 보일러플레이트 `log.info` 제거
  - 서비스 레이어 중심 로깅 구조로 정리
- 개인정보/민감정보 노출 위험을 줄였습니다.
  - 원문 개인정보 직접 로깅 대신 최소 식별 정보 사용
  - 검색어/사업자번호 등은 길이/suffix 기반으로 기록
- 입력 검증-로그 순서를 보안 관점으로 보강했습니다.
  - `BusinessRegistrationLookupService`에서 사업자등록번호 형식 검증 후 로그 기록하도록 변경

## 🔍 참고 사항
- 이번 변경은 동작 로직을 바꾸지 않고 운영 가시성(Observability) 개선에 초점을 맞춘 로그 보강입니다.
- 로그량은 줄이고(중복 제거), 추적성은 유지하도록(공통 HTTP 로그 + 서비스 핵심 로그) 정리했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #268 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인