### PR TITLE
[MCJ-1565] FEAT: 이미지 key 단일화를 위한 legacy URL 컬럼 제거

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryService.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.favorite.application.dto.WishFilterType
 import com.moongchijang.domain.favorite.application.dto.WishSortType
 import com.moongchijang.domain.favorite.application.dto.WishlistPageResponse
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -13,6 +14,7 @@ import java.time.LocalDateTime
 @Service
 class WishlistQueryService(
     private val favoriteRepository: FavoriteRepository,
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -36,7 +38,12 @@ class WishlistQueryService(
             now = now,
             deadlineTo = now.plusHours(24),
         ).toInt()
-        val response = WishlistPageResponse.from(page, now, urgentCount)
+        val response = WishlistPageResponse.from(
+            page = page,
+            thumbnailUrlResolver = { s3ImageReferenceResolver.resolveForRead(it.thumbnailKey) },
+            now = now,
+            urgentCount = urgentCount,
+        )
 
         log.info(
             "[WishlistQueryService] 찜 목록 조회 완료: userId={}, totalElements={}, totalPages={}, page={}, size={}, urgentCount={}",

--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistItemResponse.kt
@@ -62,7 +62,11 @@ data class WishlistItemResponse(
     val isWishlisted: Boolean,
 ) {
     companion object {
-        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): WishlistItemResponse {
+        fun from(
+            groupBuy: GroupBuy,
+            thumbnailUrl: String?,
+            now: LocalDateTime = LocalDateTime.now()
+        ): WishlistItemResponse {
             val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()
             val achievementRate = GroupBuyProgressCalculator.achievementRate(
                 groupBuy.currentQuantity,
@@ -71,7 +75,7 @@ data class WishlistItemResponse(
 
             return WishlistItemResponse(
                 groupBuyId = groupBuy.id,
-                thumbnailUrl = groupBuy.thumbnailUrl,
+                thumbnailUrl = thumbnailUrl,
                 dDay = dDay,
                 dDayLabel = if (groupBuy.deadline <= now) "마감" else if (dDay == 0) "D-day" else "D-$dDay",
                 storeName = groupBuy.store.name,

--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistPageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistPageResponse.kt
@@ -29,11 +29,12 @@ data class WishlistPageResponse(
     companion object {
         fun from(
             page: Page<GroupBuy>,
+            thumbnailUrlResolver: (GroupBuy) -> String?,
             now: LocalDateTime = LocalDateTime.now(),
             urgentCount: Int,
         ): WishlistPageResponse {
             return WishlistPageResponse(
-                content = page.content.map { WishlistItemResponse.from(it, now) },
+                content = page.content.map { WishlistItemResponse.from(it, thumbnailUrlResolver(it), now) },
                 totalElements = page.totalElements,
                 totalPages = page.totalPages,
                 number = page.number,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
@@ -52,7 +52,6 @@ class AdminGroupBuyRequestActionService(
             GroupBuy(
                 store = store,
                 groupBuyRequest = groupBuyRequest,
-                thumbnailUrl = thumbnail.url,
                 thumbnailKey = thumbnail.key,
                 productName = request.productName.trim(),
                 productDescription = request.productDescription.trim(),
@@ -77,7 +76,6 @@ class AdminGroupBuyRequestActionService(
             images.map {
                 GroupBuyImage(
                     groupBuy = groupBuy,
-                    imageUrl = it.url,
                     imageKey = it.key,
                 )
             }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -16,6 +16,7 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
@@ -29,6 +30,7 @@ class GroupBuyService(
     private val groupBuyImageRepository: GroupBuyImageRepository,
     private val favoriteRepository: FavoriteRepository,
     private val participationRepository: ParticipationRepository,
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver,
     @Value("\${app.share.base-url}") private val shareBaseUrl: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -69,7 +71,12 @@ class GroupBuyService(
         )
 
         return GroupBuyFeedPageResponse.from(
-            resultPage.map { GroupBuyFeedItemResponse.from(it) },
+            resultPage.map {
+                GroupBuyFeedItemResponse.from(
+                    groupBuy = it,
+                    thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.thumbnailKey),
+                )
+            },
             hasRegionalResult = hasRegionalResult
         )
     }
@@ -105,7 +112,9 @@ class GroupBuyService(
 
         return GroupBuyDetailResponse.from(
             groupBuy = groupBuy,
-            images = images,
+            thumbnailUrl = s3ImageReferenceResolver.resolveForRead(groupBuy.thumbnailKey),
+            imageUrls = images.map { s3ImageReferenceResolver.resolveForRead(it.imageKey) ?: "" }
+                .filter { it.isNotBlank() },
             isWishlisted = isWishlisted,
             isParticipated = isParticipated,
             canParticipate = canParticipate
@@ -121,7 +130,8 @@ class GroupBuyService(
 
         val response = ShareMetaResponse.from(
             groupBuy = groupBuy,
-            shareUrl = buildShareUrl(groupBuy.id)
+            shareUrl = buildShareUrl(groupBuy.id),
+            imageUrl = s3ImageReferenceResolver.resolveForRead(groupBuy.thumbnailKey),
         )
 
         log.debug("[GroupBuyService] 공구 공유 메타데이터 조회 완료: groupBuyId={}", groupBuyId)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyDetailResponse.kt
@@ -1,7 +1,6 @@
 package com.moongchijang.domain.groupbuy.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
-import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
 import io.swagger.v3.oas.annotations.media.Schema
@@ -109,7 +108,8 @@ data class GroupBuyDetailResponse(
     companion object {
         fun from(
             groupBuy: GroupBuy,
-            images: List<GroupBuyImage>,
+            thumbnailUrl: String?,
+            imageUrls: List<String>,
             isWishlisted: Boolean,
             isParticipated: Boolean,
             canParticipate: Boolean,
@@ -128,8 +128,8 @@ data class GroupBuyDetailResponse(
                 districtLabel = groupBuy.store.district.label,
                 productName = groupBuy.productName,
                 productDescription = groupBuy.productDescription,
-                thumbnailUrl = groupBuy.thumbnailUrl,
-                imageUrls = images.map { it.imageUrl },
+                thumbnailUrl = thumbnailUrl,
+                imageUrls = imageUrls,
                 price = groupBuy.price,
                 achievementRate = rate,
                 currentQuantity = groupBuy.currentQuantity,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
@@ -62,13 +62,17 @@ data class GroupBuyFeedItemResponse(
     val targetQuantity: Int
 ) {
     companion object {
-        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyFeedItemResponse {
+        fun from(
+            groupBuy: GroupBuy,
+            now: LocalDateTime = LocalDateTime.now(),
+            thumbnailUrl: String?,
+        ): GroupBuyFeedItemResponse {
             val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()
             val rate = GroupBuyProgressCalculator.achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
 
             return GroupBuyFeedItemResponse(
                 id = groupBuy.id,
-                thumbnailUrl = groupBuy.thumbnailUrl,
+                thumbnailUrl = thumbnailUrl,
                 dDay = dDay,
                 dDayLabel = if (dDay == 0) "D-day" else "D-$dDay",
                 storeName = groupBuy.store.name,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/ShareMetaResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/ShareMetaResponse.kt
@@ -39,13 +39,14 @@ data class ShareMetaResponse(
     companion object {
         fun from(
             groupBuy: GroupBuy,
-            shareUrl: String
+            shareUrl: String,
+            imageUrl: String?
         ): ShareMetaResponse {
             return ShareMetaResponse(
                 shareUrl = shareUrl,
                 title = groupBuy.productName,
                 description = groupBuy.productDescription,
-                imageUrl = groupBuy.thumbnailUrl,
+                imageUrl = imageUrl,
                 storeName = groupBuy.store.name,
                 deadline = groupBuy.deadline,
                 pickupDate = groupBuy.pickupDate,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -20,9 +20,6 @@ class GroupBuy(
     var groupBuyRequest: GroupBuyRequest,
 
     @Column(length = 500)
-    var thumbnailUrl: String? = null,
-
-    @Column(length = 500)
     var thumbnailKey: String? = null,
 
     @Column(nullable = false, length = 100)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyImage.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyImage.kt
@@ -11,9 +11,6 @@ class GroupBuyImage(
     @JoinColumn(name = "group_buy_id", nullable = false)
     var groupBuy: GroupBuy,
 
-    @Column(nullable = false, length = 500)
-    var imageUrl: String,
-
     @Column(length = 500)
     var imageKey: String? = null,
 

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -13,6 +13,7 @@ import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,7 +23,8 @@ import org.springframework.transaction.annotation.Transactional
 class MypageService(
     private val participationRepository: ParticipationRepository,
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
-    private val paymentOrderRepository: PaymentOrderRepository
+    private val paymentOrderRepository: PaymentOrderRepository,
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver,
 ) {
     private val log = LoggerFactory.getLogger(MypageService::class.java)
 
@@ -66,6 +68,7 @@ class MypageService(
         val responses = participations.map {
             MypageRefundResponse.from(
                 participation = it,
+                thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.groupBuy.thumbnailKey),
                 paymentInfo = paymentInfoByParticipationId[it.id]
             )
         }
@@ -104,6 +107,7 @@ class MypageService(
         return participations.map {
             MypageParticipationResponse.from(
                 participation = it,
+                thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.groupBuy.thumbnailKey),
                 approvedPaymentGroupBuyIds = cancellableGroupBuyIds,
                 paymentInfo = paymentInfoByParticipationId[it.id]
             )
@@ -147,6 +151,7 @@ class MypageService(
         return participations.map {
             MypageParticipationResponse.from(
                 participation = it,
+                thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.groupBuy.thumbnailKey),
                 paymentInfo = paymentInfoByParticipationId[it.id]
             )
         }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -37,13 +37,14 @@ data class MypageRefundResponse(
     companion object {
         fun from(
             participation: Participation,
+            thumbnailUrl: String?,
             paymentInfo: MypageParticipationPaymentInfo? = null
         ): MypageRefundResponse {
             val groupBuy = participation.groupBuy
 
             return MypageRefundResponse(
                 participationId = participation.id,
-                thumbnailUrl = groupBuy.thumbnailUrl,
+                thumbnailUrl = thumbnailUrl,
                 productName = groupBuy.productName,
                 refundStatus = refundStatus(participation),
                 storeName = groupBuy.store.name,
@@ -97,6 +98,7 @@ data class MypageParticipationResponse(
     companion object {
         fun from(
             participation: Participation,
+            thumbnailUrl: String?,
             approvedPaymentGroupBuyIds: Set<Long> = emptySet(),
             paymentInfo: MypageParticipationPaymentInfo? = null
         ): MypageParticipationResponse {
@@ -107,7 +109,7 @@ data class MypageParticipationResponse(
             return MypageParticipationResponse(
                 participationId = participation.id,
                 groupBuyId = groupBuy.id,
-                thumbnailUrl = groupBuy.thumbnailUrl,
+                thumbnailUrl = thumbnailUrl,
                 productName = groupBuy.productName,
                 participationStatus = participation.status.name,
                 achievementRate = achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity),

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -79,11 +79,19 @@ class OwnerGroupBuyRequestService(
         }
 
         val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
+        val thumbnailUrl = s3ImageReferenceResolver.resolveForRead(request.thumbnailKey).also {
+            if (it.isNullOrBlank()) {
+                log.warn(
+                    "[OwnerGroupBuyRequestService] 요청공구 썸네일 key 누락: ownerId={}, requestId={}",
+                    ownerId,
+                    requestId,
+                )
+            }
+        }.orEmpty()
         val response = OwnerGroupBuyRequestDetailResponse.from(
             request = request,
             images = images,
-            thumbnailUrl = s3ImageReferenceResolver.resolveForRead(request.thumbnailKey)
-                ?: throw CustomException(ErrorCode.INVALID_INPUT, "요청공구 썸네일 이미지 key가 존재하지 않습니다."),
+            thumbnailUrl = thumbnailUrl,
             imageUrls = images.mapNotNull { s3ImageReferenceResolver.resolveForRead(it.imageKey) },
         )
         log.info("[OwnerGroupBuyRequestService] 사장님 요청공구 상세 조회 완료: ownerId={}, requestId={}", ownerId, requestId)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -82,9 +82,9 @@ class OwnerGroupBuyRequestService(
         val response = OwnerGroupBuyRequestDetailResponse.from(
             request = request,
             images = images,
-            thumbnailUrl = s3ImageReferenceResolver.resolveForRead(request.thumbnailKey, null)
+            thumbnailUrl = s3ImageReferenceResolver.resolveForRead(request.thumbnailKey)
                 ?: throw CustomException(ErrorCode.INVALID_INPUT, "요청공구 썸네일 이미지 key가 존재하지 않습니다."),
-            imageUrls = images.mapNotNull { s3ImageReferenceResolver.resolveForRead(it.imageKey, null) },
+            imageUrls = images.mapNotNull { s3ImageReferenceResolver.resolveForRead(it.imageKey) },
         )
         log.info("[OwnerGroupBuyRequestService] 사장님 요청공구 상세 조회 완료: ownerId={}, requestId={}", ownerId, requestId)
         return response

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -79,7 +79,13 @@ class OwnerGroupBuyRequestService(
         }
 
         val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
-        val response = OwnerGroupBuyRequestDetailResponse.from(request, images)
+        val response = OwnerGroupBuyRequestDetailResponse.from(
+            request = request,
+            images = images,
+            thumbnailUrl = s3ImageReferenceResolver.resolveForRead(request.thumbnailKey, null)
+                ?: throw CustomException(ErrorCode.INVALID_INPUT, "요청공구 썸네일 이미지 key가 존재하지 않습니다."),
+            imageUrls = images.mapNotNull { s3ImageReferenceResolver.resolveForRead(it.imageKey, null) },
+        )
         log.info("[OwnerGroupBuyRequestService] 사장님 요청공구 상세 조회 완료: ownerId={}, requestId={}", ownerId, requestId)
         return response
     }
@@ -110,7 +116,6 @@ class OwnerGroupBuyRequestService(
                 targetQuantity = request.targetQuantity,
                 maxQuantity = request.maxQuantity,
                 perUserLimit = request.perUserLimit,
-                thumbnailUrl = thumbnail.url,
                 thumbnailKey = thumbnail.key,
                 deadline = request.deadline,
                 pickupDate = request.pickupDate,
@@ -126,7 +131,6 @@ class OwnerGroupBuyRequestService(
             imageReferences.mapIndexed { index, imageReference ->
                 OwnerGroupBuyRequestImage(
                     request = saved,
-                    imageUrl = imageReference.url,
                     imageKey = imageReference.key,
                     sortOrder = index
                 )

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestQueryResponses.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyRequestQueryResponses.kt
@@ -86,7 +86,9 @@ data class OwnerGroupBuyRequestDetailResponse(
     companion object {
         fun from(
             request: OwnerGroupBuyRequest,
-            images: List<OwnerGroupBuyRequestImage>
+            images: List<OwnerGroupBuyRequestImage>,
+            thumbnailUrl: String,
+            imageUrls: List<String>,
         ): OwnerGroupBuyRequestDetailResponse =
             OwnerGroupBuyRequestDetailResponse(
                 requestId = request.id,
@@ -99,8 +101,8 @@ data class OwnerGroupBuyRequestDetailResponse(
                 targetQuantity = request.targetQuantity,
                 maxQuantity = request.maxQuantity,
                 perUserLimit = request.perUserLimit,
-                thumbnailUrl = request.thumbnailUrl,
-                imageUrls = images.map { it.imageUrl },
+                thumbnailUrl = thumbnailUrl,
+                imageUrls = imageUrls,
                 deadline = request.deadline,
                 pickupDate = request.pickupDate,
                 pickupTimeStart = request.pickupTimeStart,

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequest.kt
@@ -61,9 +61,6 @@ class OwnerGroupBuyRequest(
     @Column(name = "per_user_limit")
     var perUserLimit: Int? = null,
 
-    @Column(name = "thumbnail_url", nullable = false, length = 500)
-    var thumbnailUrl: String,
-
     @Column(name = "thumbnail_key", length = 500)
     var thumbnailKey: String? = null,
 

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequestImage.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/entity/OwnerGroupBuyRequestImage.kt
@@ -32,9 +32,6 @@ class OwnerGroupBuyRequestImage(
     @JoinColumn(name = "request_id", nullable = false)
     var request: OwnerGroupBuyRequest,
 
-    @Column(name = "image_url", nullable = false, length = 500)
-    var imageUrl: String,
-
     @Column(name = "image_key", length = 500)
     var imageKey: String? = null,
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -32,6 +32,7 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -57,6 +58,7 @@ class PaymentService(
     private val redisLockUtil: RedisLockUtil,
     private val notificationEventPublisher: NotificationEventPublisher,
     private val refundRequestSyncService: RefundRequestSyncService,
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -75,7 +77,7 @@ class PaymentService(
             groupBuyId = groupBuy.id,
             storeName = groupBuy.store.name,
             productName = groupBuy.productName,
-            thumbnailUrl = groupBuy.thumbnailUrl,
+            thumbnailUrl = s3ImageReferenceResolver.resolveForRead(groupBuy.thumbnailKey),
             pickupDate = groupBuy.pickupDate,
             pickupTimeStart = groupBuy.pickupTimeStart,
             pickupTimeEnd = groupBuy.pickupTimeEnd,

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -16,6 +16,7 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,6 +31,7 @@ class PickupService(
     private val participationRepository: ParticipationRepository,
     private val userRepository: UserRepository,
     private val storeStaffRepository: StoreStaffRepository,
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver,
 ) {
     private val log = LoggerFactory.getLogger(PickupService::class.java)
 
@@ -50,7 +52,7 @@ class PickupService(
             latitude = store.latitude,
             longitude = store.longitude,
             transitInfo = null,
-            thumbnailUrl = groupBuy.thumbnailUrl,
+            thumbnailUrl = s3ImageReferenceResolver.resolveForRead(groupBuy.thumbnailKey),
             productName = groupBuy.productName,
             quantity = participation.quantity,
             pickupDate = groupBuy.pickupDate,

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -7,6 +7,7 @@ import com.moongchijang.domain.groupbuy.infrastructure.search.FullTextQueryBuild
 import com.moongchijang.domain.search.application.dto.SearchCase
 import com.moongchijang.domain.search.application.dto.SearchResponse
 import com.moongchijang.domain.search.domain.SearchUiState
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -17,6 +18,7 @@ import java.time.LocalDateTime
 @Component
 class FullTextSearchEngine(
     private val groupBuyRepository: GroupBuyRepository,
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver,
 ) {
     companion object {
         private const val DEFAULT_LIMIT = 50
@@ -50,7 +52,13 @@ class FullTextSearchEngine(
             confidence = 0.0,
             uiState = SearchUiState.RESULTS,
             totalCount = matches.size,
-            results = matches.map { GroupBuyFeedItemResponse.from(it, now) },
+            results = matches.map {
+                GroupBuyFeedItemResponse.from(
+                    groupBuy = it,
+                    thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.thumbnailKey),
+                    now = now,
+                )
+            },
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/global/util/S3ImageReferenceResolver.kt
+++ b/src/main/kotlin/com/moongchijang/global/util/S3ImageReferenceResolver.kt
@@ -8,6 +8,22 @@ import java.net.URI
 class S3ImageReferenceResolver(
     private val appS3Properties: AppS3Properties,
 ) {
+    fun resolveForRead(key: String?): String? = resolveForRead(key, null)
+
+    fun resolveForRead(key: String?, url: String?): String? {
+        val normalizedKey = key?.trim()?.removePrefix("/")?.takeIf { it.isNotBlank() }
+        if (normalizedKey != null) {
+            return buildPublicUrl(normalizedKey)
+        }
+
+        val normalizedUrl = url?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        return if (normalizedUrl.startsWith("http://") || normalizedUrl.startsWith("https://")) {
+            normalizedUrl
+        } else {
+            buildPublicUrl(normalizedUrl.removePrefix("/"))
+        }
+    }
+
     fun resolve(raw: String): ResolvedImageReference {
         val normalized = raw.trim()
         if (normalized.isBlank()) {

--- a/src/main/resources/db/migration/V41__drop_legacy_image_url_columns.sql
+++ b/src/main/resources/db/migration/V41__drop_legacy_image_url_columns.sql
@@ -1,0 +1,13 @@
+-- key 기반 이미지 저장 단일화를 위해 URL 컬럼을 제거한다.
+
+ALTER TABLE group_buys
+    DROP COLUMN thumbnail_url;
+
+ALTER TABLE group_buy_images
+    DROP COLUMN image_url;
+
+ALTER TABLE owner_group_buy_requests
+    DROP COLUMN thumbnail_url;
+
+ALTER TABLE owner_group_buy_request_images
+    DROP COLUMN image_url;

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2352,7 +2352,7 @@ paths:
         사장님이 본인 매장에 대한 공구 개설 요청을 제출한다.
         - SELLER 권한만 요청할 수 있다.
         - storeId는 요청자에게 연결된 매장이어야 한다.
-        - imageUrls의 첫 번째 이미지를 대표 이미지(thumbnailUrl)로 저장한다.
+        - imageUrls의 첫 번째 key를 대표 이미지(thumbnailKey)로 저장한다.
         - 희망 공구 기간은 현재 시각 기준 최소 7일 이상이어야 한다.
       security:
         - bearerAuth: []
@@ -5106,12 +5106,12 @@ components:
           type: array
           minItems: 1
           maxItems: 5
-          description: 상품 이미지 URL 목록. 첫 번째 이미지를 대표 이미지로 사용한다.
+          description: 상품 이미지 S3 key 목록. 첫 번째 key를 대표 이미지로 사용한다.
           items:
             type: string
           example:
-            - https://cdn.example.com/owner-requests/1.jpg
-            - https://cdn.example.com/owner-requests/2.jpg
+            - dev/group-buys/pending/7/20260529/products/owner-requests-1.jpg
+            - dev/group-buys/pending/7/20260529/products/owner-requests-2.jpg
         pickupDate:
           type: string
           format: date
@@ -5870,6 +5870,7 @@ components:
           type: array
           minItems: 1
           maxItems: 5
+          description: 상품 이미지 S3 key 목록
           items:
             type: string
         recruitmentStartAt: { type: string, format: date-time }

--- a/src/test/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryServiceTest.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.favorite.application.dto.WishSortType
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -25,7 +26,10 @@ class WishlistQueryServiceTest {
     @Mock
     private lateinit var favoriteRepository: FavoriteRepository
 
-    private val service by lazy { WishlistQueryService(favoriteRepository) }
+    @Mock
+    private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
+
+    private val service by lazy { WishlistQueryService(favoriteRepository, s3ImageReferenceResolver) }
 
     @Test
     fun `찜 목록 조회 요청 시 페이지 결과 반환`() {

--- a/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
@@ -96,7 +96,7 @@ class FavoriteRepositoryImplIntegrationTest {
         val groupBuy = GroupBuy(
             store = store,
             groupBuyRequest = request,
-            thumbnailUrl = "https://example.com/test.jpg",
+            thumbnailKey = "https://example.com/test.jpg",
             productName = "테스트 상품",
             productDescription = "설명",
             price = 10000,

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
@@ -21,7 +21,7 @@ class GroupBuyFeedItemResponseTest {
             deadline = LocalDateTime.of(2026, 5, 21, 6, 4, 50)
         )
 
-        val response = GroupBuyFeedItemResponse.from(groupBuy, now)
+        val response = GroupBuyFeedItemResponse.from(groupBuy, now, "https://example.com/image.jpg")
 
         assertEquals(1, response.dDay)
         assertEquals("D-1", response.dDayLabel)
@@ -34,7 +34,7 @@ class GroupBuyFeedItemResponseTest {
             deadline = LocalDateTime.of(2026, 5, 20, 23, 59, 59)
         )
 
-        val response = GroupBuyFeedItemResponse.from(groupBuy, now)
+        val response = GroupBuyFeedItemResponse.from(groupBuy, now, "https://example.com/image.jpg")
 
         assertEquals(0, response.dDay)
         assertEquals("D-day", response.dDayLabel)
@@ -59,7 +59,7 @@ class GroupBuyFeedItemResponseTest {
         return GroupBuy(
             store = store,
             groupBuyRequest = request,
-            thumbnailUrl = "https://example.com/image.jpg",
+            thumbnailKey = "dev/group-buys/test/thumbnail/image.jpg",
             productName = "버터바 4종 세트",
             productDescription = "설명",
             price = 1000,

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
@@ -248,7 +248,7 @@ class GroupBuyRepositoryImplIntegrationTest {
         val groupBuy = GroupBuy(
             store = store,
             groupBuyRequest = request,
-            thumbnailUrl = "https://example.com/$productName.jpg",
+            thumbnailKey = "https://example.com/$productName.jpg",
             productName = productName,
             productDescription = "설명",
             price = 10000,

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/AdminGroupBuyRequestActionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/AdminGroupBuyRequestActionServiceTest.kt
@@ -113,7 +113,6 @@ class AdminGroupBuyRequestActionServiceTest {
         assertEquals(20, groupBuyCaptor.value.targetQuantity)
         assertEquals(50, groupBuyCaptor.value.maxQuantity)
         assertEquals(2, groupBuyCaptor.value.perUserLimit)
-        assertEquals("https://cdn.example.com/1.jpg", groupBuyCaptor.value.thumbnailUrl)
         assertEquals("exhibition/1.jpg", groupBuyCaptor.value.thumbnailKey)
         assertEquals("01012345678", groupBuyCaptor.value.pickupContact)
         assertEquals(approveRequest.recruitmentStartAt, groupBuyCaptor.value.recruitmentStartAt)

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -10,6 +10,7 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -46,6 +47,9 @@ class GroupBuyServiceTest {
     @Mock
     private lateinit var participationRepository: ParticipationRepository
 
+    @Mock
+    private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
+
     private lateinit var service: GroupBuyService
 
     @BeforeEach
@@ -55,6 +59,7 @@ class GroupBuyServiceTest {
             groupBuyImageRepository = groupBuyImageRepository,
             favoriteRepository = favoriteRepository,
             participationRepository = participationRepository,
+            s3ImageReferenceResolver = s3ImageReferenceResolver,
             shareBaseUrl = "https://moongchijang.com"
         )
     }
@@ -324,7 +329,7 @@ class GroupBuyServiceTest {
             status = GroupBuyStatus.IN_PROGRESS,
             productName = "두쭌쿠 오리지널 1개"
         ).apply {
-            thumbnailUrl = "https://cdn.moongchijang.com/group-buys/101/thumbnail.jpg"
+            thumbnailKey = "https://cdn.moongchijang.com/group-buys/101/thumbnail.jpg"
             productDescription = "지금 함께 주문하고 픽업해요."
             pickupDate = LocalDate.of(2026, 5, 15)
             pickupTimeStart = LocalTime.of(14, 0)

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito.anyString
 import org.mockito.Mockito.never
+import org.mockito.Mockito.lenient
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -54,6 +56,7 @@ class GroupBuyServiceTest {
 
     @BeforeEach
     fun setUp() {
+        lenient().`when`(s3ImageReferenceResolver.resolveForRead(anyString())).thenAnswer { it.arguments[0] as String? }
         service = GroupBuyService(
             groupBuyRepository = groupBuyRepository,
             groupBuyImageRepository = groupBuyImageRepository,

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -376,7 +376,7 @@ class MypageServiceTest {
         val groupBuy = com.moongchijang.domain.groupbuy.domain.entity.GroupBuy(
             store = store,
             groupBuyRequest = groupBuyRequest,
-            thumbnailUrl = "https://example.com/cake.jpg",
+            thumbnailKey = "https://example.com/cake.jpg",
             productName = "초코 케이크",
             productDescription = "진한 초코 케이크",
             price = 12_000,

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -18,11 +18,14 @@ import com.moongchijang.domain.store.domain.entity.Store
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.lenient
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -43,8 +46,16 @@ class MypageServiceTest {
     @Mock
     private lateinit var paymentOrderRepository: PaymentOrderRepository
 
+    @Mock
+    private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
+
     @InjectMocks
     private lateinit var mypageService: MypageService
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        lenient().`when`(s3ImageReferenceResolver.resolveForRead(anyString())).thenAnswer { it.arguments[0] as String? }
+    }
 
     @Test
     fun `summary는 Figma 마이페이지 탭 기준 count를 반환한다`() {

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
@@ -103,7 +103,6 @@ class OwnerGroupBuyRequestServiceTest {
         assertEquals(owner, requestCaptor.value.owner)
         assertEquals(store, requestCaptor.value.store)
         assertEquals("두쫀쿠 세트", requestCaptor.value.productName)
-        assertEquals("https://cdn.example.com/1.jpg", requestCaptor.value.thumbnailUrl)
         assertEquals("1.jpg", requestCaptor.value.thumbnailKey)
 
         val imageCaptor = argumentCaptor<Iterable<OwnerGroupBuyRequestImage>>()
@@ -111,7 +110,6 @@ class OwnerGroupBuyRequestServiceTest {
         val images = imageCaptor.value.toList()
         assertEquals(2, images.size)
         assertEquals(listOf(0, 1), images.map { it.sortOrder })
-        assertEquals(listOf("https://cdn.example.com/1.jpg", "https://cdn.example.com/2.jpg"), images.map { it.imageUrl })
         assertEquals(listOf("1.jpg", "2.jpg"), images.map { it.imageKey })
         assertTrue(images.all { it.request.id == 101L })
     }
@@ -171,8 +169,8 @@ class OwnerGroupBuyRequestServiceTest {
         val owner = seller()
         val request = ownerRequest(owner = owner).apply { id = 101L }
         val images = listOf(
-            OwnerGroupBuyRequestImage(request = request, imageUrl = "https://cdn.example.com/1.jpg", sortOrder = 0),
-            OwnerGroupBuyRequestImage(request = request, imageUrl = "https://cdn.example.com/2.jpg", sortOrder = 1)
+            OwnerGroupBuyRequestImage(request = request, imageKey = "1.jpg", sortOrder = 0),
+            OwnerGroupBuyRequestImage(request = request, imageKey = "2.jpg", sortOrder = 1)
         )
 
         `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
@@ -312,7 +310,7 @@ class OwnerGroupBuyRequestServiceTest {
         targetQuantity = 20,
         maxQuantity = 50,
         perUserLimit = 2,
-        thumbnailUrl = "https://cdn.example.com/1.jpg",
+        thumbnailKey = "https://cdn.example.com/1.jpg",
         deadline = FIXED_NOW.plusDays(8),
         pickupDate = FIXED_NOW.toLocalDate().plusDays(9),
         pickupTimeStart = LocalTime.of(12, 0),

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito.any
+import org.mockito.Mockito.anyString
 import org.mockito.Mockito.lenient
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -78,6 +79,9 @@ class OwnerGroupBuyRequestServiceTest {
             .thenReturn(S3ImageReferenceResolver.ResolvedImageReference("1.jpg", "https://cdn.example.com/1.jpg"))
         lenient().`when`(s3ImageReferenceResolver.resolve("https://cdn.example.com/2.jpg"))
             .thenReturn(S3ImageReferenceResolver.ResolvedImageReference("2.jpg", "https://cdn.example.com/2.jpg"))
+        lenient().`when`(s3ImageReferenceResolver.resolveForRead(anyString())).thenAnswer { key ->
+            "https://cdn.example.com/${key.arguments[0] as String}"
+        }
     }
 
     @Test
@@ -310,7 +314,7 @@ class OwnerGroupBuyRequestServiceTest {
         targetQuantity = 20,
         maxQuantity = 50,
         perUserLimit = 2,
-        thumbnailKey = "https://cdn.example.com/1.jpg",
+        thumbnailKey = "1.jpg",
         deadline = FIXED_NOW.plusDays(8),
         pickupDate = FIXED_NOW.toLocalDate().plusDays(9),
         pickupTimeStart = LocalTime.of(12, 0),

--- a/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
@@ -90,7 +90,7 @@ class ParticipationAuditingIntegrationTest {
         val groupBuy = GroupBuy(
             store = store,
             groupBuyRequest = request,
-            thumbnailUrl = "https://example.com/image.jpg",
+            thumbnailKey = "https://example.com/image.jpg",
             productName = "테스트 상품",
             productDescription = "설명",
             price = 1000,

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -32,6 +32,7 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -96,6 +97,9 @@ class PaymentServiceTest {
     @Mock
     private lateinit var refundRequestSyncService: RefundRequestSyncService
 
+    @Mock
+    private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
+
     private val portOneProperties = PortOneProperties(
         storeId = "store-test",
         channelKey = "channel-test",
@@ -115,7 +119,8 @@ class PaymentServiceTest {
             transactionManager = transactionManager,
             redisLockUtil = redisLockUtil,
             notificationEventPublisher = notificationEventPublisher,
-            refundRequestSyncService = refundRequestSyncService
+            refundRequestSyncService = refundRequestSyncService,
+            s3ImageReferenceResolver = s3ImageReferenceResolver
         )
     }
 
@@ -968,7 +973,7 @@ class PaymentServiceTest {
         return GroupBuy(
             store = createStore(),
             groupBuyRequest = createGroupBuyRequest(),
-            thumbnailUrl = "https://example.com/image.jpg",
+            thumbnailKey = "https://example.com/image.jpg",
             productName = "두쫀쿠",
             productDescription = "설명",
             price = price,

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -23,12 +23,14 @@ import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.Mockito.never
+import org.mockito.Mockito.lenient
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
@@ -59,6 +61,11 @@ class PickupServiceTest {
             storeStaffRepository = storeStaffRepository,
             s3ImageReferenceResolver = s3ImageReferenceResolver,
         )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        lenient().`when`(s3ImageReferenceResolver.resolveForRead(anyString())).thenAnswer { it.arguments[0] as String? }
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -18,6 +18,7 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -48,11 +49,15 @@ class PickupServiceTest {
     @Mock
     private lateinit var storeStaffRepository: StoreStaffRepository
 
+    @Mock
+    private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
+
     private val service: PickupService by lazy {
         PickupService(
             participationRepository = participationRepository,
             userRepository = userRepository,
             storeStaffRepository = storeStaffRepository,
+            s3ImageReferenceResolver = s3ImageReferenceResolver,
         )
     }
 
@@ -421,7 +426,7 @@ class PickupServiceTest {
         GroupBuy(
             store = store,
             groupBuyRequest = createGroupBuyRequest(pickupDate),
-            thumbnailUrl = "https://example.com/image.jpg",
+            thumbnailKey = "https://example.com/image.jpg",
             productName = "두쫀쿠",
             productDescription = "설명",
             price = 6000,

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.search.application.dto.SearchCase
 import com.moongchijang.domain.search.domain.SearchUiState
+import com.moongchijang.global.util.S3ImageReferenceResolver
 import com.moongchijang.support.search.MockitoKotlinMatchers.anyLocalDateTime
 import com.moongchijang.support.search.MockitoKotlinMatchers.anyLongList
 import com.moongchijang.support.search.SearchTestFixtures
@@ -17,7 +18,8 @@ import org.mockito.Mockito
 class FullTextSearchEngineTest {
 
     private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
-    private val engine = FullTextSearchEngine(groupBuyRepository)
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver = Mockito.mock(S3ImageReferenceResolver::class.java)
+    private val engine = FullTextSearchEngine(groupBuyRepository, s3ImageReferenceResolver)
 
     private fun stubIds(ids: List<Long>) {
         Mockito.`when`(

--- a/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
@@ -26,7 +26,7 @@ object GroupBuyFixture {
         return GroupBuy(
             store = createStore(),
             groupBuyRequest = createGroupBuyRequest(productName = productName, desiredQuantity = targetQuantity),
-            thumbnailUrl = "https://example.jpg",
+            thumbnailKey = "dev/group-buys/test/thumbnail/example.jpg",
             productName = productName,
             productDescription = "설명",
             price = price,
@@ -79,10 +79,10 @@ object GroupBuyFixture {
         ).apply { id = 20L }
     }
 
-    fun createImage(groupBuy: GroupBuy, imageUrl: String): GroupBuyImage {
+    fun createImage(groupBuy: GroupBuy, imageKey: String): GroupBuyImage {
         return GroupBuyImage(
             groupBuy = groupBuy,
-            imageUrl = imageUrl
+            imageKey = imageKey
         )
     }
 }

--- a/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
@@ -42,7 +42,7 @@ object SearchTestFixtures {
     ): GroupBuy = GroupBuy(
         store = store,
         groupBuyRequest = groupBuyRequest(),
-        thumbnailUrl = "https://example.jpg",
+        thumbnailKey = "dev/group-buys/test/thumbnail/example.jpg",
         productName = productName,
         productDescription = "설명",
         price = 6000,


### PR DESCRIPTION
## 📌 작업한 내용
- 이미지 스키마 최종 정리를 위해 `V41` 마이그레이션을 추가했습니다.
  - legacy URL 컬럼 제거
  - 대상: `group_buys.thumbnail_url`, `group_buy_images.image_url`, `owner_group_buy_requests.thumbnail_url`, `owner_group_buy_request_images.image_url`
- key 기반 단일화 이후 테스트/조회 로직 정합성을 점검하고 깨진 테스트를 보정했습니다.
  - URL 컬럼 제거 이후에도 key 기반 조회/응답이 정상 동작하도록 테스트 픽스처/검증 코드 정리

## 🔍 참고 사항
- `V39(키 컬럼 추가)`, `V40(URL→key 백필)`이 선행 적용된 상태에서 `V41`이 적용되어야 합니다.
- 이번 PR의 핵심 변경은 **legacy URL 컬럼 제거 완료**이며, 업로드/삭제 API 자체는 이전 작업 범위입니다.
- 운영 반영 시 Flyway 순서대로 적용되며, 배포 전 DB 백업 포인트를 확보한 상태에서 진행하는 것을 권장합니다.
 
## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #273 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인- [ ] 