### PR TITLE
[MCJ-1591] FEAT: 현재 역할 기준 알림 조회 및 사장님 알림 필터 확장

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
@@ -3,7 +3,7 @@ package com.moongchijang.domain.notification.application
 import com.moongchijang.domain.notification.application.dto.NotificationUnreadCountResponse
 import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
-import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class NotificationCommandService(
     private val notificationRepository: NotificationRepository,
-    private val userRepository: UserRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -42,10 +41,10 @@ class NotificationCommandService(
     }
 
     @Transactional
-    fun markAllAsRead(userId: Long): Int {
+    fun markAllAsRead(userId: Long, currentRole: UserRole): Int {
         log.info("[NotificationCommandService] 알림 전체 읽음 처리 시작: userId={}", userId)
 
-        val scope = resolveNotificationScope(userId)
+        val scope = NotificationScope.from(currentRole)
         val updatedCount = notificationRepository.markAllAsReadByUserIdAndScope(userId, scope)
 
         log.info(
@@ -58,10 +57,10 @@ class NotificationCommandService(
     }
 
     @Transactional(readOnly = true)
-    fun getUnreadCount(userId: Long): NotificationUnreadCountResponse {
+    fun getUnreadCount(userId: Long, currentRole: UserRole): NotificationUnreadCountResponse {
         log.info("[NotificationCommandService] 미읽음 알림 개수 조회 시작: userId={}", userId)
 
-        val scope = resolveNotificationScope(userId)
+        val scope = NotificationScope.from(currentRole)
         val count = notificationRepository.countUnreadByUserIdAndScope(userId, scope)
 
         log.info(
@@ -71,11 +70,5 @@ class NotificationCommandService(
             count
         )
         return NotificationUnreadCountResponse(count = count)
-    }
-
-    private fun resolveNotificationScope(userId: Long): NotificationScope {
-        val userRole = userRepository.findByIdAndDeletedAtIsNull(userId)?.role
-            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
-        return NotificationScope.from(userRole)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
@@ -1,7 +1,10 @@
 package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.application.dto.NotificationUnreadCountResponse
+import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
@@ -10,7 +13,8 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class NotificationCommandService(
-    private val notificationRepository: NotificationRepository
+    private val notificationRepository: NotificationRepository,
+    private val userRepository: UserRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -42,11 +46,13 @@ class NotificationCommandService(
     fun markAllAsRead(userId: Long): Int {
         log.info("[NotificationCommandService] 알림 전체 읽음 처리 시작: userId={}", userId)
 
-        val updatedCount = notificationRepository.markAllAsReadByUserId(userId)
+        val scope = resolveNotificationScope(userId)
+        val updatedCount = notificationRepository.markAllAsReadByUserIdAndScope(userId, scope)
 
         log.info(
-            "[NotificationCommandService] 알림 전체 읽음 처리 완료: userId={}, updatedCount={}",
+            "[NotificationCommandService] 알림 전체 읽음 처리 완료: userId={}, scope={}, updatedCount={}",
             userId,
+            scope,
             updatedCount
         )
         return updatedCount
@@ -56,13 +62,25 @@ class NotificationCommandService(
     fun getUnreadCount(userId: Long): NotificationUnreadCountResponse {
         log.info("[NotificationCommandService] 미읽음 알림 개수 조회 시작: userId={}", userId)
 
-        val count = notificationRepository.countUnreadByUserId(userId)
+        val scope = resolveNotificationScope(userId)
+        val count = notificationRepository.countUnreadByUserIdAndScope(userId, scope)
 
         log.info(
-            "[NotificationCommandService] 미읽음 알림 개수 조회 완료: userId={}, count={}",
+            "[NotificationCommandService] 미읽음 알림 개수 조회 완료: userId={}, scope={}, count={}",
             userId,
+            scope,
             count
         )
         return NotificationUnreadCountResponse(count = count)
+    }
+
+    private fun resolveNotificationScope(userId: Long): NotificationScope {
+        val userRole = userRepository.findByIdAndDeletedAtIsNull(userId)?.role
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        return when (userRole) {
+            UserRole.BUYER -> NotificationScope.BUYER
+            UserRole.SELLER -> NotificationScope.OWNER
+            UserRole.ADMIN -> NotificationScope.BUYER
+        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationCommandService.kt
@@ -3,7 +3,6 @@ package com.moongchijang.domain.notification.application
 import com.moongchijang.domain.notification.application.dto.NotificationUnreadCountResponse
 import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
-import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -77,10 +76,6 @@ class NotificationCommandService(
     private fun resolveNotificationScope(userId: Long): NotificationScope {
         val userRole = userRepository.findByIdAndDeletedAtIsNull(userId)?.role
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
-        return when (userRole) {
-            UserRole.BUYER -> NotificationScope.BUYER
-            UserRole.SELLER -> NotificationScope.OWNER
-            UserRole.ADMIN -> NotificationScope.BUYER
-        }
+        return NotificationScope.from(userRole)
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -10,6 +10,7 @@ import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
 import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
+import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.notification.domain.repository.NotificationDispatchHistoryRepository
@@ -108,6 +109,7 @@ class NotificationImmediateDispatchService(
 
     private fun toNotificationMeta(triggerType: NotificationTriggerType, targetId: Long): NotificationMeta {
         val notificationType = toNotificationType(triggerType)
+        val notificationScope = toNotificationScope(triggerType)
         val template = notificationTemplateRegistry.getTemplateByTriggerType(triggerType)
         val rendered = notificationTemplateRenderer.render(
             template = template,
@@ -115,6 +117,7 @@ class NotificationImmediateDispatchService(
         )
         return NotificationMeta(
             type = notificationType,
+            scope = notificationScope,
             title = rendered.title,
             body = rendered.body,
             deeplinkType = rendered.deeplinkType
@@ -153,8 +156,26 @@ class NotificationImmediateDispatchService(
         }
     }
 
+    private fun toNotificationScope(triggerType: NotificationTriggerType): NotificationScope {
+        return when (triggerType) {
+            NotificationTriggerType.OWNER_PICKUP_SAME_DAY_MORNING,
+            NotificationTriggerType.OWNER_PICKUP_DAY_BEFORE_MORNING,
+            NotificationTriggerType.OWNER_GROUPBUY_ACHIEVED_IMMEDIATE,
+            NotificationTriggerType.OWNER_GROUPBUY_FAILED_IMMEDIATE,
+            NotificationTriggerType.OWNER_CLOSE_REQUEST_APPROVED_IMMEDIATE,
+            NotificationTriggerType.OWNER_CLOSE_REQUEST_REJECTED_IMMEDIATE,
+            NotificationTriggerType.OWNER_OPEN_REQUEST_APPROVED_IMMEDIATE,
+            NotificationTriggerType.OWNER_OPEN_REQUEST_REJECTED_IMMEDIATE,
+            NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE,
+            NotificationTriggerType.OWNER_ORDER_CANCELLED_IMMEDIATE -> NotificationScope.OWNER
+
+            else -> NotificationScope.BUYER
+        }
+    }
+
     private data class NotificationMeta(
         val type: NotificationType,
+        val scope: NotificationScope,
         val title: String,
         val body: String,
         val deeplinkType: NotificationDeeplinkType,
@@ -270,6 +291,7 @@ class NotificationImmediateDispatchService(
                 Notification(
                     user = user,
                     type = meta.type,
+                    scope = meta.scope,
                     title = meta.title,
                     body = meta.body,
                     occurredAt = event.occurredAt,

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
@@ -36,12 +36,21 @@ class NotificationQueryService(
             safeLimit
         )
 
-        val notifications = notificationRepository.findForList(
+        val pageable = PageRequest.of(0, safeLimit + 1)
+        val notifications = category.ownerTriggerTypesOrNull()?.let { ownerTriggerTypes ->
+            notificationRepository.findForListByTriggerTypes(
+                userId = userId,
+                triggerTypes = ownerTriggerTypes,
+                cursorOccurredAt = decodedCursor?.occurredAt,
+                cursorId = decodedCursor?.id,
+                pageable = pageable
+            )
+        } ?: notificationRepository.findForList(
             userId = userId,
             type = category.toNotificationTypeOrNull(),
             cursorOccurredAt = decodedCursor?.occurredAt,
             cursorId = decodedCursor?.id,
-            pageable = PageRequest.of(0, safeLimit + 1)
+            pageable = pageable
         )
 
         val hasNext = notifications.size > safeLimit

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
@@ -6,7 +6,7 @@ import com.moongchijang.domain.notification.application.dto.NotificationItemResp
 import com.moongchijang.domain.notification.application.dto.NotificationListResponse
 import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
-import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
@@ -19,13 +19,13 @@ import java.time.ZoneId
 @Service
 class NotificationQueryService(
     private val notificationRepository: NotificationRepository,
-    private val userRepository: UserRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional(readOnly = true)
     fun getNotifications(
         userId: Long,
+        currentRole: UserRole,
         category: NotificationCategory,
         cursor: String?,
         limit: Int
@@ -41,8 +41,6 @@ class NotificationQueryService(
             safeLimit
         )
 
-        val currentRole = userRepository.findByIdAndDeletedAtIsNull(userId)?.role
-            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
         if (!category.supportsRole(currentRole)) {
             throw CustomException(ErrorCode.INVALID_INPUT, "category is not supported for current role")
         }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
@@ -4,7 +4,12 @@ import com.moongchijang.domain.notification.application.dto.NotificationCategory
 import com.moongchijang.domain.notification.application.dto.NotificationCursor
 import com.moongchijang.domain.notification.application.dto.NotificationItemResponse
 import com.moongchijang.domain.notification.application.dto.NotificationListResponse
+import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
@@ -14,7 +19,8 @@ import java.time.ZoneId
 
 @Service
 class NotificationQueryService(
-    private val notificationRepository: NotificationRepository
+    private val notificationRepository: NotificationRepository,
+    private val userRepository: UserRepository,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -36,17 +42,26 @@ class NotificationQueryService(
             safeLimit
         )
 
+        val currentRole = userRepository.findByIdAndDeletedAtIsNull(userId)?.role
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+        if (!category.supportsRole(currentRole)) {
+            throw CustomException(ErrorCode.INVALID_INPUT, "category is not supported for current role")
+        }
+
         val pageable = PageRequest.of(0, safeLimit + 1)
+        val scope = currentRole.toNotificationScope()
         val notifications = category.ownerTriggerTypesOrNull()?.let { ownerTriggerTypes ->
-            notificationRepository.findForListByTriggerTypes(
+            notificationRepository.findForListByScopeAndTriggerTypes(
                 userId = userId,
+                scope = scope,
                 triggerTypes = ownerTriggerTypes,
                 cursorOccurredAt = decodedCursor?.occurredAt,
                 cursorId = decodedCursor?.id,
                 pageable = pageable
             )
-        } ?: notificationRepository.findForList(
+        } ?: notificationRepository.findForListByScope(
             userId = userId,
+            scope = scope,
             type = category.toNotificationTypeOrNull(),
             cursorOccurredAt = decodedCursor?.occurredAt,
             cursorId = decodedCursor?.id,
@@ -76,5 +91,13 @@ class NotificationQueryService(
     companion object {
         private const val MIN_LIMIT = 1
         private const val MAX_LIMIT = 100
+    }
+
+    private fun UserRole.toNotificationScope(): NotificationScope {
+        return when (this) {
+            UserRole.BUYER -> NotificationScope.BUYER
+            UserRole.SELLER -> NotificationScope.OWNER
+            UserRole.ADMIN -> NotificationScope.BUYER
+        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
@@ -6,7 +6,6 @@ import com.moongchijang.domain.notification.application.dto.NotificationItemResp
 import com.moongchijang.domain.notification.application.dto.NotificationListResponse
 import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
-import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -49,7 +48,7 @@ class NotificationQueryService(
         }
 
         val pageable = PageRequest.of(0, safeLimit + 1)
-        val scope = currentRole.toNotificationScope()
+        val scope = NotificationScope.from(currentRole)
         val notifications = category.ownerTriggerTypesOrNull()?.let { ownerTriggerTypes ->
             notificationRepository.findForListByScopeAndTriggerTypes(
                 userId = userId,
@@ -91,13 +90,5 @@ class NotificationQueryService(
     companion object {
         private const val MIN_LIMIT = 1
         private const val MAX_LIMIT = 100
-    }
-
-    private fun UserRole.toNotificationScope(): NotificationScope {
-        return when (this) {
-            UserRole.BUYER -> NotificationScope.BUYER
-            UserRole.SELLER -> NotificationScope.OWNER
-            UserRole.ADMIN -> NotificationScope.BUYER
-        }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCategory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCategory.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.notification.application.dto
 
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import io.swagger.v3.oas.annotations.media.Schema
@@ -58,6 +59,14 @@ enum class NotificationCategory {
     }
 
     fun isOwnerFilter(): Boolean = ownerTriggerTypesOrNull() != null
+
+    fun supportsRole(role: UserRole): Boolean {
+        return when (role) {
+            UserRole.BUYER -> this in setOf(ALL, WISH, APPLY, PICKUP, REQUEST)
+            UserRole.SELLER -> this in setOf(ALL, TODAY_PICKUP, REMINDER, CONFIRMED, CANCELLED)
+            UserRole.ADMIN -> this == ALL
+        }
+    }
 
     companion object {
         fun from(value: String): NotificationCategory {

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCategory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationCategory.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.notification.application.dto
 
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -16,7 +17,15 @@ enum class NotificationCategory {
     @Schema(description = "픽업 알림")
     PICKUP,
     @Schema(description = "요청 알림")
-    REQUEST;
+    REQUEST,
+    @Schema(description = "오늘 픽업 알림")
+    TODAY_PICKUP,
+    @Schema(description = "리마인더 알림")
+    REMINDER,
+    @Schema(description = "확정 알림")
+    CONFIRMED,
+    @Schema(description = "취소 알림")
+    CANCELLED;
 
     fun toNotificationTypeOrNull(): NotificationType? {
         return when (this) {
@@ -25,13 +34,38 @@ enum class NotificationCategory {
             APPLY -> NotificationType.APPLY
             PICKUP -> NotificationType.PICKUP
             REQUEST -> NotificationType.REQUEST
+            TODAY_PICKUP, REMINDER, CONFIRMED, CANCELLED -> null
         }
     }
+
+    fun ownerTriggerTypesOrNull(): Set<NotificationTriggerType>? {
+        return when (this) {
+            TODAY_PICKUP -> setOf(NotificationTriggerType.OWNER_PICKUP_SAME_DAY_MORNING)
+            REMINDER -> setOf(NotificationTriggerType.OWNER_PICKUP_DAY_BEFORE_MORNING)
+            CONFIRMED -> setOf(
+                NotificationTriggerType.OWNER_GROUPBUY_ACHIEVED_IMMEDIATE,
+                NotificationTriggerType.OWNER_OPEN_REQUEST_APPROVED_IMMEDIATE,
+                NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE
+            )
+            CANCELLED -> setOf(
+                NotificationTriggerType.OWNER_GROUPBUY_FAILED_IMMEDIATE,
+                NotificationTriggerType.OWNER_ORDER_CANCELLED_IMMEDIATE,
+                NotificationTriggerType.OWNER_OPEN_REQUEST_REJECTED_IMMEDIATE,
+                NotificationTriggerType.OWNER_CLOSE_REQUEST_REJECTED_IMMEDIATE
+            )
+            ALL, WISH, APPLY, PICKUP, REQUEST -> null
+        }
+    }
+
+    fun isOwnerFilter(): Boolean = ownerTriggerTypesOrNull() != null
 
     companion object {
         fun from(value: String): NotificationCategory {
             return entries.firstOrNull { it.name == value.uppercase() }
-                ?: throw CustomException(ErrorCode.INVALID_INPUT, "category must be one of ALL, WISH, APPLY, PICKUP, REQUEST")
+                ?: throw CustomException(
+                    ErrorCode.INVALID_INPUT,
+                    "category must be one of ALL, WISH, APPLY, PICKUP, REQUEST, TODAY_PICKUP, REMINDER, CONFIRMED, CANCELLED"
+                )
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/template/NotificationTemplateRegistry.kt
@@ -178,7 +178,7 @@ class NotificationTemplateRegistry {
         NotificationTemplateType.OWNER_ORDER_CANCELLED to NotificationTemplate(
             type = NotificationTemplateType.OWNER_ORDER_CANCELLED,
             titleTemplate = "발주가 취소됐어요.",
-            bodyTemplate = "{상품명} 발주 미확정으로 인해 발주가 취소됐어요.\n패널티가 1회 누적됐어요. (3회 누적 시 공구 개설 제한)",
+            bodyTemplate = "{상품명} 발주 미확정으로 인해 발주가 취소됐어요.",
             deeplinkType = NotificationDeeplinkType.GROUPBUY_DETAIL,
         ),
     )

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
@@ -35,6 +35,10 @@ class Notification(
     @Column(nullable = false, length = 20)
     var type: NotificationType,
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var scope: NotificationScope = NotificationScope.BUYER,
+
     @Column(nullable = false, length = 120)
     var title: String,
 

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/Notification.kt
@@ -22,7 +22,8 @@ import java.time.LocalDateTime
     indexes = [
         Index(name = "idx_notifications_user_occurred_at", columnList = "user_id,occurred_at"),
         Index(name = "idx_notifications_user_type_occurred_at", columnList = "user_id,type,occurred_at"),
-        Index(name = "idx_notifications_user_is_read_occurred_at", columnList = "user_id,is_read,occurred_at")
+        Index(name = "idx_notifications_user_is_read_occurred_at", columnList = "user_id,is_read,occurred_at"),
+        Index(name = "idx_notifications_user_scope_occurred_at", columnList = "user_id,scope,occurred_at")
     ]
 )
 class Notification(

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationScope.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationScope.kt
@@ -1,6 +1,18 @@
 package com.moongchijang.domain.notification.domain.entity
 
+import com.moongchijang.domain.user.domain.entity.UserRole
+
 enum class NotificationScope {
     BUYER,
-    OWNER,
+    OWNER;
+
+    companion object {
+        fun from(role: UserRole): NotificationScope {
+            return when (role) {
+                UserRole.BUYER -> BUYER
+                UserRole.SELLER -> OWNER
+                UserRole.ADMIN -> BUYER
+            }
+        }
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationScope.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationScope.kt
@@ -1,0 +1,6 @@
+package com.moongchijang.domain.notification.domain.entity
+
+enum class NotificationScope {
+    BUYER,
+    OWNER,
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.notification.domain.repository
 
 import com.moongchijang.domain.notification.domain.entity.Notification
+import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import org.springframework.data.jpa.repository.Modifying
@@ -16,6 +17,7 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         """
         SELECT n FROM Notification n
         WHERE n.user.id = :userId
+          AND n.scope = :scope
           AND (:type IS NULL OR n.type = :type)
           AND (
                 :cursorOccurredAt IS NULL
@@ -25,8 +27,9 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         ORDER BY n.occurredAt DESC, n.id DESC
         """
     )
-    fun findForList(
+    fun findForListByScope(
         @Param("userId") userId: Long,
+        @Param("scope") scope: NotificationScope,
         @Param("type") type: NotificationType?,
         @Param("cursorOccurredAt") cursorOccurredAt: LocalDateTime?,
         @Param("cursorId") cursorId: Long?,
@@ -37,6 +40,7 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         """
         SELECT n FROM Notification n
         WHERE n.user.id = :userId
+          AND n.scope = :scope
           AND n.triggerType IN :triggerTypes
           AND (
                 :cursorOccurredAt IS NULL
@@ -46,8 +50,9 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         ORDER BY n.occurredAt DESC, n.id DESC
         """
     )
-    fun findForListByTriggerTypes(
+    fun findForListByScopeAndTriggerTypes(
         @Param("userId") userId: Long,
+        @Param("scope") scope: NotificationScope,
         @Param("triggerTypes") triggerTypes: Collection<NotificationTriggerType>,
         @Param("cursorOccurredAt") cursorOccurredAt: LocalDateTime?,
         @Param("cursorId") cursorId: Long?,
@@ -60,18 +65,26 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
         UPDATE Notification n
         SET n.isRead = true
         WHERE n.user.id = :userId
+          AND n.scope = :scope
           AND n.isRead = false
         """
     )
-    fun markAllAsReadByUserId(@Param("userId") userId: Long): Int
+    fun markAllAsReadByUserIdAndScope(
+        @Param("userId") userId: Long,
+        @Param("scope") scope: NotificationScope,
+    ): Int
 
     @Query(
         """
         SELECT COUNT(n)
         FROM Notification n
         WHERE n.user.id = :userId
+          AND n.scope = :scope
           AND n.isRead = false
         """
     )
-    fun countUnreadByUserId(@Param("userId") userId: Long): Long
+    fun countUnreadByUserIdAndScope(
+        @Param("userId") userId: Long,
+        @Param("scope") scope: NotificationScope,
+    ): Long
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationRepository.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.notification.domain.repository
 
 import com.moongchijang.domain.notification.domain.entity.Notification
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.domain.Pageable
@@ -27,6 +28,27 @@ interface NotificationRepository : JpaRepository<Notification, Long> {
     fun findForList(
         @Param("userId") userId: Long,
         @Param("type") type: NotificationType?,
+        @Param("cursorOccurredAt") cursorOccurredAt: LocalDateTime?,
+        @Param("cursorId") cursorId: Long?,
+        pageable: Pageable
+    ): List<Notification>
+
+    @Query(
+        """
+        SELECT n FROM Notification n
+        WHERE n.user.id = :userId
+          AND n.triggerType IN :triggerTypes
+          AND (
+                :cursorOccurredAt IS NULL
+                OR n.occurredAt < :cursorOccurredAt
+                OR (n.occurredAt = :cursorOccurredAt AND n.id < :cursorId)
+          )
+        ORDER BY n.occurredAt DESC, n.id DESC
+        """
+    )
+    fun findForListByTriggerTypes(
+        @Param("userId") userId: Long,
+        @Param("triggerTypes") triggerTypes: Collection<NotificationTriggerType>,
         @Param("cursorOccurredAt") cursorOccurredAt: LocalDateTime?,
         @Param("cursorId") cursorId: Long?,
         pageable: Pageable

--- a/src/main/kotlin/com/moongchijang/domain/notification/presentation/NotificationController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/presentation/NotificationController.kt
@@ -67,6 +67,7 @@ class NotificationController(
         )
         val response = notificationQueryService.getNotifications(
             userId = userId,
+            currentRole = principal.role,
             category = NotificationCategory.from(category),
             cursor = cursor,
             limit = limit
@@ -143,7 +144,7 @@ class NotificationController(
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
         log.info("[NotificationController] 알림 전체 읽음 처리 요청 수신: userId={}", userId)
 
-        val updatedCount = notificationCommandService.markAllAsRead(userId = userId)
+        val updatedCount = notificationCommandService.markAllAsRead(userId = userId, currentRole = principal.role)
 
         log.info(
             "[NotificationController] 알림 전체 읽음 처리 응답 완료: userId={}, updatedCount={}",
@@ -171,7 +172,7 @@ class NotificationController(
         val userId = principal?.id ?: throw CustomException(ErrorCode.INVALID_LOGIN)
         log.info("[NotificationController] 미읽음 알림 개수 조회 요청 수신: userId={}", userId)
 
-        val response = notificationCommandService.getUnreadCount(userId = userId)
+        val response = notificationCommandService.getUnreadCount(userId = userId, currentRole = principal.role)
 
         log.info(
             "[NotificationController] 미읽음 알림 개수 조회 응답 완료: userId={}, count={}",

--- a/src/main/resources/db/migration/V45__alter_notifications_add_scope.sql
+++ b/src/main/resources/db/migration/V45__alter_notifications_add_scope.sql
@@ -1,0 +1,4 @@
+ALTER TABLE notifications
+    ADD COLUMN scope VARCHAR(20) NOT NULL DEFAULT 'BUYER' AFTER type;
+
+CREATE INDEX idx_notifications_user_scope_occurred_at ON notifications (user_id, scope, occurred_at DESC);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1761,15 +1761,23 @@ paths:
     get:
       tags: [Notification]
       summary: 알림 목록 조회 (폴링용)
+      description: |
+        현재 로그인 사용자의 활성 역할 기준으로 알림 목록을 조회한다.
+        - 소비자 역할(BUYER): 소비자 알림만 조회
+        - 사장님 역할(SELLER): 사장님 알림만 조회
+        - 역할에 맞지 않는 `category`를 요청하면 400 오류를 반환한다.
       security:
         - bearerAuth: []
       parameters:
         - name: category
           in: query
-          description: 알림 카테고리 필터
+          description: |
+            알림 카테고리 필터
+            - 소비자 역할: `ALL`, `WISH`, `APPLY`, `PICKUP`, `REQUEST`
+            - 사장님 역할: `ALL`, `TODAY_PICKUP`, `REMINDER`, `CONFIRMED`, `CANCELLED`
           schema:
             type: string
-            enum: [ALL, WISH, APPLY, PICKUP, REQUEST]
+            enum: [ALL, WISH, APPLY, PICKUP, REQUEST, TODAY_PICKUP, REMINDER, CONFIRMED, CANCELLED]
             default: ALL
         - name: cursor
           in: query
@@ -1803,6 +1811,7 @@ paths:
     get:
       tags: [Notification]
       summary: 미읽음 알림 개수 조회
+      description: 현재 로그인 사용자의 활성 역할 기준 scope에 해당하는 미읽음 알림 개수를 조회한다.
       security:
         - bearerAuth: []
       responses:
@@ -1819,6 +1828,7 @@ paths:
     patch:
       tags: [Notification]
       summary: 전체 알림 읽음 처리
+      description: 현재 로그인 사용자의 활성 역할 기준 scope에 해당하는 알림만 전체 읽음 처리한다.
       security:
         - bearerAuth: []
       responses:
@@ -4600,6 +4610,16 @@ components:
         12=REQUEST_NEW_PARTICIPANT_IMMEDIATE
         13=REQUEST_TARGET_ACHIEVED_IMMEDIATE
         14=REQUEST_DEADLINE_MINUS_3_DAYS
+        15=OWNER_PICKUP_SAME_DAY_MORNING
+        16=OWNER_PICKUP_DAY_BEFORE_MORNING
+        17=OWNER_GROUPBUY_ACHIEVED_IMMEDIATE
+        18=OWNER_GROUPBUY_FAILED_IMMEDIATE
+        19=OWNER_CLOSE_REQUEST_APPROVED_IMMEDIATE
+        20=OWNER_CLOSE_REQUEST_REJECTED_IMMEDIATE
+        21=OWNER_OPEN_REQUEST_APPROVED_IMMEDIATE
+        22=OWNER_OPEN_REQUEST_REJECTED_IMMEDIATE
+        23=OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE
+        24=OWNER_ORDER_CANCELLED_IMMEDIATE
       enum:
         - PICKUP_SAME_DAY_MORNING
         - PICKUP_DAY_BEFORE_MORNING
@@ -4615,6 +4635,16 @@ components:
         - REQUEST_NEW_PARTICIPANT_IMMEDIATE
         - REQUEST_TARGET_ACHIEVED_IMMEDIATE
         - REQUEST_DEADLINE_MINUS_3_DAYS
+        - OWNER_PICKUP_SAME_DAY_MORNING
+        - OWNER_PICKUP_DAY_BEFORE_MORNING
+        - OWNER_GROUPBUY_ACHIEVED_IMMEDIATE
+        - OWNER_GROUPBUY_FAILED_IMMEDIATE
+        - OWNER_CLOSE_REQUEST_APPROVED_IMMEDIATE
+        - OWNER_CLOSE_REQUEST_REJECTED_IMMEDIATE
+        - OWNER_OPEN_REQUEST_APPROVED_IMMEDIATE
+        - OWNER_OPEN_REQUEST_REJECTED_IMMEDIATE
+        - OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE
+        - OWNER_ORDER_CANCELLED_IMMEDIATE
 
     NotificationSection:
       type: string
@@ -4649,7 +4679,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/NotificationTriggerType'
           nullable: true
-          description: 알림 트리거 타입(1~14 시나리오 식별). 기존 데이터는 null일 수 있습니다.
+          description: 알림 트리거 타입(1~24 시나리오 식별). 기존 데이터는 null일 수 있습니다.
         deeplinkParams:
           type: object
           description: 딥링크 파라미터. PICKUP_GUIDE는 participationId, GROUPBUY_DETAIL/MY_APPLYING은 groupBuyId, REQUEST_STATUS는 requestId를 사용합니다.

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationCommandServiceTest.kt
@@ -2,7 +2,6 @@ package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
 import com.moongchijang.domain.user.domain.entity.UserRole
-import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.support.NotificationFixture
@@ -27,10 +26,7 @@ class NotificationCommandServiceTest {
     @Mock
     private lateinit var notificationRepository: NotificationRepository
 
-    @Mock
-    private lateinit var userRepository: UserRepository
-
-    private val service by lazy { NotificationCommandService(notificationRepository, userRepository) }
+    private val service by lazy { NotificationCommandService(notificationRepository) }
 
     @Test
     fun `같은 알림을 반복 읽음 처리할 때 멱등 동작 보장`() {
@@ -88,11 +84,10 @@ class NotificationCommandServiceTest {
 
     @Test
     fun `전체 읽음 처리를 반복 호출할 때 멱등 동작 보장`() {
-        `when`(userRepository.findByIdAndDeletedAtIsNull(4L)).thenReturn(UserFixture.createEmailUser(id = 4L))
         `when`(notificationRepository.markAllAsReadByUserIdAndScope(4L, com.moongchijang.domain.notification.domain.entity.NotificationScope.BUYER)).thenReturn(5, 0)
 
-        val firstUpdated = service.markAllAsRead(4L)
-        val secondUpdated = service.markAllAsRead(4L)
+        val firstUpdated = service.markAllAsRead(4L, UserRole.BUYER)
+        val secondUpdated = service.markAllAsRead(4L, UserRole.BUYER)
 
         assertEquals(5, firstUpdated)
         assertEquals(0, secondUpdated)
@@ -100,9 +95,6 @@ class NotificationCommandServiceTest {
 
     @Test
     fun `미읽음 개수를 조회할 때 count 반환`() {
-        `when`(userRepository.findByIdAndDeletedAtIsNull(5L)).thenReturn(
-            UserFixture.createEmailUser(id = 5L).apply { role = UserRole.SELLER }
-        )
         `when`(
             notificationRepository.countUnreadByUserIdAndScope(
                 5L,
@@ -110,7 +102,7 @@ class NotificationCommandServiceTest {
             )
         ).thenReturn(7L)
 
-        val response = service.getUnreadCount(5L)
+        val response = service.getUnreadCount(5L, UserRole.SELLER)
 
         assertEquals(7L, response.count)
         verify(notificationRepository, never()).markAllAsReadByUserIdAndScope(5L, com.moongchijang.domain.notification.domain.entity.NotificationScope.OWNER)

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationCommandServiceTest.kt
@@ -1,6 +1,8 @@
 package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.support.NotificationFixture
@@ -25,7 +27,10 @@ class NotificationCommandServiceTest {
     @Mock
     private lateinit var notificationRepository: NotificationRepository
 
-    private val service by lazy { NotificationCommandService(notificationRepository) }
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    private val service by lazy { NotificationCommandService(notificationRepository, userRepository) }
 
     @Test
     fun `같은 알림을 반복 읽음 처리할 때 멱등 동작 보장`() {
@@ -83,7 +88,8 @@ class NotificationCommandServiceTest {
 
     @Test
     fun `전체 읽음 처리를 반복 호출할 때 멱등 동작 보장`() {
-        `when`(notificationRepository.markAllAsReadByUserId(4L)).thenReturn(5, 0)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(4L)).thenReturn(UserFixture.createEmailUser(id = 4L))
+        `when`(notificationRepository.markAllAsReadByUserIdAndScope(4L, com.moongchijang.domain.notification.domain.entity.NotificationScope.BUYER)).thenReturn(5, 0)
 
         val firstUpdated = service.markAllAsRead(4L)
         val secondUpdated = service.markAllAsRead(4L)
@@ -94,11 +100,19 @@ class NotificationCommandServiceTest {
 
     @Test
     fun `미읽음 개수를 조회할 때 count 반환`() {
-        `when`(notificationRepository.countUnreadByUserId(5L)).thenReturn(7L)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(5L)).thenReturn(
+            UserFixture.createEmailUser(id = 5L).apply { role = UserRole.SELLER }
+        )
+        `when`(
+            notificationRepository.countUnreadByUserIdAndScope(
+                5L,
+                com.moongchijang.domain.notification.domain.entity.NotificationScope.OWNER
+            )
+        ).thenReturn(7L)
 
         val response = service.getUnreadCount(5L)
 
         assertEquals(7L, response.count)
-        verify(notificationRepository, never()).markAllAsReadByUserId(5L)
+        verify(notificationRepository, never()).markAllAsReadByUserIdAndScope(5L, com.moongchijang.domain.notification.domain.entity.NotificationScope.OWNER)
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -97,6 +97,129 @@ class NotificationQueryServiceTest {
     }
 
     @Test
+    fun `카테고리 TODAY_PICKUP으로 조회할 때 사장님 당일 픽업 triggerType 필터 적용`() {
+        `when`(
+            notificationRepository.findForListByTriggerTypes(
+                userId = 21L,
+                triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_SAME_DAY_MORNING),
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(emptyList())
+
+        service.getNotifications(
+            userId = 21L,
+            category = NotificationCategory.TODAY_PICKUP,
+            cursor = null,
+            limit = 20
+        )
+
+        verify(notificationRepository).findForListByTriggerTypes(
+            userId = 21L,
+            triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_SAME_DAY_MORNING),
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 21)
+        )
+    }
+
+    @Test
+    fun `카테고리 REMINDER로 조회할 때 사장님 전날 픽업 triggerType 필터 적용`() {
+        `when`(
+            notificationRepository.findForListByTriggerTypes(
+                userId = 22L,
+                triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_DAY_BEFORE_MORNING),
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(emptyList())
+
+        service.getNotifications(
+            userId = 22L,
+            category = NotificationCategory.REMINDER,
+            cursor = null,
+            limit = 20
+        )
+
+        verify(notificationRepository).findForListByTriggerTypes(
+            userId = 22L,
+            triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_DAY_BEFORE_MORNING),
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 21)
+        )
+    }
+
+    @Test
+    fun `카테고리 CONFIRMED로 조회할 때 사장님 확정 triggerType 필터 적용`() {
+        val confirmedTriggerTypes = setOf(
+            NotificationTriggerType.OWNER_GROUPBUY_ACHIEVED_IMMEDIATE,
+            NotificationTriggerType.OWNER_OPEN_REQUEST_APPROVED_IMMEDIATE,
+            NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE
+        )
+        `when`(
+            notificationRepository.findForListByTriggerTypes(
+                userId = 23L,
+                triggerTypes = confirmedTriggerTypes,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(emptyList())
+
+        service.getNotifications(
+            userId = 23L,
+            category = NotificationCategory.CONFIRMED,
+            cursor = null,
+            limit = 20
+        )
+
+        verify(notificationRepository).findForListByTriggerTypes(
+            userId = 23L,
+            triggerTypes = confirmedTriggerTypes,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 21)
+        )
+    }
+
+    @Test
+    fun `카테고리 CANCELLED로 조회할 때 사장님 취소 triggerType 필터 적용`() {
+        val cancelledTriggerTypes = setOf(
+            NotificationTriggerType.OWNER_GROUPBUY_FAILED_IMMEDIATE,
+            NotificationTriggerType.OWNER_ORDER_CANCELLED_IMMEDIATE,
+            NotificationTriggerType.OWNER_OPEN_REQUEST_REJECTED_IMMEDIATE,
+            NotificationTriggerType.OWNER_CLOSE_REQUEST_REJECTED_IMMEDIATE
+        )
+        `when`(
+            notificationRepository.findForListByTriggerTypes(
+                userId = 24L,
+                triggerTypes = cancelledTriggerTypes,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(emptyList())
+
+        service.getNotifications(
+            userId = 24L,
+            category = NotificationCategory.CANCELLED,
+            cursor = null,
+            limit = 20
+        )
+
+        verify(notificationRepository).findForListByTriggerTypes(
+            userId = 24L,
+            triggerTypes = cancelledTriggerTypes,
+            cursorOccurredAt = null,
+            cursorId = null,
+            pageable = PageRequest.of(0, 21)
+        )
+    }
+
+    @Test
     fun `커서 기반으로 조회할 때 hasNext와 nextCursor 반환`() {
         val user = UserFixture.createEmailUser(id = 3L)
         val now = LocalDateTime.now().withNano(0)

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -6,7 +6,7 @@ import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
-import com.moongchijang.domain.user.domain.repository.UserRepository
+import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.support.NotificationFixture
 import com.moongchijang.support.UserFixture
 import org.assertj.core.api.Assertions.assertThat
@@ -26,10 +26,7 @@ class NotificationQueryServiceTest {
     @Mock
     private lateinit var notificationRepository: NotificationRepository
 
-    @Mock
-    private lateinit var userRepository: UserRepository
-
-    private val service by lazy { NotificationQueryService(notificationRepository, userRepository) }
+    private val service by lazy { NotificationQueryService(notificationRepository) }
 
     @Test
     fun `카테고리 ALL로 조회할 때 type 필터 없는 목록 반환`() {
@@ -54,10 +51,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(notifications)
-        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
-
         val result = service.getNotifications(
             userId = 1L,
+            currentRole = UserRole.BUYER,
             category = NotificationCategory.ALL,
             cursor = null,
             limit = 20
@@ -88,10 +84,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
-        `when`(userRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(UserFixture.createEmailUser(id = 2L))
-
         service.getNotifications(
             userId = 2L,
+            currentRole = UserRole.BUYER,
             category = NotificationCategory.APPLY,
             cursor = null,
             limit = 20
@@ -119,12 +114,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
-        `when`(userRepository.findByIdAndDeletedAtIsNull(21L)).thenReturn(
-            UserFixture.createEmailUser(id = 21L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
-        )
-
         service.getNotifications(
             userId = 21L,
+            currentRole = UserRole.SELLER,
             category = NotificationCategory.TODAY_PICKUP,
             cursor = null,
             limit = 20
@@ -152,12 +144,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
-        `when`(userRepository.findByIdAndDeletedAtIsNull(22L)).thenReturn(
-            UserFixture.createEmailUser(id = 22L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
-        )
-
         service.getNotifications(
             userId = 22L,
+            currentRole = UserRole.SELLER,
             category = NotificationCategory.REMINDER,
             cursor = null,
             limit = 20
@@ -190,12 +179,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
-        `when`(userRepository.findByIdAndDeletedAtIsNull(23L)).thenReturn(
-            UserFixture.createEmailUser(id = 23L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
-        )
-
         service.getNotifications(
             userId = 23L,
+            currentRole = UserRole.SELLER,
             category = NotificationCategory.CONFIRMED,
             cursor = null,
             limit = 20
@@ -229,12 +215,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
-        `when`(userRepository.findByIdAndDeletedAtIsNull(24L)).thenReturn(
-            UserFixture.createEmailUser(id = 24L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
-        )
-
         service.getNotifications(
             userId = 24L,
+            currentRole = UserRole.SELLER,
             category = NotificationCategory.CANCELLED,
             cursor = null,
             limit = 20
@@ -269,10 +252,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 3)
             )
         ).thenReturn(listOf(n1, n2, n3))
-        `when`(userRepository.findByIdAndDeletedAtIsNull(3L)).thenReturn(user)
-
         val result = service.getNotifications(
             userId = 3L,
+            currentRole = UserRole.BUYER,
             category = NotificationCategory.ALL,
             cursor = cursor,
             limit = 2
@@ -313,10 +295,9 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(listOf(today, yesterday, older))
-        `when`(userRepository.findByIdAndDeletedAtIsNull(4L)).thenReturn(user)
-
         val result = service.getNotifications(
             userId = 4L,
+            currentRole = UserRole.BUYER,
             category = NotificationCategory.ALL,
             cursor = null,
             limit = 20
@@ -347,16 +328,16 @@ class NotificationQueryServiceTest {
                 pageable = PageRequest.of(0, 101)
             )
         ).thenReturn(emptyList())
-        `when`(userRepository.findByIdAndDeletedAtIsNull(5L)).thenReturn(UserFixture.createEmailUser(id = 5L))
-
         service.getNotifications(
             userId = 5L,
+            currentRole = UserRole.BUYER,
             category = NotificationCategory.ALL,
             cursor = null,
             limit = 0
         )
         service.getNotifications(
             userId = 5L,
+            currentRole = UserRole.BUYER,
             category = NotificationCategory.ALL,
             cursor = null,
             limit = 999

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -2,9 +2,11 @@ package com.moongchijang.domain.notification.application
 
 import com.moongchijang.domain.notification.application.dto.NotificationCategory
 import com.moongchijang.domain.notification.application.dto.NotificationCursor
+import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
+import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.support.NotificationFixture
 import com.moongchijang.support.UserFixture
 import org.assertj.core.api.Assertions.assertThat
@@ -24,7 +26,10 @@ class NotificationQueryServiceTest {
     @Mock
     private lateinit var notificationRepository: NotificationRepository
 
-    private val service by lazy { NotificationQueryService(notificationRepository) }
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    private val service by lazy { NotificationQueryService(notificationRepository, userRepository) }
 
     @Test
     fun `카테고리 ALL로 조회할 때 type 필터 없는 목록 반환`() {
@@ -40,14 +45,16 @@ class NotificationQueryServiceTest {
         )
 
         `when`(
-            notificationRepository.findForList(
+            notificationRepository.findForListByScope(
                 userId = 1L,
+                scope = NotificationScope.BUYER,
                 type = null,
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(notifications)
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
 
         val result = service.getNotifications(
             userId = 1L,
@@ -56,8 +63,9 @@ class NotificationQueryServiceTest {
             limit = 20
         )
 
-        verify(notificationRepository).findForList(
+        verify(notificationRepository).findForListByScope(
             userId = 1L,
+            scope = NotificationScope.BUYER,
             type = null,
             cursorOccurredAt = null,
             cursorId = null,
@@ -71,14 +79,16 @@ class NotificationQueryServiceTest {
     @Test
     fun `카테고리 APPLY로 조회할 때 APPLY type 필터 적용 검증`() {
         `when`(
-            notificationRepository.findForList(
+            notificationRepository.findForListByScope(
                 userId = 2L,
+                scope = NotificationScope.BUYER,
                 type = NotificationType.APPLY,
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
+        `when`(userRepository.findByIdAndDeletedAtIsNull(2L)).thenReturn(UserFixture.createEmailUser(id = 2L))
 
         service.getNotifications(
             userId = 2L,
@@ -87,8 +97,9 @@ class NotificationQueryServiceTest {
             limit = 20
         )
 
-        verify(notificationRepository).findForList(
+        verify(notificationRepository).findForListByScope(
             userId = 2L,
+            scope = NotificationScope.BUYER,
             type = NotificationType.APPLY,
             cursorOccurredAt = null,
             cursorId = null,
@@ -99,14 +110,18 @@ class NotificationQueryServiceTest {
     @Test
     fun `카테고리 TODAY_PICKUP으로 조회할 때 사장님 당일 픽업 triggerType 필터 적용`() {
         `when`(
-            notificationRepository.findForListByTriggerTypes(
+            notificationRepository.findForListByScopeAndTriggerTypes(
                 userId = 21L,
+                scope = NotificationScope.OWNER,
                 triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_SAME_DAY_MORNING),
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
+        `when`(userRepository.findByIdAndDeletedAtIsNull(21L)).thenReturn(
+            UserFixture.createEmailUser(id = 21L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
+        )
 
         service.getNotifications(
             userId = 21L,
@@ -115,8 +130,9 @@ class NotificationQueryServiceTest {
             limit = 20
         )
 
-        verify(notificationRepository).findForListByTriggerTypes(
+        verify(notificationRepository).findForListByScopeAndTriggerTypes(
             userId = 21L,
+            scope = NotificationScope.OWNER,
             triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_SAME_DAY_MORNING),
             cursorOccurredAt = null,
             cursorId = null,
@@ -127,14 +143,18 @@ class NotificationQueryServiceTest {
     @Test
     fun `카테고리 REMINDER로 조회할 때 사장님 전날 픽업 triggerType 필터 적용`() {
         `when`(
-            notificationRepository.findForListByTriggerTypes(
+            notificationRepository.findForListByScopeAndTriggerTypes(
                 userId = 22L,
+                scope = NotificationScope.OWNER,
                 triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_DAY_BEFORE_MORNING),
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
+        `when`(userRepository.findByIdAndDeletedAtIsNull(22L)).thenReturn(
+            UserFixture.createEmailUser(id = 22L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
+        )
 
         service.getNotifications(
             userId = 22L,
@@ -143,8 +163,9 @@ class NotificationQueryServiceTest {
             limit = 20
         )
 
-        verify(notificationRepository).findForListByTriggerTypes(
+        verify(notificationRepository).findForListByScopeAndTriggerTypes(
             userId = 22L,
+            scope = NotificationScope.OWNER,
             triggerTypes = setOf(NotificationTriggerType.OWNER_PICKUP_DAY_BEFORE_MORNING),
             cursorOccurredAt = null,
             cursorId = null,
@@ -160,14 +181,18 @@ class NotificationQueryServiceTest {
             NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE
         )
         `when`(
-            notificationRepository.findForListByTriggerTypes(
+            notificationRepository.findForListByScopeAndTriggerTypes(
                 userId = 23L,
+                scope = NotificationScope.OWNER,
                 triggerTypes = confirmedTriggerTypes,
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
+        `when`(userRepository.findByIdAndDeletedAtIsNull(23L)).thenReturn(
+            UserFixture.createEmailUser(id = 23L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
+        )
 
         service.getNotifications(
             userId = 23L,
@@ -176,8 +201,9 @@ class NotificationQueryServiceTest {
             limit = 20
         )
 
-        verify(notificationRepository).findForListByTriggerTypes(
+        verify(notificationRepository).findForListByScopeAndTriggerTypes(
             userId = 23L,
+            scope = NotificationScope.OWNER,
             triggerTypes = confirmedTriggerTypes,
             cursorOccurredAt = null,
             cursorId = null,
@@ -194,14 +220,18 @@ class NotificationQueryServiceTest {
             NotificationTriggerType.OWNER_CLOSE_REQUEST_REJECTED_IMMEDIATE
         )
         `when`(
-            notificationRepository.findForListByTriggerTypes(
+            notificationRepository.findForListByScopeAndTriggerTypes(
                 userId = 24L,
+                scope = NotificationScope.OWNER,
                 triggerTypes = cancelledTriggerTypes,
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(emptyList())
+        `when`(userRepository.findByIdAndDeletedAtIsNull(24L)).thenReturn(
+            UserFixture.createEmailUser(id = 24L).apply { role = com.moongchijang.domain.user.domain.entity.UserRole.SELLER }
+        )
 
         service.getNotifications(
             userId = 24L,
@@ -210,8 +240,9 @@ class NotificationQueryServiceTest {
             limit = 20
         )
 
-        verify(notificationRepository).findForListByTriggerTypes(
+        verify(notificationRepository).findForListByScopeAndTriggerTypes(
             userId = 24L,
+            scope = NotificationScope.OWNER,
             triggerTypes = cancelledTriggerTypes,
             cursorOccurredAt = null,
             cursorId = null,
@@ -229,14 +260,16 @@ class NotificationQueryServiceTest {
         val cursor = NotificationCursor(now, 100L).encode()
 
         `when`(
-            notificationRepository.findForList(
+            notificationRepository.findForListByScope(
                 userId = 3L,
+                scope = NotificationScope.BUYER,
                 type = null,
                 cursorOccurredAt = now,
                 cursorId = 100L,
                 pageable = PageRequest.of(0, 3)
             )
         ).thenReturn(listOf(n1, n2, n3))
+        `when`(userRepository.findByIdAndDeletedAtIsNull(3L)).thenReturn(user)
 
         val result = service.getNotifications(
             userId = 3L,
@@ -271,14 +304,16 @@ class NotificationQueryServiceTest {
         )
 
         `when`(
-            notificationRepository.findForList(
+            notificationRepository.findForListByScope(
                 userId = 4L,
+                scope = NotificationScope.BUYER,
                 type = null,
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 21)
             )
         ).thenReturn(listOf(today, yesterday, older))
+        `when`(userRepository.findByIdAndDeletedAtIsNull(4L)).thenReturn(user)
 
         val result = service.getNotifications(
             userId = 4L,
@@ -293,8 +328,9 @@ class NotificationQueryServiceTest {
     @Test
     fun `limit 범위를 벗어나 조회할 때 최소 최대 보정 적용`() {
         `when`(
-            notificationRepository.findForList(
+            notificationRepository.findForListByScope(
                 userId = 5L,
+                scope = NotificationScope.BUYER,
                 type = null,
                 cursorOccurredAt = null,
                 cursorId = null,
@@ -302,14 +338,16 @@ class NotificationQueryServiceTest {
             )
         ).thenReturn(emptyList())
         `when`(
-            notificationRepository.findForList(
+            notificationRepository.findForListByScope(
                 userId = 5L,
+                scope = NotificationScope.BUYER,
                 type = null,
                 cursorOccurredAt = null,
                 cursorId = null,
                 pageable = PageRequest.of(0, 101)
             )
         ).thenReturn(emptyList())
+        `when`(userRepository.findByIdAndDeletedAtIsNull(5L)).thenReturn(UserFixture.createEmailUser(id = 5L))
 
         service.getNotifications(
             userId = 5L,
@@ -324,15 +362,17 @@ class NotificationQueryServiceTest {
             limit = 999
         )
 
-        verify(notificationRepository).findForList(
+        verify(notificationRepository).findForListByScope(
             userId = 5L,
+            scope = NotificationScope.BUYER,
             type = null,
             cursorOccurredAt = null,
             cursorId = null,
             pageable = PageRequest.of(0, 2)
         )
-        verify(notificationRepository).findForList(
+        verify(notificationRepository).findForListByScope(
             userId = 5L,
+            scope = NotificationScope.BUYER,
             type = null,
             cursorOccurredAt = null,
             cursorId = null,

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
@@ -77,4 +77,18 @@ class NotificationTemplateRendererTest {
 
         assertTrue(rendered.body.contains("2026-05-28 10:00"))
     }
+
+    @Test
+    fun `사장님 발주 취소 템플릿 렌더링 시 패널티 문구 없이 본문 반환`() {
+        val rendered = renderer.render(
+            template = registry.getTemplateByType(NotificationTemplateType.OWNER_ORDER_CANCELLED),
+            variables = mapOf(
+                "상품명" to "소금빵"
+            )
+        )
+
+        assertEquals("발주가 취소됐어요.", rendered.title)
+        assertEquals("소금빵 발주 미확정으로 인해 발주가 취소됐어요.", rendered.body)
+        assertTrue(rendered.body.contains("발주 미확정"))
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/notification/repository/NotificationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/repository/NotificationRepositoryIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.notification.repository
 
 import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.notification.domain.repository.NotificationRepository
 import com.moongchijang.domain.user.domain.entity.AuthProvider
@@ -39,8 +40,9 @@ class NotificationRepositoryIntegrationTest {
 
         flushAndClear()
 
-        val result = notificationRepository.findForList(
+        val result = notificationRepository.findForListByScope(
             userId = user.id!!,
+            scope = NotificationScope.BUYER,
             type = null,
             cursorOccurredAt = null,
             cursorId = null,
@@ -58,8 +60,9 @@ class NotificationRepositoryIntegrationTest {
 
         flushAndClear()
 
-        val result = notificationRepository.findForList(
+        val result = notificationRepository.findForListByScope(
             userId = user.id!!,
+            scope = NotificationScope.BUYER,
             type = NotificationType.APPLY,
             cursorOccurredAt = null,
             cursorId = null,
@@ -82,8 +85,9 @@ class NotificationRepositoryIntegrationTest {
 
         flushAndClear()
 
-        val result = notificationRepository.findForList(
+        val result = notificationRepository.findForListByScope(
             userId = user.id!!,
+            scope = NotificationScope.BUYER,
             type = null,
             cursorOccurredAt = base,
             cursorId = sameTimeHighId.id,
@@ -100,7 +104,7 @@ class NotificationRepositoryIntegrationTest {
 
         flushAndClear()
 
-        val unreadCount = notificationRepository.countUnreadByUserId(user.id!!)
+        val unreadCount = notificationRepository.countUnreadByUserIdAndScope(user.id!!, NotificationScope.BUYER)
 
         assertThat(unreadCount).isEqualTo(2L)
     }
@@ -112,9 +116,9 @@ class NotificationRepositoryIntegrationTest {
 
         flushAndClear()
 
-        val updatedCount = notificationRepository.markAllAsReadByUserId(user.id!!)
+        val updatedCount = notificationRepository.markAllAsReadByUserIdAndScope(user.id!!, NotificationScope.BUYER)
         flushAndClear()
-        val unreadAfterUpdate = notificationRepository.countUnreadByUserId(user.id!!)
+        val unreadAfterUpdate = notificationRepository.countUnreadByUserIdAndScope(user.id!!, NotificationScope.BUYER)
 
         assertThat(updatedCount).isEqualTo(2)
         assertThat(unreadAfterUpdate).isEqualTo(0L)
@@ -134,9 +138,9 @@ class NotificationRepositoryIntegrationTest {
 
         flushAndClear()
 
-        val updatedCount = notificationRepository.markAllAsReadByUserId(user.id!!)
+        val updatedCount = notificationRepository.markAllAsReadByUserIdAndScope(user.id!!, NotificationScope.BUYER)
         flushAndClear()
-        val unreadAfterUpdate = notificationRepository.countUnreadByUserId(user.id!!)
+        val unreadAfterUpdate = notificationRepository.countUnreadByUserIdAndScope(user.id!!, NotificationScope.BUYER)
 
         assertThat(updatedCount).isEqualTo(BULK_NOTIFICATION_COUNT)
         assertThat(unreadAfterUpdate).isZero()

--- a/src/test/kotlin/com/moongchijang/support/NotificationFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/NotificationFixture.kt
@@ -2,6 +2,7 @@ package com.moongchijang.support
 
 import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
+import com.moongchijang.domain.notification.domain.entity.NotificationScope
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
 import com.moongchijang.domain.user.domain.entity.User
@@ -13,6 +14,7 @@ object NotificationFixture {
         user: User,
         id: Long = 0L,
         type: NotificationType = NotificationType.PICKUP,
+        scope: NotificationScope = NotificationScope.BUYER,
         title: String = "알림 제목",
         body: String = "알림 본문",
         isRead: Boolean = false,
@@ -24,6 +26,7 @@ object NotificationFixture {
         return Notification(
             user = user,
             type = type,
+            scope = scope,
             title = title,
             body = body,
             isRead = isRead,


### PR DESCRIPTION
## 📌 작업한 내용
- 알림에 역할 스코프(`BUYER` / `OWNER`)를 추가했습니다.
- 소비자/사장님 알림 발송 시 각각의 scope가 저장되도록 반영했습니다.
- 알림 목록 조회를 현재 로그인 사용자의 활성 역할 기준으로 분리했습니다.
  - 소비자 역할: 소비자 알림만 조회
  - 사장님 역할: 사장님 알림만 조회
- 사장님 알림 필터를 추가했습니다.
  - `TODAY_PICKUP`
  - `REMINDER`
  - `CONFIRMED`
  - `CANCELLED`
- 전체 읽음 처리와 미읽음 개수 조회도 현재 역할 기준 scope만 반영되도록 수정했습니다.
- 사장님 발주 취소 알림 템플릿 본문을 변경했습니다.
  - `{상품명} 발주 미확정으로 인해 발주가 취소됐어요.`
- 관련 테스트 및 OpenAPI 명세를 업데이트했습니다.

## 🔍 참고 사항
- 단건 읽음 처리는 기존처럼 `notificationId + userId` 기준으로 유지했습니다.
- 역할에 맞지 않는 알림 카테고리를 요청하면 `400 INVALID_INPUT`을 반환합니다.
- 사장님 공구 마감 요청 반려 흐름은 별도 후속 이슈에서 처리 예정입니다.
 
## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #305 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인