### PR TITLE
[MCJ-1588] FEAT: 사장님 정산 목록 API 및 정산 상태 필드 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -138,6 +138,13 @@ class OwnerSettlementService(
             pickupDateFrom = pickupDateFrom,
             pickupDateTo = pickupDateTo,
         )
+        if (aggregations.isEmpty()) {
+            return OwnerSettlementItemListResponse(
+                year = year,
+                month = month,
+                items = emptyList(),
+            )
+        }
         val pendingRefundCountByGroupBuyId = participationRepository.countPendingRefundsByGroupBuyIdIn(
             aggregations.map { it.groupBuyId },
         ).associate { it.groupBuyId to it.pendingRefundCount }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -10,13 +10,17 @@ import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTa
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewActionType
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitRequest
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitResponse
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementItemListResponse
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementItemResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipListResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthlySummaryResponse
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementStatus
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
 import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.repository.AdminSettlementAggregation
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
@@ -107,6 +111,47 @@ class OwnerSettlementService(
             }
 
         return OwnerSettlementMonthChipListResponse(chips)
+    }
+
+    fun getSettlementItems(ownerId: Long, year: Int, month: Int): OwnerSettlementItemListResponse {
+        log.info("[OwnerSettlementService] 정산 공구 카드 목록 조회 시작: ownerId={}, year={}, month={}", ownerId, year, month)
+        validateSeller(ownerId)
+        validateYearMonth(year, month)
+
+        val storeIds = storeStaffRepository.findStoreIdsByUserId(ownerId)
+        if (storeIds.isEmpty()) {
+            return OwnerSettlementItemListResponse(
+                year = year,
+                month = month,
+                items = emptyList(),
+            )
+        }
+
+        val pickupDateFrom = LocalDate.of(year, month, 1)
+        val pickupDateTo = pickupDateFrom.plusMonths(1)
+        val aggregations = participationRepository.findOwnerSettlementAggregations(
+            storeIds = storeIds,
+            groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,
+            transactionStatuses = SETTLEMENT_TRANSACTION_STATUSES,
+            revenueStatuses = SETTLEMENT_PARTICIPATION_STATUSES,
+            refundStatuses = REFUND_STATUSES,
+            pickupDateFrom = pickupDateFrom,
+            pickupDateTo = pickupDateTo,
+        )
+        val pendingRefundCountByGroupBuyId = participationRepository.countPendingRefundsByGroupBuyIdIn(
+            aggregations.map { it.groupBuyId },
+        ).associate { it.groupBuyId to it.pendingRefundCount }
+
+        return OwnerSettlementItemListResponse(
+            year = year,
+            month = month,
+            items = aggregations.map { aggregation ->
+                toSettlementItemResponse(
+                    aggregation = aggregation,
+                    pendingRefundCount = pendingRefundCountByGroupBuyId[aggregation.groupBuyId] ?: 0L,
+                )
+            },
+        )
     }
 
     fun getRefundRequests(ownerId: Long, tab: OwnerRefundRequestTab): OwnerRefundRequestListResponse {
@@ -279,6 +324,35 @@ class OwnerSettlementService(
         }
     }
 
