### PR TITLE
[MCJ-1583] CHORE: group_buy 참조 정합성 강화(FK 추가 및 연관관계 정비)

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
@@ -197,7 +197,7 @@ class AdminGroupBuyRequestActionService(
         groupBuyRequest.rejectionReason = rejectionReason
         groupBuyRequestStatusHistoryRepository.save(
             GroupBuyRequestStatusHistory(
-                groupBuyRequestId = groupBuyRequest.id,
+                groupBuyRequest = groupBuyRequest,
                 status = status,
                 changedAt = LocalDateTime.now()
             )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -104,15 +104,13 @@ class GroupBuyOpenRequestService(
         )
 
         val requestsByUserId = pendingRequests.groupBy { requireUserId(it) }
-        val usersById = userRepository.findByIdInAndDeletedAtIsNull(requestsByUserId.keys)
-            .associateBy { it.id }
 
         val targetUserIds = requestsByUserId.keys.toList()
         var sentCount = 0
         var failedCount = 0
 
         requestsByUserId.forEach { (userId, userRequests) ->
-            val receiverPhone = usersById[userId]?.phoneNumber
+            val receiverPhone = userRequests.first().user.phoneNumber
             val message = buildOpenNotificationMessage(userRequests.first().region, productName)
 
             val sent = if (receiverPhone.isNullOrBlank()) {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -55,13 +55,13 @@ class GroupBuyOpenRequestService(
     }
 
     fun create(userId: Long, request: CreateGroupBuyOpenRequestRequest) {
-        if (openRequestRepository.existsByUserIdAndRegionAndProductName(userId, request.region, request.productName)) {
+        if (openRequestRepository.existsByUser_IdAndRegionAndProductName(userId, request.region, request.productName)) {
             throw CustomException(ErrorCode.DUPLICATE_OPEN_REQUEST)
         }
         try {
             openRequestRepository.saveAndFlush(
                 GroupBuyOpenRequest(
-                    userId = userId,
+                    user = findUser(userId),
                     region = request.region,
                     productName = request.productName
                 )
@@ -103,7 +103,7 @@ class GroupBuyOpenRequestService(
             notificationStatus = NotificationStatus.PENDING,
         )
 
-        val requestsByUserId = pendingRequests.groupBy { it.userId }
+        val requestsByUserId = pendingRequests.groupBy { requireUserId(it) }
         val usersById = userRepository.findByIdInAndDeletedAtIsNull(requestsByUserId.keys)
             .associateBy { it.id }
 
@@ -364,6 +364,13 @@ class GroupBuyOpenRequestService(
 
     private fun elapsedMillis(startedAt: Long): Long =
         ((System.nanoTime() - startedAt) / 1_000_000.0).roundToLong()
+
+    private fun findUser(userId: Long) =
+        userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+    private fun requireUserId(openRequest: GroupBuyOpenRequest): Long =
+        openRequest.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
     private data class StoreRecommendationCandidate(
         val naverRank: Int,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestRejectedAlimtalkEventListener.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestRejectedAlimtalkEventListener.kt
@@ -6,7 +6,6 @@ import com.moongchijang.domain.notification.domain.entity.NotificationTriggerTyp
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoAlimtalkClient
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoMessageFormatter
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoProperties
-import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
@@ -19,7 +18,6 @@ import java.time.format.DateTimeFormatter
 @Component
 class GroupBuyRequestRejectedAlimtalkEventListener(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
-    private val userRepository: UserRepository,
     private val aligoAlimtalkClient: AligoAlimtalkClient,
     private val aligoProperties: AligoProperties,
 ) {
@@ -36,11 +34,11 @@ class GroupBuyRequestRejectedAlimtalkEventListener(
         runCatching {
             val request = groupBuyRequestRepository.findById(requestId)
                 .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
-            val userId = requireNotNull(request.user.id) { "GroupBuyRequest.user.id must not be null" }
-            val user = userRepository.findByIdAndDeletedAtIsNull(userId)
-            if (user == null) {
+            val user = request.user
+            val userId = requireNotNull(user.id) { "GroupBuyRequest.user.id must not be null" }
+            if (user.deletedAt != null) {
                 log.warn(
-                    "[GroupBuyRequestRejectedAlimtalkEventListener] 공구 개설 실패 알림톡 스킵(사용자 없음): requestId={}, userId={}",
+                    "[GroupBuyRequestRejectedAlimtalkEventListener] 공구 개설 실패 알림톡 스킵(사용자 탈퇴): requestId={}, userId={}",
                     requestId,
                     userId,
                 )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestRejectedAlimtalkEventListener.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestRejectedAlimtalkEventListener.kt
@@ -36,12 +36,13 @@ class GroupBuyRequestRejectedAlimtalkEventListener(
         runCatching {
             val request = groupBuyRequestRepository.findById(requestId)
                 .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
-            val user = userRepository.findByIdAndDeletedAtIsNull(request.userId)
+            val userId = requireNotNull(request.user.id) { "GroupBuyRequest.user.id must not be null" }
+            val user = userRepository.findByIdAndDeletedAtIsNull(userId)
             if (user == null) {
                 log.warn(
                     "[GroupBuyRequestRejectedAlimtalkEventListener] 공구 개설 실패 알림톡 스킵(사용자 없음): requestId={}, userId={}",
                     requestId,
-                    request.userId,
+                    userId,
                 )
                 return
             }
@@ -50,7 +51,7 @@ class GroupBuyRequestRejectedAlimtalkEventListener(
                 log.warn(
                     "[GroupBuyRequestRejectedAlimtalkEventListener] 공구 개설 실패 알림톡 스킵(전화번호 없음): requestId={}, userId={}",
                     requestId,
-                    request.userId,
+                    userId,
                 )
                 return
             }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -72,7 +72,7 @@ class GroupBuyRequestService(
 
         groupBuyRequestStatusHistoryRepository.save(
             GroupBuyRequestStatusHistory(
-                groupBuyRequestId = saved.id,
+                groupBuyRequest = saved,
                 status = GroupBuyRequestStatus.IN_REVIEW,
                 changedAt = saved.createdAt ?: LocalDateTime.now()
             )
@@ -90,8 +90,8 @@ class GroupBuyRequestService(
         if (requests.isEmpty()) return emptyList()
 
         val historyMap = groupBuyRequestStatusHistoryRepository
-            .findByGroupBuyRequestIdInOrderByChangedAtAsc(requests.map { it.id })
-            .groupBy { it.groupBuyRequestId }
+            .findByGroupBuyRequest_IdInOrderByChangedAtAsc(requests.map { it.id })
+            .groupBy { it.groupBuyRequest.id }
 
         val responses = requests.map { GroupBuyRequestResponse.from(it, historyMap[it.id] ?: emptyList()) }
         log.info("[GroupBuyRequestService] 내 공구요청 목록 조회 완료: userId={}, count={}", userId, responses.size)
@@ -109,7 +109,7 @@ class GroupBuyRequestService(
         }
 
         val history = groupBuyRequestStatusHistoryRepository
-            .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
+            .findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId)
 
         val response = GroupBuyRequestResponse.from(request, history)
         log.info("[GroupBuyRequestService] 공구요청 상세 조회 완료: userId={}, requestId={}", userId, requestId)
@@ -163,7 +163,7 @@ class GroupBuyRequestService(
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
         val requester = request.user
         val history = groupBuyRequestStatusHistoryRepository
-            .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
+            .findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId)
 
         val response = AdminGroupBuyRequestDetailResponse.from(request, requester, history)
         log.info("[GroupBuyRequestService] 관리자 공구요청 상세 조회 완료: requestId={}", requestId)
@@ -213,7 +213,7 @@ class GroupBuyRequestService(
         groupBuyRequest.status = request.targetStatus
         groupBuyRequestStatusHistoryRepository.save(
             GroupBuyRequestStatusHistory(
-                groupBuyRequestId = groupBuyRequest.id,
+                groupBuyRequest = groupBuyRequest,
                 status = request.targetStatus,
                 changedAt = LocalDateTime.now()
             )
@@ -221,7 +221,7 @@ class GroupBuyRequestService(
         openedGroupBuyForNotification?.let { notifyOpenedAfterCommit(it) }
 
         val history = groupBuyRequestStatusHistoryRepository
-            .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
+            .findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId)
 
         val response = GroupBuyRequestResponse.from(groupBuyRequest, history)
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -137,17 +137,9 @@ class GroupBuyRequestService(
             pageable = pageable
         )
 
-        val userIds = page.content.map { requesterId(it) }.distinct()
-        val usersById = if (userIds.isEmpty()) {
-            emptyMap()
-        } else {
-            userRepository.findAllById(userIds)
-                .mapNotNull { user -> user.id?.let { it to user } }
-                .toMap()
-        }
         val groupBuysById = findOpenedGroupBuys(page.content)
 
-        val response = AdminGroupBuyRequestPageResponse.from(page, usersById, groupBuysById, LocalDateTime.now(clock))
+        val response = AdminGroupBuyRequestPageResponse.from(page, groupBuysById, LocalDateTime.now(clock))
         log.info(
             "[GroupBuyRequestService] 관리자 공구요청 목록 조회 완료: status={}, totalElements={}",
             status,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -14,6 +14,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHisto
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -54,7 +55,7 @@ class GroupBuyRequestService(
 
         val saved = groupBuyRequestRepository.save(
             GroupBuyRequest(
-                userId = userId,
+                user = findUser(userId),
                 storeName = request.storeName,
                 storeAddress = storeAddress,
                 placeId = placeId,
@@ -85,7 +86,7 @@ class GroupBuyRequestService(
     @Transactional(readOnly = true)
     fun getMyRequests(userId: Long): List<GroupBuyRequestResponse> {
         log.info("[GroupBuyRequestService] 내 공구요청 목록 조회 시작: userId={}", userId)
-        val requests = groupBuyRequestRepository.findByUserIdOrderByCreatedAtDesc(userId)
+        val requests = groupBuyRequestRepository.findByUser_IdOrderByCreatedAtDesc(userId)
         if (requests.isEmpty()) return emptyList()
 
         val historyMap = groupBuyRequestStatusHistoryRepository
@@ -103,7 +104,7 @@ class GroupBuyRequestService(
         val request = groupBuyRequestRepository.findById(requestId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
 
-        if (request.userId != userId) {
+        if (requesterId(request) != userId) {
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_FORBIDDEN)
         }
 
@@ -136,7 +137,7 @@ class GroupBuyRequestService(
             pageable = pageable
         )
 
-        val userIds = page.content.map { it.userId }.distinct()
+        val userIds = page.content.map { requesterId(it) }.distinct()
         val usersById = if (userIds.isEmpty()) {
             emptyMap()
         } else {
@@ -160,7 +161,7 @@ class GroupBuyRequestService(
         log.info("[GroupBuyRequestService] 관리자 공구요청 상세 조회 시작: requestId={}", requestId)
         val request = groupBuyRequestRepository.findById(requestId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
-        val requester = userRepository.findById(request.userId).orElse(null)
+        val requester = request.user
         val history = groupBuyRequestStatusHistoryRepository
             .findByGroupBuyRequestIdOrderByChangedAtAsc(requestId)
 
@@ -271,4 +272,11 @@ class GroupBuyRequestService(
 
         return groupBuyRepository.findAllById(openedGroupBuyIds).associateBy { it.id }
     }
+
+    private fun findUser(userId: Long): User =
+        userRepository.findByIdAndDeletedAtIsNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+    private fun requesterId(request: GroupBuyRequest): Long =
+        request.user.id ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
@@ -32,7 +32,7 @@ class GroupBuyRequestStatusCommandService(
         request.markRejected(reason)
         groupBuyRequestStatusHistoryRepository.save(
             GroupBuyRequestStatusHistory(
-                groupBuyRequestId = request.id,
+                groupBuyRequest = request,
                 status = GroupBuyRequestStatus.REJECTED,
                 changedAt = changedAt
             )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
@@ -40,12 +40,12 @@ class GroupBuyRequestStatusCommandService(
 
         notificationEventPublisher.publishRequestRejected(
             requestId = request.id,
-            requesterUserId = request.userId,
+            requesterUserId = requireNotNull(request.user.id) { "GroupBuyRequest.user.id must not be null" },
             occurredAt = changedAt
         )
         log.info(
             "[GroupBuyRequestStatusCommandService] 요청공구 거절 처리 및 알림 트리거 발행: requestId={}, requesterUserId={}",
-            requestId, request.userId
+            requestId, requireNotNull(request.user.id) { "GroupBuyRequest.user.id must not be null" }
         )
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
@@ -38,7 +38,6 @@ data class AdminGroupBuyRequestPageResponse(
     companion object {
         fun from(
             page: Page<GroupBuyRequest>,
-            usersById: Map<Long, User>,
             groupBuysById: Map<Long, GroupBuy>,
             now: LocalDateTime
         ): AdminGroupBuyRequestPageResponse =
@@ -46,7 +45,7 @@ data class AdminGroupBuyRequestPageResponse(
                 content = page.content.map {
                     AdminGroupBuyRequestListItemResponse.from(
                         request = it,
-                        requester = usersById[requesterId(it)],
+                        requester = it.user,
                         groupBuy = it.openedGroupBuyId?.let(groupBuysById::get),
                         now = now
                     )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyRequestAdminResponse.kt
@@ -46,7 +46,7 @@ data class AdminGroupBuyRequestPageResponse(
                 content = page.content.map {
                     AdminGroupBuyRequestListItemResponse.from(
                         request = it,
-                        requester = usersById[it.userId],
+                        requester = usersById[requesterId(it)],
                         groupBuy = it.openedGroupBuyId?.let(groupBuysById::get),
                         now = now
                     )
@@ -88,7 +88,7 @@ data class AdminGroupBuyRequestListItemResponse(
                 desiredQuantity = request.desiredQuantity,
                 desiredPickupDate = request.desiredPickupDate,
                 status = request.status,
-                requesterId = request.userId,
+                requesterId = requesterId(request),
                 requesterName = requester?.nickname,
                 originalPrice = groupBuy?.originalPrice,
                 price = groupBuy?.price,
@@ -128,7 +128,7 @@ data class AdminGroupBuyRequestDetailResponse(
         ): AdminGroupBuyRequestDetailResponse =
             AdminGroupBuyRequestDetailResponse(
                 requestId = request.id,
-                requester = AdminGroupBuyRequestRequesterResponse.from(request.userId, requester),
+                requester = AdminGroupBuyRequestRequesterResponse.from(requesterId(request), requester),
                 storeName = request.storeName,
                 storeAddress = request.storeAddress,
                 placeId = request.placeId,
@@ -183,3 +183,6 @@ data class AdminGroupBuyRequestStatusHistoryResponse(
             )
     }
 }
+
+private fun requesterId(request: GroupBuyRequest): Long =
+    requireNotNull(request.user.id) { "GroupBuyRequest.user.id must not be null" }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOpenRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyOpenRequest.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.groupbuy.domain.entity
 
+import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.global.entity.BaseEntity
 import jakarta.persistence.*
 
@@ -14,8 +15,9 @@ import jakarta.persistence.*
     ]
 )
 class GroupBuyOpenRequest(
-    @Column(name = "user_id", nullable = false)
-    val userId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
     @Column(nullable = false, length = 50)
     val region: String,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequest.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.groupbuy.domain.entity
 
+import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.global.entity.BaseEntity
 import jakarta.persistence.*
 import java.time.LocalDate
@@ -8,8 +9,9 @@ import java.time.LocalDate
 @Table(name = "group_buy_requests")
 class GroupBuyRequest(
 
-    @Column(nullable = false)
-    val userId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
 
     @Column(nullable = false, length = 100)
     val storeName: String,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequestStatusHistory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequestStatusHistory.kt
@@ -7,8 +7,9 @@ import java.time.LocalDateTime
 @Table(name = "group_buy_request_status_histories")
 class GroupBuyRequestStatusHistory(
 
-    @Column(nullable = false)
-    val groupBuyRequestId: Long,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_buy_request_id", nullable = false)
+    val groupBuyRequest: GroupBuyRequest,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyOpenRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyOpenRequestRepository.kt
@@ -5,7 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.NotificationStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface GroupBuyOpenRequestRepository : JpaRepository<GroupBuyOpenRequest, Long> {
-    fun existsByUserIdAndRegionAndProductName(userId: Long, region: String, productName: String): Boolean
+    fun existsByUser_IdAndRegionAndProductName(userId: Long, region: String, productName: String): Boolean
 
     fun findAllByRegionAndProductNameAndNotificationStatus(
         region: String,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyOpenRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyOpenRequestRepository.kt
@@ -3,6 +3,8 @@ package com.moongchijang.domain.groupbuy.domain.repository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOpenRequest
 import com.moongchijang.domain.groupbuy.domain.entity.NotificationStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface GroupBuyOpenRequestRepository : JpaRepository<GroupBuyOpenRequest, Long> {
     fun existsByUser_IdAndRegionAndProductName(userId: Long, region: String, productName: String): Boolean
@@ -13,9 +15,20 @@ interface GroupBuyOpenRequestRepository : JpaRepository<GroupBuyOpenRequest, Lon
         notificationStatus: NotificationStatus,
     ): List<GroupBuyOpenRequest>
 
+    @Query(
+        """
+        select r
+        from GroupBuyOpenRequest r
+        join fetch r.user u
+        where r.region in :regions
+          and r.productName = :productName
+          and r.notificationStatus = :notificationStatus
+          and u.deletedAt is null
+        """
+    )
     fun findAllByRegionInAndProductNameAndNotificationStatus(
-        regions: Collection<String>,
-        productName: String,
-        notificationStatus: NotificationStatus,
+        @Param("regions") regions: Collection<String>,
+        @Param("productName") productName: String,
+        @Param("notificationStatus") notificationStatus: NotificationStatus,
     ): List<GroupBuyOpenRequest>
 }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -64,7 +64,6 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
     ): Page<GroupBuyRequest>
 
     fun countByUser_Id(userId: Long): Long
-
     fun countByStatusIn(statuses: Collection<GroupBuyRequestStatus>): Long
 
     @Query(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -27,7 +27,7 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
         value = """
             SELECT request
             FROM GroupBuyRequest request
-            LEFT JOIN request.user requester
+            LEFT JOIN FETCH request.user requester
             WHERE (:status IS NULL OR request.status = :status)
               AND (
                 :keyword IS NULL

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestRepository.kt
@@ -14,7 +14,7 @@ import java.time.LocalDateTime
 import java.util.Optional
 
 interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
-    fun findByUserIdOrderByCreatedAtDesc(userId: Long): List<GroupBuyRequest>
+    fun findByUser_IdOrderByCreatedAtDesc(userId: Long): List<GroupBuyRequest>
 
     fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<GroupBuyRequest>
 
@@ -27,7 +27,7 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
         value = """
             SELECT request
             FROM GroupBuyRequest request
-            LEFT JOIN User requester ON requester.id = request.userId
+            LEFT JOIN request.user requester
             WHERE (:status IS NULL OR request.status = :status)
               AND (
                 :keyword IS NULL
@@ -43,7 +43,7 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
         countQuery = """
             SELECT COUNT(request)
             FROM GroupBuyRequest request
-            LEFT JOIN User requester ON requester.id = request.userId
+            LEFT JOIN request.user requester
             WHERE (:status IS NULL OR request.status = :status)
               AND (
                 :keyword IS NULL
@@ -63,7 +63,7 @@ interface GroupBuyRequestRepository : JpaRepository<GroupBuyRequest, Long> {
         pageable: Pageable
     ): Page<GroupBuyRequest>
 
-    fun countByUserId(userId: Long): Long
+    fun countByUser_Id(userId: Long): Long
 
     fun countByStatusIn(statuses: Collection<GroupBuyRequestStatus>): Long
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
@@ -10,8 +10,6 @@ import java.time.LocalDateTime
 interface GroupBuyRequestStatusHistoryRepository : JpaRepository<GroupBuyRequestStatusHistory, Long> {
     fun findByGroupBuyRequest_IdOrderByChangedAtAsc(groupBuyRequestId: Long): List<GroupBuyRequestStatusHistory>
     fun findByGroupBuyRequest_IdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory>
-    fun findByGroupBuyRequestIdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory> =
-        findByGroupBuyRequest_IdInOrderByChangedAtAsc(groupBuyRequestIds)
     @Query(
         """
         select count(history)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
@@ -8,8 +8,8 @@ import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 interface GroupBuyRequestStatusHistoryRepository : JpaRepository<GroupBuyRequestStatusHistory, Long> {
-    fun findByGroupBuyRequestIdOrderByChangedAtAsc(groupBuyRequestId: Long): List<GroupBuyRequestStatusHistory>
-    fun findByGroupBuyRequestIdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory>
+    fun findByGroupBuyRequest_IdOrderByChangedAtAsc(groupBuyRequestId: Long): List<GroupBuyRequestStatusHistory>
+    fun findByGroupBuyRequest_IdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory>
     @Query(
         """
         select count(history)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRequestStatusHistoryRepository.kt
@@ -10,6 +10,8 @@ import java.time.LocalDateTime
 interface GroupBuyRequestStatusHistoryRepository : JpaRepository<GroupBuyRequestStatusHistory, Long> {
     fun findByGroupBuyRequest_IdOrderByChangedAtAsc(groupBuyRequestId: Long): List<GroupBuyRequestStatusHistory>
     fun findByGroupBuyRequest_IdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory>
+    fun findByGroupBuyRequestIdInOrderByChangedAtAsc(groupBuyRequestIds: List<Long>): List<GroupBuyRequestStatusHistory> =
+        findByGroupBuyRequest_IdInOrderByChangedAtAsc(groupBuyRequestIds)
     @Query(
         """
         select count(history)

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -50,7 +50,7 @@ class MypageService(
                 userId = userId,
                 statuses = CANCELLED_OR_REFUNDED_PARTICIPATION_STATUSES
             ),
-            requestCount = groupBuyRequestRepository.countByUserId(userId)
+            requestCount = groupBuyRequestRepository.countByUser_Id(userId)
         )
         log.info("[MypageService] 마이페이지 요약 조회 완료: userId={}", userId)
         return response
@@ -140,7 +140,7 @@ class MypageService(
     fun getGroupBuyRequests(userId: Long): List<MypageGroupBuyRequestResponse> {
         log.info("[MypageService] 요청공구 목록 조회 시작: userId={}", userId)
         val responses = groupBuyRequestRepository
-            .findByUserIdOrderByCreatedAtDesc(userId)
+            .findByUser_IdOrderByCreatedAtDesc(userId)
             .map(MypageGroupBuyRequestResponse::from)
         log.info("[MypageService] 요청공구 목록 조회 완료: userId={}, count={}", userId, responses.size)
         return responses

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -73,10 +73,11 @@ class NotificationTriggerScheduler(
         )
 
         requests.forEach { request ->
+            val requesterUserId = requireNotNull(request.user.id) { "GroupBuyRequest.user.id must not be null" }
             notificationEventPublisher.publishScheduledTrigger(
                 triggerType = NotificationTriggerType.REQUEST_DEADLINE_MINUS_3_DAYS,
                 targetId = request.id,
-                userIds = listOf(request.userId),
+                userIds = listOf(requesterUserId),
                 scheduleKey = "request-deadline-d3:${request.id}:$targetDate",
                 occurredAt = now
             )

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -444,7 +444,7 @@ class PaymentService(
         participation: Participation,
         occurredAt: LocalDateTime
     ) {
-        val requesterUserId = groupBuy.groupBuyRequest.userId
+        val requesterUserId = groupBuy.groupBuyRequest.user.id ?: return
         val requestId = groupBuy.groupBuyRequest.id
         val participantUserId = participation.user.id ?: return
         if (requesterUserId == participantUserId) return
@@ -458,7 +458,7 @@ class PaymentService(
     }
 
     private fun publishRequestTargetAchievedEvent(groupBuy: GroupBuy, occurredAt: LocalDateTime) {
-        val requesterUserId = groupBuy.groupBuyRequest.userId
+        val requesterUserId = groupBuy.groupBuyRequest.user.id ?: return
         val requestId = groupBuy.groupBuyRequest.id
         notificationEventPublisher.publishRequestTargetAchieved(
             requestId = requestId,

--- a/src/main/resources/db/migration/V43__add_fk_constraints_for_group_buy_requests.sql
+++ b/src/main/resources/db/migration/V43__add_fk_constraints_for_group_buy_requests.sql
@@ -1,0 +1,11 @@
+ALTER TABLE group_buy_requests
+    ADD CONSTRAINT fk_group_buy_requests_user_id
+        FOREIGN KEY (user_id) REFERENCES users (id);
+
+ALTER TABLE group_buy_request_status_histories
+    ADD CONSTRAINT fk_group_buy_request_status_histories_request_id
+        FOREIGN KEY (group_buy_request_id) REFERENCES group_buy_requests (id);
+
+ALTER TABLE group_buy_open_requests
+    ADD CONSTRAINT fk_group_buy_open_requests_user_id
+        FOREIGN KEY (user_id) REFERENCES users (id);

--- a/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
@@ -84,7 +84,7 @@ class FavoriteRepositoryImplIntegrationTest {
         em.persist(store)
 
         val request = GroupBuyRequest(
-            userId = requestUserId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = requestUserId),
             storeName = "찜 테스트 매장",
             storeAddress = "서울 강남구",
             productName = "테스트 상품",

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestRejectedAlimtalkEventListenerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestRejectedAlimtalkEventListenerTest.kt
@@ -6,9 +6,7 @@ import com.moongchijang.domain.notification.domain.entity.NotificationTriggerTyp
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoAlimtalkClient
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoMessageFormatter
 import com.moongchijang.domain.notification.infrastructure.aligo.AligoProperties
-import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.support.GroupBuyFixture
-import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -26,9 +24,6 @@ class GroupBuyRequestRejectedAlimtalkEventListenerTest {
     private lateinit var groupBuyRequestRepository: GroupBuyRequestRepository
 
     @Mock
-    private lateinit var userRepository: UserRepository
-
-    @Mock
     private lateinit var aligoAlimtalkClient: AligoAlimtalkClient
 
     @Mock
@@ -37,7 +32,6 @@ class GroupBuyRequestRejectedAlimtalkEventListenerTest {
     private val listener by lazy {
         GroupBuyRequestRejectedAlimtalkEventListener(
             groupBuyRequestRepository = groupBuyRequestRepository,
-            userRepository = userRepository,
             aligoAlimtalkClient = aligoAlimtalkClient,
             aligoProperties = aligoProperties,
         )
@@ -49,13 +43,13 @@ class GroupBuyRequestRejectedAlimtalkEventListenerTest {
             userId = 7L,
             productName = "황치즈 케이크",
             storeAddress = "서울 강남구 테헤란로 1",
-        ).apply { id = 401L }
-        val user = UserFixture.createKakaoUser(id = 7L, nickname = "문치").apply {
-            phoneNumber = "01012345678"
+        ).apply {
+            id = 401L
+            user.nickname = "문치"
+            user.phoneNumber = "01012345678"
         }
 
         `when`(groupBuyRequestRepository.findById(401L)).thenReturn(Optional.of(request))
-        `when`(userRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(user)
         `when`(aligoProperties.templateCodeGroupBuyOpenFailed).thenReturn("UH_8527")
 
         listener.on(

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
@@ -48,7 +48,7 @@ class GroupBuyFeedItemResponseTest {
             district = DistrictType.SEOUL_SINSA_APGUJEONG_CHEONGDAM
         ).apply { id = 1L }
         val request = GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "청담 버터룸",
             storeAddress = "서울 강남구 도산대로 420",
             productName = "버터바 4종 세트",

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
@@ -146,7 +146,7 @@ class GroupBuyRepositoryImplIntegrationTest {
         )
         em.persist(requester)
         val matched = GroupBuyRequest(
-            userId = requester.id!!,
+            user = requester,
             storeName = "성심당",
             productName = "튀김소보로",
             desiredQuantity = 20,
@@ -156,7 +156,7 @@ class GroupBuyRepositoryImplIntegrationTest {
         em.persist(matched)
         em.persist(
             GroupBuyRequest(
-                userId = requester.id!!,
+                user = requester,
                 storeName = "다른 매장",
                 productName = "단팥빵",
                 desiredQuantity = 10,
@@ -225,8 +225,9 @@ class GroupBuyRepositoryImplIntegrationTest {
     }
 
     private fun persistGroupBuyRequest(): GroupBuyRequest {
+        val requester = persistUser("requester-${System.nanoTime()}@example.com")
         val request = GroupBuyRequest(
-            userId = 1L,
+            user = requester,
             storeName = "테스트 매장",
             storeAddress = "서울 강남구",
             productName = "테스트 상품",

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/AdminGroupBuyRequestActionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/AdminGroupBuyRequestActionServiceTest.kt
@@ -245,7 +245,7 @@ class AdminGroupBuyRequestActionServiceTest {
 
     private fun groupBuyRequest(status: GroupBuyRequestStatus): GroupBuyRequest =
         GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "뭉치장 베이커리",
             storeAddress = "서울 성동구 성수이로 1",
             productName = "두쫀쿠",

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -26,9 +26,11 @@ import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.support.GroupBuyFixture
 import com.moongchijang.support.NaverFixture
+import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
@@ -68,15 +70,21 @@ class GroupBuyOpenRequestServiceTest {
     @InjectMocks
     private lateinit var service: GroupBuyOpenRequestService
 
+    @BeforeEach
+    fun setUp() {
+        lenient().`when`(userRepository.findByIdAndDeletedAtIsNull(anyLong()))
+            .thenAnswer { UserFixture.createKakaoUser(id = it.getArgument(0)) }
+    }
+
     @Test
     fun `정상 알림 신청 시 저장 성공`() {
         val userId = 1L
         val request = CreateGroupBuyOpenRequestRequest(region = "성수", productName = "소금빵")
 
-        `when`(openRequestRepository.existsByUserIdAndRegionAndProductName(userId, "성수", "소금빵"))
+        `when`(openRequestRepository.existsByUser_IdAndRegionAndProductName(userId, "성수", "소금빵"))
             .thenReturn(false)
         `when`(openRequestRepository.saveAndFlush(any())).thenReturn(
-            GroupBuyOpenRequest(userId = userId, region = "성수", productName = "소금빵").apply { id = 1L }
+            GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId), region = "성수", productName = "소금빵").apply { id = 1L }
         )
 
         service.create(userId, request)
@@ -89,7 +97,7 @@ class GroupBuyOpenRequestServiceTest {
         val userId = 1L
         val request = CreateGroupBuyOpenRequestRequest(region = "성수", productName = "소금빵")
 
-        `when`(openRequestRepository.existsByUserIdAndRegionAndProductName(userId, "성수", "소금빵"))
+        `when`(openRequestRepository.existsByUser_IdAndRegionAndProductName(userId, "성수", "소금빵"))
             .thenReturn(true)
 
         val ex = assertThrows<CustomException> { service.create(userId, request) }
@@ -102,7 +110,7 @@ class GroupBuyOpenRequestServiceTest {
         val userId = 1L
         val request = CreateGroupBuyOpenRequestRequest(region = "성수", productName = "소금빵")
 
-        `when`(openRequestRepository.existsByUserIdAndRegionAndProductName(userId, "성수", "소금빵"))
+        `when`(openRequestRepository.existsByUser_IdAndRegionAndProductName(userId, "성수", "소금빵"))
             .thenReturn(false)
         `when`(openRequestRepository.saveAndFlush(any<GroupBuyOpenRequest>()))
             .thenThrow(DataIntegrityViolationException("uk_open_req_user_region_product"))
@@ -199,7 +207,7 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `공구 개설 알림 발송 성공 시 PENDING 요청을 SENT 처리`() {
-        val openRequest = GroupBuyOpenRequest(userId = 1L, region = "성수", productName = "소금빵")
+        val openRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "성수", productName = "소금빵")
         val user = createUser(id = 1L, phoneNumber = "01012345678")
 
         `when`(
@@ -225,7 +233,7 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `공구 개설 알림 발송 실패 시 FAILED 처리`() {
-        val openRequest = GroupBuyOpenRequest(userId = 1L, region = "성수", productName = "소금빵")
+        val openRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "성수", productName = "소금빵")
         val user = createUser(id = 1L, phoneNumber = "01012345678")
 
         `when`(
@@ -250,7 +258,7 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `전화번호가 없으면 알리고 호출 없이 FAILED 처리`() {
-        val openRequest = GroupBuyOpenRequest(userId = 1L, region = "성수", productName = "소금빵")
+        val openRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "성수", productName = "소금빵")
         val user = createUser(id = 1L, phoneNumber = null)
 
         `when`(
@@ -274,8 +282,8 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `공구 기준 알림은 매장 지역과 세부지역을 모두 매칭하고 사용자별 중복 발송을 막는다`() {
-        val regionRequest = GroupBuyOpenRequest(userId = 1L, region = "SEOUL_ALL", productName = "소금빵").apply { id = 10L }
-        val districtRequest = GroupBuyOpenRequest(userId = 1L, region = "SEOUL_SEONGSU_GEONDAE_GWANGJIN", productName = "소금빵").apply { id = 11L }
+        val regionRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "SEOUL_ALL", productName = "소금빵").apply { id = 10L }
+        val districtRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "SEOUL_SEONGSU_GEONDAE_GWANGJIN", productName = "소금빵").apply { id = 11L }
         val user = createUser(id = 1L, phoneNumber = "01012345678")
         val groupBuy = createGroupBuy(productName = "소금빵")
 
@@ -323,7 +331,7 @@ class GroupBuyOpenRequestServiceTest {
                 district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN,
             ),
             groupBuyRequest = GroupBuyRequest(
-                userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
                 storeName = "테스트 매장",
                 productName = productName,
                 desiredQuantity = 10,

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -207,8 +207,11 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `공구 개설 알림 발송 성공 시 PENDING 요청을 SENT 처리`() {
-        val openRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "성수", productName = "소금빵")
-        val user = createUser(id = 1L, phoneNumber = "01012345678")
+        val openRequest = GroupBuyOpenRequest(
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L).apply { phoneNumber = "01012345678" },
+            region = "성수",
+            productName = "소금빵"
+        )
 
         `when`(
             openRequestRepository.findAllByRegionInAndProductNameAndNotificationStatus(
@@ -217,7 +220,6 @@ class GroupBuyOpenRequestServiceTest {
                 NotificationStatus.PENDING,
             )
         ).thenReturn(listOf(openRequest))
-        `when`(userRepository.findByIdInAndDeletedAtIsNull(setOf(1L))).thenReturn(listOf(user))
         `when`(aligoAlimtalkClient.send("01012345678", "[뭉치장] 요청하신 성수 소금빵 공구가 열렸어요."))
             .thenReturn(true)
 
@@ -233,8 +235,11 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `공구 개설 알림 발송 실패 시 FAILED 처리`() {
-        val openRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "성수", productName = "소금빵")
-        val user = createUser(id = 1L, phoneNumber = "01012345678")
+        val openRequest = GroupBuyOpenRequest(
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L).apply { phoneNumber = "01012345678" },
+            region = "성수",
+            productName = "소금빵"
+        )
 
         `when`(
             openRequestRepository.findAllByRegionInAndProductNameAndNotificationStatus(
@@ -243,7 +248,6 @@ class GroupBuyOpenRequestServiceTest {
                 NotificationStatus.PENDING,
             )
         ).thenReturn(listOf(openRequest))
-        `when`(userRepository.findByIdInAndDeletedAtIsNull(setOf(1L))).thenReturn(listOf(user))
         `when`(aligoAlimtalkClient.send("01012345678", "[뭉치장] 요청하신 성수 소금빵 공구가 열렸어요."))
             .thenReturn(false)
 
@@ -258,8 +262,11 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `전화번호가 없으면 알리고 호출 없이 FAILED 처리`() {
-        val openRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "성수", productName = "소금빵")
-        val user = createUser(id = 1L, phoneNumber = null)
+        val openRequest = GroupBuyOpenRequest(
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L).apply { phoneNumber = null },
+            region = "성수",
+            productName = "소금빵"
+        )
 
         `when`(
             openRequestRepository.findAllByRegionInAndProductNameAndNotificationStatus(
@@ -268,8 +275,6 @@ class GroupBuyOpenRequestServiceTest {
                 NotificationStatus.PENDING,
             )
         ).thenReturn(listOf(openRequest))
-        `when`(userRepository.findByIdInAndDeletedAtIsNull(setOf(1L))).thenReturn(listOf(user))
-
         val result = service.notifyOpened(region = "성수", productName = "소금빵")
 
         assertEquals(NotificationStatus.FAILED, openRequest.notificationStatus)
@@ -282,9 +287,16 @@ class GroupBuyOpenRequestServiceTest {
 
     @Test
     fun `공구 기준 알림은 매장 지역과 세부지역을 모두 매칭하고 사용자별 중복 발송을 막는다`() {
-        val regionRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "SEOUL_ALL", productName = "소금빵").apply { id = 10L }
-        val districtRequest = GroupBuyOpenRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), region = "SEOUL_SEONGSU_GEONDAE_GWANGJIN", productName = "소금빵").apply { id = 11L }
-        val user = createUser(id = 1L, phoneNumber = "01012345678")
+        val regionRequest = GroupBuyOpenRequest(
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L).apply { phoneNumber = "01012345678" },
+            region = "SEOUL_ALL",
+            productName = "소금빵"
+        ).apply { id = 10L }
+        val districtRequest = GroupBuyOpenRequest(
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L).apply { phoneNumber = "01012345678" },
+            region = "SEOUL_SEONGSU_GEONDAE_GWANGJIN",
+            productName = "소금빵"
+        ).apply { id = 11L }
         val groupBuy = createGroupBuy(productName = "소금빵")
 
         `when`(
@@ -294,7 +306,6 @@ class GroupBuyOpenRequestServiceTest {
                 NotificationStatus.PENDING,
             )
         ).thenReturn(listOf(regionRequest, districtRequest))
-        `when`(userRepository.findByIdInAndDeletedAtIsNull(setOf(1L))).thenReturn(listOf(user))
         `when`(aligoAlimtalkClient.send("01012345678", "[뭉치장] 요청하신 서울 전체 소금빵 공구가 열렸어요."))
             .thenReturn(true)
 
@@ -313,14 +324,6 @@ class GroupBuyOpenRequestServiceTest {
         assertEquals(listOf(1L), invocation.arguments[1])
         assertTrue(invocation.arguments[2] is LocalDateTime)
     }
-
-    private fun createUser(id: Long, phoneNumber: String?): User =
-        User(
-            provider = AuthProvider.EMAIL,
-            email = "$id@example.com",
-            passwordHash = "password",
-            phoneNumber = phoneNumber,
-        ).apply { this.id = id }
 
     private fun createGroupBuy(productName: String): GroupBuy =
         GroupBuy(

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -365,7 +365,7 @@ class GroupBuyRequestServiceTest {
         val pageable = PageRequest.of(0, 20)
         val requester = UserFixture.createKakaoUser(id = 1L, nickname = "은서")
         val request = GroupBuyRequest(
-            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+            user = requester,
             storeName = "성심당",
             productName = "튀김소보로",
             desiredQuantity = 20,
@@ -374,8 +374,6 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.searchAdminRequests(null, null, null, pageable))
             .thenReturn(PageImpl(listOf(request), pageable, 1))
-        `when`(userRepository.findAllById(listOf(1L))).thenReturn(listOf(requester))
-
         val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, null, pageable)
 
         assertEquals(1, result.content.size)
@@ -398,7 +396,7 @@ class GroupBuyRequestServiceTest {
     fun `운영자는 상태별 공구 요청 목록을 페이징 조회한다`() {
         val pageable = PageRequest.of(1, 10)
         val request = GroupBuyRequest(
-            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 2L),
+            user = UserFixture.createKakaoUser(id = 2L),
             storeName = "파리바게뜨",
             productName = "단팥빵",
             desiredQuantity = 5,
@@ -408,8 +406,6 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.searchAdminRequests(GroupBuyRequestStatus.REJECTED, null, null, pageable))
             .thenReturn(PageImpl(listOf(request), pageable, 11))
-        `when`(userRepository.findAllById(listOf(2L))).thenReturn(emptyList())
-
         val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.REJECTED, null, pageable)
 
         assertEquals(1, result.content.size)
@@ -419,7 +415,7 @@ class GroupBuyRequestServiceTest {
         assertEquals(10, result.size)
         assertEquals(GroupBuyRequestStatus.REJECTED, result.content[0].status)
         assertEquals(2L, result.content[0].requesterId)
-        assertNull(result.content[0].requesterName)
+        assertEquals("테스트유저", result.content[0].requesterName)
         assertFalse(result.content[0].actionable)
         verify(groupBuyRequestRepository).searchAdminRequests(GroupBuyRequestStatus.REJECTED, null, null, pageable)
     }
@@ -434,7 +430,6 @@ class GroupBuyRequestServiceTest {
 
         assertTrue(result.content.isEmpty())
         assertEquals(0, result.totalElements)
-        verify(userRepository, never()).findAllById(anyList())
     }
 
     @Test
@@ -459,7 +454,6 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.searchAdminRequests(null, "10", 10L, pageable))
             .thenReturn(PageImpl(listOf(request), pageable, 1))
-        `when`(userRepository.findAllById(listOf(1L))).thenReturn(emptyList())
         `when`(groupBuyRepository.findAllById(listOf(30L))).thenReturn(listOf(groupBuy))
 
         val result = service.getAdminRequests(AdminGroupBuyRequestStatusFilter.ALL, " 10 ", pageable)

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -63,6 +63,8 @@ class GroupBuyRequestServiceTest {
     fun setUpClock() {
         lenient().`when`(clock.instant()).thenReturn(Instant.parse("2026-05-27T04:00:00Z"))
         lenient().`when`(clock.zone).thenReturn(ZoneId.of("Asia/Seoul"))
+        lenient().`when`(userRepository.findByIdAndDeletedAtIsNull(anyLong()))
+            .thenAnswer { UserFixture.createKakaoUser(id = it.getArgument(0)) }
     }
 
     @Test
@@ -72,7 +74,7 @@ class GroupBuyRequestServiceTest {
             desiredPickupDate = LocalDate.now().plusDays(3)
         )
         val saved = GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = request.storeName,
             storeAddress = request.storeAddress,
             productName = request.productName,
@@ -83,7 +85,14 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.save(any())).thenReturn(saved)
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = 42L, status = GroupBuyRequestStatus.IN_REVIEW)
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = 42L }, status = GroupBuyRequestStatus.IN_REVIEW)
         )
 
         val result = service.create(userId, request)
@@ -109,7 +118,7 @@ class GroupBuyRequestServiceTest {
             longitude = 127.0
         )
         val saved = GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = request.storeName,
             storeAddress = request.roadAddress,
             placeId = request.placeId,
@@ -125,7 +134,14 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.save(any())).thenReturn(saved)
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = 43L, status = GroupBuyRequestStatus.IN_REVIEW)
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = 43L }, status = GroupBuyRequestStatus.IN_REVIEW)
         )
 
         val result = service.create(userId, request)
@@ -153,7 +169,7 @@ class GroupBuyRequestServiceTest {
             longitude = 127.0
         )
         val saved = GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = request.storeName,
             storeAddress = request.storeAddress,
             productName = request.productName,
@@ -163,7 +179,14 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.save(any())).thenReturn(saved)
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = 44L, status = GroupBuyRequestStatus.IN_REVIEW)
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = 44L }, status = GroupBuyRequestStatus.IN_REVIEW)
         )
 
         service.create(userId, request)
@@ -190,7 +213,7 @@ class GroupBuyRequestServiceTest {
             longitude = 127.0
         )
         val saved = GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = request.storeName,
             storeAddress = request.lotAddress,
             productName = request.productName,
@@ -200,7 +223,14 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.save(any())).thenReturn(saved)
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = 45L, status = GroupBuyRequestStatus.IN_REVIEW)
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = 45L }, status = GroupBuyRequestStatus.IN_REVIEW)
         )
 
         service.create(userId, request)
@@ -230,13 +260,20 @@ class GroupBuyRequestServiceTest {
     fun `내 요청 목록 조회 시 본인 요청만 반환`() {
         val userId = 1L
         val requests = listOf(
-            GroupBuyRequest(userId = userId, storeName = "성심당", productName = "튀김소보로",
+            GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId), storeName = "성심당", productName = "튀김소보로",
                 desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5)).apply { id = 1L }
         )
-        `when`(groupBuyRequestRepository.findByUserIdOrderByCreatedAtDesc(userId)).thenReturn(requests)
-        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdInOrderByChangedAtAsc(listOf(1L)))
+        `when`(groupBuyRequestRepository.findByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(requests)
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequest_IdInOrderByChangedAtAsc(listOf(1L)))
             .thenReturn(listOf(
-                GroupBuyRequestStatusHistory(groupBuyRequestId = 1L, status = GroupBuyRequestStatus.IN_REVIEW,
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = 1L }, status = GroupBuyRequestStatus.IN_REVIEW,
                     changedAt = LocalDateTime.now())
             ))
 
@@ -250,7 +287,7 @@ class GroupBuyRequestServiceTest {
 
     @Test
     fun `요청 목록이 없으면 빈 리스트 반환`() {
-        `when`(groupBuyRequestRepository.findByUserIdOrderByCreatedAtDesc(1L)).thenReturn(emptyList())
+        `when`(groupBuyRequestRepository.findByUser_IdOrderByCreatedAtDesc(1L)).thenReturn(emptyList())
 
         val result = service.getMyRequests(1L)
 
@@ -261,19 +298,33 @@ class GroupBuyRequestServiceTest {
     fun `상세 조회 시 statusHistory 포함 반환`() {
         val userId = 1L
         val requestId = 10L
-        val groupBuyRequest = GroupBuyRequest(userId = userId, storeName = "뚜레쥬르", productName = "크림빵",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId), storeName = "뚜레쥬르", productName = "크림빵",
             desiredQuantity = 1, desiredPickupDate = LocalDate.now().plusDays(7),
             placeId = "naver-place-2", roadAddress = "서울 강남구 도산대로 1",
             lotAddress = "서울 강남구 신사동 1", latitude = 37.1, longitude = 127.1).apply { id = requestId }
         val history = listOf(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_REVIEW,
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_REVIEW,
                 changedAt = LocalDateTime.now().minusDays(2)),
-            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT,
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_CONTACT,
                 changedAt = LocalDateTime.now().minusDays(1))
         )
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
-        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId))
             .thenReturn(history)
 
         val result = service.getDetail(userId, requestId)
@@ -300,7 +351,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `다른 사용자의 요청 조회 시 GROUPBUY_REQUEST_FORBIDDEN 예외`() {
         val requestId = 10L
-        val groupBuyRequest = GroupBuyRequest(userId = 2L, storeName = "파리바게뜨", productName = "단팥빵",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 2L), storeName = "파리바게뜨", productName = "단팥빵",
             desiredQuantity = 1, desiredPickupDate = LocalDate.now().plusDays(5)).apply { id = requestId }
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
@@ -314,7 +365,7 @@ class GroupBuyRequestServiceTest {
         val pageable = PageRequest.of(0, 20)
         val requester = UserFixture.createKakaoUser(id = 1L, nickname = "은서")
         val request = GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "성심당",
             productName = "튀김소보로",
             desiredQuantity = 20,
@@ -347,7 +398,7 @@ class GroupBuyRequestServiceTest {
     fun `운영자는 상태별 공구 요청 목록을 페이징 조회한다`() {
         val pageable = PageRequest.of(1, 10)
         val request = GroupBuyRequest(
-            userId = 2L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 2L),
             storeName = "파리바게뜨",
             productName = "단팥빵",
             desiredQuantity = 5,
@@ -390,7 +441,7 @@ class GroupBuyRequestServiceTest {
     fun `운영자 공구 요청 목록은 검색어와 승인 공구 가격을 반영한다`() {
         val pageable = PageRequest.of(0, 20)
         val request = GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "성심당",
             productName = "튀김소보로",
             desiredQuantity = 20,
@@ -429,7 +480,7 @@ class GroupBuyRequestServiceTest {
             nickname = "요청자"
         ).apply { phoneNumber = "01012345678" }
         val request = GroupBuyRequest(
-            userId = 3L,
+            user = requester,
             storeName = "뚜레쥬르",
             storeAddress = "서울 성동구",
             placeId = "place-1",
@@ -445,20 +496,31 @@ class GroupBuyRequestServiceTest {
         ).apply { id = requestId }
         val history = listOf(
             GroupBuyRequestStatusHistory(
-                groupBuyRequestId = requestId,
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId },
                 status = GroupBuyRequestStatus.IN_REVIEW,
                 changedAt = LocalDateTime.now().minusDays(1)
             ),
             GroupBuyRequestStatusHistory(
-                groupBuyRequestId = requestId,
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId },
                 status = GroupBuyRequestStatus.IN_CONTACT,
                 changedAt = LocalDateTime.now()
             )
         )
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(request))
-        `when`(userRepository.findById(3L)).thenReturn(Optional.of(requester))
-        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId))
             .thenReturn(history)
 
         val result = service.getAdminDetail(requestId)
@@ -482,17 +544,38 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `IN_REVIEW 요청을 IN_CONTACT로 변경하면 상태와 히스토리를 저장한다`() {
         val requestId = 10L
-        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5)).apply { id = requestId }
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT)
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_CONTACT)
         )
-        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId))
             .thenReturn(listOf(
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_REVIEW),
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT)
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_REVIEW),
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_CONTACT)
             ))
 
         val result = service.updateStatus(
@@ -505,7 +588,7 @@ class GroupBuyRequestServiceTest {
         assertEquals(2, result.statusHistory.size)
         val captor = argumentCaptor<GroupBuyRequestStatusHistory>()
         verify(groupBuyRequestStatusHistoryRepository).save(captor.capture())
-        assertEquals(requestId, captor.value.groupBuyRequestId)
+        assertEquals(requestId, captor.value.groupBuyRequest.id)
         assertEquals(GroupBuyRequestStatus.IN_CONTACT, captor.value.status)
         assertNotNull(captor.value.changedAt)
     }
@@ -513,7 +596,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `IN_CONTACT 요청을 REJECTED로 변경할 때 거절 사유를 저장한다`() {
         val requestId = 11L
-        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
             status = GroupBuyRequestStatus.IN_CONTACT).apply {
             id = requestId
@@ -522,13 +605,41 @@ class GroupBuyRequestServiceTest {
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.REJECTED)
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.REJECTED)
         )
-        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId))
             .thenReturn(listOf(
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_REVIEW),
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT),
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.REJECTED)
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_REVIEW),
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_CONTACT),
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.REJECTED)
             ))
 
         val result = service.updateStatus(
@@ -548,7 +659,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `REJECTED 변경 시 거절 사유가 없으면 GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED 예외`() {
         val requestId = 12L
-        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
             status = GroupBuyRequestStatus.IN_CONTACT).apply { id = requestId }
 
@@ -572,7 +683,7 @@ class GroupBuyRequestServiceTest {
     fun `IN_CONTACT 요청을 OPENED로 변경할 때 공구 id가 있으면 존재 검증 후 저장한다`() {
         val requestId = 13L
         val openedGroupBuyId = 100L
-        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
             status = GroupBuyRequestStatus.IN_CONTACT).apply {
             id = requestId
@@ -587,13 +698,41 @@ class GroupBuyRequestServiceTest {
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))
         `when`(groupBuyRepository.findWithStoreById(openedGroupBuyId)).thenReturn(Optional.of(openedGroupBuy))
         `when`(groupBuyRequestStatusHistoryRepository.save(any())).thenReturn(
-            GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.OPENED)
+            GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.OPENED)
         )
-        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequestIdOrderByChangedAtAsc(requestId))
+        `when`(groupBuyRequestStatusHistoryRepository.findByGroupBuyRequest_IdOrderByChangedAtAsc(requestId))
             .thenReturn(listOf(
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_REVIEW),
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.IN_CONTACT),
-                GroupBuyRequestStatusHistory(groupBuyRequestId = requestId, status = GroupBuyRequestStatus.OPENED)
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_REVIEW),
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.IN_CONTACT),
+                GroupBuyRequestStatusHistory(
+                    groupBuyRequest = GroupBuyRequest(
+                        user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
+                        storeName = "stub",
+                        productName = "stub",
+                        desiredQuantity = 1,
+                        desiredPickupDate = java.time.LocalDate.now()
+                    ).apply { id = requestId }, status = GroupBuyRequestStatus.OPENED)
             ))
 
         val result = service.updateStatus(
@@ -615,7 +754,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `OPENED 변경 시 공구 id가 없으면 GROUPBUY_REQUEST_OPENED_GROUP_BUY_REQUIRED 예외`() {
         val requestId = 14L
-        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
             status = GroupBuyRequestStatus.IN_CONTACT).apply { id = requestId }
 
@@ -637,7 +776,7 @@ class GroupBuyRequestServiceTest {
     fun `OPENED 변경 시 공구 id가 존재하지 않으면 GROUPBUY_NOT_FOUND 예외`() {
         val requestId = 15L
         val openedGroupBuyId = 100L
-        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5),
             status = GroupBuyRequestStatus.IN_CONTACT).apply { id = requestId }
 
@@ -662,7 +801,7 @@ class GroupBuyRequestServiceTest {
     @Test
     fun `허용되지 않는 상태 전이는 GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION 예외`() {
         val requestId = 16L
-        val groupBuyRequest = GroupBuyRequest(userId = 1L, storeName = "성심당", productName = "튀김소보로",
+        val groupBuyRequest = GroupBuyRequest(user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L), storeName = "성심당", productName = "튀김소보로",
             desiredQuantity = 2, desiredPickupDate = LocalDate.now().plusDays(5)).apply { id = requestId }
 
         `when`(groupBuyRequestRepository.findById(requestId)).thenReturn(Optional.of(groupBuyRequest))

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -88,7 +88,7 @@ class MypageServiceTest {
             )
         )
             .thenReturn(1L)
-        `when`(groupBuyRequestRepository.countByUserId(userId)).thenReturn(4L)
+        `when`(groupBuyRequestRepository.countByUser_Id(userId)).thenReturn(4L)
 
         val result = mypageService.getSummary(userId)
 
@@ -341,14 +341,14 @@ class MypageServiceTest {
     fun `group-buy-requests는 내 개설 요청 내역 DTO로 변환한다`() {
         val userId = 1L
         val request = GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = "문치 베이커리",
             productName = "소금빵",
             desiredQuantity = 5,
             desiredPickupDate = LocalDate.of(2026, 5, 27),
             status = GroupBuyRequestStatus.IN_CONTACT
         ).apply { id = 20L }
-        `when`(groupBuyRequestRepository.findByUserIdOrderByCreatedAtDesc(userId)).thenReturn(listOf(request))
+        `when`(groupBuyRequestRepository.findByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(listOf(request))
 
         val result = mypageService.getGroupBuyRequests(userId)
 
@@ -360,7 +360,7 @@ class MypageServiceTest {
         assertEquals(LocalDate.of(2026, 5, 27), result[0].desiredPickupDate)
         assertEquals(5, result[0].desiredQuantity)
 
-        verify(groupBuyRequestRepository).findByUserIdOrderByCreatedAtDesc(userId)
+        verify(groupBuyRequestRepository).findByUser_IdOrderByCreatedAtDesc(userId)
     }
 
     private fun createParticipation(): Participation {
@@ -378,7 +378,7 @@ class MypageServiceTest {
             district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN
         )
         val groupBuyRequest = GroupBuyRequest(
-            userId = 2L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 2L),
             storeName = store.name,
             productName = "초코 케이크",
             desiredQuantity = 10,

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
@@ -181,7 +181,7 @@ class NotificationTriggerSchedulerTest {
     fun `요청공구 D3 스케줄러를 실행할 때 요청자 대상 알림 발행`() {
         val now = LocalDateTime.of(2026, 5, 23, 7, 0)
         val request = GroupBuyRequest(
-            userId = 7L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 7L),
             storeName = "테스트 매장",
             storeAddress = "서울",
             productName = "소금빵",

--- a/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
@@ -78,7 +78,7 @@ class ParticipationAuditingIntegrationTest {
         em.persist(store)
 
         val request = GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = "테스트 매장",
             storeAddress = "서울 성동구",
             productName = "테스트 상품",

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -368,7 +368,7 @@ class PaymentServiceTest {
         val participantUser = UserFixture.createKakaoUser(id = 2L)
         val groupBuy = createGroupBuy().apply {
             groupBuyRequest = GroupBuyRequest(
-                userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
                 storeName = "뭉치장 베이커리",
                 storeAddress = "서울 성동구",
                 productName = "두쫀쿠",
@@ -999,7 +999,7 @@ class PaymentServiceTest {
 
     private fun createGroupBuyRequest(): GroupBuyRequest =
         GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "뭉치장 베이커리",
             storeAddress = "서울 성동구",
             productName = "두쫀쿠",

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -464,7 +464,7 @@ class PickupServiceTest {
 
     private fun createGroupBuyRequest(pickupDate: LocalDate): GroupBuyRequest =
         GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "뭉치장 베이커리",
             storeAddress = "서울 성동구 성수동",
             productName = "두쫀쿠",

--- a/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
@@ -70,7 +70,7 @@ object GroupBuyFixture {
         desiredPickupDate: LocalDate = LocalDate.now().plusDays(5)
     ): GroupBuyRequest {
         return GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = storeName,
             storeAddress = storeAddress,
             productName = productName,

--- a/src/test/kotlin/com/moongchijang/support/GroupBuyRequestFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/GroupBuyRequestFixture.kt
@@ -41,7 +41,7 @@ object GroupBuyRequestFixture {
         storeAddress: String? = null
     ): GroupBuyRequest {
         return GroupBuyRequest(
-            userId = userId,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = userId),
             storeName = storeName,
             storeAddress = storeAddress,
             productName = productName,

--- a/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
@@ -72,7 +72,7 @@ object ParticipationFixture {
             district = DistrictType.SEOUL_GANGNAM_YEOKSAM_SAMSEONG
         )
         val request = GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "사이드템포",
             productName = "두쫀쿠 오리지널 1개",
             desiredQuantity = 50,

--- a/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
@@ -26,7 +26,7 @@ object SearchTestFixtures {
 
     fun groupBuyRequest(id: Long = 100L): GroupBuyRequest =
         GroupBuyRequest(
-            userId = 1L,
+            user = com.moongchijang.support.UserFixture.createKakaoUser(id = 1L),
             storeName = "뭉치장 베이커리",
             storeAddress = "서울 성동구",
             productName = "두쫀쿠",


### PR DESCRIPTION
## 📌 작업한 내용
- `GroupBuyRequest`의 `user_id`를 `User` 연관관계(`@ManyToOne`)로 전환했습니다.
- `GroupBuyRequestStatusHistory`의 `group_buy_request_id`를 `GroupBuyRequest` 연관관계(`@ManyToOne`)로 전환했습니다.
- `GroupBuyOpenRequest`의 `user_id`를 `User` 연관관계(`@ManyToOne`)로 전환했습니다.
- 연관관계 전환에 맞춰 서비스/리포지토리/조회 로직을 정비했습니다.
- 테스트 코드(단위/통합)에서 엔티티 참조 매핑 변경 사항을 반영해 전면 정리했습니다.
- Flyway 마이그레이션(`V43`)을 추가해 아래 FK 제약을 반영했습니다.
  - `group_buy_requests.user_id -> users.id`
  - `group_buy_request_status_histories.group_buy_request_id -> group_buy_requests.id`
  - `group_buy_open_requests.user_id -> users.id`

## 🔍 참고 사항
- FK 적용 전 고아 데이터 점검 결과 대상 3개 관계 모두 0건임을 확인했습니다.
- 현재 기준 `compileKotlin`, `compileTestKotlin`, 관련 실패 테스트 재실행 통과 상태입니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #294 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인