### PR TITLE
FIX: 공구 상세 imageUrls 에서 썸네일 동일 키 제외

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -113,8 +113,9 @@ class GroupBuyService(
         return GroupBuyDetailResponse.from(
             groupBuy = groupBuy,
             thumbnailUrl = s3ImageReferenceResolver.resolveForRead(groupBuy.thumbnailKey),
-            imageUrls = images.map { s3ImageReferenceResolver.resolveForRead(it.imageKey) ?: "" }
-                .filter { it.isNotBlank() },
+            imageUrls = images
+                .filter { it.imageKey != groupBuy.thumbnailKey }
+                .mapNotNull { s3ImageReferenceResolver.resolveForRead(it.imageKey) },
             isWishlisted = isWishlisted,
             isParticipated = isParticipated,
             canParticipate = canParticipate

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -204,9 +204,11 @@ class GroupBuyServiceTest {
     fun `상세 조회 시 썸네일과 동일한 키의 이미지는 imageUrls 에서 제외된다`() {
         val groupBuyId = 13L
         val userId = 1L
+        val thumbnailKey = "test-thumbnail-key"
         val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
+            .apply { this.thumbnailKey = thumbnailKey }
         val images = listOf(
-            GroupBuyFixture.createImage(groupBuy, groupBuy.thumbnailKey!!),
+            GroupBuyFixture.createImage(groupBuy, thumbnailKey),
             GroupBuyFixture.createImage(groupBuy, "https://image-detail.jpg"),
         )
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -201,6 +201,27 @@ class GroupBuyServiceTest {
     }
 
     @Test
+    fun `상세 조회 시 썸네일과 동일한 키의 이미지는 imageUrls 에서 제외된다`() {
+        val groupBuyId = 13L
+        val userId = 1L
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
+        val images = listOf(
+            GroupBuyFixture.createImage(groupBuy, groupBuy.thumbnailKey!!),
+            GroupBuyFixture.createImage(groupBuy, "https://image-detail.jpg"),
+        )
+
+        `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+        `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(images)
+        `when`(favoriteRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+
+        val result = service.getDetail(groupBuyId, userId)
+
+        assertEquals(listOf("https://image-detail.jpg"), result.imageUrls)
+        assertEquals(groupBuy.thumbnailKey, result.thumbnailUrl)
+    }
+
+    @Test
     fun `비로그인 사용자 상세 조회 시 찜 여부와 참여 여부 false 반환`() {
         val groupBuyId = 11L
         val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)


### PR DESCRIPTION
## 📌 작업한 내용
- `GroupBuyService.getDetail` 에서 `imageUrls` 구성 시 `imageKey == thumbnailKey` 인 항목을 제외합니다.
- 응답 조립 시점 필터링이라 기존 모든 공구 데이터에 자동 적용되게끔 구현했습다.

## 🔍 참고 사항
- 운영 응답의 `imageUrls[0]` 이 `thumbnailUrl` 과 동일 키였던 문제였습니다.
- 현재는 `thumbnailKey` 가 null 이면 아무것도 필터되지 않기에 수정 완료됐습니다.

## 🖼️ 스크린샷

## 🔗 관련 이슈
- closes #282

## ✅ 체크리스트
- [x] 테스트 통과
- [x] OpenAPI 영향 없음 (스키마 그대로)
