### PR TITLE
RELEASE: 카카오 로그인 닉네임 선저장 500 오류 수정 배포

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -536,14 +536,20 @@ class UserService(
         email: String,
         nickname: String,
     ): User {
+        val sanitizedNickname = sanitizeKakaoNicknameForPreload(nickname)
         val newUser = User.newKakaoUser(
             providerId = providerId,
             email = email,
-            nickname = nickname,
+            nickname = sanitizedNickname,
         )
         val savedUser = userRepository.save(newUser)
         log.info("[UserService] 신규 카카오 사용자 생성 완료: userId={}", savedUser.id)
         return savedUser
+    }
+
+    private fun sanitizeKakaoNicknameForPreload(rawNickname: String?): String? {
+        val nickname = rawNickname?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        return if (KAKAO_PRELOAD_NICKNAME_REGEX.matches(nickname)) nickname else null
     }
 
     private fun validateRejoinAvailable(deletedAt: LocalDateTime) {
@@ -603,5 +609,6 @@ class UserService(
     companion object {
         private val EMAIL_REGEX = Regex("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
         private val PASSWORD_REGEX = Regex("^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}$")
+        private val KAKAO_PRELOAD_NICKNAME_REGEX = Regex("^[A-Za-z0-9가-힣]{2,10}$")
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -522,8 +522,9 @@ class UserService(
 
         deletedUser.deletedAt = null
         deletedUser.email = email
+        val sanitizedNickname = sanitizeKakaoNicknameForPreload(nickname)
         if (deletedUser.nickname.isNullOrBlank()) {
-            deletedUser.nickname = nickname
+            deletedUser.nickname = sanitizedNickname
         }
         deletedUser.signupCompleted = false
         deletedUser.sellerSignupCompleted = false

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -548,9 +548,9 @@ class UserService(
         return savedUser
     }
 
-    private fun sanitizeKakaoNicknameForPreload(rawNickname: String?): String? {
-        val nickname = rawNickname?.trim()?.takeIf { it.isNotBlank() } ?: return null
-        return if (KAKAO_PRELOAD_NICKNAME_REGEX.matches(nickname)) nickname else null
+    private fun sanitizeKakaoNicknameForPreload(rawNickname: String): String? {
+        val nickname = rawNickname.trim()
+        return if (NICKNAME_REGEX.matches(nickname)) nickname else null
     }
 
     private fun validateRejoinAvailable(deletedAt: LocalDateTime) {
@@ -561,8 +561,7 @@ class UserService(
     }
 
     private fun validateNicknameFormat(nickname: String) {
-        val nicknameRegex = Regex("^[A-Za-z0-9가-힣]{2,10}$")
-        if (!nicknameRegex.matches(nickname)) {
+        if (!NICKNAME_REGEX.matches(nickname)) {
             throw CustomException(ErrorCode.INVALID_NICKNAME_FORMAT)
         }
     }
@@ -610,6 +609,6 @@ class UserService(
     companion object {
         private val EMAIL_REGEX = Regex("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
         private val PASSWORD_REGEX = Regex("^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}$")
-        private val KAKAO_PRELOAD_NICKNAME_REGEX = Regex("^[A-Za-z0-9가-힣]{2,10}$")
+        private val NICKNAME_REGEX = Regex("^[A-Za-z0-9가-힣]{2,10}$")
     }
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -55,7 +55,9 @@ paths:
     post:
       tags: [Auth]
       summary: 카카오 로그인 / 회원가입
-      description: 카카오 인가 코드로 로그인하거나 최초 가입 처리한다.
+      description: |
+        카카오 인가 코드로 로그인하거나 최초 가입 처리한다.
+        카카오 닉네임은 선저장 단계에서 2~10자/한글·영문·숫자 조건을 만족할 때만 저장되며, 조건 미충족 시 null로 저장된다.
       requestBody:
         required: true
         content:

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -31,6 +31,7 @@ import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
@@ -109,6 +110,60 @@ class UserServiceTest {
     }
 
     @Test
+    fun `신규 카카오 사용자 생성 시 닉네임이 형식 조건을 만족하면 선저장한다`() {
+        val savedUser = UserFixture.createKakaoUser(
+            id = 11L,
+            providerId = "kakao-valid",
+            email = "valid@example.com",
+            nickname = "정상닉네임",
+        )
+        val userCaptor: ArgumentCaptor<User> = ArgumentCaptor.forClass(User::class.java)
+
+        Mockito.`when`(
+            userRepository.findByProviderAndProviderIdAndDeletedAtIsNull(AuthProvider.KAKAO, "kakao-valid"),
+        ).thenReturn(null)
+        Mockito.`when`(
+            userRepository.findByProviderAndProviderIdAndDeletedAtIsNotNull(AuthProvider.KAKAO, "kakao-valid"),
+        ).thenReturn(null)
+        Mockito.`when`(userRepository.save(userCaptor.capture())).thenReturn(savedUser)
+
+        userService.findOrCreateKakaoUser(
+            providerId = "kakao-valid",
+            email = "valid@example.com",
+            nickname = "정상닉네임",
+        )
+
+        Assertions.assertEquals("정상닉네임", userCaptor.value.nickname)
+    }
+
+    @Test
+    fun `신규 카카오 사용자 생성 시 닉네임이 형식 조건을 벗어나면 null로 선저장한다`() {
+        val savedUser = UserFixture.createKakaoUser(
+            id = 12L,
+            providerId = "kakao-invalid",
+            email = "invalid@example.com",
+            nickname = "임시닉네임",
+        )
+        val userCaptor: ArgumentCaptor<User> = ArgumentCaptor.forClass(User::class.java)
+
+        Mockito.`when`(
+            userRepository.findByProviderAndProviderIdAndDeletedAtIsNull(AuthProvider.KAKAO, "kakao-invalid"),
+        ).thenReturn(null)
+        Mockito.`when`(
+            userRepository.findByProviderAndProviderIdAndDeletedAtIsNotNull(AuthProvider.KAKAO, "kakao-invalid"),
+        ).thenReturn(null)
+        Mockito.`when`(userRepository.save(userCaptor.capture())).thenReturn(savedUser)
+
+        userService.findOrCreateKakaoUser(
+            providerId = "kakao-invalid",
+            email = "invalid@example.com",
+            nickname = "너무긴닉네임입니다초과",
+        )
+
+        Assertions.assertEquals(null, userCaptor.value.nickname)
+    }
+
+    @Test
     fun `추가정보 입력 시 닉네임 형식 오류 예외`() {
         val exception = assertThrows<CustomException> {
             userService.updateAdditionalInfo(
@@ -174,6 +229,34 @@ class UserServiceTest {
         }
 
         Assertions.assertEquals(ErrorCode.REJOIN_NOT_AVAILABLE_YET, exception.errorCode)
+    }
+
+    @Test
+    fun `탈퇴 복구 시 기존 닉네임이 비어있고 카카오 닉네임이 무효면 null 유지`() {
+        val deletedUser = UserFixture.createKakaoUser(
+            id = 21L,
+            providerId = "kakao-restore",
+            email = "restore@example.com",
+            nickname = "",
+            deletedAt = LocalDateTime.now().minusDays(40),
+        )
+
+        Mockito.`when`(
+            userRepository.findByProviderAndProviderIdAndDeletedAtIsNull(AuthProvider.KAKAO, "kakao-restore"),
+        ).thenReturn(null)
+        Mockito.`when`(
+            userRepository.findByProviderAndProviderIdAndDeletedAtIsNotNull(AuthProvider.KAKAO, "kakao-restore"),
+        ).thenReturn(deletedUser)
+
+        val (restoredUser, isNewUser) = userService.findOrCreateKakaoUser(
+            providerId = "kakao-restore",
+            email = "restore@example.com",
+            nickname = "invalid-nickname-too-long",
+        )
+
+        Assertions.assertFalse(isNewUser)
+        Assertions.assertEquals(null, restoredUser.nickname)
+        Assertions.assertEquals(null, restoredUser.deletedAt)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -125,7 +125,7 @@ class UserServiceTest {
         Mockito.`when`(
             userRepository.findByProviderAndProviderIdAndDeletedAtIsNotNull(AuthProvider.KAKAO, "kakao-valid"),
         ).thenReturn(null)
-        Mockito.`when`(userRepository.save(userCaptor.capture())).thenReturn(savedUser)
+        Mockito.`when`(userRepository.save(Mockito.any(User::class.java))).thenReturn(savedUser)
 
         userService.findOrCreateKakaoUser(
             providerId = "kakao-valid",
@@ -133,6 +133,7 @@ class UserServiceTest {
             nickname = "정상닉네임",
         )
 
+        Mockito.verify(userRepository).save(userCaptor.capture())
         Assertions.assertEquals("정상닉네임", userCaptor.value.nickname)
     }
 
@@ -152,7 +153,7 @@ class UserServiceTest {
         Mockito.`when`(
             userRepository.findByProviderAndProviderIdAndDeletedAtIsNotNull(AuthProvider.KAKAO, "kakao-invalid"),
         ).thenReturn(null)
-        Mockito.`when`(userRepository.save(userCaptor.capture())).thenReturn(savedUser)
+        Mockito.`when`(userRepository.save(Mockito.any(User::class.java))).thenReturn(savedUser)
 
         userService.findOrCreateKakaoUser(
             providerId = "kakao-invalid",
@@ -160,6 +161,7 @@ class UserServiceTest {
             nickname = "너무긴닉네임입니다초과",
         )
 
+        Mockito.verify(userRepository).save(userCaptor.capture())
         Assertions.assertEquals(null, userCaptor.value.nickname)
     }
 


### PR DESCRIPTION
## 📌 작업한 내용
- 카카오 닉네임 선저장 시 유효값만 저장하고, 무효값은 `null`로 저장하도록 수정했습니다.
- 신규 생성/탈퇴 복구 경로에 동일 정책을 적용했습니다.
- 관련 테스트와 OpenAPI 문서를 업데이트했습니다.

## 🔍 참고 사항
- 카카오 닉네임은 선저장 단계에서 보정될 수 있고, 최종 닉네임은 추가정보 입력 단계에서 확정됩니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #288 
- Closed #289 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인