### PR TITLE
RELEASE: 공구 상세 imageUrls 썸네일 중복 제거 main 배포

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -113,8 +113,9 @@ class GroupBuyService(
         return GroupBuyDetailResponse.from(
             groupBuy = groupBuy,
             thumbnailUrl = s3ImageReferenceResolver.resolveForRead(groupBuy.thumbnailKey),
-            imageUrls = images.map { s3ImageReferenceResolver.resolveForRead(it.imageKey) ?: "" }
-                .filter { it.isNotBlank() },
+            imageUrls = images
+                .filter { it.imageKey != groupBuy.thumbnailKey }
+                .mapNotNull { s3ImageReferenceResolver.resolveForRead(it.imageKey) },
             isWishlisted = isWishlisted,
             isParticipated = isParticipated,
             canParticipate = canParticipate

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -204,9 +204,11 @@ class GroupBuyServiceTest {
     fun `상세 조회 시 썸네일과 동일한 키의 이미지는 imageUrls 에서 제외된다`() {
         val groupBuyId = 13L
         val userId = 1L
+        val thumbnailKey = "test-thumbnail-key"
         val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
+            .apply { this.thumbnailKey = thumbnailKey }
         val images = listOf(
-            GroupBuyFixture.createImage(groupBuy, groupBuy.thumbnailKey!!),
+            GroupBuyFixture.createImage(groupBuy, thumbnailKey),
             GroupBuyFixture.createImage(groupBuy, "https://image-detail.jpg"),
         )
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -201,6 +201,27 @@ class GroupBuyServiceTest {
     }
 
     @Test
+    fun `상세 조회 시 썸네일과 동일한 키의 이미지는 imageUrls 에서 제외된다`() {
+        val groupBuyId = 13L
+        val userId = 1L
+        val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)
+        val images = listOf(
+            GroupBuyFixture.createImage(groupBuy, groupBuy.thumbnailKey!!),
+            GroupBuyFixture.createImage(groupBuy, "https://image-detail.jpg"),
+        )
+
+        `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
+        `when`(groupBuyImageRepository.findAllByGroupBuyId(groupBuyId)).thenReturn(images)
+        `when`(favoriteRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(userId, groupBuyId)).thenReturn(false)
+
+        val result = service.getDetail(groupBuyId, userId)
+
+        assertEquals(listOf("https://image-detail.jpg"), result.imageUrls)
+        assertEquals(groupBuy.thumbnailKey, result.thumbnailUrl)
+    }
+
+    @Test
     fun `비로그인 사용자 상세 조회 시 찜 여부와 참여 여부 false 반환`() {
         val groupBuyId = 11L
         val groupBuy = GroupBuyFixture.createGroupBuy(id = groupBuyId, status = GroupBuyStatus.IN_PROGRESS)


### PR DESCRIPTION
## 📌 작업한 내용
- 공구 상세 응답의 `imageUrls` 에서 `thumbnailKey` 와 동일한 S3 키를 가진 이미지를 제외해 모든 공구에 자동 적용합니다.

## 🔍 참고 사항
- 운영 데이터 응답의 `imageUrls[0]` 이 `thumbnailUrl` 과 동일 키였던 문제 해결
- DB 데이터 정리 없이 응답 시점 필터링이라 기존 모든 공구에 일괄 적용

## 🖼️ 스크린샷
N/A

## 🔗 관련 이슈
- #282

## ✅ 체크리스트
- [x] develop CI 통과
- [x] 회귀 테스트 추가됨
