### PR TITLE
[MCJ-1586] FEAT: 어드민 대시보드 긴급 환불 요청 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundService.kt
@@ -1,0 +1,58 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundItemResponse
+import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundResponse
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class AdminDashboardUrgentRefundService(
+    private val participationRepository: ParticipationRepository,
+    private val clock: Clock,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun getUrgentRefunds(pageable: Pageable): AdminDashboardUrgentRefundResponse {
+        val now = LocalDateTime.now(clock)
+        val requestedBefore = now.minusHours(URGENT_REFUND_THRESHOLD_HOURS)
+        log.info(
+            "[AdminDashboardUrgentRefundService] 긴급 환불 요청 조회 시작: requestedBefore={}, page={}, size={}",
+            requestedBefore,
+            pageable.pageNumber,
+            pageable.pageSize,
+        )
+
+        val page = participationRepository.findDashboardUrgentRefundRequests(
+            status = ParticipationStatus.REFUND_PENDING,
+            requestedBefore = requestedBefore,
+            pageable = pageable,
+        )
+        val content = page.content.map { AdminDashboardUrgentRefundItemResponse.from(it, now) }
+
+        val response = AdminDashboardUrgentRefundResponse(
+            totalUrgentCount = page.totalElements,
+            hasUrgentRefunds = page.totalElements > 0,
+            content = content,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            number = page.number,
+            size = page.size,
+        )
+        log.info(
+            "[AdminDashboardUrgentRefundService] 긴급 환불 요청 조회 완료: totalElements={}",
+            response.totalElements,
+        )
+        return response
+    }
+
+    private companion object {
+        const val URGENT_REFUND_THRESHOLD_HOURS = 1L
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardUrgentRefundResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminDashboardUrgentRefundResponse.kt
@@ -1,0 +1,99 @@
+package com.moongchijang.domain.admin.application.dto
+
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Duration
+import java.time.LocalDateTime
+
+@Schema(description = "대시보드 긴급 환불 요청 목록 응답")
+data class AdminDashboardUrgentRefundResponse(
+    @Schema(description = "1시간 초과 환불 요청 건수")
+    val totalUrgentCount: Long,
+
+    @Schema(description = "1시간 초과 환불 요청 존재 여부")
+    val hasUrgentRefunds: Boolean,
+
+    @Schema(description = "목록")
+    val content: List<AdminDashboardUrgentRefundItemResponse>,
+
+    @Schema(description = "전체 건수")
+    val totalElements: Long,
+
+    @Schema(description = "전체 페이지 수")
+    val totalPages: Int,
+
+    @Schema(description = "현재 페이지 번호(0-base)")
+    val number: Int,
+
+    @Schema(description = "페이지 크기")
+    val size: Int,
+)
+
+@Schema(description = "대시보드 긴급 환불 요청 목록 아이템")
+data class AdminDashboardUrgentRefundItemResponse(
+    @Schema(description = "환불 요청 ID(참여 ID)")
+    val requestId: Long,
+
+    @Schema(description = "환불 케이스")
+    val caseFilter: AdminRefundRequestCaseFilter,
+
+    @Schema(description = "소비자 이름")
+    val consumerName: String,
+
+    @Schema(description = "공구명")
+    val groupBuyName: String,
+
+    @Schema(description = "환불 금액")
+    val refundAmount: Int,
+
+    @Schema(description = "요청 일시")
+    val requestedAt: LocalDateTime,
+
+    @Schema(description = "요청 후 경과 시간(시간)")
+    val slaElapsedHours: Long,
+) {
+    companion object {
+        fun from(participation: Participation, now: LocalDateTime): AdminDashboardUrgentRefundItemResponse {
+            val requestedAt = participation.cancelledAt ?: participation.createdAt ?: now
+            return AdminDashboardUrgentRefundItemResponse(
+                requestId = participation.id,
+                caseFilter = participation.toDashboardRefundCase(),
+                consumerName = participation.user.nickname ?: "알 수 없음",
+                groupBuyName = participation.groupBuy.productName,
+                refundAmount = participation.expectedRefundAmount(),
+                requestedAt = requestedAt,
+                slaElapsedHours = Duration.between(requestedAt, now).toHours().coerceAtLeast(0),
+            )
+        }
+    }
+}
+
+private fun Participation.expectedRefundAmount(): Int {
+    approvedRefundAmount?.let { return it }
+    return if (cancelReason == null) {
+        totalAmount
+    } else {
+        (totalAmount - feeAmount.coerceAtLeast(0)).coerceAtLeast(0)
+    }
+}
+
+private fun Participation.toDashboardRefundCase(): AdminRefundRequestCaseFilter {
+    val reason = cancelReason ?: run {
+        return if (groupBuy.status == GroupBuyStatus.FAILED) {
+            AdminRefundRequestCaseFilter.TARGET_NOT_MET
+        } else {
+            AdminRefundRequestCaseFilter.OWNER_FAULT_CANCEL
+        }
+    }
+
+    return when (reason) {
+        ParticipationCancelReason.TIME_UNAVAILABLE -> AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW
+        ParticipationCancelReason.NO_LONGER_WANTED -> AdminRefundRequestCaseFilter.PRE_ACHIEVEMENT_FREE_CANCEL
+        ParticipationCancelReason.PREFER_DIRECT_VISIT,
+        ParticipationCancelReason.BOUGHT_ELSEWHERE -> AdminRefundRequestCaseFilter.POST_ACHIEVEMENT_CANCEL
+        ParticipationCancelReason.OTHER -> AdminRefundRequestCaseFilter.DISPUTE_OR_DROPOUT_REFUND
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardController.kt
@@ -2,8 +2,10 @@ package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminDashboardOrderMonitoringService
 import com.moongchijang.domain.admin.application.AdminDashboardSummaryService
+import com.moongchijang.domain.admin.application.AdminDashboardUrgentRefundService
 import com.moongchijang.domain.admin.application.dto.AdminDashboardUnconfirmedOrderResponse
 import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
+import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundResponse
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 class AdminDashboardController(
     private val adminDashboardSummaryService: AdminDashboardSummaryService,
     private val adminDashboardOrderMonitoringService: AdminDashboardOrderMonitoringService,
+    private val adminDashboardUrgentRefundService: AdminDashboardUrgentRefundService,
 ) {
 
     @GetMapping("/summary")
@@ -34,6 +37,15 @@ class AdminDashboardController(
         pageable: Pageable
     ): ResponseEntity<ApiResponse<AdminDashboardUnconfirmedOrderResponse>> {
         val response = ResponseEntity.ok(ApiResponse.success(adminDashboardOrderMonitoringService.getUnconfirmedOrders(pageable)))
+        return response
+    }
+
+    @GetMapping("/dashboard/urgent-refunds")
+    @Operation(summary = "운영자 대시보드 긴급 환불 요청 조회")
+    fun getUrgentRefunds(
+        pageable: Pageable
+    ): ResponseEntity<ApiResponse<AdminDashboardUrgentRefundResponse>> {
+        val response = ResponseEntity.ok(ApiResponse.success(adminDashboardUrgentRefundService.getUrgentRefunds(pageable)))
         return response
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -603,6 +603,30 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
     ): Page<Participation>
 
     @Query(
+        value = """
+        select p
+        from Participation p
+        join fetch p.user
+        join fetch p.groupBuy gb
+        join fetch gb.store
+        where p.status = :status
+          and coalesce(p.cancelledAt, p.createdAt) <= :requestedBefore
+        order by coalesce(p.cancelledAt, p.createdAt) asc, p.id asc
+        """,
+        countQuery = """
+        select count(p)
+        from Participation p
+        where p.status = :status
+          and coalesce(p.cancelledAt, p.createdAt) <= :requestedBefore
+        """
+    )
+    fun findDashboardUrgentRefundRequests(
+        @Param("status") status: ParticipationStatus,
+        @Param("requestedBefore") requestedBefore: LocalDateTime,
+        pageable: Pageable,
+    ): Page<Participation>
+
+    @Query(
         """
         select p
         from Participation p

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -608,16 +608,21 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
         from Participation p
         join fetch p.user
         join fetch p.groupBuy gb
-        join fetch gb.store
         where p.status = :status
-          and coalesce(p.cancelledAt, p.createdAt) <= :requestedBefore
+          and (
+            (p.cancelledAt is not null and p.cancelledAt <= :requestedBefore)
+            or (p.cancelledAt is null and p.createdAt <= :requestedBefore)
+          )
         order by coalesce(p.cancelledAt, p.createdAt) asc, p.id asc
         """,
         countQuery = """
         select count(p)
         from Participation p
         where p.status = :status
-          and coalesce(p.cancelledAt, p.createdAt) <= :requestedBefore
+          and (
+            (p.cancelledAt is not null and p.cancelledAt <= :requestedBefore)
+            or (p.cancelledAt is null and p.createdAt <= :requestedBefore)
+          )
         """
     )
     fun findDashboardUrgentRefundRequests(

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1283,6 +1283,26 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
+  /api/v1/admin/dashboard/urgent-refunds:
+    get:
+      tags: [Admin]
+      summary: 대시보드 긴급 환불 요청 조회 (운영자)
+      description: 요청 후 1시간을 초과한 REFUND_PENDING 환불 요청을 조회한다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 긴급 환불 요청 목록과 요약
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminDashboardUrgentRefunds'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
   /api/v1/admin/orders:
     get:
       tags: [Admin]
@@ -5501,6 +5521,58 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    ApiResponseAdminDashboardUrgentRefunds:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          type: object
+          required: [totalUrgentCount, hasUrgentRefunds, content, totalElements, totalPages, number, size]
+          properties:
+            totalUrgentCount:
+              type: integer
+              format: int64
+              description: 요청 후 1시간을 초과한 환불 요청 건수
+            hasUrgentRefunds:
+              type: boolean
+              description: 긴급 환불 요청 존재 여부
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/AdminDashboardUrgentRefundItem'
+            totalElements: { type: integer, format: int64 }
+            totalPages: { type: integer }
+            number: { type: integer }
+            size: { type: integer }
+        error: { nullable: true, example: null }
+
+    AdminDashboardUrgentRefundItem:
+      type: object
+      required: [requestId, caseFilter, consumerName, groupBuyName, refundAmount, requestedAt, slaElapsedHours]
+      properties:
+        requestId:
+          type: integer
+          format: int64
+          description: 환불 요청 ID. 현재는 participationId와 동일
+        caseFilter:
+          type: string
+          enum: [ALL, PRE_ACHIEVEMENT_FREE_CANCEL, POST_ACHIEVEMENT_CANCEL, PICKUP_PERIOD_NO_SHOW, OWNER_FAULT_CANCEL, TARGET_NOT_MET, DISPUTE_OR_DROPOUT_REFUND]
+          description: 환불 케이스
+        consumerName: { type: string }
+        groupBuyName: { type: string }
+        refundAmount:
+          type: integer
+          description: 승인 전에는 환불 가능 예상 금액, 승인 후에는 승인 환불 금액
+        requestedAt:
+          type: string
+          format: date-time
+          description: 환불 요청 일시
+        slaElapsedHours:
+          type: integer
+          format: int64
+          description: 요청 후 경과 시간(시간)
 
     ApiResponseAdminOrderPage:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundServiceTest.kt
@@ -1,0 +1,89 @@
+package com.moongchijang.domain.admin.application
+
+import com.moongchijang.domain.admin.application.dto.refund.AdminRefundRequestCaseFilter
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.support.GroupBuyFixture
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class AdminDashboardUrgentRefundServiceTest {
+
+    private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T01:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val service = AdminDashboardUrgentRefundService(
+        participationRepository = participationRepository,
+        clock = clock,
+    )
+
+    @Test
+    fun `1시간 초과 환불 요청을 경과 시간과 환불 예상 금액으로 반환한다`() {
+        val pageable = PageRequest.of(0, 10)
+        val requestedAt = LocalDateTime.now(clock).minusHours(2).minusMinutes(10)
+        val participation = refundParticipation(id = 101L, cancelledAt = requestedAt)
+        val requestedBefore = LocalDateTime.now(clock).minusHours(1)
+        `when`(
+            participationRepository.findDashboardUrgentRefundRequests(
+                status = ParticipationStatus.REFUND_PENDING,
+                requestedBefore = requestedBefore,
+                pageable = pageable,
+            )
+        ).thenReturn(PageImpl(listOf(participation), pageable, 1))
+
+        val result = service.getUrgentRefunds(pageable)
+
+        assertTrue(result.hasUrgentRefunds)
+        assertEquals(1L, result.totalUrgentCount)
+        assertEquals(1, result.content.size)
+        assertEquals(101L, result.content.first().requestId)
+        assertEquals(AdminRefundRequestCaseFilter.PICKUP_PERIOD_NO_SHOW, result.content.first().caseFilter)
+        assertEquals("환불유저", result.content.first().consumerName)
+        assertEquals("초코 크루아상", result.content.first().groupBuyName)
+        assertEquals(21_600, result.content.first().refundAmount)
+        assertEquals(2L, result.content.first().slaElapsedHours)
+        verify(participationRepository).findDashboardUrgentRefundRequests(
+            ParticipationStatus.REFUND_PENDING,
+            requestedBefore,
+            pageable,
+        )
+    }
+
+    private fun refundParticipation(id: Long, cancelledAt: LocalDateTime): Participation {
+        val user = UserFixture.createKakaoUser(id = 7L, nickname = "환불유저")
+        val groupBuy = GroupBuyFixture.createGroupBuy(
+            id = 3001L,
+            status = GroupBuyStatus.ACHIEVED,
+            productName = "초코 크루아상",
+            price = 24_000,
+        )
+        groupBuy.store.id = 11L
+
+        return Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 21_600,
+            feeAmount = 2_400,
+            totalAmount = 24_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelReason = ParticipationCancelReason.TIME_UNAVAILABLE,
+            cancelReasonDetail = "환불 요청",
+            cancelledAt = cancelledAt,
+            id = id,
+        )
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminDashboardControllerTest.kt
@@ -2,8 +2,10 @@ package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminDashboardOrderMonitoringService
 import com.moongchijang.domain.admin.application.AdminDashboardSummaryService
+import com.moongchijang.domain.admin.application.AdminDashboardUrgentRefundService
 import com.moongchijang.domain.admin.application.dto.AdminDashboardSummaryResponse
 import com.moongchijang.domain.admin.application.dto.AdminDashboardUnconfirmedOrderResponse
+import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundResponse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -16,9 +18,12 @@ class AdminDashboardControllerTest {
     private val adminDashboardSummaryService: AdminDashboardSummaryService = mock(AdminDashboardSummaryService::class.java)
     private val adminDashboardOrderMonitoringService: AdminDashboardOrderMonitoringService =
         mock(AdminDashboardOrderMonitoringService::class.java)
+    private val adminDashboardUrgentRefundService: AdminDashboardUrgentRefundService =
+        mock(AdminDashboardUrgentRefundService::class.java)
     private val controller = AdminDashboardController(
         adminDashboardSummaryService = adminDashboardSummaryService,
-        adminDashboardOrderMonitoringService = adminDashboardOrderMonitoringService
+        adminDashboardOrderMonitoringService = adminDashboardOrderMonitoringService,
+        adminDashboardUrgentRefundService = adminDashboardUrgentRefundService
     )
 
     @Test
@@ -62,5 +67,25 @@ class AdminDashboardControllerTest {
 
         assertEquals(response, result.body?.data)
         verify(adminDashboardOrderMonitoringService).getUnconfirmedOrders(pageable)
+    }
+
+    @Test
+    fun `운영자 대시보드 긴급 환불 요청은 페이징을 서비스로 전달한다`() {
+        val pageable = PageRequest.of(0, 5)
+        val response = AdminDashboardUrgentRefundResponse(
+            totalUrgentCount = 0L,
+            hasUrgentRefunds = false,
+            content = emptyList(),
+            totalElements = 0L,
+            totalPages = 0,
+            number = 0,
+            size = 5
+        )
+        `when`(adminDashboardUrgentRefundService.getUrgentRefunds(pageable)).thenReturn(response)
+
+        val result = controller.getUrgentRefunds(pageable)
+
+        assertEquals(response, result.body?.data)
+        verify(adminDashboardUrgentRefundService).getUrgentRefunds(pageable)
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 대시보드용 긴급 환불 요청 조회 API를 추가했습니다.
- `REFUND_PENDING` 중 요청 후 1시간 이상 지난 환불 요청을 페이징 조회합니다.
- 응답에 요청 ID, 케이스, 소비자 이름, 공구명, 환불 금액, 요청 일시, SLA 경과 시간을 포함했습니다.
- 서비스/컨트롤러 테스트를 추가했습니다.
- OpenAPI에 실제 구현 API 스펙을 동기화했습니다.

## 🔍 참고 사항
- API: `GET /api/v1/admin/dashboard/urgent-refunds`
- 환불 금액은 승인 전이면 환불 가능 예상 금액 기준으로 반환합니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- Closes #297

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인