### PR TITLE
[MCJ-1570] FIX: 비로그인 검색 허용 및 합성어 매칭 정확도 보강

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
@@ -17,29 +17,30 @@ object FullTextQueryBuilder {
     private const val NGRAM_TOKEN_SIZE = 2
 
     /**
-     * 1차 strict 쿼리.
-     * 토큰별 prefix wildcard(`*`)와 필수(`+`) 연산자를 붙여 모든 토큰이 매칭되는 AND 의미를 만든다.
+     * 1차 strict 쿼리와 2차 fallback 쿼리를 한 번의 sanitize 로 동시에 생성한다.
+     *
+     * - strict: 모든 토큰에 `+token*` 를 붙여 AND 의미로 결합.
+     * - fallback: `+` 제거한 OR 결합. 단일 토큰이 ngram_token_size 를 초과하면 2글자 ngram 으로 분해.
+     * - 토큰이 하나도 남지 않으면 두 쿼리 모두 빈 문자열을 반환한다.
+     *   호출 측은 strict 가 빈 문자열이면 fallback 도 빈 문자열임을 가정할 수 있다.
      */
-    fun toBooleanQuery(rawQuery: String): String {
+    fun buildQueries(rawQuery: String): Pair<String, String> {
         val tokens = sanitize(rawQuery)
-        return tokens.joinToString(" ") { "+$it*" }
+        if (tokens.isEmpty()) return "" to ""
+        val strict = tokens.joinToString(" ") { "+$it*" }
+        val fallback = if (tokens.size == 1 && tokens[0].length > NGRAM_TOKEN_SIZE) {
+            decomposeToNgrams(tokens[0]).joinToString(" ")
+        } else {
+            tokens.joinToString(" ")
+        }
+        return strict to fallback
     }
 
-    /**
-     * 2차 fallback 쿼리. 1차에서 0건일 때 사용한다.
-     *
-     * - `+` 연산자를 제거해 OR 의미로 결합한다. 토큰 중 일부만 포함된 문서도 매치된다.
-     * - 단일 토큰이고 길이가 ngram_token_size 를 초과하면 2글자 ngram 으로 분해해 결합한다.
-     *   예: "카레소시지" → "카레 레소 소시 시지". 합성어 한 덩어리 입력에서도 부분 매칭이 가능해진다.
-     */
-    fun toFallbackQuery(rawQuery: String): String {
-        val tokens = sanitize(rawQuery)
-        if (tokens.isEmpty()) return ""
-        if (tokens.size == 1 && tokens[0].length > NGRAM_TOKEN_SIZE) {
-            return decomposeToNgrams(tokens[0]).joinToString(" ")
-        }
-        return tokens.joinToString(" ")
-    }
+    /** 1차 strict 쿼리 단독 호출용 wrapper. */
+    fun toBooleanQuery(rawQuery: String): String = buildQueries(rawQuery).first
+
+    /** 2차 fallback 쿼리 단독 호출용 wrapper. */
+    fun toFallbackQuery(rawQuery: String): String = buildQueries(rawQuery).second
 
     private fun sanitize(rawQuery: String): List<String> {
         return rawQuery

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
@@ -4,8 +4,8 @@ package com.moongchijang.domain.groupbuy.infrastructure.search
  * 사용자 검색어를 MySQL FULLTEXT BOOLEAN MODE 쿼리 문자열로 변환한다.
  *
  * - BOOLEAN MODE 연산자 문자(+, -, >, <, (, ), ~, *, ", @, \)는 사용자 입력에서 제거한다.
- * - 토큰별 prefix wildcard(`*`)와 필수(`+`) 연산자를 붙여 모든 토큰이 매칭되는 AND 의미를 만든다.
  * - ngram_token_size(기본 2) 미만의 한 글자 토큰은 매칭되지 않으므로 제외한다.
+ * - 1차 strict([toBooleanQuery]) 와 2차 fallback([toFallbackQuery]) 두 단계 쿼리를 제공한다.
  *
  * 모든 토큰이 제거되면 빈 문자열을 반환한다. 호출 측에서 빈 문자열이면 검색을 스킵해야 한다.
  */
@@ -14,13 +14,42 @@ object FullTextQueryBuilder {
     private val FORBIDDEN_CHARS = Regex("""[+\-><()~*"@\\]""")
     private val WHITESPACE = Regex("""\s+""")
     private const val MIN_TOKEN_LENGTH = 2
+    private const val NGRAM_TOKEN_SIZE = 2
 
+    /**
+     * 1차 strict 쿼리.
+     * 토큰별 prefix wildcard(`*`)와 필수(`+`) 연산자를 붙여 모든 토큰이 매칭되는 AND 의미를 만든다.
+     */
     fun toBooleanQuery(rawQuery: String): String {
-        val tokens = rawQuery
+        val tokens = sanitize(rawQuery)
+        return tokens.joinToString(" ") { "+$it*" }
+    }
+
+    /**
+     * 2차 fallback 쿼리. 1차에서 0건일 때 사용한다.
+     *
+     * - `+` 연산자를 제거해 OR 의미로 결합한다. 토큰 중 일부만 포함된 문서도 매치된다.
+     * - 단일 토큰이고 길이가 ngram_token_size 를 초과하면 2글자 ngram 으로 분해해 결합한다.
+     *   예: "카레소시지" → "카레 레소 소시 시지". 합성어 한 덩어리 입력에서도 부분 매칭이 가능해진다.
+     */
+    fun toFallbackQuery(rawQuery: String): String {
+        val tokens = sanitize(rawQuery)
+        if (tokens.isEmpty()) return ""
+        if (tokens.size == 1 && tokens[0].length > NGRAM_TOKEN_SIZE) {
+            return decomposeToNgrams(tokens[0]).joinToString(" ")
+        }
+        return tokens.joinToString(" ")
+    }
+
+    private fun sanitize(rawQuery: String): List<String> {
+        return rawQuery
             .replace(FORBIDDEN_CHARS, " ")
             .trim()
             .split(WHITESPACE)
             .filter { it.length >= MIN_TOKEN_LENGTH }
-        return tokens.joinToString(" ") { "+$it*" }
+    }
+
+    private fun decomposeToNgrams(token: String): List<String> {
+        return (0..token.length - NGRAM_TOKEN_SIZE).map { token.substring(it, it + NGRAM_TOKEN_SIZE) }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -29,13 +29,13 @@ class FullTextSearchEngine(
     fun search(query: String): SearchResponse {
         val now = LocalDateTime.now()
 
-        val strictQuery = FullTextQueryBuilder.toBooleanQuery(query)
-        val strictIds = if (strictQuery.isEmpty()) emptyList() else searchIds(strictQuery, now)
-
-        val ids = strictIds.ifEmpty {
-            val fallbackQuery = FullTextQueryBuilder.toFallbackQuery(query)
-            if (fallbackQuery.isEmpty()) emptyList() else searchIds(fallbackQuery, now)
+        val (strictQuery, fallbackQuery) = FullTextQueryBuilder.buildQueries(query)
+        if (strictQuery.isEmpty()) {
+            return emptyResponse()
         }
+
+        val strictIds = searchIds(strictQuery, now)
+        val ids = strictIds.ifEmpty { searchIds(fallbackQuery, now) }
 
         if (ids.isEmpty()) {
             return emptyResponse()

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -12,7 +12,11 @@ import java.time.LocalDateTime
 
 /**
  * ngram FULLTEXT 인덱스 기반 검색 엔진.
- * BOOLEAN MODE 쿼리로 변환한 토큰이 하나도 없으면 검색을 스킵한다.
+ *
+ * 1차: strict AND 쿼리(`+token*`)로 정확 매칭 우선.
+ * 2차: 1차에서 0건이면 fallback OR 쿼리로 재조회. 합성어/부분 매칭 케이스를 잡는다.
+ *
+ * 1·2차 모두 0건이거나 사용자 입력이 빈 토큰뿐이면 [emptyResponse] 를 반환한다.
  */
 @Component
 class FullTextSearchEngine(
@@ -23,18 +27,16 @@ class FullTextSearchEngine(
     }
 
     fun search(query: String): SearchResponse {
-        val booleanQuery = FullTextQueryBuilder.toBooleanQuery(query)
-        if (booleanQuery.isEmpty()) {
-            return emptyResponse()
-        }
         val now = LocalDateTime.now()
 
-        val ids = groupBuyRepository.searchIdsByFullText(
-            query = booleanQuery,
-            status = GroupBuyStatus.IN_PROGRESS.name,
-            now = now,
-            limit = DEFAULT_LIMIT,
-        )
+        val strictQuery = FullTextQueryBuilder.toBooleanQuery(query)
+        val strictIds = if (strictQuery.isEmpty()) emptyList() else searchIds(strictQuery, now)
+
+        val ids = strictIds.ifEmpty {
+            val fallbackQuery = FullTextQueryBuilder.toFallbackQuery(query)
+            if (fallbackQuery.isEmpty()) emptyList() else searchIds(fallbackQuery, now)
+        }
+
         if (ids.isEmpty()) {
             return emptyResponse()
         }
@@ -53,6 +55,14 @@ class FullTextSearchEngine(
             results = matches.map { GroupBuyFeedItemResponse.from(it, now) },
         )
     }
+
+    private fun searchIds(booleanQuery: String, now: LocalDateTime): List<Long> =
+        groupBuyRepository.searchIdsByFullText(
+            query = booleanQuery,
+            status = GroupBuyStatus.IN_PROGRESS.name,
+            now = now,
+            limit = DEFAULT_LIMIT,
+        )
 
     private fun emptyResponse() = SearchResponse(
         searchCase = SearchCase.NONE_DETECTED,

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -56,6 +56,7 @@ class SecurityConfig(
                 it.requestMatchers(
                     HttpMethod.POST,
                     "/api/v1/group-buys/*/viewers/heartbeat",
+                    "/api/v1/search",
                 ).permitAll()
                 it.requestMatchers(
                     HttpMethod.POST,

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
@@ -93,4 +93,60 @@ class FullTextQueryBuilderTest {
 
         assertThat(result).isEqualTo("+seongsu* +cafe* +2024*")
     }
+
+    @Test
+    @DisplayName("fallback 쿼리는 + 연산자를 제거해 OR 의미로 결합된다")
+    fun `fallback query joins tokens without required operator`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("성수 소금빵")
+
+        assertThat(result).isEqualTo("성수 소금빵")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리는 단일 토큰이 ngram 크기를 초과하면 2글자 ngram으로 분해한다")
+    fun `fallback query decomposes a single long token into 2 char ngrams`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레소시지")
+
+        assertThat(result).isEqualTo("카레 레소 소시 시지")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리에서 단일 2글자 토큰은 ngram 분해 없이 그대로 사용된다")
+    fun `fallback query keeps a single two char token unchanged`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레")
+
+        assertThat(result).isEqualTo("카레")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리는 빈 입력에 빈 문자열을 반환한다")
+    fun `fallback query returns empty string for empty input`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리도 한 글자 토큰은 제외한다")
+    fun `fallback query filters out single character tokens`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("성 수 빵")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리에서 두 글자 이상 토큰이 다수면 그대로 OR 결합된다")
+    fun `fallback query keeps multiple tokens as separate OR terms`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레 소시지")
+
+        assertThat(result).isEqualTo("카레 소시지")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리는 BOOLEAN MODE 연산자 문자를 제거한다")
+    fun `fallback query strips boolean mode operator characters`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("(성수)~소금빵")
+
+        assertThat(result).isEqualTo("성수 소금빵")
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -67,7 +67,7 @@ class FullTextSearchEngineTest {
     }
 
     @Test
-    @DisplayName("매칭 id가 0개면 fetch를 호출하지 않고 EMPTY_CAN_REQUEST를 반환한다")
+    @DisplayName("1차 strict 와 2차 fallback 모두 0건이면 fetch를 호출하지 않고 EMPTY_CAN_REQUEST를 반환한다")
     fun `empty id list short circuits fetch`() {
         stubIds(emptyList())
 
@@ -77,5 +77,46 @@ class FullTextSearchEngineTest {
         assertThat(response.totalCount).isZero
         assertThat(response.results).isEmpty()
         Mockito.verify(groupBuyRepository, Mockito.never()).findAllWithStoreByIdIn(anyLongList())
+    }
+
+    @Test
+    @DisplayName("1차 strict 가 hit 하면 2차 fallback 쿼리는 실행되지 않는다")
+    fun `strict hit skips fallback query`() {
+        val match = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
+        stubIds(listOf(10L))
+        stubFetch(listOf(10L), listOf(match))
+
+        val response = engine.search("소금빵")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(1)
+        Mockito.verify(groupBuyRepository, Mockito.times(1))
+            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+    }
+
+    @Test
+    @DisplayName("1차 strict 가 0건이면 2차 fallback 쿼리로 재조회한 결과를 사용한다")
+    fun `strict miss falls back to OR query`() {
+        val curry = SearchTestFixtures.groupBuy(id = 20L, productName = "카레")
+        val sausage = SearchTestFixtures.groupBuy(id = 30L, productName = "소시지")
+        Mockito.`when`(
+            groupBuyRepository.searchIdsByFullText(
+                anyString(),
+                anyString(),
+                anyLocalDateTime(),
+                anyInt(),
+            )
+        )
+            .thenReturn(emptyList())
+            .thenReturn(listOf(20L, 30L))
+        stubFetch(listOf(20L, 30L), listOf(curry, sausage))
+
+        val response = engine.search("카레소시지")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(2)
+        assertThat(response.results.map { it.id }).containsExactly(20L, 30L)
+        Mockito.verify(groupBuyRepository, Mockito.times(2))
+            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용

- `SecurityConfig` 화이트리스트에 `POST /api/v1/search` 추가하여 비로그인 사용자의 검색 호출 허용. `/api/v1/search/recent/**` 등 사용자 이력 엔드포인트는 인증 유지.
- `FullTextQueryBuilder` 에 2단계 쿼리 빌더 분리.
  - 1차 strict: 기존 `+token*` AND 결합 (정확 매칭 우선).
  - 2차 fallback: `+` 제거한 OR 결합. 단일 토큰이 ngram_token_size 초과면 2글자 ngram 으로 분해해 결합 
- `FullTextSearchEngine` 에 2단계 폴백 실행 로직 추가. 1차에서 0건이면 2차 쿼리로 재조회하고, 둘 다 0건이면 기존 `EMPTY_CAN_REQUEST` 응답을 유지.
- `FullTextQueryBuilderTest` / `FullTextSearchEngineTest` 보강: strict / fallback / 합성어 분해 / 모두 miss 분기 케이스 검증.

## 🔍 참고 사항

- 비로그인 진입 점검은 운영에서 발견된 401 응답이 트리거였습니다. 컨트롤러/서비스는 nullable principal 을 받고 있어 보안 설정과 코드 의도가 어긋난 상태였습니다.
- 2차 폴백은 1차 strict 가 0건일 때만 실행되어 정확 매칭 품질은 그대로 유지됩니다.

## 🖼️ 스크린샷

해당 없음 (백엔드 변경).

## 🔗 관련 이슈

- Closes #276

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인