### PR TITLE
[MCJ-1582] FIX: S3 Presigned Upload CORS 설정 추가

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -38,6 +38,19 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_test_bu
   }
 }
 
+// S3 CORS 설정 (Presigned PUT 업로드용)
+resource "aws_s3_bucket_cors_configuration" "terraform_test_bucket" {
+  bucket = aws_s3_bucket.terraform_test_bucket.id
+
+  cors_rule {
+    allowed_methods = ["PUT", "GET", "HEAD"]
+    allowed_origins = var.s3_cors_allowed_origins
+    allowed_headers = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  }
+}
+
 // 애플리케이션 서버 보안 그룹 설정
 resource "aws_security_group" "app_sg" {
   name        = "${var.project_name}-app-sg"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -13,6 +13,16 @@ variable "bucket_name" {
   type        = string
 }
 
+variable "s3_cors_allowed_origins" {
+  description = "Allowed origins for S3 presigned upload CORS"
+  type        = list(string)
+  default = [
+    "http://localhost:3000",
+    "https://moongchijang.com",
+    "https://www.moongchijang.com",
+  ]
+}
+
 variable "ec2_instance_type" {
   description = "EC2 instance type"
   type        = string


### PR DESCRIPTION
## 📌 작업한 내용
- Terraform에 S3 버킷 CORS 설정 리소스 추가
- Presigned 업로드 대응을 위해 허용 메서드에 `PUT`, `GET`, `HEAD` 반영
- 허용 헤더에 `*` 적용(`Content-Type` 포함)
- 허용 Origin에 아래 도메인 반영
- `http://localhost:3000`
- `https://moongchijang.com`
- `https://www.moongchijang.com`
- 응답 헤더 노출(`ETag`) 및 preflight 캐시 시간(`max_age_seconds`) 설정

## 🔍 참고 사항
- `terraform plan` 기준 변경사항은 CORS 리소스 1건 추가만 발생함 (`1 to add, 0 to change, 0 to destroy`)
- 적용 후 브라우저에서 S3 preflight(OPTIONS) 403 해소 여부 확인 필요

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #291 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인