### PR TITLE
[MCJ-1571] FIX: 검색 응답 분류(searchCase) FULLTEXT 기반 복원

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -112,9 +112,9 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
     fun findWithLockById(id: Long): Optional<GroupBuy>
 
     /**
-     * ngram FULLTEXT 인덱스로 매칭되는 공구 id 만 반환한다.
+     * 상품명 FULLTEXT 인덱스(`idx_group_buys_product_name`) 매칭 공구 id 를 deadline ASC 로 반환한다.
      *
-     * status/deadline 필터를 각 UNION 분기 안에 둬서 매칭 후 집계되는 임시 테이블 크기를 줄인다.
+     * 인덱스 단위 매칭 여부를 호출 측에서 직접 확인할 수 있도록 매장/주소 인덱스와 분리한다.
      * store fetch 는 [findAllWithStoreByIdIn] 으로 별도 수행해 native + lazy 조합의 N+1 을 회피한다.
      *
      * @param query   FullTextQueryBuilder.toBooleanQuery 로 변환된 BOOLEAN MODE 쿼리. 빈 문자열이면 빈 결과.
@@ -124,24 +124,45 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
      */
     @Query(
         value = """
-            SELECT id FROM (
-                SELECT gb.id, gb.deadline FROM group_buys gb
-                WHERE MATCH(gb.product_name) AGAINST(:query IN BOOLEAN MODE)
-                  AND gb.status = :status
-                  AND gb.deadline > :now
-                UNION
-                SELECT gb.id, gb.deadline FROM group_buys gb
-                JOIN stores s ON gb.store_id = s.id
-                WHERE MATCH(s.name, s.address) AGAINST(:query IN BOOLEAN MODE)
-                  AND gb.status = :status
-                  AND gb.deadline > :now
-            ) AS merged
-            ORDER BY merged.deadline ASC
+            SELECT gb.id FROM group_buys gb
+            WHERE MATCH(gb.product_name) AGAINST(:query IN BOOLEAN MODE)
+              AND gb.status = :status
+              AND gb.deadline > :now
+            ORDER BY gb.deadline ASC
             LIMIT :limit
         """,
         nativeQuery = true
     )
