### PR TITLE
RELEASE: 카카오 회원가입 닉네임 중복 판정 오류 수정 배포

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -116,9 +116,14 @@ class UserService(
     }
 
     @Transactional(readOnly = true)
-    fun checkNicknameAvailability(nickname: String): NicknameAvailabilityResponse {
+    fun checkNicknameAvailability(nickname: String, userId: Long?): NicknameAvailabilityResponse {
         validateNicknameFormat(nickname)
-        val duplicated = userRepository.existsByNicknameAndDeletedAtIsNull(nickname)
+        val duplicated = if (userId == null) {
+            userRepository.existsByNicknameAndDeletedAtIsNull(nickname)
+        } else {
+            val nicknameOwner = userRepository.findByNicknameAndDeletedAtIsNull(nickname)
+            nicknameOwner != null && nicknameOwner.id != userId
+        }
         return NicknameAvailabilityResponse(
             nickname = nickname,
             available = !duplicated,

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -165,7 +165,7 @@ class UserService(
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        assertNoDuplicateNickname(request.nickname, user.id, user.nickname)
+        assertNoDuplicateNickname(request.nickname, user.nickname)
 
         user.completeSignup(request.nickname, request.phoneNumber)
         log.info("[UserService] 추가정보 입력 처리 완료: userId={}", userId)
@@ -295,7 +295,7 @@ class UserService(
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        assertNoDuplicateNickname(request.nickname, user.id, user.nickname)
+        assertNoDuplicateNickname(request.nickname, user.nickname)
 
         user.nickname = request.nickname
         log.info("[UserService] 닉네임 변경 처리 완료: userId={}", userId)
@@ -567,12 +567,12 @@ class UserService(
         }
     }
 
-    private fun assertNoDuplicateNickname(nickname: String, userId: Long?, currentNickname: String?) {
+    private fun assertNoDuplicateNickname(nickname: String, currentNickname: String?) {
         if (currentNickname == nickname) {
             return
         }
 
-        if (isNicknameDuplicated(nickname, userId)) {
+        if (userRepository.existsByNicknameAndDeletedAtIsNull(nickname)) {
             throw CustomException(ErrorCode.DUPLICATE_NICKNAME)
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -118,12 +118,7 @@ class UserService(
     @Transactional(readOnly = true)
     fun checkNicknameAvailability(nickname: String, userId: Long?): NicknameAvailabilityResponse {
         validateNicknameFormat(nickname)
-        val duplicated = if (userId == null) {
-            userRepository.existsByNicknameAndDeletedAtIsNull(nickname)
-        } else {
-            val nicknameOwner = userRepository.findByNicknameAndDeletedAtIsNull(nickname)
-            nicknameOwner != null && nicknameOwner.id != userId
-        }
+        val duplicated = isNicknameDuplicated(nickname, userId)
         return NicknameAvailabilityResponse(
             nickname = nickname,
             available = !duplicated,
@@ -170,11 +165,7 @@ class UserService(
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val duplicated = userRepository.existsByNicknameAndDeletedAtIsNull(request.nickname) &&
-            user.nickname != request.nickname
-        if (duplicated) {
-            throw CustomException(ErrorCode.DUPLICATE_NICKNAME)
-        }
+        assertNoDuplicateNickname(request.nickname, user.id, user.nickname)
 
         user.completeSignup(request.nickname, request.phoneNumber)
         log.info("[UserService] 추가정보 입력 처리 완료: userId={}", userId)
@@ -304,11 +295,7 @@ class UserService(
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val duplicated = userRepository.existsByNicknameAndDeletedAtIsNull(request.nickname) &&
-            user.nickname != request.nickname
-        if (duplicated) {
-            throw CustomException(ErrorCode.DUPLICATE_NICKNAME)
-        }
+        assertNoDuplicateNickname(request.nickname, user.id, user.nickname)
 
         user.nickname = request.nickname
         log.info("[UserService] 닉네임 변경 처리 완료: userId={}", userId)
@@ -578,6 +565,25 @@ class UserService(
         if (!phoneRegex.matches(phoneNumber)) {
             throw CustomException(ErrorCode.INVALID_PHONE_NUMBER_FORMAT)
         }
+    }
+
+    private fun assertNoDuplicateNickname(nickname: String, userId: Long?, currentNickname: String?) {
+        if (currentNickname == nickname) {
+            return
+        }
+
+        if (isNicknameDuplicated(nickname, userId)) {
+            throw CustomException(ErrorCode.DUPLICATE_NICKNAME)
+        }
+    }
+
+    private fun isNicknameDuplicated(nickname: String, userId: Long?): Boolean {
+        if (userId == null) {
+            return userRepository.existsByNicknameAndDeletedAtIsNull(nickname)
+        }
+
+        val nicknameOwner = userRepository.findByNicknameAndDeletedAtIsNull(nickname)
+        return nicknameOwner != null && nicknameOwner.id != userId
     }
 
     private fun validateEmailFormat(email: String) {

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -165,7 +165,7 @@ class UserService(
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        assertNoDuplicateNickname(request.nickname, user.nickname)
+        assertNoDuplicateNickname(request.nickname, userId)
 
         user.completeSignup(request.nickname, request.phoneNumber)
         log.info("[UserService] 추가정보 입력 처리 완료: userId={}", userId)
@@ -295,7 +295,7 @@ class UserService(
         val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        assertNoDuplicateNickname(request.nickname, user.nickname)
+        assertNoDuplicateNickname(request.nickname, userId)
 
         user.nickname = request.nickname
         log.info("[UserService] 닉네임 변경 처리 완료: userId={}", userId)
@@ -567,12 +567,8 @@ class UserService(
         }
     }
 
-    private fun assertNoDuplicateNickname(nickname: String, currentNickname: String?) {
-        if (currentNickname == nickname) {
-            return
-        }
-
-        if (userRepository.existsByNicknameAndDeletedAtIsNull(nickname)) {
+    private fun assertNoDuplicateNickname(nickname: String, userId: Long) {
+        if (userRepository.existsByNicknameAndIdNotAndDeletedAtIsNull(nickname, userId)) {
             throw CustomException(ErrorCode.DUPLICATE_NICKNAME)
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -582,8 +582,7 @@ class UserService(
             return userRepository.existsByNicknameAndDeletedAtIsNull(nickname)
         }
 
-        val nicknameOwner = userRepository.findByNicknameAndDeletedAtIsNull(nickname)
-        return nicknameOwner != null && nicknameOwner.id != userId
+        return userRepository.existsByNicknameAndIdNotAndDeletedAtIsNull(nickname, userId)
     }
 
     private fun validateEmailFormat(email: String) {

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
@@ -30,7 +30,7 @@ interface UserRepository : JpaRepository<User, Long> {
 
     fun existsByNicknameAndDeletedAtIsNull(nickname: String): Boolean
 
-    fun findByNicknameAndDeletedAtIsNull(nickname: String): User?
+    fun existsByNicknameAndIdNotAndDeletedAtIsNull(nickname: String, id: Long): Boolean
 
     fun findByIdAndDeletedAtIsNull(id: Long): User?
 

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/repository/UserRepository.kt
@@ -30,6 +30,8 @@ interface UserRepository : JpaRepository<User, Long> {
 
     fun existsByNicknameAndDeletedAtIsNull(nickname: String): Boolean
 
+    fun findByNicknameAndDeletedAtIsNull(nickname: String): User?
+
     fun findByIdAndDeletedAtIsNull(id: Long): User?
 
     fun findByIdInAndDeletedAtIsNull(ids: Collection<Long>): List<User>

--- a/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/presentation/UserController.kt
@@ -72,8 +72,9 @@ class UserController(
     )
     fun checkNicknameAvailability(
         @RequestParam nickname: String,
+        @AuthenticationPrincipal principal: CustomUserPrincipal?,
     ): ApiResponse<NicknameAvailabilityResponse> {
-        val response = userService.checkNicknameAvailability(nickname)
+        val response = userService.checkNicknameAvailability(nickname, principal?.id)
         return ApiResponse.success(response)
     }
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -197,7 +197,9 @@ paths:
     get:
       tags: [Auth]
       summary: 닉네임 중복 확인
-      description: 추가정보 입력(0.5) 단계에서 닉네임 사용 가능 여부를 확인한다.
+      description: |
+        추가정보 입력(0.5) 단계에서 닉네임 사용 가능 여부를 확인한다.
+        인증 사용자가 호출한 경우 본인 현재 닉네임은 중복으로 보지 않는다.
       security:
         - bearerAuth: []
       parameters:
@@ -228,6 +230,7 @@ paths:
       summary: 추가 정보 입력 완료
       description: |
         신규 가입 공통(카카오/이메일) 추가 정보 입력을 저장한다.
+        닉네임은 최종 저장 시점에 중복 검증되며, 본인 현재 닉네임과 동일한 값은 허용된다.
         성공 시 nickname, phoneNumber, signupCompleted가 반영된다.
       security:
         - bearerAuth: []

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -133,7 +133,7 @@ class UserServiceTest {
         )
 
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
-        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(true)
+        Mockito.`when`(userRepository.existsByNicknameAndIdNotAndDeletedAtIsNull("중복닉네임", 1L)).thenReturn(true)
 
         val exception = assertThrows<CustomException> {
             userService.updateAdditionalInfo(
@@ -334,7 +334,7 @@ class UserServiceTest {
     fun `닉네임 변경할 때 정상 요청이면 닉네임이 변경됨`() {
         val user = UserFixture.createKakaoUser(id = 51L, providerId = "kakao-51", nickname = "기존닉네임")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(51L)).thenReturn(user)
-        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("새닉네임")).thenReturn(false)
+        Mockito.`when`(userRepository.existsByNicknameAndIdNotAndDeletedAtIsNull("새닉네임", 51L)).thenReturn(false)
 
         val response = userService.updateNickname(
             request = NicknameUpdateRequest(nickname = "새닉네임"),
@@ -350,7 +350,7 @@ class UserServiceTest {
     fun `닉네임 변경할 때 중복 닉네임이면 예외`() {
         val user = UserFixture.createKakaoUser(id = 52L, providerId = "kakao-52", nickname = "기존닉네임")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(52L)).thenReturn(user)
-        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(true)
+        Mockito.`when`(userRepository.existsByNicknameAndIdNotAndDeletedAtIsNull("중복닉네임", 52L)).thenReturn(true)
 
         val exception = assertThrows<CustomException> {
             userService.updateNickname(

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -131,15 +131,9 @@ class UserServiceTest {
             email = "dup@example.com",
             nickname = "기존닉네임"
         )
-        val anotherUser = UserFixture.createKakaoUser(
-            id = 2L,
-            providerId = "kakao-another",
-            email = "another@example.com",
-            nickname = "중복닉네임",
-        )
 
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
-        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(anotherUser)
+        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(true)
 
         val exception = assertThrows<CustomException> {
             userService.updateAdditionalInfo(
@@ -196,12 +190,7 @@ class UserServiceTest {
 
     @Test
     fun `닉네임 중복 확인 시 로그인 사용자 본인 닉네임이면 사용 가능`() {
-        val user = UserFixture.createKakaoUser(
-            id = 61L,
-            providerId = "kakao-61",
-            nickname = "내닉네임",
-        )
-        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("내닉네임")).thenReturn(user)
+        Mockito.`when`(userRepository.existsByNicknameAndIdNotAndDeletedAtIsNull("내닉네임", 61L)).thenReturn(false)
 
         val response = userService.checkNicknameAvailability("내닉네임", 61L)
 
@@ -345,7 +334,7 @@ class UserServiceTest {
     fun `닉네임 변경할 때 정상 요청이면 닉네임이 변경됨`() {
         val user = UserFixture.createKakaoUser(id = 51L, providerId = "kakao-51", nickname = "기존닉네임")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(51L)).thenReturn(user)
-        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("새닉네임")).thenReturn(null)
+        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("새닉네임")).thenReturn(false)
 
         val response = userService.updateNickname(
             request = NicknameUpdateRequest(nickname = "새닉네임"),
@@ -360,9 +349,8 @@ class UserServiceTest {
     @Test
     fun `닉네임 변경할 때 중복 닉네임이면 예외`() {
         val user = UserFixture.createKakaoUser(id = 52L, providerId = "kakao-52", nickname = "기존닉네임")
-        val duplicatedUser = UserFixture.createKakaoUser(id = 70L, providerId = "kakao-70", nickname = "중복닉네임")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(52L)).thenReturn(user)
-        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(duplicatedUser)
+        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(true)
 
         val exception = assertThrows<CustomException> {
             userService.updateNickname(

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -131,9 +131,15 @@ class UserServiceTest {
             email = "dup@example.com",
             nickname = "기존닉네임"
         )
+        val anotherUser = UserFixture.createKakaoUser(
+            id = 2L,
+            providerId = "kakao-another",
+            email = "another@example.com",
+            nickname = "중복닉네임",
+        )
 
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
-        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(true)
+        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(anotherUser)
 
         val exception = assertThrows<CustomException> {
             userService.updateAdditionalInfo(
@@ -186,6 +192,31 @@ class UserServiceTest {
 
         Assertions.assertTrue(response.available)
         Assertions.assertEquals("new@example.com", response.email)
+    }
+
+    @Test
+    fun `닉네임 중복 확인 시 로그인 사용자 본인 닉네임이면 사용 가능`() {
+        val user = UserFixture.createKakaoUser(
+            id = 61L,
+            providerId = "kakao-61",
+            nickname = "내닉네임",
+        )
+        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("내닉네임")).thenReturn(user)
+
+        val response = userService.checkNicknameAvailability("내닉네임", 61L)
+
+        Assertions.assertTrue(response.available)
+        Assertions.assertEquals("내닉네임", response.nickname)
+    }
+
+    @Test
+    fun `닉네임 중복 확인 시 비로그인 사용자는 중복 닉네임이면 사용 불가`() {
+        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(true)
+
+        val response = userService.checkNicknameAvailability("중복닉네임", null)
+
+        Assertions.assertFalse(response.available)
+        Assertions.assertEquals("중복닉네임", response.nickname)
     }
 
     @Test
@@ -314,7 +345,7 @@ class UserServiceTest {
     fun `닉네임 변경할 때 정상 요청이면 닉네임이 변경됨`() {
         val user = UserFixture.createKakaoUser(id = 51L, providerId = "kakao-51", nickname = "기존닉네임")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(51L)).thenReturn(user)
-        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("새닉네임")).thenReturn(false)
+        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("새닉네임")).thenReturn(null)
 
         val response = userService.updateNickname(
             request = NicknameUpdateRequest(nickname = "새닉네임"),
@@ -329,8 +360,9 @@ class UserServiceTest {
     @Test
     fun `닉네임 변경할 때 중복 닉네임이면 예외`() {
         val user = UserFixture.createKakaoUser(id = 52L, providerId = "kakao-52", nickname = "기존닉네임")
+        val duplicatedUser = UserFixture.createKakaoUser(id = 70L, providerId = "kakao-70", nickname = "중복닉네임")
         Mockito.`when`(userRepository.findByIdAndDeletedAtIsNull(52L)).thenReturn(user)
-        Mockito.`when`(userRepository.existsByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(true)
+        Mockito.`when`(userRepository.findByNicknameAndDeletedAtIsNull("중복닉네임")).thenReturn(duplicatedUser)
 
         val exception = assertThrows<CustomException> {
             userService.updateNickname(


### PR DESCRIPTION
## 📌 작업한 내용
- 카카오 추가정보 입력 시 본인 닉네임이 중복으로 판정되던 문제를 수정했습니다.
- 닉네임 중복 검증 로직을 정리하고 관련 테스트를 보강했습니다.
- OpenAPI 문서에 닉네임 검증 기준을 반영했습니다.

## 🔍 참고 사항
- 본인 닉네임은 허용되며, 타 사용자 닉네임 중복 차단 정책은 그대로 유지됩니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #285 
- Closed #286 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인