+    private fun toSettlementItemResponse(
+        aggregation: AdminSettlementAggregation,
+        pendingRefundCount: Long,
+    ): OwnerSettlementItemResponse {
+        return OwnerSettlementItemResponse(
+            groupBuyId = aggregation.groupBuyId,
+            productName = aggregation.productName,
+            participantCount = aggregation.participantCount.toInt(),
+            pickupDate = aggregation.pickupCompletedDate,
+            amount = (aggregation.totalPaymentAmount - aggregation.refundDeductionAmount).coerceAtLeast(0L),
+            settlementStatus = resolveSettlementStatus(aggregation, pendingRefundCount),
+        )
+    }
+
+    private fun resolveSettlementStatus(
+        aggregation: AdminSettlementAggregation,
+        pendingRefundCount: Long,
+    ): OwnerSettlementStatus {
+        if (pendingRefundCount > 0 || aggregation.refundDeductionAmount > 0L) {
+            return OwnerSettlementStatus.REFUND_PROCESSING
+        }
+
+        return if (aggregation.pickupCompletedDate.plusDays(OWNER_SETTLEMENT_DELAY_DAYS).isAfter(LocalDate.now(SEOUL_ZONE_ID))) {
+            OwnerSettlementStatus.SETTLEMENT_PENDING
+        } else {
+            OwnerSettlementStatus.SETTLEMENT_COMPLETED
+        }
+    }
+
     private fun toRefundReasonLabel(reason: ParticipationCancelReason?): String {
         return when (reason) {
             ParticipationCancelReason.TIME_UNAVAILABLE -> "픽업 불가"
@@ -330,8 +404,14 @@ class OwnerSettlementService(
     private companion object {
         val SETTLEMENT_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
         val SETTLEMENT_PARTICIPATION_STATUSES = listOf(ParticipationStatus.CONFIRMED)
+        val SETTLEMENT_TRANSACTION_STATUSES = listOf(
+            ParticipationStatus.CONFIRMED,
+            ParticipationStatus.REFUND_PENDING,
+            ParticipationStatus.REFUNDED,
+        )
         val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
         val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+        const val OWNER_SETTLEMENT_DELAY_DAYS: Long = 3
         const val REFUND_LIST_LOOKBACK_MONTHS: Long = 6
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementItemListResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementItemListResponse.kt
@@ -1,0 +1,16 @@
+package com.moongchijang.domain.owner.application.dto.settlement
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 정산 공구 카드 목록 응답")
+data class OwnerSettlementItemListResponse(
+
+    @field:Schema(description = "조회 기준 연도", example = "2026")
+    val year: Int,
+
+    @field:Schema(description = "조회 기준 월(1~12)", example = "5")
+    val month: Int,
+
+    @field:Schema(description = "정산 공구 카드 목록")
+    val items: List<OwnerSettlementItemResponse>,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementItemResponse.kt
@@ -1,0 +1,26 @@
+package com.moongchijang.domain.owner.application.dto.settlement
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "사장님 정산 공구 카드 응답")
+data class OwnerSettlementItemResponse(
+
+    @field:Schema(description = "공구 ID", example = "901001")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "공구명", example = "딸기 타르트")
+    val productName: String,
+
+    @field:Schema(description = "참여 인원 수", example = "18")
+    val participantCount: Int,
+
+    @field:Schema(description = "픽업일", example = "2026-05-02")
+    val pickupDate: LocalDate,
+
+    @field:Schema(description = "정산 금액", example = "432000")
+    val amount: Long,
+
+    @field:Schema(description = "정산 상태", example = "SETTLEMENT_COMPLETED")
+    val settlementStatus: OwnerSettlementStatus,
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/settlement/OwnerSettlementStatus.kt
@@ -1,0 +1,15 @@
+package com.moongchijang.domain.owner.application.dto.settlement
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사장님 공구 정산 상태")
+enum class OwnerSettlementStatus {
+    @Schema(description = "정산 완료")
+    SETTLEMENT_COMPLETED,
+
+    @Schema(description = "정산 대기")
+    SETTLEMENT_PENDING,
+
+    @Schema(description = "환불 처리")
+    REFUND_PROCESSING,
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerSettlementController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/OwnerSettlementController.kt
@@ -6,6 +6,7 @@ import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestLi
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitRequest
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitResponse
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementItemListResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthChipListResponse
 import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementMonthlySummaryResponse
 import com.moongchijang.global.response.ApiResponse
@@ -72,6 +73,27 @@ class OwnerSettlementController(
         log.info("[OwnerSettlementController] 정산 월 칩 조회 요청 수신: ownerId={}", principal.id)
         val response = ownerSettlementService.getSettlementMonthChips(principal.id)
         log.info("[OwnerSettlementController] 정산 월 칩 조회 응답 완료: ownerId={}, count={}", principal.id, response.chips.size)
+        return ResponseEntity.ok(ApiResponse.success(response))
+    }
+
+    @GetMapping("/items")
+    @Operation(summary = "사장님 정산 공구 카드 목록 조회")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "조회 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "요청 파라미터 오류", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "인증 필요", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "403", description = "사장님 권한 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun getSettlementItems(
+        @AuthenticationPrincipal principal: CustomUserPrincipal,
+        @RequestParam year: Int,
+        @RequestParam month: Int,
+    ): ResponseEntity<ApiResponse<OwnerSettlementItemListResponse>> {
+        log.info("[OwnerSettlementController] 정산 공구 카드 목록 조회 요청 수신: ownerId={}, year={}, month={}", principal.id, year, month)
+        val response = ownerSettlementService.getSettlementItems(principal.id, year, month)
+        log.info("[OwnerSettlementController] 정산 공구 카드 목록 조회 응답 완료: ownerId={}, year={}, month={}, count={}", principal.id, year, month, response.items.size)
         return ResponseEntity.ok(ApiResponse.success(response))
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -469,6 +469,36 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                0 as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
+        where gb.store.id in :storeIds
+          and gb.status in :groupBuyStatuses
+          and gb.pickupDate >= :pickupDateFrom
+          and gb.pickupDate < :pickupDateTo
+        group by gb.id, gb.store.name, gb.productName, gb.pickupDate
+        order by gb.pickupDate desc, gb.id desc
+        """
+    )
+    fun findOwnerSettlementAggregations(
+        @Param("storeIds") storeIds: Collection<Long>,
+        @Param("groupBuyStatuses") groupBuyStatuses: Collection<GroupBuyStatus>,
+        @Param("transactionStatuses") transactionStatuses: Collection<ParticipationStatus>,
+        @Param("revenueStatuses") revenueStatuses: Collection<ParticipationStatus>,
+        @Param("refundStatuses") refundStatuses: Collection<ParticipationStatus>,
+        @Param("pickupDateFrom") pickupDateFrom: LocalDate,
+        @Param("pickupDateTo") pickupDateTo: LocalDate,
+    ): List<AdminSettlementAggregation>
+
+    @Query(
+        """
+        select gb.id as groupBuyId,
+               gb.store.name as storeName,
+               gb.productName as productName,
+               gb.pickupDate as pickupCompletedDate,
+               coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
+               coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
+               coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
+               0 as platformFeeAmount
+        from GroupBuy gb
+        left join Participation p on p.groupBuy = gb
         where gb.id = :groupBuyId
           and gb.status in :groupBuyStatuses
         group by gb.id, gb.store.name, gb.productName, gb.pickupDate

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -17,6 +17,8 @@ info:
   version: v1
 
 servers:
+  - url: https://api.moongchijang.com
+    description: 운영 서버
   - url: https://api.moongchijang.com/dev
     description: 개발 서버
   - url: http://localhost:8080
@@ -2255,6 +2257,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseOwnerSettlementMonthChipList'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/owner/settlements/items:
+    get:
+      tags: [Owner]
+      summary: 사장님 정산 공구 카드 목록 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 2000
+            maximum: 2100
+            example: 2026
+        - name: month
+          in: query
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 12
+            example: 5
+      responses:
+        '200':
+          description: 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseOwnerSettlementItemList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -5060,6 +5099,43 @@ components:
         year: { type: integer, example: 2026 }
         month: { type: integer, example: 5 }
         label: { type: string, example: "2026년 5월" }
+
+    ApiResponseOwnerSettlementItemList:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/OwnerSettlementItemList'
+        error: { nullable: true, example: null }
+
+    OwnerSettlementItemList:
+      type: object
+      required: [year, month, items]
+      properties:
+        year: { type: integer, example: 2026 }
+        month: { type: integer, example: 5 }
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OwnerSettlementItem'
+
+    OwnerSettlementItem:
+      type: object
+      required: [groupBuyId, productName, participantCount, pickupDate, amount, settlementStatus]
+      properties:
+        groupBuyId: { type: integer, format: int64, example: 901001 }
+        productName: { type: string, example: "딸기 타르트" }
+        participantCount: { type: integer, example: 18 }
+        pickupDate: { type: string, format: date, example: "2026-05-02" }
+        amount: { type: integer, format: int64, example: 432000 }
+        settlementStatus:
+          $ref: '#/components/schemas/OwnerSettlementStatus'
+
+    OwnerSettlementStatus:
+      type: string
+      description: 사장님 공구 정산 상태
+      enum: [SETTLEMENT_COMPLETED, SETTLEMENT_PENDING, REFUND_PROCESSING]
 
     ApiResponseOwnerRefundRequestList:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -5,6 +5,8 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundRequestTab
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewActionType
 import com.moongchijang.domain.owner.application.dto.refund.OwnerRefundReviewSubmitRequest
+import com.moongchijang.domain.owner.application.dto.settlement.OwnerSettlementStatus
+import com.moongchijang.domain.participation.domain.repository.AdminSettlementAggregation
 import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
@@ -110,6 +112,162 @@ class OwnerSettlementServiceTest {
         assertEquals(2, result.chips.size)
         assertEquals("2026년 5월", result.chips[0].label)
         assertEquals("2026년 4월", result.chips[1].label)
+    }
+
+    @Test
+    fun `정산 공구 카드 목록은 정산완료 상태를 반환한다`() {
+        val owner = seller()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val pickupDate = today.minusDays(4)
+        val year = pickupDate.year
+        val month = pickupDate.monthValue
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
+        `when`(
+            participationRepository.findOwnerSettlementAggregations(
+                defaultStoreIds(),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+                listOf(ParticipationStatus.CONFIRMED, ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                listOf(ParticipationStatus.CONFIRMED),
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                LocalDate.of(year, month, 1),
+                LocalDate.of(year, month, 1).plusMonths(1),
+            )
+        ).thenReturn(
+            listOf(
+                settlementAggregation(
+                    groupBuyId = 901001L,
+                    productName = "딸기 타르트",
+                    pickupDate = pickupDate,
+                    participantCount = 18L,
+                    totalPaymentAmount = 432000L,
+                    refundDeductionAmount = 0L,
+                )
+            )
+        )
+        `when`(participationRepository.countPendingRefundsByGroupBuyIdIn(listOf(901001L))).thenReturn(emptyList())
+
+        val result = service.getSettlementItems(owner.id!!, year, month)
+
+        assertEquals(1, result.items.size)
+        assertEquals(OwnerSettlementStatus.SETTLEMENT_COMPLETED, result.items[0].settlementStatus)
+        assertEquals(432000L, result.items[0].amount)
+    }
+
+    @Test
+    fun `정산 공구 카드 목록은 정산대기 상태를 반환한다`() {
+        val owner = seller()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val pickupDate = today.minusDays(1)
+        val year = pickupDate.year
+        val month = pickupDate.monthValue
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
+        `when`(
+            participationRepository.findOwnerSettlementAggregations(
+                defaultStoreIds(),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+                listOf(ParticipationStatus.CONFIRMED, ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                listOf(ParticipationStatus.CONFIRMED),
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                LocalDate.of(year, month, 1),
+                LocalDate.of(year, month, 1).plusMonths(1),
+            )
+        ).thenReturn(
+            listOf(
+                settlementAggregation(
+                    groupBuyId = 901002L,
+                    productName = "크로아상 3개입",
+                    pickupDate = pickupDate,
+                    participantCount = 18L,
+                    totalPaymentAmount = 720000L,
+                    refundDeductionAmount = 0L,
+                )
+            )
+        )
+        `when`(participationRepository.countPendingRefundsByGroupBuyIdIn(listOf(901002L))).thenReturn(emptyList())
+
+        val result = service.getSettlementItems(owner.id!!, year, month)
+
+        assertEquals(OwnerSettlementStatus.SETTLEMENT_PENDING, result.items[0].settlementStatus)
+    }
+
+    @Test
+    fun `정산 공구 카드 목록은 환불처리 상태를 우선 반환한다`() {
+        val owner = seller()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val pickupDate = today.minusDays(5)
+        val year = pickupDate.year
+        val month = pickupDate.monthValue
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
+        `when`(
+            participationRepository.findOwnerSettlementAggregations(
+                defaultStoreIds(),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+                listOf(ParticipationStatus.CONFIRMED, ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                listOf(ParticipationStatus.CONFIRMED),
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                LocalDate.of(year, month, 1),
+                LocalDate.of(year, month, 1).plusMonths(1),
+            )
+        ).thenReturn(
+            listOf(
+                settlementAggregation(
+                    groupBuyId = 901003L,
+                    productName = "레몬 마들렌",
+                    pickupDate = pickupDate,
+                    participantCount = 10L,
+                    totalPaymentAmount = 300000L,
+                    refundDeductionAmount = 24000L,
+                )
+            )
+        )
+        `when`(participationRepository.countPendingRefundsByGroupBuyIdIn(listOf(901003L))).thenReturn(emptyList())
+
+        val result = service.getSettlementItems(owner.id!!, year, month)
+
+        assertEquals(OwnerSettlementStatus.REFUND_PROCESSING, result.items[0].settlementStatus)
+        assertEquals(276000L, result.items[0].amount)
+    }
+
+    @Test
+    fun `정산 공구 카드 목록은 환불 대기 건이 있으면 정산완료보다 환불처리를 우선한다`() {
+        val owner = seller()
+        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val pickupDate = today.minusDays(7)
+        val year = pickupDate.year
+        val month = pickupDate.monthValue
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
+        `when`(
+            participationRepository.findOwnerSettlementAggregations(
+                defaultStoreIds(),
+                listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED),
+                listOf(ParticipationStatus.CONFIRMED, ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                listOf(ParticipationStatus.CONFIRMED),
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                LocalDate.of(year, month, 1),
+                LocalDate.of(year, month, 1).plusMonths(1),
+            )
+        ).thenReturn(
+            listOf(
+                settlementAggregation(
+                    groupBuyId = 901004L,
+                    productName = "버터 스콘",
+                    pickupDate = pickupDate,
+                    participantCount = 8L,
+                    totalPaymentAmount = 160000L,
+                    refundDeductionAmount = 0L,
+                )
+            )
+        )
+        `when`(participationRepository.countPendingRefundsByGroupBuyIdIn(listOf(901004L))).thenReturn(
+            listOf(object : com.moongchijang.domain.participation.domain.repository.GroupBuyPendingRefundCount {
+                override val groupBuyId: Long = 901004L
+                override val pendingRefundCount: Long = 1L
+            })
+        )
+
+        val result = service.getSettlementItems(owner.id!!, year, month)
+
+        assertEquals(OwnerSettlementStatus.REFUND_PROCESSING, result.items[0].settlementStatus)
     }
 
     @Test
@@ -262,6 +420,26 @@ class OwnerSettlementServiceTest {
             id = id,
         ).also {
             setAuditFields(it, LocalDateTime.now().minusDays(2), LocalDateTime.now().minusDays(1))
+        }
+    }
+
+    private fun settlementAggregation(
+        groupBuyId: Long,
+        productName: String,
+        pickupDate: LocalDate,
+        participantCount: Long,
+        totalPaymentAmount: Long,
+        refundDeductionAmount: Long,
+    ): AdminSettlementAggregation {
+        return object : AdminSettlementAggregation {
+            override val groupBuyId: Long = groupBuyId
+            override val storeName: String = "남남베이커리"
+            override val productName: String = productName
+            override val pickupCompletedDate: LocalDate = pickupDate
+            override val participantCount: Long = participantCount
+            override val totalPaymentAmount: Long = totalPaymentAmount
+            override val refundDeductionAmount: Long = refundDeductionAmount
+            override val platformFeeAmount: Long = 0L
         }
     }
 


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 정산 공구 카드 목록 응답 DTO를 추가했습니다.
- 정산 상태 enum을 추가했습니다.
  - `SETTLEMENT_COMPLETED`
  - `SETTLEMENT_PENDING`
  - `REFUND_PROCESSING`
- 사장님 정산 목록 조회 API를 추가했습니다.
  - `GET /api/v1/owner/settlements/items?year=&month=`
- 월별 정산 카드 목록 조회 및 상태 판정 로직을 구현했습니다.
  - 환불 진행 건 우선
  - 픽업일 기준 정산 완료/대기 판정
- 관련 리포지토리 조회를 추가했습니다.
- OpenAPI 명세에 신규 API 및 정산 상태 필드를 반영했습니다.
- 정산 상태 서비스 테스트를 추가했습니다.
  - 정산완료
  - 정산대기
  - 환불처리
  - 환불 우선순위

## 🔍 참고 사항
- 정산 상태는 현재 아래 우선순위로 계산됩니다.
  - `REFUND_PROCESSING` > `SETTLEMENT_COMPLETED` / `SETTLEMENT_PENDING`

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #302 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인