-    fun searchIdsByFullText(
+    fun searchProductIdsByFullText(
+        @Param("query") query: String,
+        @Param("status") status: String,
+        @Param("now") now: LocalDateTime,
+        @Param("limit") limit: Int,
+    ): List<Long>
+
+    /**
+     * 매장 FULLTEXT 인덱스(`idx_stores_name_address`) 매칭 공구 id 를 deadline ASC 로 반환한다.
+     *
+     * 인덱스 단위 매칭 여부를 호출 측에서 직접 확인할 수 있도록 상품명 인덱스와 분리한다.
+     *
+     * @param query   FullTextQueryBuilder.toBooleanQuery 로 변환된 BOOLEAN MODE 쿼리. 빈 문자열이면 빈 결과.
+     * @param status  노출 허용 상태 (보통 IN_PROGRESS)
+     * @param now     마감 비교 기준 시각 (deadline > now 인 공구만 반환)
+     * @param limit   반환할 최대 결과 수
+     */
+    @Query(
+        value = """
+            SELECT gb.id FROM group_buys gb
+            JOIN stores s ON gb.store_id = s.id
+            WHERE MATCH(s.name, s.address) AGAINST(:query IN BOOLEAN MODE)
+              AND gb.status = :status
+              AND gb.deadline > :now
+            ORDER BY gb.deadline ASC
+            LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun searchStoreIdsByFullText(
         @Param("query") query: String,
         @Param("status") status: String,
         @Param("now") now: LocalDateTime,

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -14,8 +14,11 @@ import java.time.LocalDateTime
 /**
  * ngram FULLTEXT 인덱스 기반 검색 엔진.
  *
+ * 두 개의 FULLTEXT 인덱스(상품명 / 매장·주소)에 각각 매칭 여부를 확인해
+ * `SearchCase` 4분기(BOTH/PRODUCT_ONLY/NEIGHBORHOOD_ONLY/NONE_DETECTED) 를 복원한다.
+ *
  * 1차: strict AND 쿼리(`+token*`)로 정확 매칭 우선.
- * 2차: 1차에서 0건이면 fallback OR 쿼리로 재조회. 합성어/부분 매칭 케이스를 잡는다.
+ * 2차: 1차에서 양쪽 인덱스 모두 0건이면 fallback OR 쿼리로 재조회. 합성어/부분 매칭 케이스를 잡는다.
  *
  * 1·2차 모두 0건이거나 사용자 입력이 빈 토큰뿐이면 [emptyResponse] 를 반환한다.
  */
@@ -26,6 +29,9 @@ class FullTextSearchEngine(
 ) {
     companion object {
         private const val DEFAULT_LIMIT = 50
+        private const val CONFIDENCE_BOTH = 1.0
+        private const val CONFIDENCE_SINGLE = 0.5
+        private const val CONFIDENCE_NONE = 0.0
     }
 
     fun search(query: String): SearchResponse {
@@ -36,22 +42,33 @@ class FullTextSearchEngine(
             return emptyResponse()
         }
 
-        val strictIds = searchIds(strictQuery, now)
-        val ids = strictIds.ifEmpty { searchIds(fallbackQuery, now) }
+        var productIds = searchProductIds(strictQuery, now)
+        var storeIds = searchStoreIds(strictQuery, now)
 
-        if (ids.isEmpty()) {
+        if (productIds.isEmpty() && storeIds.isEmpty()) {
+            productIds = searchProductIds(fallbackQuery, now)
+            storeIds = searchStoreIds(fallbackQuery, now)
+        }
+
+        val mergedIds = mergeIds(productIds, storeIds)
+        if (mergedIds.isEmpty()) {
             return emptyResponse()
         }
 
-        // store fetch join + 1차 쿼리의 deadline ASC 순서 보존
-        val byId = groupBuyRepository.findAllWithStoreByIdIn(ids).associateBy { it.id }
-        val matches = ids.mapNotNull { byId[it] }
+        // store fetch join 후 deadline ASC 재정렬 (두 인덱스 결과를 한 줄로 머지)
+        val matches = groupBuyRepository.findAllWithStoreByIdIn(mergedIds)
+            .sortedBy { it.deadline }
+            .take(DEFAULT_LIMIT)
+
+        val productHit = productIds.isNotEmpty()
+        val storeHit = storeIds.isNotEmpty()
+        val trimmedQuery = query.trim()
 
         return SearchResponse(
-            searchCase = SearchCase.NONE_DETECTED,
-            detectedRegion = null,
-            detectedProduct = null,
-            confidence = 0.0,
+            searchCase = classifyCase(productHit, storeHit),
+            detectedRegion = trimmedQuery.takeIf { storeHit },
+            detectedProduct = trimmedQuery.takeIf { productHit },
+            confidence = confidenceOf(productHit, storeHit),
             uiState = SearchUiState.RESULTS,
             totalCount = matches.size,
             results = matches.map {
@@ -64,19 +81,48 @@ class FullTextSearchEngine(
         )
     }
 
-    private fun searchIds(booleanQuery: String, now: LocalDateTime): List<Long> =
-        groupBuyRepository.searchIdsByFullText(
+    private fun searchProductIds(booleanQuery: String, now: LocalDateTime): List<Long> =
+        if (booleanQuery.isEmpty()) emptyList()
+        else groupBuyRepository.searchProductIdsByFullText(
             query = booleanQuery,
             status = GroupBuyStatus.IN_PROGRESS.name,
             now = now,
             limit = DEFAULT_LIMIT,
         )
 
+    private fun searchStoreIds(booleanQuery: String, now: LocalDateTime): List<Long> =
+        if (booleanQuery.isEmpty()) emptyList()
+        else groupBuyRepository.searchStoreIdsByFullText(
+            query = booleanQuery,
+            status = GroupBuyStatus.IN_PROGRESS.name,
+            now = now,
+            limit = DEFAULT_LIMIT,
+        )
+
+    private fun mergeIds(productIds: List<Long>, storeIds: List<Long>): List<Long> =
+        LinkedHashSet<Long>(productIds.size + storeIds.size).apply {
+            addAll(productIds)
+            addAll(storeIds)
+        }.toList()
+
+    private fun classifyCase(productHit: Boolean, storeHit: Boolean): SearchCase = when {
+        productHit && storeHit -> SearchCase.BOTH_DETECTED
+        productHit -> SearchCase.PRODUCT_ONLY
+        storeHit -> SearchCase.NEIGHBORHOOD_ONLY
+        else -> SearchCase.NONE_DETECTED
+    }
+
+    private fun confidenceOf(productHit: Boolean, storeHit: Boolean): Double = when {
+        productHit && storeHit -> CONFIDENCE_BOTH
+        productHit || storeHit -> CONFIDENCE_SINGLE
+        else -> CONFIDENCE_NONE
+    }
+
     private fun emptyResponse() = SearchResponse(
         searchCase = SearchCase.NONE_DETECTED,
         detectedRegion = null,
         detectedProduct = null,
-        confidence = 0.0,
+        confidence = CONFIDENCE_NONE,
         uiState = SearchUiState.EMPTY_CAN_REQUEST,
         totalCount = 0,
         results = emptyList(),

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -99,11 +99,8 @@ class FullTextSearchEngine(
             limit = DEFAULT_LIMIT,
         )
 
-    private fun mergeIds(productIds: List<Long>, storeIds: List<Long>): List<Long> =
-        LinkedHashSet<Long>(productIds.size + storeIds.size).apply {
-            addAll(productIds)
-            addAll(storeIds)
-        }.toList()
+    private fun mergeIds(productIds: List<Long>, storeIds: List<Long>): Set<Long> =
+        productIds.union(storeIds)
 
     private fun classifyCase(productHit: Boolean, storeHit: Boolean): SearchCase = when {
         productHit && storeHit -> SearchCase.BOTH_DETECTED

--- a/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/search")
-@Tag(name = "Search", description = "공구 검색 (AI 자연어)")
+@Tag(name = "Search", description = "공구 검색 (FULLTEXT 기반)")
 @Validated
 class SearchController(
     private val searchService: SearchService
@@ -24,7 +24,7 @@ class SearchController(
     data class SearchRequest(@field:NotBlank val keyword: String)
 
     @PostMapping
-    @Operation(summary = "검색어 입력 및 AI 분석 (1.1.4-1)")
+    @Operation(summary = "검색어 입력 및 FULLTEXT 기반 분류 (1.1.4-1)")
     fun search(
         @Valid @RequestBody request: SearchRequest,
         @AuthenticationPrincipal principal: CustomUserPrincipal?

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -935,16 +935,16 @@ paths:
   /api/v1/search:
     post:
       tags: [GroupBuy]
-      summary: 검색 실행 및 AI 키워드 분석 (1.1.4-1)
+      summary: 검색 실행 및 FULLTEXT 기반 분류 (1.1.4-1)
       description: |
-        검색어를 입력하면 동네/베이커리 키워드를 AI로 분석하고 최근 검색어로 저장한다.
-        분석 결과에 따라 4가지 케이스로 분기한다.
+        검색어를 ngram FULLTEXT 인덱스 두 축(상품명 / 매장·주소)에 각각 매칭해 동네/상품 키워드 검출 여부를 판정하고
+        최근 검색어로 저장한다. 두 인덱스 매칭 결과 조합에 따라 4가지 케이스로 분기한다.
         자체 검색 결과가 없을 때 제공되는 recommendedStores는 Naver Local Search 결과 중
         베이커리/디저트 도메인으로 분류된 매장만 반환한다.
-        - case 1: 베이커리 인식, 동네 미인식
-        - case 2: 동네 인식, 베이커리 미인식
-        - case 3: 동네+베이커리 모두 인식
-        - case 4: 모두 인식 불가
+        - PRODUCT_ONLY: 상품명 인덱스만 매치
+        - NEIGHBORHOOD_ONLY: 매장/주소 인덱스만 매치
+        - BOTH_DETECTED: 두 인덱스 모두 매치
+        - NONE_DETECTED: 두 인덱스 모두 미매치
       security:
         - bearerAuth: []
       requestBody:
@@ -960,7 +960,7 @@ paths:
                   minLength: 1
       responses:
         '200':
-          description: AI 분석 결과
+          description: FULLTEXT 기반 분류 결과
           content:
             application/json:
               schema:
@@ -6067,19 +6067,19 @@ components:
             searchCase:
               type: string
               enum: [BOTH_DETECTED, PRODUCT_ONLY, NEIGHBORHOOD_ONLY, NONE_DETECTED]
-              description: AI 키워드 분류 케이스
+              description: FULLTEXT 인덱스 매칭 결과 기반 분류 케이스(상품 인덱스 + 매장/주소 인덱스 hit 조합)
             detectedRegion:
               type: string
               nullable: true
-              description: AI가 감지한 동네 키워드
+              description: 매장/주소 인덱스가 매치된 경우 검색어, 아니면 null
             detectedProduct:
               type: string
               nullable: true
-              description: AI가 감지한 상품/베이커리 키워드
+              description: 상품 인덱스가 매치된 경우 검색어, 아니면 null
             confidence:
               type: number
               format: double
-              description: AI 분류 신뢰도(0.0~1.0)
+              description: FULLTEXT 분류 신뢰도. BOTH=1.0 / 단일 인덱스 매치=0.5 / NONE=0.0
             uiState:
               type: string
               enum: [RESULTS, EMPTY_CAN_REQUEST, NEED_REGION, NEED_PRODUCT, NEED_BOTH, AMBIGUOUS_CONFIRMATION]
@@ -6088,7 +6088,7 @@ components:
                 RESULTS=공구 결과 노출 /
                 EMPTY_CAN_REQUEST=검색 결과 없음, 공구 개설 요청 진입점 /
                 NEED_REGION/NEED_PRODUCT/NEED_BOTH=추가 키워드 입력 안내 /
-                AMBIGUOUS_CONFIRMATION=AI 인식 결과 재확인 필요
+                AMBIGUOUS_CONFIRMATION=분류 결과 재확인 필요
             totalCount:
               type: integer
               description: 전체 공구 결과 개수

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
+import java.time.LocalDateTime
 
 class FullTextSearchEngineTest {
 
@@ -21,21 +22,23 @@ class FullTextSearchEngineTest {
     private val s3ImageReferenceResolver: S3ImageReferenceResolver = Mockito.mock(S3ImageReferenceResolver::class.java)
     private val engine = FullTextSearchEngine(groupBuyRepository, s3ImageReferenceResolver)
 
-    private fun stubIds(ids: List<Long>) {
-        Mockito.`when`(
-            groupBuyRepository.searchIdsByFullText(
-                anyString(),
-                anyString(),
-                anyLocalDateTime(),
-                anyInt(),
-            )
-        ).thenReturn(ids)
+    private fun stubProductIds(vararg sequentialReturns: List<Long>) {
+        val stubbing = Mockito.`when`(
+            groupBuyRepository.searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        )
+        sequentialReturns.fold(stubbing) { acc, ret -> acc.thenReturn(ret) }
     }
 
-    private fun stubFetch(ids: Collection<Long>, matches: List<GroupBuy>) {
-        Mockito.`when`(
-            groupBuyRepository.findAllWithStoreByIdIn(ids)
-        ).thenReturn(matches)
+    private fun stubStoreIds(vararg sequentialReturns: List<Long>) {
+        val stubbing = Mockito.`when`(
+            groupBuyRepository.searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        )
+        sequentialReturns.fold(stubbing) { acc, ret -> acc.thenReturn(ret) }
+    }
+
+    private fun stubFetch(matches: List<GroupBuy>) {
+        Mockito.`when`(groupBuyRepository.findAllWithStoreByIdIn(Mockito.anyCollection()))
+            .thenReturn(matches)
     }
 
     @Test
@@ -47,78 +50,139 @@ class FullTextSearchEngineTest {
         assertThat(response.totalCount).isZero
         assertThat(response.results).isEmpty()
         assertThat(response.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+        assertThat(response.confidence).isEqualTo(0.0)
         Mockito.verifyNoInteractions(groupBuyRepository)
     }
 
     @Test
-    @DisplayName("매칭 id가 있으면 fetch join 결과를 1차 쿼리 순서대로 RESULTS 카드 DTO로 반환한다")
-    fun `non empty id list produces RESULTS with mapped cards in id order`() {
-        val first = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
-        val second = SearchTestFixtures.groupBuy(id = 20L, productName = "크루아상")
-        stubIds(listOf(10L, 20L))
-        // fetch 결과는 의도적으로 역순 — 1차 id 순서로 재정렬되는지 검증
-        stubFetch(listOf(10L, 20L), listOf(second, first))
+    @DisplayName("상품 인덱스만 hit 하면 PRODUCT_ONLY 로 분류하고 detectedProduct 에 검색어를 채운다")
+    fun `product only hit yields PRODUCT_ONLY case`() {
+        val saltBread = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
+        stubProductIds(listOf(10L))
+        stubStoreIds(emptyList())
+        stubFetch(listOf(saltBread))
 
         val response = engine.search("소금빵")
 
-        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
-        assertThat(response.totalCount).isEqualTo(2)
-        assertThat(response.results.map { it.id }).containsExactly(10L, 20L)
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+        assertThat(response.detectedProduct).isEqualTo("소금빵")
         assertThat(response.detectedRegion).isNull()
-        assertThat(response.detectedProduct).isNull()
+        assertThat(response.confidence).isEqualTo(0.5)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.results.map { it.id }).containsExactly(10L)
     }
 
     @Test
-    @DisplayName("1차 strict 와 2차 fallback 모두 0건이면 fetch를 호출하지 않고 EMPTY_CAN_REQUEST를 반환한다")
-    fun `empty id list short circuits fetch`() {
-        stubIds(emptyList())
+    @DisplayName("매장/주소 인덱스만 hit 하면 NEIGHBORHOOD_ONLY 로 분류하고 detectedRegion 에 검색어를 채운다")
+    fun `store only hit yields NEIGHBORHOOD_ONLY case`() {
+        val seongsuStoreGroupBuy = SearchTestFixtures.groupBuy(id = 20L, productName = "베이글")
+        stubProductIds(emptyList())
+        stubStoreIds(listOf(20L))
+        stubFetch(listOf(seongsuStoreGroupBuy))
+
+        val response = engine.search("성수")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.NEIGHBORHOOD_ONLY)
+        assertThat(response.detectedRegion).isEqualTo("성수")
+        assertThat(response.detectedProduct).isNull()
+        assertThat(response.confidence).isEqualTo(0.5)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.results.map { it.id }).containsExactly(20L)
+    }
+
+    @Test
+    @DisplayName("양쪽 인덱스가 모두 hit 하면 BOTH_DETECTED 로 분류하고 detectedProduct/Region 모두 채운다")
+    fun `both indexes hit yields BOTH_DETECTED case`() {
+        val saltBread = SearchTestFixtures.groupBuy(
+            id = 10L,
+            productName = "소금빵",
+            deadline = LocalDateTime.now().plusDays(1),
+        )
+        val seongsuBagel = SearchTestFixtures.groupBuy(
+            id = 20L,
+            productName = "베이글",
+            deadline = LocalDateTime.now().plusDays(2),
+        )
+        stubProductIds(listOf(10L))
+        stubStoreIds(listOf(20L))
+        stubFetch(listOf(saltBread, seongsuBagel))
+
+        val response = engine.search("성수 소금빵")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+        assertThat(response.detectedProduct).isEqualTo("성수 소금빵")
+        assertThat(response.detectedRegion).isEqualTo("성수 소금빵")
+        assertThat(response.confidence).isEqualTo(1.0)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(2)
+        // deadline ASC 정렬 검증 (saltBread = +1일, seongsuBagel = +2일)
+        assertThat(response.results.map { it.id }).containsExactly(10L, 20L)
+    }
+
+    @Test
+    @DisplayName("양쪽 인덱스에서 동일한 id 가 반환되면 dedupe 되어 한 번만 결과에 포함된다")
+    fun `overlapping ids are deduplicated`() {
+        val sharedHit = SearchTestFixtures.groupBuy(id = 10L, productName = "성수 소금빵")
+        stubProductIds(listOf(10L))
+        stubStoreIds(listOf(10L))
+        stubFetch(listOf(sharedHit))
+
+        val response = engine.search("성수 소금빵")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+        assertThat(response.totalCount).isEqualTo(1)
+        assertThat(response.results.map { it.id }).containsExactly(10L)
+    }
+
+    @Test
+    @DisplayName("1차 strict 양쪽 모두 0건이고 2차 fallback 도 모두 0건이면 NONE_DETECTED + EMPTY_CAN_REQUEST")
+    fun `all empty yields NONE_DETECTED and EMPTY_CAN_REQUEST`() {
+        stubProductIds(emptyList(), emptyList())
+        stubStoreIds(emptyList(), emptyList())
 
         val response = engine.search("존재하지않는상품")
 
+        assertThat(response.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
         assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
-        assertThat(response.totalCount).isZero
-        assertThat(response.results).isEmpty()
+        assertThat(response.confidence).isEqualTo(0.0)
+        assertThat(response.detectedProduct).isNull()
+        assertThat(response.detectedRegion).isNull()
         Mockito.verify(groupBuyRepository, Mockito.never()).findAllWithStoreByIdIn(anyLongList())
     }
 
     @Test
-    @DisplayName("1차 strict 가 hit 하면 2차 fallback 쿼리는 실행되지 않는다")
-    fun `strict hit skips fallback query`() {
-        val match = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
-        stubIds(listOf(10L))
-        stubFetch(listOf(10L), listOf(match))
+    @DisplayName("1차 strict 가 한쪽이라도 hit 하면 2차 fallback 쿼리는 실행되지 않는다")
+    fun `strict any hit skips fallback`() {
+        val saltBread = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
+        stubProductIds(listOf(10L))
+        stubStoreIds(emptyList())
+        stubFetch(listOf(saltBread))
 
-        val response = engine.search("소금빵")
+        engine.search("소금빵")
 
-        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
-        assertThat(response.totalCount).isEqualTo(1)
         Mockito.verify(groupBuyRepository, Mockito.times(1))
-            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+            .searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        Mockito.verify(groupBuyRepository, Mockito.times(1))
+            .searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
     }
 
     @Test
-    @DisplayName("1차 strict 가 0건이면 2차 fallback 쿼리로 재조회한 결과를 사용한다")
-    fun `strict miss falls back to OR query`() {
-        val curry = SearchTestFixtures.groupBuy(id = 20L, productName = "카레")
-        val sausage = SearchTestFixtures.groupBuy(id = 30L, productName = "소시지")
-        Mockito.`when`(
-            groupBuyRepository.searchIdsByFullText(
-                anyString(),
-                anyString(),
-                anyLocalDateTime(),
-                anyInt(),
-            )
-        )
-            .thenReturn(emptyList())
-            .thenReturn(listOf(20L, 30L))
-        stubFetch(listOf(20L, 30L), listOf(curry, sausage))
+    @DisplayName("1차 strict 양쪽 0건이면 2차 fallback 쿼리로 양쪽 인덱스를 재조회한다")
+    fun `strict miss falls back on both axes`() {
+        val curry = SearchTestFixtures.groupBuy(id = 30L, productName = "카레")
+        val sausage = SearchTestFixtures.groupBuy(id = 40L, productName = "소시지")
+        stubProductIds(emptyList(), listOf(30L, 40L))
+        stubStoreIds(emptyList(), emptyList())
+        stubFetch(listOf(curry, sausage))
 
         val response = engine.search("카레소시지")
 
-        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
         assertThat(response.totalCount).isEqualTo(2)
-        assertThat(response.results.map { it.id }).containsExactly(20L, 30L)
+        assertThat(response.results.map { it.id }).containsExactlyInAnyOrder(30L, 40L)
         Mockito.verify(groupBuyRepository, Mockito.times(2))
-            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+            .searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        Mockito.verify(groupBuyRepository, Mockito.times(2))
+            .searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
     }
 }

--- a/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
@@ -38,7 +38,8 @@ object SearchTestFixtures {
         id: Long,
         productName: String = "두쫀쿠",
         store: Store = store(),
-        status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
+        status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS,
+        deadline: LocalDateTime = LocalDateTime.now().plusDays(3),
     ): GroupBuy = GroupBuy(
         store = store,
         groupBuyRequest = groupBuyRequest(),
@@ -50,7 +51,7 @@ object SearchTestFixtures {
         currentQuantity = 10,
         maxQuantity = 100,
         status = status,
-        deadline = LocalDateTime.now().plusDays(3),
+        deadline = deadline,
         pickupDate = LocalDate.now().plusDays(5),
         pickupTimeStart = LocalTime.of(14, 0),
         pickupTimeEnd = LocalTime.of(18, 0),


### PR DESCRIPTION
## 📌 작업한 내용

- `GroupBuyRepository.searchIdsByFullText` (UNION) 를 인덱스별로 분리.
- `FullTextSearchEngine` 에 인덱스별 hit 여부 기반 분류 로직 복원.
  - 상품 인덱스만 hit → `PRODUCT_ONLY`, `detectedProduct` 채움
  - 매장/주소 인덱스만 hit → `NEIGHBORHOOD_ONLY`, `detectedRegion` 채움
  - 둘 다 hit → `BOTH_DETECTED`, 양쪽 채움
  - 둘 다 miss → `NONE_DETECTED` + `EMPTY_CAN_REQUEST`
  - 양쪽 strict 모두 0건일 때만 양쪽 fallback 으로 재조회.
- `confidence` 산정 정의: BOTH=1.0 / 단일 hit=0.5 / NONE=0.0.
- 결과 머지 시 dedupe → fetch join → deadline ASC 재정렬 → limit 적용.
- `SearchController` `@Tag` / `@Operation` 문구도 FULLTEXT 기반으로 정정.
- `FullTextSearchEngineTest` 4분기 분류(BOTH/PRODUCT_ONLY/NEIGHBORHOOD_ONLY/NONE), dedupe, strict→fallback 확장 케이스 추가.

## 🔍 참고 사항

- 응답 스키마(`searchCase` / `detectedRegion` / `detectedProduct` / `confidence`) 는 그대로 유지. 분류 책임만 AI 파이프라인에서 FULLTEXT 매칭 결과로 옮긴 형태입니다.
- 2축 인덱스에 각각 쿼리하므로 strict 단계 SQL 호출이 1→2건으로 늘어납니다. 두 쿼리 모두 인덱스/limit 50 으로 가벼우며, fallback 단계도 동일하게 두 축 모두에 적용됩니다.
- `detectedRegion` / `detectedProduct` 는 hit 시 사용자 입력 원문(trim) 으로 채웁니다. 

## 🖼️ 스크린샷

해당 없음 (백엔드 변경).

## 🔗 관련 이슈

- Closes #277

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인