### PR TITLE
[MCJ-1585] FEAT: 디스코드 관리자 알림 구현 및 이벤트 연동

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -14,6 +14,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHisto
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
@@ -37,6 +38,7 @@ class GroupBuyRequestService(
     private val groupBuyOpenRequestService: GroupBuyOpenRequestService,
     private val userRepository: UserRepository,
     private val clock: Clock,
+    private val adminDiscordAlertService: AdminDiscordAlertService,
 ) {
     private val log = LoggerFactory.getLogger(GroupBuyRequestService::class.java)
 
@@ -77,6 +79,7 @@ class GroupBuyRequestService(
                 changedAt = saved.createdAt ?: LocalDateTime.now()
             )
         )
+        adminDiscordAlertService.sendNewGroupBuyRequest(saved)
 
         val response = GroupBuyRequestIdResponse(saved.id)
         log.info("[GroupBuyRequestService] 공구요청 생성 완료: userId={}, requestId={}", userId, saved.id)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.groupbuy.application
 
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
@@ -20,6 +21,7 @@ class GroupBuyStatusTransitionService(
     private val groupBuyRepository: GroupBuyRepository,
     private val participationRepository: ParticipationRepository,
     private val notificationEventPublisher: NotificationEventPublisher,
+    private val adminDiscordAlertService: AdminDiscordAlertService,
     private val transactionManager: PlatformTransactionManager,
     @Value("\${groupbuy.status-transition.batch-size:500}")
     private val batchSize: Int
@@ -81,7 +83,9 @@ class GroupBuyStatusTransitionService(
                 GroupBuyStatus.IN_PROGRESS -> {
                     groupBuy.transitionToFailedByDeadline(now)
                     markParticipationsRefundPending(groupBuy.id, now)
-                    publishApplyGroupBuyFailedEvent(groupBuy.id, now)
+                    val participantUserIds = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuy.id)
+                    publishApplyGroupBuyFailedEvent(groupBuy.id, participantUserIds, now)
+                    adminDiscordAlertService.sendGroupBuyFailed(groupBuy, participantUserIds.size)
                     inProgressToFailed++
                 }
                 GroupBuyStatus.ACHIEVED -> {
@@ -104,8 +108,7 @@ class GroupBuyStatusTransitionService(
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
         }
 
-    private fun publishApplyGroupBuyFailedEvent(groupBuyId: Long, occurredAt: LocalDateTime) {
-        val participantUserIds = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuyId)
+    private fun publishApplyGroupBuyFailedEvent(groupBuyId: Long, participantUserIds: List<Long>, occurredAt: LocalDateTime) {
         if (participantUserIds.isEmpty()) return
 
         notificationEventPublisher.publishApplyGroupBuyFailed(

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertEventListener.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertEventListener.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.domain.notification.application.discord
+
+import com.moongchijang.domain.notification.application.discord.event.AdminDiscordAlertRequestedEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class AdminDiscordAlertEventListener(
+    private val discordMessageSender: DiscordMessageSender,
+) {
+
+    @Async("notificationEventExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun on(event: AdminDiscordAlertRequestedEvent) {
+        discordMessageSender.send(event.channel, event.message)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
@@ -2,7 +2,6 @@ package com.moongchijang.domain.notification.application.discord
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
-import com.moongchijang.domain.notification.infrastructure.discord.DiscordWebhookClient
 import com.moongchijang.domain.user.domain.entity.SellerBusinessProfile
 import org.springframework.stereotype.Service
 import java.text.NumberFormat
@@ -10,7 +9,7 @@ import java.util.Locale
 
 @Service
 class AdminDiscordAlertService(
-    private val discordWebhookClient: DiscordWebhookClient,
+    private val discordMessageSender: DiscordMessageSender,
 ) {
     fun sendNewGroupBuyRequest(request: GroupBuyRequest) {
         val requester = request.user.nickname ?: "이름미입력"
@@ -20,7 +19,7 @@ class AdminDiscordAlertService(
             희망날짜: ${request.desiredPickupDate}
             → 어드민 확인 필요
         """.trimIndent()
-        discordWebhookClient.send(AdminDiscordChannel.ONBOARDING, message)
+        discordMessageSender.send(AdminDiscordChannel.ONBOARDING, message)
     }
 
     fun sendGroupBuyAchieved(groupBuy: GroupBuy, participantCount: Int) {
@@ -31,7 +30,7 @@ class AdminDiscordAlertService(
             픽업일: ${groupBuy.pickupDate}
             → 발주 확정 필요
         """.trimIndent()
-        discordWebhookClient.send(AdminDiscordChannel.GROUPBUY, message)
+        discordMessageSender.send(AdminDiscordChannel.GROUPBUY, message)
     }
 
     fun sendGroupBuyFailed(groupBuy: GroupBuy, participantCount: Int) {
@@ -39,7 +38,7 @@ class AdminDiscordAlertService(
             [미달성] ${groupBuy.store.name} - ${groupBuy.productName} 해산
             참여자 ${participantCount}명 자동 환불 처리 중
         """.trimIndent()
-        discordWebhookClient.send(AdminDiscordChannel.GROUPBUY, message)
+        discordMessageSender.send(AdminDiscordChannel.GROUPBUY, message)
     }
 
     fun sendRefundFailedSummary(failedCount: Int) {
@@ -48,7 +47,7 @@ class AdminDiscordAlertService(
             실패 건수: ${failedCount}건
             → 수동 처리 필요
         """.trimIndent()
-        discordWebhookClient.send(AdminDiscordChannel.REFUND, message)
+        discordMessageSender.send(AdminDiscordChannel.REFUND, message)
     }
 
     fun sendNewSellerSignup(profile: SellerBusinessProfile) {
@@ -58,7 +57,7 @@ class AdminDiscordAlertService(
             ${profile.storeName} / ${ownerName}
             → 입점 검토 필요
         """.trimIndent()
-        discordWebhookClient.send(AdminDiscordChannel.ONBOARDING, message)
+        discordMessageSender.send(AdminDiscordChannel.ONBOARDING, message)
     }
 
     private fun toWon(amount: Int): String =

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
@@ -1,0 +1,66 @@
+package com.moongchijang.domain.notification.application.discord
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.notification.infrastructure.discord.DiscordWebhookClient
+import com.moongchijang.domain.user.domain.entity.SellerBusinessProfile
+import org.springframework.stereotype.Service
+import java.text.NumberFormat
+import java.util.Locale
+
+@Service
+class AdminDiscordAlertService(
+    private val discordWebhookClient: DiscordWebhookClient,
+) {
+    fun sendNewGroupBuyRequest(request: GroupBuyRequest) {
+        val requester = request.user.nickname ?: "이름미입력"
+        val message = """
+            [새 요청] ${request.storeName} - ${request.productName}
+            요청자: $requester / 희망수량: ${request.desiredQuantity}개
+            희망날짜: ${request.desiredPickupDate}
+            → 어드민 확인 필요
+        """.trimIndent()
+        discordWebhookClient.send(AdminDiscordChannel.ONBOARDING, message)
+    }
+
+    fun sendGroupBuyAchieved(groupBuy: GroupBuy, participantCount: Int) {
+        val totalAmount = groupBuy.currentQuantity * groupBuy.price
+        val message = """
+            [달성] ${groupBuy.store.name} - ${groupBuy.productName} 확정
+            참여자 ${participantCount}명 / 총 ${toWon(totalAmount)}원
+            픽업일: ${groupBuy.pickupDate}
+            → 발주 확정 필요
+        """.trimIndent()
+        discordWebhookClient.send(AdminDiscordChannel.GROUPBUY, message)
+    }
+
+    fun sendGroupBuyFailed(groupBuy: GroupBuy, participantCount: Int) {
+        val message = """
+            [미달성] ${groupBuy.store.name} - ${groupBuy.productName} 해산
+            참여자 ${participantCount}명 자동 환불 처리 중
+        """.trimIndent()
+        discordWebhookClient.send(AdminDiscordChannel.GROUPBUY, message)
+    }
+
+    fun sendRefundFailedSummary(failedCount: Int) {
+        val message = """
+            [긴급] 환불 실패 발생
+            실패 건수: ${failedCount}건
+            → 수동 처리 필요
+        """.trimIndent()
+        discordWebhookClient.send(AdminDiscordChannel.REFUND, message)
+    }
+
+    fun sendNewSellerSignup(profile: SellerBusinessProfile) {
+        val ownerName = profile.ownerName.ifBlank { "이름미입력" }
+        val message = """
+            [신규] 새 사장님 가입
+            ${profile.storeName} / ${ownerName}
+            → 입점 검토 필요
+        """.trimIndent()
+        discordWebhookClient.send(AdminDiscordChannel.ONBOARDING, message)
+    }
+
+    private fun toWon(amount: Int): String =
+        NumberFormat.getNumberInstance(Locale.KOREA).format(amount)
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
@@ -2,14 +2,16 @@ package com.moongchijang.domain.notification.application.discord
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
+import com.moongchijang.domain.notification.application.discord.event.AdminDiscordAlertRequestedEvent
 import com.moongchijang.domain.user.domain.entity.SellerBusinessProfile
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.text.NumberFormat
 import java.util.Locale
 
 @Service
 class AdminDiscordAlertService(
-    private val discordMessageSender: DiscordMessageSender,
+    private val eventPublisher: ApplicationEventPublisher,
 ) {
     fun sendNewGroupBuyRequest(request: GroupBuyRequest) {
         val requester = request.user.nickname ?: "이름미입력"
@@ -19,7 +21,7 @@ class AdminDiscordAlertService(
             희망날짜: ${request.desiredPickupDate}
             → 어드민 확인 필요
         """.trimIndent()
-        discordMessageSender.send(AdminDiscordChannel.ONBOARDING, message)
+        eventPublisher.publishEvent(AdminDiscordAlertRequestedEvent(AdminDiscordChannel.ONBOARDING, message))
     }
 
     fun sendGroupBuyAchieved(groupBuy: GroupBuy, participantCount: Int) {
@@ -30,7 +32,7 @@ class AdminDiscordAlertService(
             픽업일: ${groupBuy.pickupDate}
             → 발주 확정 필요
         """.trimIndent()
-        discordMessageSender.send(AdminDiscordChannel.GROUPBUY, message)
+        eventPublisher.publishEvent(AdminDiscordAlertRequestedEvent(AdminDiscordChannel.GROUPBUY, message))
     }
 
     fun sendGroupBuyFailed(groupBuy: GroupBuy, participantCount: Int) {
@@ -38,7 +40,7 @@ class AdminDiscordAlertService(
             [미달성] ${groupBuy.store.name} - ${groupBuy.productName} 해산
             참여자 ${participantCount}명 자동 환불 처리 중
         """.trimIndent()
-        discordMessageSender.send(AdminDiscordChannel.GROUPBUY, message)
+        eventPublisher.publishEvent(AdminDiscordAlertRequestedEvent(AdminDiscordChannel.GROUPBUY, message))
     }
 
     fun sendRefundFailedSummary(failedCount: Int) {
@@ -47,7 +49,7 @@ class AdminDiscordAlertService(
             실패 건수: ${failedCount}건
             → 수동 처리 필요
         """.trimIndent()
-        discordMessageSender.send(AdminDiscordChannel.REFUND, message)
+        eventPublisher.publishEvent(AdminDiscordAlertRequestedEvent(AdminDiscordChannel.REFUND, message))
     }
 
     fun sendNewSellerSignup(profile: SellerBusinessProfile) {
@@ -57,7 +59,7 @@ class AdminDiscordAlertService(
             ${profile.storeName} / ${ownerName}
             → 입점 검토 필요
         """.trimIndent()
-        discordMessageSender.send(AdminDiscordChannel.ONBOARDING, message)
+        eventPublisher.publishEvent(AdminDiscordAlertRequestedEvent(AdminDiscordChannel.ONBOARDING, message))
     }
 
     private fun toWon(amount: Int): String =

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordChannel.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordChannel.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.notification.application.discord
+
+enum class AdminDiscordChannel {
+    REFUND,
+    GROUPBUY,
+    ONBOARDING,
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/DiscordMessageSender.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/DiscordMessageSender.kt
@@ -1,0 +1,5 @@
+package com.moongchijang.domain.notification.application.discord
+
+interface DiscordMessageSender {
+    fun send(channel: AdminDiscordChannel, message: String): Boolean
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/event/AdminDiscordAlertRequestedEvent.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/event/AdminDiscordAlertRequestedEvent.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.notification.application.discord.event
+
+import com.moongchijang.domain.notification.application.discord.AdminDiscordChannel
+
+data class AdminDiscordAlertRequestedEvent(
+    val channel: AdminDiscordChannel,
+    val message: String,
+)

--- a/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordProperties.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordProperties.kt
@@ -1,0 +1,15 @@
+package com.moongchijang.domain.notification.infrastructure.discord
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "discord")
+data class DiscordProperties(
+    val enabled: Boolean = false,
+    val webhook: Webhook = Webhook(),
+) {
+    data class Webhook(
+        val refund: String = "",
+        val groupbuy: String = "",
+        val onboarding: String = "",
+    )
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
@@ -9,10 +9,11 @@ import org.springframework.web.client.RestClient
 
 @Component
 class DiscordWebhookClient(
-    private val restClient: RestClient,
+    restClientBuilder: RestClient.Builder,
     private val discordProperties: DiscordProperties,
 ) : DiscordMessageSender {
     private val log = LoggerFactory.getLogger(javaClass)
+    private val restClient: RestClient = restClientBuilder.build()
 
     override fun send(channel: AdminDiscordChannel, message: String): Boolean {
         if (!discordProperties.enabled) {

--- a/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
@@ -1,0 +1,49 @@
+package com.moongchijang.domain.notification.infrastructure.discord
+
+import com.moongchijang.domain.notification.application.discord.AdminDiscordChannel
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class DiscordWebhookClient(
+    private val restClient: RestClient,
+    private val discordProperties: DiscordProperties,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun send(channel: AdminDiscordChannel, message: String): Boolean {
+        if (!discordProperties.enabled) {
+            log.debug("[DiscordWebhookClient] 비활성화 상태로 전송을 건너뜁니다: channel={}", channel)
+            return false
+        }
+
+        val webhookUrl = resolveWebhookUrl(channel)
+        if (webhookUrl.isBlank()) {
+            log.warn("[DiscordWebhookClient] webhook URL이 비어있습니다.: channel={}", channel)
+            return false
+        }
+
+        val payload = mapOf("content" to message)
+        return try {
+            restClient.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(payload)
+                .retrieve()
+                .toBodilessEntity()
+            true
+        } catch (e: Exception) {
+            log.error("[DiscordWebhookClient] send failed: channel={}", channel, e)
+            false
+        }
+    }
+
+    private fun resolveWebhookUrl(channel: AdminDiscordChannel): String =
+        when (channel) {
+            AdminDiscordChannel.REFUND -> discordProperties.webhook.refund
+            AdminDiscordChannel.GROUPBUY -> discordProperties.webhook.groupbuy
+            AdminDiscordChannel.ONBOARDING -> discordProperties.webhook.onboarding
+        }.trim()
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.notification.infrastructure.discord
 
 import com.moongchijang.domain.notification.application.discord.AdminDiscordChannel
+import com.moongchijang.domain.notification.application.discord.DiscordMessageSender
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -10,10 +11,10 @@ import org.springframework.web.client.RestClient
 class DiscordWebhookClient(
     private val restClient: RestClient,
     private val discordProperties: DiscordProperties,
-) {
+) : DiscordMessageSender {
     private val log = LoggerFactory.getLogger(javaClass)
 
-    fun send(channel: AdminDiscordChannel, message: String): Boolean {
+    override fun send(channel: AdminDiscordChannel, message: String): Boolean {
         if (!discordProperties.enabled) {
             log.debug("[DiscordWebhookClient] 비활성화 상태로 전송을 건너뜁니다: channel={}", channel)
             return false

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -390,13 +390,12 @@ class PaymentService(
         publishApplyPaymentSuccessEvent(order, approvedAt)
 
         if (groupBuy.status == GroupBuyStatus.ACHIEVED) {
-            publishApplyGroupBuyAchievedEvent(groupBuy.id, approvedAt)
+            val participantUserIds = publishApplyGroupBuyAchievedEvent(groupBuy.id, approvedAt)
             publishWishTargetAchievedEvent(groupBuy.id, approvedAt)
             publishRequestTargetAchievedEvent(groupBuy, approvedAt)
-        }
-        if (achievedNow) {
-            val participantCount = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuy.id).size
-            adminDiscordAlertService.sendGroupBuyAchieved(groupBuy, participantCount)
+            if (achievedNow) {
+                adminDiscordAlertService.sendGroupBuyAchieved(groupBuy, participantUserIds.size)
+            }
         }
 
         publishRequestNewParticipantEvent(groupBuy, participation, approvedAt)
@@ -424,15 +423,16 @@ class PaymentService(
         )
     }
 
-    private fun publishApplyGroupBuyAchievedEvent(groupBuyId: Long, occurredAt: LocalDateTime) {
+    private fun publishApplyGroupBuyAchievedEvent(groupBuyId: Long, occurredAt: LocalDateTime): List<Long> {
         val participantUserIds = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuyId)
-        if (participantUserIds.isEmpty()) return
+        if (participantUserIds.isEmpty()) return emptyList()
 
         notificationEventPublisher.publishApplyGroupBuyAchieved(
             groupBuyId = groupBuyId,
             participantUserIds = participantUserIds,
             occurredAt = occurredAt
         )
+        return participantUserIds
     }
 
     private fun publishWishTargetAchievedEvent(groupBuyId: Long, occurredAt: LocalDateTime) {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -6,6 +6,7 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
@@ -57,6 +58,7 @@ class PaymentService(
     private val transactionManager: PlatformTransactionManager,
     private val redisLockUtil: RedisLockUtil,
     private val notificationEventPublisher: NotificationEventPublisher,
+    private val adminDiscordAlertService: AdminDiscordAlertService,
     private val refundRequestSyncService: RefundRequestSyncService,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
 ) {
@@ -363,7 +365,8 @@ class PaymentService(
             )
         )
 
-        if (groupBuy.currentQuantity >= groupBuy.targetQuantity && groupBuy.status == GroupBuyStatus.IN_PROGRESS) {
+        val achievedNow = groupBuy.currentQuantity >= groupBuy.targetQuantity && groupBuy.status == GroupBuyStatus.IN_PROGRESS
+        if (achievedNow) {
             groupBuy.transitionToAchieved()
         }
         if (groupBuy.status == GroupBuyStatus.ACHIEVED && groupBuy.currentQuantity >= groupBuy.maxQuantity) {
@@ -390,6 +393,10 @@ class PaymentService(
             publishApplyGroupBuyAchievedEvent(groupBuy.id, approvedAt)
             publishWishTargetAchievedEvent(groupBuy.id, approvedAt)
             publishRequestTargetAchievedEvent(groupBuy, approvedAt)
+        }
+        if (achievedNow) {
+            val participantCount = participationRepository.findDistinctUserIdsByGroupBuyId(groupBuy.id).size
+            adminDiscordAlertService.sendGroupBuyAchieved(groupBuy, participantCount)
         }
 
         publishRequestNewParticipantEvent(groupBuy, participation, approvedAt)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PendingRefundScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PendingRefundScheduler.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.payment.application
 
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component
 class PendingRefundScheduler(
     private val paymentService: PaymentService,
     private val redisLockUtil: RedisLockUtil,
+    private val adminDiscordAlertService: AdminDiscordAlertService,
     @Value("\${payment.pending-refund.batch-size:100}")
     private val batchSize: Int,
     @Value("\${payment.pending-refund.lock.wait-ms:100}")
@@ -42,6 +44,9 @@ class PendingRefundScheduler(
                     result.successCount,
                     result.failedCount
                 )
+                if (result.failedCount > 0) {
+                    adminDiscordAlertService.sendRefundFailedSummary(result.failedCount)
+                }
             }
         } finally {
             val unlocked = redisLockUtil.unlock(PENDING_REFUND_LOCK_KEY, token)

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.user.application
 
 import com.moongchijang.domain.auth.application.PhoneVerificationService
 import com.moongchijang.domain.auth.application.TokenService
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.auth.application.dto.AuthUserResponse
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
@@ -57,6 +58,7 @@ class UserService(
     private val favoriteRepository: FavoriteRepository,
     private val paymentService: PaymentService,
     private val passwordEncoder: PasswordEncoder,
+    private val adminDiscordAlertService: AdminDiscordAlertService,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -404,6 +406,9 @@ class UserService(
         user.role = UserRole.SELLER
         user.saveLastRole(UserRole.SELLER)
         user.completeSellerSignup()
+        sellerBusinessProfileRepository.findByUserId(userId)?.let { profile ->
+            adminDiscordAlertService.sendNewSellerSignup(profile)
+        }
 
         log.info("[UserService] 사장님 정산 정보 저장 완료: userId={}", userId)
         return SellerSignupStatusResponse(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -89,6 +89,13 @@ aligo:
   template-code-pickup-day-reminder: ${ALIGO_TEMPLATE_PICKUP_DAY_REMINDER:${ALIGO_TEMPLATE_GROUP_BUY_OPEN_SUCCESS:${ALIGO_TEMPLATE_CODE}}}
   sender: ${ALIGO_SENDER}
 
+discord:
+  enabled: ${DISCORD_ENABLED:false}
+  webhook:
+    refund: ${DISCORD_WEBHOOK_REFUND:}
+    groupbuy: ${DISCORD_WEBHOOK_GROUPBUY:}
+    onboarding: ${DISCORD_WEBHOOK_ONBOARDING:}
+
 ses:
   enabled: ${SES_ENABLED:false}
   region: ${SES_REGION}

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -113,3 +113,10 @@ aligo:
   template-code-pickup-d1-reminder: ${ALIGO_TEMPLATE_PICKUP_D1_REMINDER:${ALIGO_TEMPLATE_GROUP_BUY_OPEN_SUCCESS:${ALIGO_TEMPLATE_CODE:local-template-code}}}
   template-code-pickup-day-reminder: ${ALIGO_TEMPLATE_PICKUP_DAY_REMINDER:${ALIGO_TEMPLATE_GROUP_BUY_OPEN_SUCCESS:${ALIGO_TEMPLATE_CODE:local-template-code}}}
   sender: ${ALIGO_SENDER:01000000000}
+
+discord:
+  enabled: ${DISCORD_ENABLED:false}
+  webhook:
+    refund: ${DISCORD_WEBHOOK_REFUND:}
+    groupbuy: ${DISCORD_WEBHOOK_GROUPBUY:}
+    onboarding: ${DISCORD_WEBHOOK_ONBOARDING:}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -79,6 +79,13 @@ aligo:
   template-code-pickup-day-reminder: ${ALIGO_TEMPLATE_PICKUP_DAY_REMINDER:${ALIGO_TEMPLATE_GROUP_BUY_OPEN_SUCCESS:${ALIGO_TEMPLATE_CODE}}}
   sender: ${ALIGO_SENDER}
 
+discord:
+  enabled: ${DISCORD_ENABLED:true}
+  webhook:
+    refund: ${DISCORD_WEBHOOK_REFUND:}
+    groupbuy: ${DISCORD_WEBHOOK_GROUPBUY:}
+    onboarding: ${DISCORD_WEBHOOK_ONBOARDING:}
+
 ses:
   enabled: ${SES_ENABLED:false}
   region: ${SES_REGION}

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyRequestServiceTest.kt
@@ -11,6 +11,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequestStatusHisto
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -55,6 +56,9 @@ class GroupBuyRequestServiceTest {
 
     @Mock
     private lateinit var clock: Clock
+
+    @Mock
+    private lateinit var adminDiscordAlertService: AdminDiscordAlertService
 
     @InjectMocks
     private lateinit var service: GroupBuyRequestService

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.groupbuy.service
 import com.moongchijang.domain.groupbuy.application.GroupBuyStatusTransitionService
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
@@ -40,6 +41,9 @@ class GroupBuyStatusTransitionServiceTest {
     @Mock
     private lateinit var notificationEventPublisher: NotificationEventPublisher
 
+    @Mock
+    private lateinit var adminDiscordAlertService: AdminDiscordAlertService
+
     private lateinit var service: GroupBuyStatusTransitionService
 
     @BeforeEach
@@ -49,6 +53,7 @@ class GroupBuyStatusTransitionServiceTest {
             groupBuyRepository,
             participationRepository,
             notificationEventPublisher,
+            adminDiscordAlertService,
             transactionManager,
             500
         )
@@ -151,6 +156,7 @@ class GroupBuyStatusTransitionServiceTest {
             groupBuyRepository,
             participationRepository,
             notificationEventPublisher,
+            adminDiscordAlertService,
             transactionManager,
             2
         )

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertServiceTest.kt
@@ -1,0 +1,50 @@
+package com.moongchijang.domain.notification.application.discord
+
+import com.moongchijang.support.GroupBuyFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AdminDiscordAlertServiceTest {
+
+    @Test
+    fun `새 공구 요청 알림을 보낼 때 온보딩 채널로 전송됨`() {
+        val sender = FakeDiscordMessageSender()
+        val service = AdminDiscordAlertService(sender)
+        val request = GroupBuyFixture.createGroupBuyRequest(storeName = "몽치장베이커리", productName = "소금빵", desiredQuantity = 3)
+
+        service.sendNewGroupBuyRequest(request)
+
+        assertEquals(AdminDiscordChannel.ONBOARDING, sender.lastChannel)
+        assertTrue(sender.lastMessage!!.contains("[새 요청]"))
+    }
+
+    @Test
+    fun `공구 달성 알림을 보낼 때 공구 채널로 전송되고 금액 문구가 포함됨`() {
+        val sender = FakeDiscordMessageSender()
+        val service = AdminDiscordAlertService(sender)
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 11L,
+            status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.ACHIEVED,
+            productName = "소금빵",
+            price = 5000,
+            currentQuantity = 20,
+        )
+
+        service.sendGroupBuyAchieved(groupBuy, participantCount = 18)
+
+        assertEquals(AdminDiscordChannel.GROUPBUY, sender.lastChannel)
+        assertTrue(sender.lastMessage!!.contains("총 100,000원"))
+    }
+
+    private class FakeDiscordMessageSender : DiscordMessageSender {
+        var lastChannel: AdminDiscordChannel? = null
+        var lastMessage: String? = null
+
+        override fun send(channel: AdminDiscordChannel, message: String): Boolean {
+            lastChannel = channel
+            lastMessage = message
+            return true
+        }
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertServiceTest.kt
@@ -1,28 +1,35 @@
 package com.moongchijang.domain.notification.application.discord
 
+import com.moongchijang.domain.notification.application.discord.event.AdminDiscordAlertRequestedEvent
 import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.springframework.context.ApplicationEventPublisher
 
 class AdminDiscordAlertServiceTest {
 
     @Test
     fun `새 공구 요청 알림을 보낼 때 온보딩 채널로 전송됨`() {
-        val sender = FakeDiscordMessageSender()
-        val service = AdminDiscordAlertService(sender)
+        val publisher = mock(ApplicationEventPublisher::class.java)
+        val service = AdminDiscordAlertService(publisher)
         val request = GroupBuyFixture.createGroupBuyRequest(storeName = "몽치장베이커리", productName = "소금빵", desiredQuantity = 3)
 
         service.sendNewGroupBuyRequest(request)
 
-        assertEquals(AdminDiscordChannel.ONBOARDING, sender.lastChannel)
-        assertTrue(sender.lastMessage!!.contains("[새 요청]"))
+        val captor = ArgumentCaptor.forClass(AdminDiscordAlertRequestedEvent::class.java)
+        verify(publisher).publishEvent(captor.capture())
+        assertEquals(AdminDiscordChannel.ONBOARDING, captor.value.channel)
+        assertTrue(captor.value.message.contains("[새 요청]"))
     }
 
     @Test
     fun `공구 달성 알림을 보낼 때 공구 채널로 전송되고 금액 문구가 포함됨`() {
-        val sender = FakeDiscordMessageSender()
-        val service = AdminDiscordAlertService(sender)
+        val publisher = mock(ApplicationEventPublisher::class.java)
+        val service = AdminDiscordAlertService(publisher)
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = 11L,
             status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.ACHIEVED,
@@ -33,18 +40,9 @@ class AdminDiscordAlertServiceTest {
 
         service.sendGroupBuyAchieved(groupBuy, participantCount = 18)
 
-        assertEquals(AdminDiscordChannel.GROUPBUY, sender.lastChannel)
-        assertTrue(sender.lastMessage!!.contains("총 100,000원"))
-    }
-
-    private class FakeDiscordMessageSender : DiscordMessageSender {
-        var lastChannel: AdminDiscordChannel? = null
-        var lastMessage: String? = null
-
-        override fun send(channel: AdminDiscordChannel, message: String): Boolean {
-            lastChannel = channel
-            lastMessage = message
-            return true
-        }
+        val captor = ArgumentCaptor.forClass(AdminDiscordAlertRequestedEvent::class.java)
+        verify(publisher).publishEvent(captor.capture())
+        assertEquals(AdminDiscordChannel.GROUPBUY, captor.value.channel)
+        assertTrue(captor.value.message.contains("총 100,000원"))
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -6,6 +6,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
@@ -95,6 +96,9 @@ class PaymentServiceTest {
     private lateinit var notificationEventPublisher: NotificationEventPublisher
 
     @Mock
+    private lateinit var adminDiscordAlertService: AdminDiscordAlertService
+
+    @Mock
     private lateinit var refundRequestSyncService: RefundRequestSyncService
 
     @Mock
@@ -119,6 +123,7 @@ class PaymentServiceTest {
             transactionManager = transactionManager,
             redisLockUtil = redisLockUtil,
             notificationEventPublisher = notificationEventPublisher,
+            adminDiscordAlertService = adminDiscordAlertService,
             refundRequestSyncService = refundRequestSyncService,
             s3ImageReferenceResolver = s3ImageReferenceResolver
         )

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PendingRefundSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PendingRefundSchedulerTest.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.payment.application
 
 import com.moongchijang.domain.groupbuy.infrastructure.lock.RedisLockUtil
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.junit.jupiter.api.Test
@@ -20,11 +21,15 @@ class PendingRefundSchedulerTest {
     @Mock
     private lateinit var redisLockUtil: RedisLockUtil
 
+    @Mock
+    private lateinit var adminDiscordAlertService: AdminDiscordAlertService
+
     @Test
     fun `분산락 획득 성공 시 환불대기 처리를 실행하고 락을 해제한다`() {
         val scheduler = PendingRefundScheduler(
             paymentService = paymentService,
             redisLockUtil = redisLockUtil,
+            adminDiscordAlertService = adminDiscordAlertService,
             batchSize = 100,
             lockWaitMs = 100,
             lockLeaseMs = 55_000,
@@ -44,6 +49,7 @@ class PendingRefundSchedulerTest {
         val scheduler = PendingRefundScheduler(
             paymentService = paymentService,
             redisLockUtil = redisLockUtil,
+            adminDiscordAlertService = adminDiscordAlertService,
             batchSize = 100,
             lockWaitMs = 100,
             lockLeaseMs = 55_000,

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -11,6 +11,7 @@ import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.payment.application.PaymentService
 import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
 import com.moongchijang.domain.user.application.dto.AdditionalInfoUpsertRequest
 import com.moongchijang.domain.user.application.dto.NicknameUpdateRequest
 import com.moongchijang.domain.user.application.dto.PasswordChangeRequest
@@ -49,6 +50,7 @@ class UserServiceTest {
     private val participationRepository: ParticipationRepository = Mockito.mock(ParticipationRepository::class.java)
     private val favoriteRepository: FavoriteRepository = Mockito.mock(FavoriteRepository::class.java)
     private val paymentService: PaymentService = Mockito.mock(PaymentService::class.java)
+    private val adminDiscordAlertService: AdminDiscordAlertService = Mockito.mock(AdminDiscordAlertService::class.java)
     private val passwordEncoder: PasswordEncoder = Mockito.mock(PasswordEncoder::class.java)
     private val userService = UserService(
         userRepository,
@@ -60,6 +62,7 @@ class UserServiceTest {
         favoriteRepository,
         paymentService,
         passwordEncoder,
+        adminDiscordAlertService,
     )
 
     @Test


### PR DESCRIPTION
## 📌 작업한 내용
- 디스코드 관리자 알림 전송 기능을 구현했습니다.
- 공구 요청 생성, 공구 달성/미달성, 환불 실패 요약, 사장님 가입 이벤트에 디스코드 알림을 연동했습니다.
- 디스코드 알림 설정을 환경변수 기반으로 추가해 운영 환경에서 웹훅을 주입할 수 있도록 구성했습니다.
- 알림 연동으로 변경된 서비스 생성자 의존성을 테스트 코드에 반영했습니다.
- 알림 서비스 테스트를 이벤트 발행 검증 기반으로 작성해 메시지/채널 라우팅 검증이 가능하도록 구성했습니다.

## ✨ 코드리뷰 반영 내용
- 트랜잭션 내 디스코드 동기 호출 이슈를 반영했습니다.
  - 디스코드 전송을 서비스 직접 호출에서 분리하고, `ApplicationEventPublisher` 기반 이벤트 발행 구조로 전환했습니다.
  - 실제 전송은 `@TransactionalEventListener(phase = AFTER_COMMIT)` + `@Async("notificationEventExecutor")` 리스너에서 처리하도록 변경했습니다.
- HTTP 클라이언트 주입 안정성 이슈를 반영했습니다.
  - `DiscordWebhookClient`에서 `RestClient` 직접 주입 대신 `RestClient.Builder` 주입 후 `build()` 방식으로 변경했습니다.
- 공구 달성 시 참여자 조회 중복 이슈를 반영했습니다.
  - `PaymentService`에서 참여자 ID 조회를 1회로 줄이고, 알림 이벤트 발행/디스코드 알림 인원수 계산에 재사용하도록 정리했습니다.

## 🔍 참고 사항
- `DISCORD_ENABLED=false`이면 알림 전송이 비활성화됩니다.
- 웹훅 값이 비어 있으면 해당 알림은 전송되지 않습니다.
- 테스트는 외부 디스코드 호출 없이 내부 로직만 검증합니다.
 
## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #296

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인