### PR TITLE
[MCJ-1587] FEAT: 어드민 사장님 공구 요청 승인 및 반려 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -77,8 +77,9 @@ class GroupBuyOpenRequestService(
             productName = groupBuy.productName,
         )
         if (result.targetUserIds.isNotEmpty()) {
+            val requestId = groupBuy.groupBuyRequest?.id ?: return result
             notificationEventPublisher.publishRequestOpened(
-                requestId = groupBuy.groupBuyRequest.id,
+                requestId = requestId,
                 requesterUserIds = result.targetUserIds,
                 occurredAt = java.time.LocalDateTime.now()
             )

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -16,8 +16,8 @@ class GroupBuy(
     var store: Store,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_buy_request_id", nullable = false)
-    var groupBuyRequest: GroupBuyRequest,
+    @JoinColumn(name = "group_buy_request_id")
+    var groupBuyRequest: GroupBuyRequest? = null,
 
     @Column(length = 500)
     var thumbnailKey: String? = null,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestService.kt
@@ -49,7 +49,12 @@ class AdminOwnerGroupBuyRequestService(
             pageable.pageNumber,
             pageable.pageSize,
         )
-        val page = ownerGroupBuyRequestRepository.searchAdminRequests(status, normalizedKeyword, pageable)
+        val page = ownerGroupBuyRequestRepository.searchAdminRequests(
+            status = status,
+            requestId = normalizedKeyword?.toLongOrNull(),
+            keyword = normalizedKeyword,
+            pageable = pageable
+        )
         val response = AdminOwnerGroupBuyRequestPageResponse.from(page, LocalDateTime.now(clock))
         log.info(
             "[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 목록 조회 완료: totalElements={}",
@@ -177,10 +182,20 @@ class AdminOwnerGroupBuyRequestService(
         ) {
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_APPROVAL_INVALID_QUANTITY)
         }
-        if (!request.pickupDate.isAfter(request.deadline.toLocalDate()) ||
-            !request.pickupTimeStart.isBefore(request.pickupTimeEnd)
+        if (!request.pickupTimeStart.isBefore(request.pickupTimeEnd) ||
+            !isPickupAfterDeadline(request.deadline, request.pickupDate, request.pickupTimeStart)
         ) {
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_APPROVAL_INVALID_PICKUP)
         }
+    }
+
+    private fun isPickupAfterDeadline(
+        deadline: LocalDateTime,
+        pickupDate: java.time.LocalDate,
+        pickupTimeStart: java.time.LocalTime
+    ): Boolean {
+        val deadlineDate = deadline.toLocalDate()
+        return pickupDate.isAfter(deadlineDate) ||
+            (pickupDate.isEqual(deadlineDate) && pickupTimeStart.isAfter(deadline.toLocalTime()))
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestService.kt
@@ -1,0 +1,186 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestDetailResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestPageResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestImageRepository
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class AdminOwnerGroupBuyRequestService(
+    private val ownerGroupBuyRequestRepository: OwnerGroupBuyRequestRepository,
+    private val ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository,
+    private val groupBuyRepository: GroupBuyRepository,
+    private val groupBuyImageRepository: GroupBuyImageRepository,
+    private val s3ImageReferenceResolver: S3ImageReferenceResolver,
+    private val clock: Clock,
+) {
+    private val log = LoggerFactory.getLogger(AdminOwnerGroupBuyRequestService::class.java)
+
+    @Transactional(readOnly = true)
+    fun getRequests(
+        status: OwnerGroupBuyRequestStatus?,
+        keyword: String?,
+        pageable: Pageable
+    ): AdminOwnerGroupBuyRequestPageResponse {
+        val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
+        log.info(
+            "[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 목록 조회 시작: status={}, keyword={}, page={}, size={}",
+            status,
+            normalizedKeyword,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
+        val page = ownerGroupBuyRequestRepository.searchAdminRequests(status, normalizedKeyword, pageable)
+        val response = AdminOwnerGroupBuyRequestPageResponse.from(page, LocalDateTime.now(clock))
+        log.info(
+            "[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 목록 조회 완료: totalElements={}",
+            response.totalElements,
+        )
+        return response
+    }
+
+    @Transactional(readOnly = true)
+    fun getDetail(requestId: Long): AdminOwnerGroupBuyRequestDetailResponse {
+        log.info("[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 상세 조회 시작: requestId={}", requestId)
+        val request = ownerGroupBuyRequestRepository.findAdminDetailById(requestId)
+            .orElseThrow { CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_NOT_FOUND) }
+        val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
+        val response = AdminOwnerGroupBuyRequestDetailResponse.from(
+            request = request,
+            images = images,
+            imageUrls = images.map { s3ImageReferenceResolver.resolveForRead(it.imageKey).orEmpty() },
+        )
+        log.info("[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 상세 조회 완료: requestId={}", requestId)
+        return response
+    }
+
+    fun approve(requestId: Long): AdminOwnerGroupBuyRequestActionResponse {
+        log.info("[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 승인 시작: requestId={}", requestId)
+        val request = findRequestForAction(requestId)
+        validatePending(request)
+        validateApprovalSource(request)
+
+        val now = LocalDateTime.now(clock)
+        val groupBuy = groupBuyRepository.save(
+            GroupBuy(
+                store = request.store,
+                groupBuyRequest = null,
+                thumbnailKey = request.thumbnailKey,
+                productName = request.productName.trim(),
+                productDescription = request.productDescription.trim(),
+                price = request.price,
+                originalPrice = request.originalPrice,
+                targetQuantity = request.targetQuantity,
+                currentQuantity = 0,
+                maxQuantity = request.maxQuantity,
+                perUserLimit = request.perUserLimit,
+                status = GroupBuyStatus.IN_PROGRESS,
+                recruitmentStartAt = now,
+                deadline = request.deadline,
+                pickupDate = request.pickupDate,
+                pickupTimeStart = request.pickupTimeStart,
+                pickupTimeEnd = request.pickupTimeEnd,
+                pickupLocation = request.pickupLocation.trim(),
+                pickupContact = request.pickupContact?.trim()?.ifBlank { null },
+            )
+        )
+
+        val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
+        groupBuyImageRepository.saveAll(
+            images.map {
+                GroupBuyImage(
+                    groupBuy = groupBuy,
+                    imageKey = it.imageKey,
+                )
+            }
+        )
+
+        request.status = OwnerGroupBuyRequestStatus.APPROVED
+        request.approvedGroupBuy = groupBuy
+        request.rejectionReason = null
+        request.reviewedAt = now
+
+        val response = AdminOwnerGroupBuyRequestActionResponse(
+            requestId = request.id,
+            status = request.status,
+            groupBuyId = groupBuy.id
+        )
+        log.info(
+            "[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 승인 완료: requestId={}, groupBuyId={}",
+            requestId,
+            groupBuy.id,
+        )
+        return response
+    }
+
+    fun reject(requestId: Long, rejectRequest: AdminOwnerGroupBuyRequestRejectRequest): AdminOwnerGroupBuyRequestActionResponse {
+        log.info("[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 반려 시작: requestId={}", requestId)
+        val request = findRequestForAction(requestId)
+        validatePending(request)
+
+        val reason = rejectRequest.rejectionReason.trim()
+        if (reason.isBlank()) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED)
+        }
+
+        request.status = OwnerGroupBuyRequestStatus.REJECTED
+        request.rejectionReason = reason
+        request.reviewedAt = LocalDateTime.now(clock)
+        request.approvedGroupBuy = null
+
+        val response = AdminOwnerGroupBuyRequestActionResponse(
+            requestId = request.id,
+            status = request.status,
+            groupBuyId = null
+        )
+        log.info("[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 반려 완료: requestId={}", requestId)
+        return response
+    }
+
+    private fun findRequestForAction(requestId: Long): OwnerGroupBuyRequest =
+        ownerGroupBuyRequestRepository.findWithLockById(requestId)
+            .orElseThrow { CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_NOT_FOUND) }
+
+    private fun validatePending(request: OwnerGroupBuyRequest) {
+        if (request.status != OwnerGroupBuyRequestStatus.PENDING) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION)
+        }
+    }
+
+    private fun validateApprovalSource(request: OwnerGroupBuyRequest) {
+        val originalPrice = request.originalPrice
+        if (originalPrice != null && originalPrice < request.price) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_APPROVAL_INVALID_PRICE)
+        }
+        val perUserLimit = request.perUserLimit
+        if (request.targetQuantity > request.maxQuantity ||
+            (perUserLimit != null && perUserLimit > request.maxQuantity)
+        ) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_APPROVAL_INVALID_QUANTITY)
+        }
+        if (!request.pickupDate.isAfter(request.deadline.toLocalDate()) ||
+            !request.pickupTimeStart.isBefore(request.pickupTimeEnd)
+        ) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_APPROVAL_INVALID_PICKUP)
+        }
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -187,9 +187,19 @@ class OwnerGroupBuyRequestService(
             throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_TIME)
         }
 
