### PR TITLE
RELEASE: 검색 비로그인 허용·합성어 매칭/분류 복원 main 배포

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -112,9 +112,9 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
     fun findWithLockById(id: Long): Optional<GroupBuy>
 
     /**
-     * ngram FULLTEXT 인덱스로 매칭되는 공구 id 만 반환한다.
+     * 상품명 FULLTEXT 인덱스(`idx_group_buys_product_name`) 매칭 공구 id 를 deadline ASC 로 반환한다.
      *
-     * status/deadline 필터를 각 UNION 분기 안에 둬서 매칭 후 집계되는 임시 테이블 크기를 줄인다.
+     * 인덱스 단위 매칭 여부를 호출 측에서 직접 확인할 수 있도록 매장/주소 인덱스와 분리한다.
      * store fetch 는 [findAllWithStoreByIdIn] 으로 별도 수행해 native + lazy 조합의 N+1 을 회피한다.
      *
      * @param query   FullTextQueryBuilder.toBooleanQuery 로 변환된 BOOLEAN MODE 쿼리. 빈 문자열이면 빈 결과.
@@ -124,24 +124,45 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
      */
     @Query(
         value = """
-            SELECT id FROM (
-                SELECT gb.id, gb.deadline FROM group_buys gb
-                WHERE MATCH(gb.product_name) AGAINST(:query IN BOOLEAN MODE)
-                  AND gb.status = :status
-                  AND gb.deadline > :now
-                UNION
-                SELECT gb.id, gb.deadline FROM group_buys gb
-                JOIN stores s ON gb.store_id = s.id
-                WHERE MATCH(s.name, s.address) AGAINST(:query IN BOOLEAN MODE)
-                  AND gb.status = :status
-                  AND gb.deadline > :now
-            ) AS merged
-            ORDER BY merged.deadline ASC
+            SELECT gb.id FROM group_buys gb
+            WHERE MATCH(gb.product_name) AGAINST(:query IN BOOLEAN MODE)
+              AND gb.status = :status
+              AND gb.deadline > :now
+            ORDER BY gb.deadline ASC
             LIMIT :limit
         """,
         nativeQuery = true
     )