-        if (!request.pickupDate.isAfter(request.deadline.toLocalDate())) {
+        if (!isPickupAfterDeadline(request.deadline, request.pickupDate, request.pickupTimeStart)) {
             throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_PICKUP_DATE)
         }
+    }
+
+    private fun isPickupAfterDeadline(
+        deadline: LocalDateTime,
+        pickupDate: java.time.LocalDate,
+        pickupTimeStart: java.time.LocalTime
+    ): Boolean {
+        val deadlineDate = deadline.toLocalDate()
+        return pickupDate.isAfter(deadlineDate) ||
+            (pickupDate.isEqual(deadlineDate) && pickupTimeStart.isAfter(deadline.toLocalTime()))
     }
 
     private companion object {

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyRequestDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyRequestDtos.kt
@@ -198,7 +198,7 @@ private const val REQUEST_TYPE = "OWNER"
 
 private fun OwnerGroupBuyRequest.discountRate(): Int? {
     val original = originalPrice ?: return null
-    if (original <= 0 || original < price) {
+    if (original <= price) {
         return null
     }
     return ((original - price) * 100) / original

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyRequestDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyRequestDtos.kt
@@ -1,0 +1,205 @@
+package com.moongchijang.domain.owner.application.dto
+
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.springframework.data.domain.Page
+import java.time.Duration
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+data class AdminOwnerGroupBuyRequestPageResponse(
+    val content: List<AdminOwnerGroupBuyRequestListItemResponse>,
+    val totalElements: Long,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int
+) {
+    companion object {
+        fun from(page: Page<OwnerGroupBuyRequest>, now: LocalDateTime): AdminOwnerGroupBuyRequestPageResponse =
+            AdminOwnerGroupBuyRequestPageResponse(
+                content = page.content.map { AdminOwnerGroupBuyRequestListItemResponse.from(it, now) },
+                totalElements = page.totalElements,
+                totalPages = page.totalPages,
+                number = page.number,
+                size = page.size
+            )
+    }
+}
+
+data class AdminOwnerGroupBuyRequestListItemResponse(
+    val requestId: Long,
+    val requestType: String,
+    val productName: String,
+    val storeName: String,
+    val ownerName: String?,
+    val originalPrice: Int?,
+    val price: Int,
+    val discountRate: Int?,
+    val targetQuantity: Int,
+    val pickupDate: LocalDate,
+    val requestedAt: LocalDateTime?,
+    val reviewElapsedMinutes: Long,
+    val status: OwnerGroupBuyRequestStatus,
+    val actionable: Boolean,
+    val approvedGroupBuyId: Long?
+) {
+    companion object {
+        fun from(request: OwnerGroupBuyRequest, now: LocalDateTime): AdminOwnerGroupBuyRequestListItemResponse =
+            AdminOwnerGroupBuyRequestListItemResponse(
+                requestId = request.id,
+                requestType = REQUEST_TYPE,
+                productName = request.productName,
+                storeName = request.store.name,
+                ownerName = request.owner.nickname,
+                originalPrice = request.originalPrice,
+                price = request.price,
+                discountRate = request.discountRate(),
+                targetQuantity = request.targetQuantity,
+                pickupDate = request.pickupDate,
+                requestedAt = request.createdAt,
+                reviewElapsedMinutes = request.createdAt?.let { Duration.between(it, now).toMinutes().coerceAtLeast(0) } ?: 0,
+                status = request.status,
+                actionable = request.status == OwnerGroupBuyRequestStatus.PENDING,
+                approvedGroupBuyId = request.approvedGroupBuy?.id
+            )
+    }
+}
+
+data class AdminOwnerGroupBuyRequestDetailResponse(
+    val requestId: Long,
+    val requestType: String,
+    val status: OwnerGroupBuyRequestStatus,
+    val owner: AdminOwnerGroupBuyRequestOwnerResponse,
+    val store: AdminOwnerGroupBuyRequestStoreResponse,
+    val product: AdminOwnerGroupBuyRequestProductResponse,
+    val recruitment: AdminOwnerGroupBuyRequestRecruitmentResponse,
+    val images: List<AdminOwnerGroupBuyRequestImageResponse>,
+    val imageCount: Int,
+    val rejectionReason: String?,
+    val approvedGroupBuyId: Long?,
+    val reviewedAt: LocalDateTime?,
+    val requestedAt: LocalDateTime?,
+    val actionable: Boolean
+) {
+    companion object {
+        fun from(
+            request: OwnerGroupBuyRequest,
+            images: List<OwnerGroupBuyRequestImage>,
+            imageUrls: List<String>,
+        ): AdminOwnerGroupBuyRequestDetailResponse =
+            AdminOwnerGroupBuyRequestDetailResponse(
+                requestId = request.id,
+                requestType = REQUEST_TYPE,
+                status = request.status,
+                owner = AdminOwnerGroupBuyRequestOwnerResponse(
+                    ownerId = request.owner.id,
+                    nickname = request.owner.nickname,
+                    phoneNumber = request.owner.phoneNumber,
+                    email = request.owner.email
+                ),
+                store = AdminOwnerGroupBuyRequestStoreResponse(
+                    storeId = request.store.id,
+                    storeName = request.store.name,
+                    address = request.store.address,
+                    phoneNumber = request.store.phoneNumber
+                ),
+                product = AdminOwnerGroupBuyRequestProductResponse(
+                    productName = request.productName,
+                    productDescription = request.productDescription,
+                    originalPrice = request.originalPrice,
+                    price = request.price,
+                    discountRate = request.discountRate(),
+                    targetQuantity = request.targetQuantity,
+                    maxQuantity = request.maxQuantity,
+                    perUserLimit = request.perUserLimit
+                ),
+                recruitment = AdminOwnerGroupBuyRequestRecruitmentResponse(
+                    recruitmentStartAt = request.approvedGroupBuy?.recruitmentStartAt,
+                    deadline = request.deadline,
+                    pickupDate = request.pickupDate,
+                    pickupTimeStart = request.pickupTimeStart,
+                    pickupTimeEnd = request.pickupTimeEnd,
+                    pickupLocation = request.pickupLocation,
+                    pickupContact = request.pickupContact
+                ),
+                images = images.mapIndexed { index, image ->
+                    AdminOwnerGroupBuyRequestImageResponse(
+                        imageUrl = imageUrls.getOrNull(index).orEmpty(),
+                        sortOrder = image.sortOrder
+                    )
+                },
+                imageCount = images.size,
+                rejectionReason = request.rejectionReason,
+                approvedGroupBuyId = request.approvedGroupBuy?.id,
+                reviewedAt = request.reviewedAt,
+                requestedAt = request.createdAt,
+                actionable = request.status == OwnerGroupBuyRequestStatus.PENDING
+            )
+    }
+}
+
+data class AdminOwnerGroupBuyRequestOwnerResponse(
+    val ownerId: Long?,
+    val nickname: String?,
+    val phoneNumber: String?,
+    val email: String?
+)
+
+data class AdminOwnerGroupBuyRequestStoreResponse(
+    val storeId: Long,
+    val storeName: String,
+    val address: String,
+    val phoneNumber: String?
+)
+
+data class AdminOwnerGroupBuyRequestProductResponse(
+    val productName: String,
+    val productDescription: String,
+    val originalPrice: Int?,
+    val price: Int,
+    val discountRate: Int?,
+    val targetQuantity: Int,
+    val maxQuantity: Int,
+    val perUserLimit: Int?
+)
+
+data class AdminOwnerGroupBuyRequestRecruitmentResponse(
+    val recruitmentStartAt: LocalDateTime?,
+    val deadline: LocalDateTime,
+    val pickupDate: LocalDate,
+    val pickupTimeStart: LocalTime,
+    val pickupTimeEnd: LocalTime,
+    val pickupLocation: String,
+    val pickupContact: String?
+)
+
+data class AdminOwnerGroupBuyRequestImageResponse(
+    val imageUrl: String,
+    val sortOrder: Int
+)
+
+data class AdminOwnerGroupBuyRequestRejectRequest(
+    @field:NotBlank(message = "반려 사유는 필수입니다")
+    @field:Size(max = 200, message = "반려 사유는 200자 이하이어야 합니다")
+    val rejectionReason: String
+)
+
+data class AdminOwnerGroupBuyRequestActionResponse(
+    val requestId: Long,
+    val status: OwnerGroupBuyRequestStatus,
+    val groupBuyId: Long? = null
+)
+
+private const val REQUEST_TYPE = "OWNER"
+
+private fun OwnerGroupBuyRequest.discountRate(): Int? {
+    val original = originalPrice ?: return null
+    if (original <= 0 || original < price) {
+        return null
+    }
+    return ((original - price) * 100) / original
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
@@ -62,10 +62,10 @@ interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, L
             WHERE (:status IS NULL OR r.status = :status)
               AND (
                 :keyword IS NULL
+                OR (:requestId IS NOT NULL AND r.id = :requestId)
                 OR LOWER(r.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(r.owner.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(r.store.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR str(r.id) = :keyword
               )
             ORDER BY r.createdAt DESC
         """,
@@ -74,15 +74,16 @@ interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, L
             WHERE (:status IS NULL OR r.status = :status)
               AND (
                 :keyword IS NULL
+                OR (:requestId IS NOT NULL AND r.id = :requestId)
                 OR LOWER(r.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(r.owner.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(r.store.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR str(r.id) = :keyword
               )
         """
     )
     fun searchAdminRequests(
         @Param("status") status: OwnerGroupBuyRequestStatus?,
+        @Param("requestId") requestId: Long?,
         @Param("keyword") keyword: String?,
         pageable: Pageable
     ): Page<OwnerGroupBuyRequest>

--- a/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/domain/repository/OwnerGroupBuyRequestRepository.kt
@@ -2,11 +2,14 @@ package com.moongchijang.domain.owner.domain.repository
 
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import jakarta.persistence.LockModeType
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.util.Optional
 
 interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, Long> {
 
@@ -50,4 +53,52 @@ interface OwnerGroupBuyRequestRepository : JpaRepository<OwnerGroupBuyRequest, L
     ): List<OwnerGroupBuyRequest>
 
     fun findByStatusOrderByCreatedAtAsc(status: OwnerGroupBuyRequestStatus): List<OwnerGroupBuyRequest>
+
+    @Query(
+        value = """
+            SELECT r FROM OwnerGroupBuyRequest r
+            JOIN FETCH r.owner
+            JOIN FETCH r.store
+            WHERE (:status IS NULL OR r.status = :status)
+              AND (
+                :keyword IS NULL
+                OR LOWER(r.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(r.owner.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(r.store.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR str(r.id) = :keyword
+              )
+            ORDER BY r.createdAt DESC
+        """,
+        countQuery = """
+            SELECT COUNT(r) FROM OwnerGroupBuyRequest r
+            WHERE (:status IS NULL OR r.status = :status)
+              AND (
+                :keyword IS NULL
+                OR LOWER(r.productName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(r.owner.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(r.store.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR str(r.id) = :keyword
+              )
+        """
+    )
+    fun searchAdminRequests(
+        @Param("status") status: OwnerGroupBuyRequestStatus?,
+        @Param("keyword") keyword: String?,
+        pageable: Pageable
+    ): Page<OwnerGroupBuyRequest>
+
+    @Query(
+        """
+            SELECT r FROM OwnerGroupBuyRequest r
+            JOIN FETCH r.owner
+            JOIN FETCH r.store
+            LEFT JOIN FETCH r.approvedGroupBuy
+            WHERE r.id = :id
+        """
+    )
+    fun findAdminDetailById(@Param("id") id: Long): Optional<OwnerGroupBuyRequest>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM OwnerGroupBuyRequest r WHERE r.id = :id")
+    fun findWithLockById(@Param("id") id: Long): Optional<OwnerGroupBuyRequest>
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyRequestController.kt
@@ -1,0 +1,73 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyRequestService
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestDetailResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestPageResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/owner-group-buy-requests")
+@Tag(name = "AdminOwnerGroupBuyRequest", description = "어드민 사장님 공구 개설 요청 관리")
+class AdminOwnerGroupBuyRequestController(
+    private val adminOwnerGroupBuyRequestService: AdminOwnerGroupBuyRequestService
+) {
+
+    @GetMapping
+    @Operation(summary = "사장님 공구 개설 요청 목록 조회")
+    fun getRequests(
+        @RequestParam(required = false) status: OwnerGroupBuyRequestStatus?,
+        @RequestParam(required = false) keyword: String?,
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyRequestPageResponse>> {
+        val response = ResponseEntity.ok(
+            ApiResponse.success(adminOwnerGroupBuyRequestService.getRequests(status, keyword, pageable))
+        )
+        return response
+    }
+
+    @GetMapping("/{requestId}")
+    @Operation(summary = "사장님 공구 개설 요청 상세 조회")
+    fun getDetail(
+        @PathVariable requestId: Long
+    ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyRequestDetailResponse>> {
+        val response = ResponseEntity.ok(ApiResponse.success(adminOwnerGroupBuyRequestService.getDetail(requestId)))
+        return response
+    }
+
+    @PostMapping("/{requestId}/approve")
+    @Operation(summary = "사장님 공구 개설 요청 승인 및 공구 생성")
+    fun approve(
+        @PathVariable requestId: Long
+    ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyRequestActionResponse>> {
+        val response = ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(adminOwnerGroupBuyRequestService.approve(requestId)))
+        return response
+    }
+
+    @PostMapping("/{requestId}/reject")
+    @Operation(summary = "사장님 공구 개설 요청 반려")
+    fun reject(
+        @PathVariable requestId: Long,
+        @Valid @RequestBody request: AdminOwnerGroupBuyRequestRejectRequest
+    ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyRequestActionResponse>> {
+        val response = ResponseEntity.ok(ApiResponse.success(adminOwnerGroupBuyRequestService.reject(requestId, request)))
+        return response
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -444,8 +444,9 @@ class PaymentService(
         participation: Participation,
         occurredAt: LocalDateTime
     ) {
-        val requesterUserId = groupBuy.groupBuyRequest.user.id ?: return
-        val requestId = groupBuy.groupBuyRequest.id
+        val groupBuyRequest = groupBuy.groupBuyRequest ?: return
+        val requesterUserId = groupBuyRequest.user.id ?: return
+        val requestId = groupBuyRequest.id
         val participantUserId = participation.user.id ?: return
         if (requesterUserId == participantUserId) return
 
@@ -458,8 +459,9 @@ class PaymentService(
     }
 
     private fun publishRequestTargetAchievedEvent(groupBuy: GroupBuy, occurredAt: LocalDateTime) {
-        val requesterUserId = groupBuy.groupBuyRequest.user.id ?: return
-        val requestId = groupBuy.groupBuyRequest.id
+        val groupBuyRequest = groupBuy.groupBuyRequest ?: return
+        val requesterUserId = groupBuyRequest.user.id ?: return
+        val requestId = groupBuyRequest.id
         notificationEventPublisher.publishRequestTargetAchieved(
             requestId = requestId,
             requesterUserId = requesterUserId,

--- a/src/main/resources/db/migration/V44__alter_group_buys_allow_owner_requests.sql
+++ b/src/main/resources/db/migration/V44__alter_group_buys_allow_owner_requests.sql
@@ -1,0 +1,9 @@
+ALTER TABLE group_buys
+    DROP FOREIGN KEY fk_group_buys_request_id;
+
+ALTER TABLE group_buys
+    MODIFY group_buy_request_id BIGINT NULL;
+
+ALTER TABLE group_buys
+    ADD CONSTRAINT fk_group_buys_request_id
+        FOREIGN KEY (group_buy_request_id) REFERENCES group_buy_requests (id);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2575,6 +2575,103 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /api/v1/admin/owner-group-buy-requests:
+    get:
+      tags: [Admin]
+      summary: 사장님 공구 개설 요청 목록 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [PENDING, APPROVED, REJECTED]
+          description: 미입력 시 전체 조회
+        - name: keyword
+          in: query
+          required: false
+          schema:
+            type: string
+          description: 요청 ID, 공구명, 사장님 닉네임, 매장명 검색어
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 사장님 공구 개설 요청 목록
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOwnerGroupBuyRequestPage'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/admin/owner-group-buy-requests/{requestId}:
+    get:
+      tags: [Admin]
+      summary: 사장님 공구 개설 요청 상세 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RequestId'
+      responses:
+        '200':
+          description: 사장님 공구 개설 요청 상세
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOwnerGroupBuyRequestDetail'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/admin/owner-group-buy-requests/{requestId}/approve:
+    post:
+      tags: [Admin]
+      summary: 사장님 공구 개설 요청 승인 및 공구 생성
+      description: 요청에 저장된 상품/가격/모집/픽업/이미지 정보로 공구를 생성한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RequestId'
+      responses:
+        '201':
+          description: 사장님 요청 승인 및 공구 생성 완료
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOwnerGroupBuyRequestAction'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/admin/owner-group-buy-requests/{requestId}/reject:
+    post:
+      tags: [Admin]
+      summary: 사장님 공구 개설 요청 반려
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/RequestId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminOwnerGroupBuyRequestReject'
+      responses:
+        '200':
+          description: 사장님 요청 반려 완료
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOwnerGroupBuyRequestAction'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/admin/refunds:
     get:
       tags: [Admin]
@@ -5907,6 +6004,222 @@ components:
             status:
               type: string
               enum: [OPENED, REJECTED]
+            groupBuyId:
+              type: integer
+              format: int64
+              nullable: true
+        error: { nullable: true, example: null }
+
+    ApiResponseAdminOwnerGroupBuyRequestPage:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [content, totalElements, totalPages, number, size]
+          properties:
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/AdminOwnerGroupBuyRequestListItem'
+            totalElements: { type: integer, format: int64 }
+            totalPages: { type: integer }
+            number: { type: integer }
+            size: { type: integer }
+        error: { nullable: true, example: null }
+
+    AdminOwnerGroupBuyRequestListItem:
+      type: object
+      required: [requestId, requestType, productName, storeName, originalPrice, price, targetQuantity, pickupDate, reviewElapsedMinutes, status, actionable]
+      properties:
+        requestId: { type: integer, format: int64, example: 101 }
+        requestType:
+          type: string
+          enum: [OWNER]
+          description: 사장님 요청 공구 구분 칩
+        productName: { type: string, example: 두쫀쿠 세트 }
+        storeName: { type: string, example: 뭉치장 베이커리 }
+        ownerName:
+          type: string
+          nullable: true
+          example: 은서사장
+        originalPrice:
+          type: integer
+          nullable: true
+          example: 12000
+        price: { type: integer, example: 9900 }
+        discountRate:
+          type: integer
+          nullable: true
+          description: 정가 대비 할인율(%)
+          example: 17
+        targetQuantity: { type: integer, example: 20 }
+        pickupDate: { type: string, format: date, example: "2026-06-12" }
+        requestedAt: { type: string, format: date-time, nullable: true }
+        reviewElapsedMinutes:
+          type: integer
+          format: int64
+          description: 요청 생성 후 경과한 검토 시간(분)
+        status:
+          type: string
+          enum: [PENDING, APPROVED, REJECTED]
+        actionable:
+          type: boolean
+          description: 승인/반려 작업 가능 여부
+        approvedGroupBuyId:
+          type: integer
+          format: int64
+          nullable: true
+
+    ApiResponseAdminOwnerGroupBuyRequestDetail:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/AdminOwnerGroupBuyRequestDetail'
+        error: { nullable: true, example: null }
+
+    AdminOwnerGroupBuyRequestDetail:
+      type: object
+      required: [requestId, requestType, status, owner, store, product, recruitment, images, imageCount, actionable]
+      properties:
+        requestId: { type: integer, format: int64, example: 101 }
+        requestType:
+          type: string
+          enum: [OWNER]
+          description: 사장님 요청 공구 구분 칩
+        status:
+          type: string
+          enum: [PENDING, APPROVED, REJECTED]
+        owner:
+          $ref: '#/components/schemas/AdminOwnerGroupBuyRequestOwner'
+        store:
+          $ref: '#/components/schemas/AdminOwnerGroupBuyRequestStore'
+        product:
+          $ref: '#/components/schemas/AdminOwnerGroupBuyRequestProduct'
+        recruitment:
+          $ref: '#/components/schemas/AdminOwnerGroupBuyRequestRecruitment'
+        images:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminOwnerGroupBuyRequestImage'
+        imageCount:
+          type: integer
+          description: 승인 확인 팝업에 표시할 이미지 장수
+          example: 2
+        rejectionReason:
+          type: string
+          nullable: true
+          maxLength: 200
+        approvedGroupBuyId:
+          type: integer
+          format: int64
+          nullable: true
+        reviewedAt: { type: string, format: date-time, nullable: true }
+        requestedAt: { type: string, format: date-time, nullable: true }
+        actionable:
+          type: boolean
+          description: 승인/반려 작업 가능 여부
+
+    AdminOwnerGroupBuyRequestOwner:
+      type: object
+      properties:
+        ownerId:
+          type: integer
+          format: int64
+          nullable: true
+        nickname:
+          type: string
+          nullable: true
+        phoneNumber:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+
+    AdminOwnerGroupBuyRequestStore:
+      type: object
+      required: [storeId, storeName, address]
+      properties:
+        storeId: { type: integer, format: int64 }
+        storeName: { type: string }
+        address: { type: string }
+        phoneNumber:
+          type: string
+          nullable: true
+
+    AdminOwnerGroupBuyRequestProduct:
+      type: object
+      required: [productName, productDescription, price, targetQuantity, maxQuantity]
+      properties:
+        productName: { type: string }
+        productDescription: { type: string }
+        originalPrice:
+          type: integer
+          nullable: true
+        price: { type: integer }
+        discountRate:
+          type: integer
+          nullable: true
+          description: 정가 대비 할인율(%)
+        targetQuantity: { type: integer }
+        maxQuantity: { type: integer }
+        perUserLimit:
+          type: integer
+          nullable: true
+
+    AdminOwnerGroupBuyRequestRecruitment:
+      type: object
+      required: [deadline, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation]
+      properties:
+        recruitmentStartAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: 승인 후 생성된 공구의 모집 시작일시. 승인 전 요청은 null
+        deadline:
+          type: string
+          format: date-time
+          description: 모집 마감일시
+        pickupDate: { type: string, format: date }
+        pickupTimeStart: { type: string, format: time }
+        pickupTimeEnd: { type: string, format: time }
+        pickupLocation: { type: string }
+        pickupContact:
+          type: string
+          nullable: true
+
+    AdminOwnerGroupBuyRequestImage:
+      type: object
+      required: [imageUrl, sortOrder]
+      properties:
+        imageUrl: { type: string }
+        sortOrder: { type: integer }
+
+    AdminOwnerGroupBuyRequestReject:
+      type: object
+      required: [rejectionReason]
+      properties:
+        rejectionReason:
+          type: string
+          maxLength: 200
+
+    ApiResponseAdminOwnerGroupBuyRequestAction:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [requestId, status]
+          properties:
+            requestId: { type: integer, format: int64 }
+            status:
+              type: string
+              enum: [APPROVED, REJECTED]
             groupBuyId:
               type: integer
               format: int64

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestServiceTest.kt
@@ -1,0 +1,177 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestImageRepository
+import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
+import com.moongchijang.domain.store.domain.entity.DistrictType
+import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.domain.store.domain.entity.Store
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.util.S3ImageReferenceResolver
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class AdminOwnerGroupBuyRequestServiceTest {
+
+    @Mock
+    private lateinit var ownerGroupBuyRequestRepository: OwnerGroupBuyRequestRepository
+
+    @Mock
+    private lateinit var ownerGroupBuyRequestImageRepository: OwnerGroupBuyRequestImageRepository
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var groupBuyImageRepository: GroupBuyImageRepository
+
+    @Mock
+    private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
+
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-06-01T03:00:00Z"), ZoneId.of("Asia/Seoul"))
+
+    private lateinit var service: AdminOwnerGroupBuyRequestService
+
+    @BeforeEach
+    fun setUp() {
+        service = AdminOwnerGroupBuyRequestService(
+            ownerGroupBuyRequestRepository = ownerGroupBuyRequestRepository,
+            ownerGroupBuyRequestImageRepository = ownerGroupBuyRequestImageRepository,
+            groupBuyRepository = groupBuyRepository,
+            groupBuyImageRepository = groupBuyImageRepository,
+            s3ImageReferenceResolver = s3ImageReferenceResolver,
+            clock = clock,
+        )
+    }
+
+    @Test
+    fun `사장님 요청을 승인하면 요청 정보로 공구와 이미지를 생성하고 APPROVED로 전환한다`() {
+        val requestId = 10L
+        val request = ownerRequest(status = OwnerGroupBuyRequestStatus.PENDING).apply { id = requestId }
+        val images = listOf(
+            OwnerGroupBuyRequestImage(request, "owner/1.jpg", 0),
+            OwnerGroupBuyRequestImage(request, "owner/2.jpg", 1),
+        )
+        `when`(ownerGroupBuyRequestRepository.findWithLockById(requestId)).thenReturn(Optional.of(request))
+        `when`(ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)).thenReturn(images)
+        `when`(groupBuyRepository.save(any(GroupBuy::class.java))).thenAnswer {
+            (it.arguments[0] as GroupBuy).apply { id = 30L }
+        }
+
+        val result = service.approve(requestId)
+
+        assertEquals(requestId, result.requestId)
+        assertEquals(OwnerGroupBuyRequestStatus.APPROVED, result.status)
+        assertEquals(30L, result.groupBuyId)
+        assertEquals(OwnerGroupBuyRequestStatus.APPROVED, request.status)
+        assertEquals(LocalDateTime.of(2026, 6, 1, 12, 0), request.reviewedAt)
+        assertEquals(30L, request.approvedGroupBuy?.id)
+        assertNull(request.rejectionReason)
+
+        val groupBuyCaptor = argumentCaptor<GroupBuy>()
+        verify(groupBuyRepository).save(groupBuyCaptor.capture())
+        assertNull(groupBuyCaptor.value.groupBuyRequest)
+        assertEquals(request.store, groupBuyCaptor.value.store)
+        assertEquals("두쫀쿠 세트", groupBuyCaptor.value.productName)
+        assertEquals("owner-thumb.jpg", groupBuyCaptor.value.thumbnailKey)
+        assertEquals(LocalDateTime.of(2026, 6, 1, 12, 0), groupBuyCaptor.value.recruitmentStartAt)
+        assertEquals(request.deadline, groupBuyCaptor.value.deadline)
+        assertEquals(request.pickupDate, groupBuyCaptor.value.pickupDate)
+
+        val imageCaptor = argumentCaptor<Iterable<GroupBuyImage>>()
+        verify(groupBuyImageRepository).saveAll(imageCaptor.capture())
+        assertEquals(listOf("owner/1.jpg", "owner/2.jpg"), imageCaptor.value.toList().map { it.imageKey })
+    }
+
+    @Test
+    fun `이미 처리된 사장님 요청은 승인할 수 없다`() {
+        val requestId = 11L
+        val request = ownerRequest(status = OwnerGroupBuyRequestStatus.APPROVED).apply { id = requestId }
+        `when`(ownerGroupBuyRequestRepository.findWithLockById(requestId)).thenReturn(Optional.of(request))
+
+        val ex = assertThrows<CustomException> {
+            service.approve(requestId)
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION, ex.errorCode)
+        verify(groupBuyRepository, never()).save(any(GroupBuy::class.java))
+    }
+
+    @Test
+    fun `사장님 요청을 반려하면 사유와 검토 시간을 저장한다`() {
+        val requestId = 12L
+        val request = ownerRequest(status = OwnerGroupBuyRequestStatus.PENDING).apply { id = requestId }
+        `when`(ownerGroupBuyRequestRepository.findWithLockById(requestId)).thenReturn(Optional.of(request))
+
+        val result = service.reject(requestId, AdminOwnerGroupBuyRequestRejectRequest("  이미지 품질 보완 필요  "))
+
+        assertEquals(OwnerGroupBuyRequestStatus.REJECTED, result.status)
+        assertEquals(OwnerGroupBuyRequestStatus.REJECTED, request.status)
+        assertEquals("이미지 품질 보완 필요", request.rejectionReason)
+        assertEquals(LocalDateTime.of(2026, 6, 1, 12, 0), request.reviewedAt)
+        assertNull(request.approvedGroupBuy)
+    }
+
+    private fun ownerRequest(status: OwnerGroupBuyRequestStatus): OwnerGroupBuyRequest =
+        OwnerGroupBuyRequest(
+            owner = UserFixture.createKakaoUser(id = 1L, nickname = "은서사장").apply {
+                role = UserRole.SELLER
+                phoneNumber = "01011112222"
+            },
+            store = store(),
+            productName = "두쫀쿠 세트",
+            productDescription = "두바이 초코 쿠키 세트",
+            originalPrice = 12000,
+            price = 9900,
+            targetQuantity = 20,
+            maxQuantity = 50,
+            perUserLimit = 2,
+            thumbnailKey = "owner-thumb.jpg",
+            deadline = LocalDateTime.of(2026, 6, 10, 18, 0),
+            pickupDate = LocalDate.of(2026, 6, 12),
+            pickupTimeStart = LocalTime.of(12, 0),
+            pickupTimeEnd = LocalTime.of(18, 0),
+            pickupLocation = "서울 성동구 성수이로 1",
+            pickupContact = "01012345678",
+            status = status,
+        )
+
+    private fun store(): Store =
+        Store(
+            name = "뭉치장 베이커리",
+            address = "서울 성동구 성수이로 1",
+            phoneNumber = "01012345678",
+            region = RegionType.SEOUL,
+            district = DistrictType.SEOUL_SEONGSU_GEONDAE_GWANGJIN,
+        ).apply { id = 20L }
+
+    private inline fun <reified T> argumentCaptor() = org.mockito.ArgumentCaptor.forClass(T::class.java)
+}

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyRequestServiceTest.kt
@@ -30,6 +30,8 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -73,6 +75,24 @@ class AdminOwnerGroupBuyRequestServiceTest {
     }
 
     @Test
+    fun `목록 검색어가 숫자이면 요청 ID 파라미터로 조회하고 동일 가격 할인율은 null로 반환한다`() {
+        val pageable = PageRequest.of(0, 20)
+        val request = ownerRequest(
+            status = OwnerGroupBuyRequestStatus.PENDING,
+            originalPrice = 9900,
+            price = 9900,
+        ).apply { id = 10L }
+        `when`(ownerGroupBuyRequestRepository.searchAdminRequests(null, 10L, "10", pageable))
+            .thenReturn(PageImpl(listOf(request), pageable, 1))
+
+        val result = service.getRequests(status = null, keyword = " 10 ", pageable = pageable)
+
+        assertEquals(1, result.content.size)
+        assertNull(result.content.first().discountRate)
+        verify(ownerGroupBuyRequestRepository).searchAdminRequests(null, 10L, "10", pageable)
+    }
+
+    @Test
     fun `사장님 요청을 승인하면 요청 정보로 공구와 이미지를 생성하고 APPROVED로 전환한다`() {
         val requestId = 10L
         val request = ownerRequest(status = OwnerGroupBuyRequestStatus.PENDING).apply { id = requestId }
@@ -112,6 +132,29 @@ class AdminOwnerGroupBuyRequestServiceTest {
     }
 
     @Test
+    fun `픽업일이 모집 마감일과 같아도 픽업 시작 시간이 이후이면 승인할 수 있다`() {
+        val requestId = 13L
+        val deadline = LocalDateTime.of(2026, 6, 10, 12, 0)
+        val request = ownerRequest(
+            status = OwnerGroupBuyRequestStatus.PENDING,
+            deadline = deadline,
+            pickupDate = deadline.toLocalDate(),
+            pickupTimeStart = LocalTime.of(13, 0),
+            pickupTimeEnd = LocalTime.of(18, 0),
+        ).apply { id = requestId }
+        `when`(ownerGroupBuyRequestRepository.findWithLockById(requestId)).thenReturn(Optional.of(request))
+        `when`(ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)).thenReturn(emptyList())
+        `when`(groupBuyRepository.save(any(GroupBuy::class.java))).thenAnswer {
+            (it.arguments[0] as GroupBuy).apply { id = 33L }
+        }
+
+        val result = service.approve(requestId)
+
+        assertEquals(OwnerGroupBuyRequestStatus.APPROVED, result.status)
+        assertEquals(33L, result.groupBuyId)
+    }
+
+    @Test
     fun `이미 처리된 사장님 요청은 승인할 수 없다`() {
         val requestId = 11L
         val request = ownerRequest(status = OwnerGroupBuyRequestStatus.APPROVED).apply { id = requestId }
@@ -140,7 +183,15 @@ class AdminOwnerGroupBuyRequestServiceTest {
         assertNull(request.approvedGroupBuy)
     }
 
-    private fun ownerRequest(status: OwnerGroupBuyRequestStatus): OwnerGroupBuyRequest =
+    private fun ownerRequest(
+        status: OwnerGroupBuyRequestStatus,
+        originalPrice: Int? = 12000,
+        price: Int = 9900,
+        deadline: LocalDateTime = LocalDateTime.of(2026, 6, 10, 18, 0),
+        pickupDate: LocalDate = LocalDate.of(2026, 6, 12),
+        pickupTimeStart: LocalTime = LocalTime.of(12, 0),
+        pickupTimeEnd: LocalTime = LocalTime.of(18, 0),
+    ): OwnerGroupBuyRequest =
         OwnerGroupBuyRequest(
             owner = UserFixture.createKakaoUser(id = 1L, nickname = "은서사장").apply {
                 role = UserRole.SELLER
@@ -149,16 +200,16 @@ class AdminOwnerGroupBuyRequestServiceTest {
             store = store(),
             productName = "두쫀쿠 세트",
             productDescription = "두바이 초코 쿠키 세트",
-            originalPrice = 12000,
-            price = 9900,
+            originalPrice = originalPrice,
+            price = price,
             targetQuantity = 20,
             maxQuantity = 50,
             perUserLimit = 2,
             thumbnailKey = "owner-thumb.jpg",
-            deadline = LocalDateTime.of(2026, 6, 10, 18, 0),
-            pickupDate = LocalDate.of(2026, 6, 12),
-            pickupTimeStart = LocalTime.of(12, 0),
-            pickupTimeEnd = LocalTime.of(18, 0),
+            deadline = deadline,
+            pickupDate = pickupDate,
+            pickupTimeStart = pickupTimeStart,
+            pickupTimeEnd = pickupTimeEnd,
             pickupLocation = "서울 성동구 성수이로 1",
             pickupContact = "01012345678",
             status = status,

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestServiceTest.kt
@@ -279,12 +279,13 @@ class OwnerGroupBuyRequestServiceTest {
     }
 
     @Test
-    fun `픽업일이 공구 마감일과 같으면 예외가 발생한다`() {
+    fun `픽업 시작 시간이 공구 마감 시간 이전이면 예외가 발생한다`() {
         val owner = seller()
         val deadline = FIXED_NOW.plusDays(8)
         val request = validRequest(
             deadline = deadline,
-            pickupDate = deadline.toLocalDate()
+            pickupDate = deadline.toLocalDate(),
+            pickupTimeStart = deadline.toLocalTime()
         )
 
         `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
@@ -327,7 +328,9 @@ class OwnerGroupBuyRequestServiceTest {
         deadline: LocalDateTime = FIXED_NOW.plusDays(8),
         targetQuantity: Int = 20,
         maxQuantity: Int = 50,
-        pickupDate: LocalDate = deadline.toLocalDate().plusDays(1)
+        pickupDate: LocalDate = deadline.toLocalDate().plusDays(1),
+        pickupTimeStart: LocalTime = LocalTime.of(12, 0),
+        pickupTimeEnd: LocalTime = LocalTime.of(18, 0)
     ) = OwnerGroupBuyRequestCreateRequest(
         storeId = 1L,
         productName = "두쫀쿠 세트",
@@ -340,8 +343,8 @@ class OwnerGroupBuyRequestServiceTest {
         perUserLimit = 2,
         imageUrls = listOf("https://cdn.example.com/1.jpg", "https://cdn.example.com/2.jpg"),
         pickupDate = pickupDate,
-        pickupTimeStart = LocalTime.of(12, 0),
-        pickupTimeEnd = LocalTime.of(18, 0),
+        pickupTimeStart = pickupTimeStart,
+        pickupTimeEnd = pickupTimeEnd,
         pickupLocation = "서울 성동구 성수이로 1",
         pickupContact = "01012345678"
     )

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyRequestControllerTest.kt
@@ -1,0 +1,51 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyRequestService
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.http.HttpStatus
+
+class AdminOwnerGroupBuyRequestControllerTest {
+
+    private val service: AdminOwnerGroupBuyRequestService = mock(AdminOwnerGroupBuyRequestService::class.java)
+    private val controller = AdminOwnerGroupBuyRequestController(service)
+
+    @Test
+    fun `사장님 공구 요청 승인 시 201과 생성된 공구 id를 반환한다`() {
+        val response = AdminOwnerGroupBuyRequestActionResponse(
+            requestId = 10L,
+            status = OwnerGroupBuyRequestStatus.APPROVED,
+            groupBuyId = 30L
+        )
+        `when`(service.approve(10L)).thenReturn(response)
+
+        val result = controller.approve(10L)
+
+        assertEquals(HttpStatus.CREATED, result.statusCode)
+        assertEquals(response, result.body?.data)
+        verify(service).approve(10L)
+    }
+
+    @Test
+    fun `사장님 공구 요청 반려 시 REJECTED 상태를 반환한다`() {
+        val request = AdminOwnerGroupBuyRequestRejectRequest("재고 확보 불가")
+        val response = AdminOwnerGroupBuyRequestActionResponse(
+            requestId = 11L,
+            status = OwnerGroupBuyRequestStatus.REJECTED,
+            groupBuyId = null
+        )
+        `when`(service.reject(11L, request)).thenReturn(response)
+
+        val result = controller.reject(11L, request)
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(response, result.body?.data)
+        verify(service).reject(11L, request)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 어드민 사장님 공구 개설 요청 목록/상세 조회 API를 추가했습니다.
- 사장님 요청 승인 시 요청에 저장된 상품/가격/픽업/이미지 정보로 GroupBuy를 생성하고 요청 상태를 APPROVED로 전환합니다.
- 사장님 요청 반려 시 200자 이하 반려 사유와 검토 시간을 저장하고 REJECTED로 전환합니다.
- 사장님 요청으로 생성된 공구를 지원하기 위해 `group_buys.group_buy_request_id`를 nullable로 변경하고 소비자 요청 전용 알림 발행 지점을 null-safe하게 조정했습니다.
- OpenAPI에 `/api/v1/admin/owner-group-buy-requests` 계열 목록/상세/승인/반려 스펙을 추가했습니다.

## 🔍 참고 사항
- 승인 API는 별도 request body 없이 기존 사장님 요청 데이터를 그대로 사용
- 승인 후 생성되는 공구의 recruitmentStartAt은 승인 시각으로 저장
- 기존 사장님 요청 생성 스펙에는 모집 시작일이 없어서 승인 전 상세 응답의 recruitmentStartAt은 null

## 🖼️ 스크린샷
- 백엔드 API 변경이라 없음

## 🔗 관련 이슈
- Closes #298

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인