-    fun searchIdsByFullText(
+    fun searchProductIdsByFullText(
+        @Param("query") query: String,
+        @Param("status") status: String,
+        @Param("now") now: LocalDateTime,
+        @Param("limit") limit: Int,
+    ): List<Long>
+
+    /**
+     * 매장 FULLTEXT 인덱스(`idx_stores_name_address`) 매칭 공구 id 를 deadline ASC 로 반환한다.
+     *
+     * 인덱스 단위 매칭 여부를 호출 측에서 직접 확인할 수 있도록 상품명 인덱스와 분리한다.
+     *
+     * @param query   FullTextQueryBuilder.toBooleanQuery 로 변환된 BOOLEAN MODE 쿼리. 빈 문자열이면 빈 결과.
+     * @param status  노출 허용 상태 (보통 IN_PROGRESS)
+     * @param now     마감 비교 기준 시각 (deadline > now 인 공구만 반환)
+     * @param limit   반환할 최대 결과 수
+     */
+    @Query(
+        value = """
+            SELECT gb.id FROM group_buys gb
+            JOIN stores s ON gb.store_id = s.id
+            WHERE MATCH(s.name, s.address) AGAINST(:query IN BOOLEAN MODE)
+              AND gb.status = :status
+              AND gb.deadline > :now
+            ORDER BY gb.deadline ASC
+            LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun searchStoreIdsByFullText(
         @Param("query") query: String,
         @Param("status") status: String,
         @Param("now") now: LocalDateTime,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
@@ -20,7 +20,7 @@ object FullTextQueryBuilder {
      * 1차 strict 쿼리와 2차 fallback 쿼리를 한 번의 sanitize 로 동시에 생성한다.
      *
      * - strict: 모든 토큰에 `+token*` 를 붙여 AND 의미로 결합.
-     * - fallback: `+` 제거한 OR 결합. 단일 토큰이 ngram_token_size 를 초과하면 2글자 ngram 으로 분해.
+     * - fallback: `+` 제거한 OR 결합. ngram_token_size 를 초과하는 토큰은 토큰별로 2글자 ngram 으로 분해.
      * - 토큰이 하나도 남지 않으면 두 쿼리 모두 빈 문자열을 반환한다.
      *   호출 측은 strict 가 빈 문자열이면 fallback 도 빈 문자열임을 가정할 수 있다.
      */
@@ -28,11 +28,10 @@ object FullTextQueryBuilder {
         val tokens = sanitize(rawQuery)
         if (tokens.isEmpty()) return "" to ""
         val strict = tokens.joinToString(" ") { "+$it*" }
-        val fallback = if (tokens.size == 1 && tokens[0].length > NGRAM_TOKEN_SIZE) {
-            decomposeToNgrams(tokens[0]).joinToString(" ")
-        } else {
-            tokens.joinToString(" ")
-        }
+        val fallback = tokens.flatMap { token ->
+            if (token.length > NGRAM_TOKEN_SIZE) decomposeToNgrams(token)
+            else listOf(token)
+        }.joinToString(" ")
         return strict to fallback
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
@@ -17,29 +17,30 @@ object FullTextQueryBuilder {
     private const val NGRAM_TOKEN_SIZE = 2
 
     /**
-     * 1차 strict 쿼리.
-     * 토큰별 prefix wildcard(`*`)와 필수(`+`) 연산자를 붙여 모든 토큰이 매칭되는 AND 의미를 만든다.
+     * 1차 strict 쿼리와 2차 fallback 쿼리를 한 번의 sanitize 로 동시에 생성한다.
+     *
+     * - strict: 모든 토큰에 `+token*` 를 붙여 AND 의미로 결합.
+     * - fallback: `+` 제거한 OR 결합. 단일 토큰이 ngram_token_size 를 초과하면 2글자 ngram 으로 분해.
+     * - 토큰이 하나도 남지 않으면 두 쿼리 모두 빈 문자열을 반환한다.
+     *   호출 측은 strict 가 빈 문자열이면 fallback 도 빈 문자열임을 가정할 수 있다.
      */
-    fun toBooleanQuery(rawQuery: String): String {
+    fun buildQueries(rawQuery: String): Pair<String, String> {
         val tokens = sanitize(rawQuery)
-        return tokens.joinToString(" ") { "+$it*" }
+        if (tokens.isEmpty()) return "" to ""
+        val strict = tokens.joinToString(" ") { "+$it*" }
+        val fallback = if (tokens.size == 1 && tokens[0].length > NGRAM_TOKEN_SIZE) {
+            decomposeToNgrams(tokens[0]).joinToString(" ")
+        } else {
+            tokens.joinToString(" ")
+        }
+        return strict to fallback
     }
 
-    /**
-     * 2차 fallback 쿼리. 1차에서 0건일 때 사용한다.
-     *
-     * - `+` 연산자를 제거해 OR 의미로 결합한다. 토큰 중 일부만 포함된 문서도 매치된다.
-     * - 단일 토큰이고 길이가 ngram_token_size 를 초과하면 2글자 ngram 으로 분해해 결합한다.
-     *   예: "카레소시지" → "카레 레소 소시 시지". 합성어 한 덩어리 입력에서도 부분 매칭이 가능해진다.
-     */
-    fun toFallbackQuery(rawQuery: String): String {
-        val tokens = sanitize(rawQuery)
-        if (tokens.isEmpty()) return ""
-        if (tokens.size == 1 && tokens[0].length > NGRAM_TOKEN_SIZE) {
-            return decomposeToNgrams(tokens[0]).joinToString(" ")
-        }
-        return tokens.joinToString(" ")
-    }
+    /** 1차 strict 쿼리 단독 호출용 wrapper. */
+    fun toBooleanQuery(rawQuery: String): String = buildQueries(rawQuery).first
+
+    /** 2차 fallback 쿼리 단독 호출용 wrapper. */
+    fun toFallbackQuery(rawQuery: String): String = buildQueries(rawQuery).second
 
     private fun sanitize(rawQuery: String): List<String> {
         return rawQuery

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilder.kt
@@ -4,8 +4,8 @@ package com.moongchijang.domain.groupbuy.infrastructure.search
  * 사용자 검색어를 MySQL FULLTEXT BOOLEAN MODE 쿼리 문자열로 변환한다.
  *
  * - BOOLEAN MODE 연산자 문자(+, -, >, <, (, ), ~, *, ", @, \)는 사용자 입력에서 제거한다.
- * - 토큰별 prefix wildcard(`*`)와 필수(`+`) 연산자를 붙여 모든 토큰이 매칭되는 AND 의미를 만든다.
  * - ngram_token_size(기본 2) 미만의 한 글자 토큰은 매칭되지 않으므로 제외한다.
+ * - 1차 strict([toBooleanQuery]) 와 2차 fallback([toFallbackQuery]) 두 단계 쿼리를 제공한다.
  *
  * 모든 토큰이 제거되면 빈 문자열을 반환한다. 호출 측에서 빈 문자열이면 검색을 스킵해야 한다.
  */
@@ -14,13 +14,42 @@ object FullTextQueryBuilder {
     private val FORBIDDEN_CHARS = Regex("""[+\-><()~*"@\\]""")
     private val WHITESPACE = Regex("""\s+""")
     private const val MIN_TOKEN_LENGTH = 2
+    private const val NGRAM_TOKEN_SIZE = 2
 
+    /**
+     * 1차 strict 쿼리.
+     * 토큰별 prefix wildcard(`*`)와 필수(`+`) 연산자를 붙여 모든 토큰이 매칭되는 AND 의미를 만든다.
+     */
     fun toBooleanQuery(rawQuery: String): String {
-        val tokens = rawQuery
+        val tokens = sanitize(rawQuery)
+        return tokens.joinToString(" ") { "+$it*" }
+    }
+
+    /**
+     * 2차 fallback 쿼리. 1차에서 0건일 때 사용한다.
+     *
+     * - `+` 연산자를 제거해 OR 의미로 결합한다. 토큰 중 일부만 포함된 문서도 매치된다.
+     * - 단일 토큰이고 길이가 ngram_token_size 를 초과하면 2글자 ngram 으로 분해해 결합한다.
+     *   예: "카레소시지" → "카레 레소 소시 시지". 합성어 한 덩어리 입력에서도 부분 매칭이 가능해진다.
+     */
+    fun toFallbackQuery(rawQuery: String): String {
+        val tokens = sanitize(rawQuery)
+        if (tokens.isEmpty()) return ""
+        if (tokens.size == 1 && tokens[0].length > NGRAM_TOKEN_SIZE) {
+            return decomposeToNgrams(tokens[0]).joinToString(" ")
+        }
+        return tokens.joinToString(" ")
+    }
+
+    private fun sanitize(rawQuery: String): List<String> {
+        return rawQuery
             .replace(FORBIDDEN_CHARS, " ")
             .trim()
             .split(WHITESPACE)
             .filter { it.length >= MIN_TOKEN_LENGTH }
-        return tokens.joinToString(" ") { "+$it*" }
+    }
+
+    private fun decomposeToNgrams(token: String): List<String> {
+        return (0..token.length - NGRAM_TOKEN_SIZE).map { token.substring(it, it + NGRAM_TOKEN_SIZE) }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -29,13 +29,13 @@ class FullTextSearchEngine(
     fun search(query: String): SearchResponse {
         val now = LocalDateTime.now()
 
-        val strictQuery = FullTextQueryBuilder.toBooleanQuery(query)
-        val strictIds = if (strictQuery.isEmpty()) emptyList() else searchIds(strictQuery, now)
-
-        val ids = strictIds.ifEmpty {
-            val fallbackQuery = FullTextQueryBuilder.toFallbackQuery(query)
-            if (fallbackQuery.isEmpty()) emptyList() else searchIds(fallbackQuery, now)
+        val (strictQuery, fallbackQuery) = FullTextQueryBuilder.buildQueries(query)
+        if (strictQuery.isEmpty()) {
+            return emptyResponse()
         }
+
+        val strictIds = searchIds(strictQuery, now)
+        val ids = strictIds.ifEmpty { searchIds(fallbackQuery, now) }
 
         if (ids.isEmpty()) {
             return emptyResponse()

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -12,7 +12,11 @@ import java.time.LocalDateTime
 
 /**
  * ngram FULLTEXT 인덱스 기반 검색 엔진.
- * BOOLEAN MODE 쿼리로 변환한 토큰이 하나도 없으면 검색을 스킵한다.
+ *
+ * 1차: strict AND 쿼리(`+token*`)로 정확 매칭 우선.
+ * 2차: 1차에서 0건이면 fallback OR 쿼리로 재조회. 합성어/부분 매칭 케이스를 잡는다.
+ *
+ * 1·2차 모두 0건이거나 사용자 입력이 빈 토큰뿐이면 [emptyResponse] 를 반환한다.
  */
 @Component
 class FullTextSearchEngine(
@@ -23,18 +27,16 @@ class FullTextSearchEngine(
     }
 
     fun search(query: String): SearchResponse {
-        val booleanQuery = FullTextQueryBuilder.toBooleanQuery(query)
-        if (booleanQuery.isEmpty()) {
-            return emptyResponse()
-        }
         val now = LocalDateTime.now()
 
-        val ids = groupBuyRepository.searchIdsByFullText(
-            query = booleanQuery,
-            status = GroupBuyStatus.IN_PROGRESS.name,
-            now = now,
-            limit = DEFAULT_LIMIT,
-        )
+        val strictQuery = FullTextQueryBuilder.toBooleanQuery(query)
+        val strictIds = if (strictQuery.isEmpty()) emptyList() else searchIds(strictQuery, now)
+
+        val ids = strictIds.ifEmpty {
+            val fallbackQuery = FullTextQueryBuilder.toFallbackQuery(query)
+            if (fallbackQuery.isEmpty()) emptyList() else searchIds(fallbackQuery, now)
+        }
+
         if (ids.isEmpty()) {
             return emptyResponse()
         }
@@ -53,6 +55,14 @@ class FullTextSearchEngine(
             results = matches.map { GroupBuyFeedItemResponse.from(it, now) },
         )
     }
+
+    private fun searchIds(booleanQuery: String, now: LocalDateTime): List<Long> =
+        groupBuyRepository.searchIdsByFullText(
+            query = booleanQuery,
+            status = GroupBuyStatus.IN_PROGRESS.name,
+            now = now,
+            limit = DEFAULT_LIMIT,
+        )
 
     private fun emptyResponse() = SearchResponse(
         searchCase = SearchCase.NONE_DETECTED,

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -14,8 +14,11 @@ import java.time.LocalDateTime
 /**
  * ngram FULLTEXT 인덱스 기반 검색 엔진.
  *
+ * 두 개의 FULLTEXT 인덱스(상품명 / 매장·주소)에 각각 매칭 여부를 확인해
+ * `SearchCase` 4분기(BOTH/PRODUCT_ONLY/NEIGHBORHOOD_ONLY/NONE_DETECTED) 를 복원한다.
+ *
  * 1차: strict AND 쿼리(`+token*`)로 정확 매칭 우선.
- * 2차: 1차에서 0건이면 fallback OR 쿼리로 재조회. 합성어/부분 매칭 케이스를 잡는다.
+ * 2차: 1차에서 양쪽 인덱스 모두 0건이면 fallback OR 쿼리로 재조회. 합성어/부분 매칭 케이스를 잡는다.
  *
  * 1·2차 모두 0건이거나 사용자 입력이 빈 토큰뿐이면 [emptyResponse] 를 반환한다.
  */
@@ -26,6 +29,9 @@ class FullTextSearchEngine(
 ) {
     companion object {
         private const val DEFAULT_LIMIT = 50
+        private const val CONFIDENCE_BOTH = 1.0
+        private const val CONFIDENCE_SINGLE = 0.5
+        private const val CONFIDENCE_NONE = 0.0
     }
 
     fun search(query: String): SearchResponse {
@@ -36,22 +42,33 @@ class FullTextSearchEngine(
             return emptyResponse()
         }
 
-        val strictIds = searchIds(strictQuery, now)
-        val ids = strictIds.ifEmpty { searchIds(fallbackQuery, now) }
+        var productIds = searchProductIds(strictQuery, now)
+        var storeIds = searchStoreIds(strictQuery, now)
 
-        if (ids.isEmpty()) {
+        if (productIds.isEmpty() && storeIds.isEmpty()) {
+            productIds = searchProductIds(fallbackQuery, now)
+            storeIds = searchStoreIds(fallbackQuery, now)
+        }
+
+        val mergedIds = mergeIds(productIds, storeIds)
+        if (mergedIds.isEmpty()) {
             return emptyResponse()
         }
 
-        // store fetch join + 1차 쿼리의 deadline ASC 순서 보존
-        val byId = groupBuyRepository.findAllWithStoreByIdIn(ids).associateBy { it.id }
-        val matches = ids.mapNotNull { byId[it] }
+        // store fetch join 후 deadline ASC 재정렬 (두 인덱스 결과를 한 줄로 머지)
+        val matches = groupBuyRepository.findAllWithStoreByIdIn(mergedIds)
+            .sortedBy { it.deadline }
+            .take(DEFAULT_LIMIT)
+
+        val productHit = productIds.isNotEmpty()
+        val storeHit = storeIds.isNotEmpty()
+        val trimmedQuery = query.trim()
 
         return SearchResponse(
-            searchCase = SearchCase.NONE_DETECTED,
-            detectedRegion = null,
-            detectedProduct = null,
-            confidence = 0.0,
+            searchCase = classifyCase(productHit, storeHit),
+            detectedRegion = trimmedQuery.takeIf { storeHit },
+            detectedProduct = trimmedQuery.takeIf { productHit },
+            confidence = confidenceOf(productHit, storeHit),
             uiState = SearchUiState.RESULTS,
             totalCount = matches.size,
             results = matches.map {
@@ -64,19 +81,48 @@ class FullTextSearchEngine(
         )
     }
 
-    private fun searchIds(booleanQuery: String, now: LocalDateTime): List<Long> =
-        groupBuyRepository.searchIdsByFullText(
+    private fun searchProductIds(booleanQuery: String, now: LocalDateTime): List<Long> =
+        if (booleanQuery.isEmpty()) emptyList()
+        else groupBuyRepository.searchProductIdsByFullText(
             query = booleanQuery,
             status = GroupBuyStatus.IN_PROGRESS.name,
             now = now,
             limit = DEFAULT_LIMIT,
         )
 
+    private fun searchStoreIds(booleanQuery: String, now: LocalDateTime): List<Long> =
+        if (booleanQuery.isEmpty()) emptyList()
+        else groupBuyRepository.searchStoreIdsByFullText(
+            query = booleanQuery,
+            status = GroupBuyStatus.IN_PROGRESS.name,
+            now = now,
+            limit = DEFAULT_LIMIT,
+        )
+
+    private fun mergeIds(productIds: List<Long>, storeIds: List<Long>): List<Long> =
+        LinkedHashSet<Long>(productIds.size + storeIds.size).apply {
+            addAll(productIds)
+            addAll(storeIds)
+        }.toList()
+
+    private fun classifyCase(productHit: Boolean, storeHit: Boolean): SearchCase = when {
+        productHit && storeHit -> SearchCase.BOTH_DETECTED
+        productHit -> SearchCase.PRODUCT_ONLY
+        storeHit -> SearchCase.NEIGHBORHOOD_ONLY
+        else -> SearchCase.NONE_DETECTED
+    }
+
+    private fun confidenceOf(productHit: Boolean, storeHit: Boolean): Double = when {
+        productHit && storeHit -> CONFIDENCE_BOTH
+        productHit || storeHit -> CONFIDENCE_SINGLE
+        else -> CONFIDENCE_NONE
+    }
+
     private fun emptyResponse() = SearchResponse(
         searchCase = SearchCase.NONE_DETECTED,
         detectedRegion = null,
         detectedProduct = null,
-        confidence = 0.0,
+        confidence = CONFIDENCE_NONE,
         uiState = SearchUiState.EMPTY_CAN_REQUEST,
         totalCount = 0,
         results = emptyList(),

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -99,11 +99,8 @@ class FullTextSearchEngine(
             limit = DEFAULT_LIMIT,
         )
 
-    private fun mergeIds(productIds: List<Long>, storeIds: List<Long>): List<Long> =
-        LinkedHashSet<Long>(productIds.size + storeIds.size).apply {
-            addAll(productIds)
-            addAll(storeIds)
-        }.toList()
+    private fun mergeIds(productIds: List<Long>, storeIds: List<Long>): Set<Long> =
+        productIds.union(storeIds)
 
     private fun classifyCase(productHit: Boolean, storeHit: Boolean): SearchCase = when {
         productHit && storeHit -> SearchCase.BOTH_DETECTED

--- a/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/presentation/SearchController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/search")
-@Tag(name = "Search", description = "공구 검색 (AI 자연어)")
+@Tag(name = "Search", description = "공구 검색 (FULLTEXT 기반)")
 @Validated
 class SearchController(
     private val searchService: SearchService
@@ -24,7 +24,7 @@ class SearchController(
     data class SearchRequest(@field:NotBlank val keyword: String)
 
     @PostMapping
-    @Operation(summary = "검색어 입력 및 AI 분석 (1.1.4-1)")
+    @Operation(summary = "검색어 입력 및 FULLTEXT 기반 분류 (1.1.4-1)")
     fun search(
         @Valid @RequestBody request: SearchRequest,
         @AuthenticationPrincipal principal: CustomUserPrincipal?

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -56,6 +56,7 @@ class SecurityConfig(
                 it.requestMatchers(
                     HttpMethod.POST,
                     "/api/v1/group-buys/*/viewers/heartbeat",
+                    "/api/v1/search",
                 ).permitAll()
                 it.requestMatchers(
                     HttpMethod.POST,

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -935,16 +935,16 @@ paths:
   /api/v1/search:
     post:
       tags: [GroupBuy]
-      summary: 검색 실행 및 AI 키워드 분석 (1.1.4-1)
+      summary: 검색 실행 및 FULLTEXT 기반 분류 (1.1.4-1)
       description: |
-        검색어를 입력하면 동네/베이커리 키워드를 AI로 분석하고 최근 검색어로 저장한다.
-        분석 결과에 따라 4가지 케이스로 분기한다.
+        검색어를 ngram FULLTEXT 인덱스 두 축(상품명 / 매장·주소)에 각각 매칭해 동네/상품 키워드 검출 여부를 판정하고
+        최근 검색어로 저장한다. 두 인덱스 매칭 결과 조합에 따라 4가지 케이스로 분기한다.
         자체 검색 결과가 없을 때 제공되는 recommendedStores는 Naver Local Search 결과 중
         베이커리/디저트 도메인으로 분류된 매장만 반환한다.
-        - case 1: 베이커리 인식, 동네 미인식
-        - case 2: 동네 인식, 베이커리 미인식
-        - case 3: 동네+베이커리 모두 인식
-        - case 4: 모두 인식 불가
+        - PRODUCT_ONLY: 상품명 인덱스만 매치
+        - NEIGHBORHOOD_ONLY: 매장/주소 인덱스만 매치
+        - BOTH_DETECTED: 두 인덱스 모두 매치
+        - NONE_DETECTED: 두 인덱스 모두 미매치
       security:
         - bearerAuth: []
       requestBody:
@@ -960,7 +960,7 @@ paths:
                   minLength: 1
       responses:
         '200':
-          description: AI 분석 결과
+          description: FULLTEXT 기반 분류 결과
           content:
             application/json:
               schema:
@@ -6067,19 +6067,19 @@ components:
             searchCase:
               type: string
               enum: [BOTH_DETECTED, PRODUCT_ONLY, NEIGHBORHOOD_ONLY, NONE_DETECTED]
-              description: AI 키워드 분류 케이스
+              description: FULLTEXT 인덱스 매칭 결과 기반 분류 케이스(상품 인덱스 + 매장/주소 인덱스 hit 조합)
             detectedRegion:
               type: string
               nullable: true
-              description: AI가 감지한 동네 키워드
+              description: 매장/주소 인덱스가 매치된 경우 검색어, 아니면 null
             detectedProduct:
               type: string
               nullable: true
-              description: AI가 감지한 상품/베이커리 키워드
+              description: 상품 인덱스가 매치된 경우 검색어, 아니면 null
             confidence:
               type: number
               format: double
-              description: AI 분류 신뢰도(0.0~1.0)
+              description: FULLTEXT 분류 신뢰도. BOTH=1.0 / 단일 인덱스 매치=0.5 / NONE=0.0
             uiState:
               type: string
               enum: [RESULTS, EMPTY_CAN_REQUEST, NEED_REGION, NEED_PRODUCT, NEED_BOTH, AMBIGUOUS_CONFIRMATION]
@@ -6088,7 +6088,7 @@ components:
                 RESULTS=공구 결과 노출 /
                 EMPTY_CAN_REQUEST=검색 결과 없음, 공구 개설 요청 진입점 /
                 NEED_REGION/NEED_PRODUCT/NEED_BOTH=추가 키워드 입력 안내 /
-                AMBIGUOUS_CONFIRMATION=AI 인식 결과 재확인 필요
+                AMBIGUOUS_CONFIRMATION=분류 결과 재확인 필요
             totalCount:
               type: integer
               description: 전체 공구 결과 개수

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
@@ -99,7 +99,7 @@ class FullTextQueryBuilderTest {
     fun `fallback query joins tokens without required operator`() {
         val result = FullTextQueryBuilder.toFallbackQuery("성수 소금빵")
 
-        assertThat(result).isEqualTo("성수 소금빵")
+        assertThat(result).isEqualTo("성수 소금 금빵")
     }
 
     @Test
@@ -135,11 +135,19 @@ class FullTextQueryBuilderTest {
     }
 
     @Test
-    @DisplayName("fallback 쿼리에서 두 글자 이상 토큰이 다수면 그대로 OR 결합된다")
-    fun `fallback query keeps multiple tokens as separate OR terms`() {
-        val result = FullTextQueryBuilder.toFallbackQuery("카레 소시지")
+    @DisplayName("fallback 쿼리에서 모든 토큰이 ngram 크기 이하면 분해 없이 OR 결합된다")
+    fun `fallback query keeps tokens unchanged when all are within ngram size`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레 우동")
 
-        assertThat(result).isEqualTo("카레 소시지")
+        assertThat(result).isEqualTo("카레 우동")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리에서 다중 토큰이라도 ngram 크기를 초과하는 토큰은 토큰별로 ngram 분해된다")
+    fun `fallback query decomposes long tokens per-token even with multiple tokens`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레소시지 성수")
+
+        assertThat(result).isEqualTo("카레 레소 소시 시지 성수")
     }
 
     @Test
@@ -147,6 +155,6 @@ class FullTextQueryBuilderTest {
     fun `fallback query strips boolean mode operator characters`() {
         val result = FullTextQueryBuilder.toFallbackQuery("(성수)~소금빵")
 
-        assertThat(result).isEqualTo("성수 소금빵")
+        assertThat(result).isEqualTo("성수 소금 금빵")
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/infrastructure/search/FullTextQueryBuilderTest.kt
@@ -93,4 +93,60 @@ class FullTextQueryBuilderTest {
 
         assertThat(result).isEqualTo("+seongsu* +cafe* +2024*")
     }
+
+    @Test
+    @DisplayName("fallback 쿼리는 + 연산자를 제거해 OR 의미로 결합된다")
+    fun `fallback query joins tokens without required operator`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("성수 소금빵")
+
+        assertThat(result).isEqualTo("성수 소금빵")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리는 단일 토큰이 ngram 크기를 초과하면 2글자 ngram으로 분해한다")
+    fun `fallback query decomposes a single long token into 2 char ngrams`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레소시지")
+
+        assertThat(result).isEqualTo("카레 레소 소시 시지")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리에서 단일 2글자 토큰은 ngram 분해 없이 그대로 사용된다")
+    fun `fallback query keeps a single two char token unchanged`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레")
+
+        assertThat(result).isEqualTo("카레")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리는 빈 입력에 빈 문자열을 반환한다")
+    fun `fallback query returns empty string for empty input`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리도 한 글자 토큰은 제외한다")
+    fun `fallback query filters out single character tokens`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("성 수 빵")
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리에서 두 글자 이상 토큰이 다수면 그대로 OR 결합된다")
+    fun `fallback query keeps multiple tokens as separate OR terms`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("카레 소시지")
+
+        assertThat(result).isEqualTo("카레 소시지")
+    }
+
+    @Test
+    @DisplayName("fallback 쿼리는 BOOLEAN MODE 연산자 문자를 제거한다")
+    fun `fallback query strips boolean mode operator characters`() {
+        val result = FullTextQueryBuilder.toFallbackQuery("(성수)~소금빵")
+
+        assertThat(result).isEqualTo("성수 소금빵")
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
+import java.time.LocalDateTime
 
 class FullTextSearchEngineTest {
 
@@ -21,21 +22,23 @@ class FullTextSearchEngineTest {
     private val s3ImageReferenceResolver: S3ImageReferenceResolver = Mockito.mock(S3ImageReferenceResolver::class.java)
     private val engine = FullTextSearchEngine(groupBuyRepository, s3ImageReferenceResolver)
 
-    private fun stubIds(ids: List<Long>) {
-        Mockito.`when`(
-            groupBuyRepository.searchIdsByFullText(
-                anyString(),
-                anyString(),
-                anyLocalDateTime(),
-                anyInt(),
-            )
-        ).thenReturn(ids)
+    private fun stubProductIds(vararg sequentialReturns: List<Long>) {
+        val stubbing = Mockito.`when`(
+            groupBuyRepository.searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        )
+        sequentialReturns.fold(stubbing) { acc, ret -> acc.thenReturn(ret) }
     }
 
-    private fun stubFetch(ids: Collection<Long>, matches: List<GroupBuy>) {
-        Mockito.`when`(
-            groupBuyRepository.findAllWithStoreByIdIn(ids)
-        ).thenReturn(matches)
+    private fun stubStoreIds(vararg sequentialReturns: List<Long>) {
+        val stubbing = Mockito.`when`(
+            groupBuyRepository.searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        )
+        sequentialReturns.fold(stubbing) { acc, ret -> acc.thenReturn(ret) }
+    }
+
+    private fun stubFetch(matches: List<GroupBuy>) {
+        Mockito.`when`(groupBuyRepository.findAllWithStoreByIdIn(Mockito.anyCollection()))
+            .thenReturn(matches)
     }
 
     @Test
@@ -47,78 +50,139 @@ class FullTextSearchEngineTest {
         assertThat(response.totalCount).isZero
         assertThat(response.results).isEmpty()
         assertThat(response.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
+        assertThat(response.confidence).isEqualTo(0.0)
         Mockito.verifyNoInteractions(groupBuyRepository)
     }
 
     @Test
-    @DisplayName("매칭 id가 있으면 fetch join 결과를 1차 쿼리 순서대로 RESULTS 카드 DTO로 반환한다")
-    fun `non empty id list produces RESULTS with mapped cards in id order`() {
-        val first = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
-        val second = SearchTestFixtures.groupBuy(id = 20L, productName = "크루아상")
-        stubIds(listOf(10L, 20L))
-        // fetch 결과는 의도적으로 역순 — 1차 id 순서로 재정렬되는지 검증
-        stubFetch(listOf(10L, 20L), listOf(second, first))
+    @DisplayName("상품 인덱스만 hit 하면 PRODUCT_ONLY 로 분류하고 detectedProduct 에 검색어를 채운다")
+    fun `product only hit yields PRODUCT_ONLY case`() {
+        val saltBread = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
+        stubProductIds(listOf(10L))
+        stubStoreIds(emptyList())
+        stubFetch(listOf(saltBread))
 
         val response = engine.search("소금빵")
 
-        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
-        assertThat(response.totalCount).isEqualTo(2)
-        assertThat(response.results.map { it.id }).containsExactly(10L, 20L)
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+        assertThat(response.detectedProduct).isEqualTo("소금빵")
         assertThat(response.detectedRegion).isNull()
-        assertThat(response.detectedProduct).isNull()
+        assertThat(response.confidence).isEqualTo(0.5)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.results.map { it.id }).containsExactly(10L)
     }
 
     @Test
-    @DisplayName("1차 strict 와 2차 fallback 모두 0건이면 fetch를 호출하지 않고 EMPTY_CAN_REQUEST를 반환한다")
-    fun `empty id list short circuits fetch`() {
-        stubIds(emptyList())
+    @DisplayName("매장/주소 인덱스만 hit 하면 NEIGHBORHOOD_ONLY 로 분류하고 detectedRegion 에 검색어를 채운다")
+    fun `store only hit yields NEIGHBORHOOD_ONLY case`() {
+        val seongsuStoreGroupBuy = SearchTestFixtures.groupBuy(id = 20L, productName = "베이글")
+        stubProductIds(emptyList())
+        stubStoreIds(listOf(20L))
+        stubFetch(listOf(seongsuStoreGroupBuy))
+
+        val response = engine.search("성수")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.NEIGHBORHOOD_ONLY)
+        assertThat(response.detectedRegion).isEqualTo("성수")
+        assertThat(response.detectedProduct).isNull()
+        assertThat(response.confidence).isEqualTo(0.5)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.results.map { it.id }).containsExactly(20L)
+    }
+
+    @Test
+    @DisplayName("양쪽 인덱스가 모두 hit 하면 BOTH_DETECTED 로 분류하고 detectedProduct/Region 모두 채운다")
+    fun `both indexes hit yields BOTH_DETECTED case`() {
+        val saltBread = SearchTestFixtures.groupBuy(
+            id = 10L,
+            productName = "소금빵",
+            deadline = LocalDateTime.now().plusDays(1),
+        )
+        val seongsuBagel = SearchTestFixtures.groupBuy(
+            id = 20L,
+            productName = "베이글",
+            deadline = LocalDateTime.now().plusDays(2),
+        )
+        stubProductIds(listOf(10L))
+        stubStoreIds(listOf(20L))
+        stubFetch(listOf(saltBread, seongsuBagel))
+
+        val response = engine.search("성수 소금빵")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+        assertThat(response.detectedProduct).isEqualTo("성수 소금빵")
+        assertThat(response.detectedRegion).isEqualTo("성수 소금빵")
+        assertThat(response.confidence).isEqualTo(1.0)
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(2)
+        // deadline ASC 정렬 검증 (saltBread = +1일, seongsuBagel = +2일)
+        assertThat(response.results.map { it.id }).containsExactly(10L, 20L)
+    }
+
+    @Test
+    @DisplayName("양쪽 인덱스에서 동일한 id 가 반환되면 dedupe 되어 한 번만 결과에 포함된다")
+    fun `overlapping ids are deduplicated`() {
+        val sharedHit = SearchTestFixtures.groupBuy(id = 10L, productName = "성수 소금빵")
+        stubProductIds(listOf(10L))
+        stubStoreIds(listOf(10L))
+        stubFetch(listOf(sharedHit))
+
+        val response = engine.search("성수 소금빵")
+
+        assertThat(response.searchCase).isEqualTo(SearchCase.BOTH_DETECTED)
+        assertThat(response.totalCount).isEqualTo(1)
+        assertThat(response.results.map { it.id }).containsExactly(10L)
+    }
+
+    @Test
+    @DisplayName("1차 strict 양쪽 모두 0건이고 2차 fallback 도 모두 0건이면 NONE_DETECTED + EMPTY_CAN_REQUEST")
+    fun `all empty yields NONE_DETECTED and EMPTY_CAN_REQUEST`() {
+        stubProductIds(emptyList(), emptyList())
+        stubStoreIds(emptyList(), emptyList())
 
         val response = engine.search("존재하지않는상품")
 
+        assertThat(response.searchCase).isEqualTo(SearchCase.NONE_DETECTED)
         assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
-        assertThat(response.totalCount).isZero
-        assertThat(response.results).isEmpty()
+        assertThat(response.confidence).isEqualTo(0.0)
+        assertThat(response.detectedProduct).isNull()
+        assertThat(response.detectedRegion).isNull()
         Mockito.verify(groupBuyRepository, Mockito.never()).findAllWithStoreByIdIn(anyLongList())
     }
 
     @Test
-    @DisplayName("1차 strict 가 hit 하면 2차 fallback 쿼리는 실행되지 않는다")
-    fun `strict hit skips fallback query`() {
-        val match = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
-        stubIds(listOf(10L))
-        stubFetch(listOf(10L), listOf(match))
+    @DisplayName("1차 strict 가 한쪽이라도 hit 하면 2차 fallback 쿼리는 실행되지 않는다")
+    fun `strict any hit skips fallback`() {
+        val saltBread = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
+        stubProductIds(listOf(10L))
+        stubStoreIds(emptyList())
+        stubFetch(listOf(saltBread))
 
-        val response = engine.search("소금빵")
+        engine.search("소금빵")
 
-        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
-        assertThat(response.totalCount).isEqualTo(1)
         Mockito.verify(groupBuyRepository, Mockito.times(1))
-            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+            .searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        Mockito.verify(groupBuyRepository, Mockito.times(1))
+            .searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
     }
 
     @Test
-    @DisplayName("1차 strict 가 0건이면 2차 fallback 쿼리로 재조회한 결과를 사용한다")
-    fun `strict miss falls back to OR query`() {
-        val curry = SearchTestFixtures.groupBuy(id = 20L, productName = "카레")
-        val sausage = SearchTestFixtures.groupBuy(id = 30L, productName = "소시지")
-        Mockito.`when`(
-            groupBuyRepository.searchIdsByFullText(
-                anyString(),
-                anyString(),
-                anyLocalDateTime(),
-                anyInt(),
-            )
-        )
-            .thenReturn(emptyList())
-            .thenReturn(listOf(20L, 30L))
-        stubFetch(listOf(20L, 30L), listOf(curry, sausage))
+    @DisplayName("1차 strict 양쪽 0건이면 2차 fallback 쿼리로 양쪽 인덱스를 재조회한다")
+    fun `strict miss falls back on both axes`() {
+        val curry = SearchTestFixtures.groupBuy(id = 30L, productName = "카레")
+        val sausage = SearchTestFixtures.groupBuy(id = 40L, productName = "소시지")
+        stubProductIds(emptyList(), listOf(30L, 40L))
+        stubStoreIds(emptyList(), emptyList())
+        stubFetch(listOf(curry, sausage))
 
         val response = engine.search("카레소시지")
 
-        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
         assertThat(response.totalCount).isEqualTo(2)
-        assertThat(response.results.map { it.id }).containsExactly(20L, 30L)
+        assertThat(response.results.map { it.id }).containsExactlyInAnyOrder(30L, 40L)
         Mockito.verify(groupBuyRepository, Mockito.times(2))
-            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+            .searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        Mockito.verify(groupBuyRepository, Mockito.times(2))
+            .searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -67,7 +67,7 @@ class FullTextSearchEngineTest {
     }
 
     @Test
-    @DisplayName("매칭 id가 0개면 fetch를 호출하지 않고 EMPTY_CAN_REQUEST를 반환한다")
+    @DisplayName("1차 strict 와 2차 fallback 모두 0건이면 fetch를 호출하지 않고 EMPTY_CAN_REQUEST를 반환한다")
     fun `empty id list short circuits fetch`() {
         stubIds(emptyList())
 
@@ -77,5 +77,46 @@ class FullTextSearchEngineTest {
         assertThat(response.totalCount).isZero
         assertThat(response.results).isEmpty()
         Mockito.verify(groupBuyRepository, Mockito.never()).findAllWithStoreByIdIn(anyLongList())
+    }
+
+    @Test
+    @DisplayName("1차 strict 가 hit 하면 2차 fallback 쿼리는 실행되지 않는다")
+    fun `strict hit skips fallback query`() {
+        val match = SearchTestFixtures.groupBuy(id = 10L, productName = "소금빵")
+        stubIds(listOf(10L))
+        stubFetch(listOf(10L), listOf(match))
+
+        val response = engine.search("소금빵")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(1)
+        Mockito.verify(groupBuyRepository, Mockito.times(1))
+            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+    }
+
+    @Test
+    @DisplayName("1차 strict 가 0건이면 2차 fallback 쿼리로 재조회한 결과를 사용한다")
+    fun `strict miss falls back to OR query`() {
+        val curry = SearchTestFixtures.groupBuy(id = 20L, productName = "카레")
+        val sausage = SearchTestFixtures.groupBuy(id = 30L, productName = "소시지")
+        Mockito.`when`(
+            groupBuyRepository.searchIdsByFullText(
+                anyString(),
+                anyString(),
+                anyLocalDateTime(),
+                anyInt(),
+            )
+        )
+            .thenReturn(emptyList())
+            .thenReturn(listOf(20L, 30L))
+        stubFetch(listOf(20L, 30L), listOf(curry, sausage))
+
+        val response = engine.search("카레소시지")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.totalCount).isEqualTo(2)
+        assertThat(response.results.map { it.id }).containsExactly(20L, 30L)
+        Mockito.verify(groupBuyRepository, Mockito.times(2))
+            .searchIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
     }
 }

--- a/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
@@ -38,7 +38,8 @@ object SearchTestFixtures {
         id: Long,
         productName: String = "두쫀쿠",
         store: Store = store(),
-        status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS
+        status: GroupBuyStatus = GroupBuyStatus.IN_PROGRESS,
+        deadline: LocalDateTime = LocalDateTime.now().plusDays(3),
     ): GroupBuy = GroupBuy(
         store = store,
         groupBuyRequest = groupBuyRequest(),
@@ -50,7 +51,7 @@ object SearchTestFixtures {
         currentQuantity = 10,
         maxQuantity = 100,
         status = status,
-        deadline = LocalDateTime.now().plusDays(3),
+        deadline = deadline,
         pickupDate = LocalDate.now().plusDays(5),
         pickupTimeStart = LocalTime.of(14, 0),
         pickupTimeEnd = LocalTime.of(18, 0),


### PR DESCRIPTION
## 📌 작업한 내용

develop에서 작업한 내용을 main에 병합시킵니다. 

## 🔍 참고 사항

- 응답 스키마 변경 없음. 프론트의 `searchCase` 4분기 UI 가 다시 정상 동작합니다.
- 검색 SQL 호출이 strict 1건 → strict 2건로 늘어나지만 인덱스/limit 50 기준 가벼움.

## 🖼️ 스크린샷


## 🔗 관련 이슈

- #276, #277

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

[MCJ-1570]: https://moongchijang.atlassian.net/browse/MCJ-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MCJ-1571]: https://moongchijang.atlassian.net/browse/MCJ-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