### PR TITLE
[MCJ-1593] FEAT: 사장님 공구 마감 요청 기타 사유 검토 흐름 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -181,8 +181,25 @@ class GroupBuy(
         closeReason = reason
         closeReasonDetail = reasonDetail
         closeRequestedAt = requestedAt
+        closeRequestReviewStatus = GroupBuyCloseRequestReviewStatus.APPROVED
+        closeRequestRejectionReason = null
+        closeReviewedAt = requestedAt
         closedByType = GroupBuyClosedByType.OWNER
         transitionToClosed()
+    }
+
+    fun requestCloseReview(
+        reason: GroupBuyCloseReason,
+        reasonDetail: String?,
+        requestedAt: LocalDateTime = LocalDateTime.now()
+    ) {
+        closeReason = reason
+        closeReasonDetail = reasonDetail
+        closeRequestedAt = requestedAt
+        closeRequestReviewStatus = GroupBuyCloseRequestReviewStatus.PENDING
+        closeRequestRejectionReason = null
+        closeReviewedAt = null
+        closedByType = null
     }
 
     fun isTerminalStatus(): Boolean {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -193,6 +193,15 @@ class GroupBuy(
         reasonDetail: String?,
         requestedAt: LocalDateTime = LocalDateTime.now()
     ) {
+        require(status == GroupBuyStatus.IN_PROGRESS || status == GroupBuyStatus.ACHIEVED) {
+            "IN_PROGRESS 또는 ACHIEVED 상태에서만 마감 요청을 할 수 있습니다."
+        }
+        require(reason == GroupBuyCloseReason.OTHER) {
+            "기타(OTHER) 사유만 검토 요청을 할 수 있습니다."
+        }
+        require(closeRequestReviewStatus != GroupBuyCloseRequestReviewStatus.PENDING) {
+            "이미 검토 대기 중인 마감 요청이 존재합니다."
+        }
         closeReason = reason
         closeReasonDetail = reasonDetail
         closeRequestedAt = requestedAt

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -85,6 +85,16 @@ class GroupBuy(
     var closeRequestedAt: LocalDateTime? = null,
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "close_request_review_status", length = 20)
+    var closeRequestReviewStatus: GroupBuyCloseRequestReviewStatus? = null,
+
+    @Column(name = "close_request_rejection_reason", length = 200)
+    var closeRequestRejectionReason: String? = null,
+
+    @Column(name = "close_reviewed_at")
+    var closeReviewedAt: LocalDateTime? = null,
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "closed_by_type", length = 20)
     var closedByType: GroupBuyClosedByType? = null,
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -202,6 +202,30 @@ class GroupBuy(
         closedByType = null
     }
 
+    fun approveCloseReview(reviewedAt: LocalDateTime = LocalDateTime.now()) {
+        require(closeRequestReviewStatus == GroupBuyCloseRequestReviewStatus.PENDING) {
+            "PENDING 상태의 마감 요청만 승인할 수 있습니다."
+        }
+        closeRequestReviewStatus = GroupBuyCloseRequestReviewStatus.APPROVED
+        closeRequestRejectionReason = null
+        closeReviewedAt = reviewedAt
+        closedByType = GroupBuyClosedByType.OWNER
+        transitionToClosed()
+    }
+
+    fun rejectCloseReview(
+        rejectionReason: String,
+        reviewedAt: LocalDateTime = LocalDateTime.now()
+    ) {
+        require(closeRequestReviewStatus == GroupBuyCloseRequestReviewStatus.PENDING) {
+            "PENDING 상태의 마감 요청만 반려할 수 있습니다."
+        }
+        closeRequestReviewStatus = GroupBuyCloseRequestReviewStatus.REJECTED
+        closeRequestRejectionReason = rejectionReason
+        closeReviewedAt = reviewedAt
+        closedByType = null
+    }
+
     fun isTerminalStatus(): Boolean {
         return status == GroupBuyStatus.COMPLETED || status == GroupBuyStatus.FAILED || status == GroupBuyStatus.CLOSED
     }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyCloseRequestReviewStatus.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyCloseRequestReviewStatus.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.groupbuy.domain.entity
+
+enum class GroupBuyCloseRequestReviewStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+}

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationEventPublisher.kt
@@ -167,6 +167,20 @@ class NotificationEventPublisher(
         )
     }
 
+    fun publishOwnerCloseRequestRejected(
+        groupBuyId: Long,
+        ownerUserIds: List<Long>,
+        occurredAt: LocalDateTime
+    ) {
+        publish(
+            triggerType = NotificationTriggerType.OWNER_CLOSE_REQUEST_REJECTED_IMMEDIATE,
+            targetId = groupBuyId,
+            userIds = ownerUserIds,
+            scheduleKey = "owner-close-rejected:$groupBuyId:$occurredAt",
+            occurredAt = occurredAt
+        )
+    }
+
     fun publishOwnerOpenRequestApproved(
         requestId: Long,
         ownerUserId: Long,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyCloseRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyCloseRequestService.kt
@@ -38,7 +38,7 @@ class AdminOwnerGroupBuyCloseRequestService(
 
         val response = AdminOwnerGroupBuyCloseRequestActionResponse(
             groupBuyId = groupBuy.id,
-            reviewStatus = groupBuy.closeRequestReviewStatus!!,
+            reviewStatus = GroupBuyCloseRequestReviewStatus.APPROVED,
             groupBuyStatus = groupBuy.status
         )
         log.info(
@@ -66,7 +66,7 @@ class AdminOwnerGroupBuyCloseRequestService(
 
         val response = AdminOwnerGroupBuyCloseRequestActionResponse(
             groupBuyId = groupBuy.id,
-            reviewStatus = groupBuy.closeRequestReviewStatus!!,
+            reviewStatus = GroupBuyCloseRequestReviewStatus.REJECTED,
             groupBuyStatus = groupBuy.status
         )
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyCloseRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyCloseRequestService.kt
@@ -1,0 +1,113 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+@Transactional
+class AdminOwnerGroupBuyCloseRequestService(
+    private val groupBuyRepository: GroupBuyRepository,
+    private val storeStaffRepository: StoreStaffRepository,
+    private val notificationEventPublisher: NotificationEventPublisher,
+    private val clock: Clock,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun approve(groupBuyId: Long): AdminOwnerGroupBuyCloseRequestActionResponse {
+        log.info("[AdminOwnerGroupBuyCloseRequestService] 사장님 공구 마감 요청 승인 시작: groupBuyId={}", groupBuyId)
+        val groupBuy = findGroupBuyForReview(groupBuyId)
+        validatePendingReview(groupBuy)
+
+        val reviewedAt = LocalDateTime.now(clock)
+        groupBuy.approveCloseReview(reviewedAt)
+        publishApproved(groupBuy, reviewedAt)
+
+        val response = AdminOwnerGroupBuyCloseRequestActionResponse(
+            groupBuyId = groupBuy.id,
+            reviewStatus = groupBuy.closeRequestReviewStatus!!,
+            groupBuyStatus = groupBuy.status
+        )
+        log.info(
+            "[AdminOwnerGroupBuyCloseRequestService] 사장님 공구 마감 요청 승인 완료: groupBuyId={}, status={}, reviewStatus={}",
+            groupBuyId,
+            groupBuy.status,
+            groupBuy.closeRequestReviewStatus
+        )
+        return response
+    }
+
+    fun reject(groupBuyId: Long, request: AdminOwnerGroupBuyCloseRequestRejectRequest): AdminOwnerGroupBuyCloseRequestActionResponse {
+        log.info("[AdminOwnerGroupBuyCloseRequestService] 사장님 공구 마감 요청 반려 시작: groupBuyId={}", groupBuyId)
+        val groupBuy = findGroupBuyForReview(groupBuyId)
+        validatePendingReview(groupBuy)
+
+        val reason = request.rejectionReason.trim()
+        if (reason.isBlank()) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED)
+        }
+
+        val reviewedAt = LocalDateTime.now(clock)
+        groupBuy.rejectCloseReview(reason, reviewedAt)
+        publishRejected(groupBuy, reviewedAt)
+
+        val response = AdminOwnerGroupBuyCloseRequestActionResponse(
+            groupBuyId = groupBuy.id,
+            reviewStatus = groupBuy.closeRequestReviewStatus!!,
+            groupBuyStatus = groupBuy.status
+        )
+        log.info(
+            "[AdminOwnerGroupBuyCloseRequestService] 사장님 공구 마감 요청 반려 완료: groupBuyId={}, status={}, reviewStatus={}",
+            groupBuyId,
+            groupBuy.status,
+            groupBuy.closeRequestReviewStatus
+        )
+        return response
+    }
+
+    private fun findGroupBuyForReview(groupBuyId: Long): GroupBuy =
+        groupBuyRepository.findWithLockById(groupBuyId)
+            .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
+
+    private fun validatePendingReview(groupBuy: GroupBuy) {
+        if (groupBuy.closeReason != GroupBuyCloseReason.OTHER ||
+            groupBuy.closeRequestReviewStatus != GroupBuyCloseRequestReviewStatus.PENDING ||
+            groupBuy.status !in listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED)
+        ) {
+            throw CustomException(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION)
+        }
+    }
+
+    private fun publishApproved(groupBuy: GroupBuy, occurredAt: LocalDateTime) {
+        val ownerUserIds = storeStaffRepository.findUserIdsByStoreId(groupBuy.store.id).distinct()
+        if (ownerUserIds.isEmpty()) return
+        notificationEventPublisher.publishOwnerCloseRequestApproved(
+            groupBuyId = groupBuy.id,
+            ownerUserIds = ownerUserIds,
+            occurredAt = occurredAt
+        )
+    }
+
+    private fun publishRejected(groupBuy: GroupBuy, occurredAt: LocalDateTime) {
+        val ownerUserIds = storeStaffRepository.findUserIdsByStoreId(groupBuy.store.id).distinct()
+        if (ownerUserIds.isEmpty()) return
+        notificationEventPublisher.publishOwnerCloseRequestRejected(
+            groupBuyId = groupBuy.id,
+            ownerUserIds = ownerUserIds,
+            occurredAt = occurredAt
+        )
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -234,24 +234,38 @@ class OwnerGroupBuyService(
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
         validateCloseReason(request)
+        val requestedAt = java.time.LocalDateTime.now(SEOUL_ZONE_ID)
+        val reason = toGroupBuyCloseReason(request.reason)
+        val reasonDetail = request.reasonDetail?.trim()?.takeIf { it.isNotBlank() }
 
-        groupBuy.closeByOwner(
-            reason = toGroupBuyCloseReason(request.reason),
-            reasonDetail = request.reasonDetail?.trim()?.takeIf { it.isNotBlank() },
-            requestedAt = java.time.LocalDateTime.now(SEOUL_ZONE_ID)
-        )
+        if (request.reason == OwnerGroupBuyCloseReasonType.OTHER) {
+            groupBuy.requestCloseReview(
+                reason = reason,
+                reasonDetail = reasonDetail,
+                requestedAt = requestedAt
+            )
+        } else {
+            groupBuy.closeByOwner(
+                reason = reason,
+                reasonDetail = reasonDetail,
+                requestedAt = requestedAt
+            )
+        }
         groupBuyRepository.save(groupBuy)
-        notificationEventPublisher.publishOwnerCloseRequestApproved(
-            groupBuyId = groupBuy.id,
-            ownerUserIds = listOf(ownerId),
-            occurredAt = java.time.LocalDateTime.now(SEOUL_ZONE_ID)
-        )
+        if (request.reason != OwnerGroupBuyCloseReasonType.OTHER) {
+            notificationEventPublisher.publishOwnerCloseRequestApproved(
+                groupBuyId = groupBuy.id,
+                ownerUserIds = listOf(ownerId),
+                occurredAt = requestedAt
+            )
+        }
         log.info(
-            "[OwnerGroupBuyService] 사장님 공구 마감 요청 완료: ownerId={}, groupBuyId={}, reason={}, reasonDetail={}",
+            "[OwnerGroupBuyService] 사장님 공구 마감 요청 완료: ownerId={}, groupBuyId={}, reason={}, reasonDetail={}, reviewStatus={}",
             ownerId,
             groupBuyId,
             request.reason,
-            request.reasonDetail
+            request.reasonDetail,
+            groupBuy.closeRequestReviewStatus
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyCloseRequestActionResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyCloseRequestActionResponse.kt
@@ -1,0 +1,17 @@
+package com.moongchijang.domain.owner.application.dto
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "운영자 사장님 공구 마감 요청 처리 응답")
+data class AdminOwnerGroupBuyCloseRequestActionResponse(
+    @field:Schema(description = "공구 ID", example = "21")
+    val groupBuyId: Long,
+
+    @field:Schema(description = "마감 요청 검토 상태", example = "APPROVED")
+    val reviewStatus: GroupBuyCloseRequestReviewStatus,
+
+    @field:Schema(description = "처리 후 공구 상태", example = "CLOSED")
+    val groupBuyStatus: GroupBuyStatus
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyCloseRequestRejectRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/AdminOwnerGroupBuyCloseRequestRejectRequest.kt
@@ -1,0 +1,13 @@
+package com.moongchijang.domain.owner.application.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "운영자 사장님 공구 마감 요청 반려 요청")
+data class AdminOwnerGroupBuyCloseRequestRejectRequest(
+    @field:NotBlank(message = "반려 사유는 필수입니다")
+    @field:Size(max = 200, message = "반려 사유는 200자 이하이어야 합니다")
+    @field:Schema(description = "반려 사유 (최대 200자)", example = "증빙 정보가 부족해 반려합니다.")
+    val rejectionReason: String
+)

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestController.kt
@@ -7,7 +7,6 @@ import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -27,9 +26,7 @@ class AdminOwnerGroupBuyCloseRequestController(
     fun approve(
         @PathVariable groupBuyId: Long
     ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyCloseRequestActionResponse>> {
-        val response = ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(ApiResponse.success(adminOwnerGroupBuyCloseRequestService.approve(groupBuyId)))
+        val response = ResponseEntity.ok(ApiResponse.success(adminOwnerGroupBuyCloseRequestService.approve(groupBuyId)))
         return response
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestController.kt
@@ -1,0 +1,45 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyCloseRequestService
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/admin/owner-group-buys")
+@Tag(name = "AdminOwnerGroupBuyCloseRequest", description = "어드민 사장님 공구 마감 요청 관리")
+class AdminOwnerGroupBuyCloseRequestController(
+    private val adminOwnerGroupBuyCloseRequestService: AdminOwnerGroupBuyCloseRequestService
+) {
+
+    @PostMapping("/{groupBuyId}/close-requests/approve")
+    @Operation(summary = "사장님 공구 마감 요청 승인")
+    fun approve(
+        @PathVariable groupBuyId: Long
+    ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyCloseRequestActionResponse>> {
+        val response = ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(ApiResponse.success(adminOwnerGroupBuyCloseRequestService.approve(groupBuyId)))
+        return response
+    }
+
+    @PostMapping("/{groupBuyId}/close-requests/reject")
+    @Operation(summary = "사장님 공구 마감 요청 반려")
+    fun reject(
+        @PathVariable groupBuyId: Long,
+        @Valid @RequestBody request: AdminOwnerGroupBuyCloseRequestRejectRequest
+    ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyCloseRequestActionResponse>> {
+        val response = ResponseEntity.ok(ApiResponse.success(adminOwnerGroupBuyCloseRequestService.reject(groupBuyId, request)))
+        return response
+    }
+}

--- a/src/main/resources/db/migration/V46__alter_group_buys_add_close_request_review_fields.sql
+++ b/src/main/resources/db/migration/V46__alter_group_buys_add_close_request_review_fields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE group_buys
+    ADD COLUMN close_request_review_status VARCHAR(20) NULL AFTER close_requested_at,
+    ADD COLUMN close_request_rejection_reason VARCHAR(200) NULL AFTER close_request_review_status,
+    ADD COLUMN close_reviewed_at DATETIME NULL AFTER close_request_rejection_reason;
+
+CREATE INDEX idx_group_buys_close_request_review_status ON group_buys (close_request_review_status);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2239,7 +2239,7 @@ paths:
             type: integer
             format: int64
       responses:
-        '201':
+        '200':
           description: 마감 요청 승인 처리 성공
           content:
             application/json:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2192,6 +2192,9 @@ paths:
     post:
       tags: [Owner]
       summary: 사장님 공구 마감 요청
+      description: |
+        사장님 공구 마감 요청을 접수한다.
+        `SOLD_OUT`, `STORE_CONDITION`은 즉시 마감 처리되며, `OTHER`는 즉시 마감되지 않고 운영자 검토 대기 상태로 저장된다.
       security:
         - bearerAuth: []
       parameters:
@@ -2210,6 +2213,76 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SuccessNoData'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/admin/owner-group-buys/{groupBuyId}/close-requests/approve:
+    post:
+      tags: [Admin]
+      summary: 사장님 공구 마감 요청 승인 (운영자)
+      description: |
+        `OTHER` 사유로 접수된 사장님 공구 마감 요청을 승인한다.
+        승인 시 공구는 실제로 CLOSED 상태로 전환되고 사장님에게 승인 알림이 발송된다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupBuyId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '201':
+          description: 마감 요청 승인 처리 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOwnerGroupBuyCloseRequestAction'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/admin/owner-group-buys/{groupBuyId}/close-requests/reject:
+    post:
+      tags: [Admin]
+      summary: 사장님 공구 마감 요청 반려 (운영자)
+      description: |
+        `OTHER` 사유로 접수된 사장님 공구 마감 요청을 반려한다.
+        반려 시 공구 상태는 유지되며 반려 사유가 저장되고 사장님에게 반려 알림이 발송된다.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: groupBuyId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminOwnerGroupBuyCloseRequestReject'
+      responses:
+        '200':
+          description: 마감 요청 반려 처리 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAdminOwnerGroupBuyCloseRequestAction'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -5072,6 +5145,11 @@ components:
       type: string
       enum: [SOLD_OUT, STORE_CONDITION, OTHER]
 
+    GroupBuyCloseRequestReviewStatus:
+      type: string
+      description: 사장님 공구 마감 요청 검토 상태
+      enum: [PENDING, APPROVED, REJECTED]
+
     OwnerGroupBuyCloseRequest:
       type: object
       required: [reason]
@@ -5084,6 +5162,42 @@ components:
           maxLength: 100
           description: reason이 OTHER일 때 필수
           example: 재고 수급 이슈로 조기 마감합니다.
+
+    AdminOwnerGroupBuyCloseRequestReject:
+      type: object
+      required: [rejectionReason]
+      properties:
+        rejectionReason:
+          type: string
+          maxLength: 200
+          description: 운영자 반려 사유
+          example: 증빙 정보가 부족해 반려합니다.
+
+    ApiResponseAdminOwnerGroupBuyCloseRequestAction:
+      type: object
+      required: [success, data, error]
+      properties:
+        success: { type: boolean, example: true }
+        data:
+          $ref: '#/components/schemas/AdminOwnerGroupBuyCloseRequestAction'
+        error: { nullable: true, example: null }
+
+    AdminOwnerGroupBuyCloseRequestAction:
+      type: object
+      required: [groupBuyId, reviewStatus, groupBuyStatus]
+      properties:
+        groupBuyId:
+          type: integer
+          format: int64
+          description: 마감 요청을 처리한 공구 ID
+          example: 21
+        reviewStatus:
+          $ref: '#/components/schemas/GroupBuyCloseRequestReviewStatus'
+        groupBuyStatus:
+          type: string
+          description: 처리 후 공구 상태
+          enum: [IN_PROGRESS, ACHIEVED, COMPLETED, FAILED, CLOSED]
+          example: CLOSED
 
     ApiResponseOwnerSettlementMonthlySummary:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTemplateRendererTest.kt
@@ -91,4 +91,32 @@ class NotificationTemplateRendererTest {
         assertEquals("소금빵 발주 미확정으로 인해 발주가 취소됐어요.", rendered.body)
         assertTrue(rendered.body.contains("발주 미확정"))
     }
+
+    @Test
+    fun `사장님 마감 요청 승인 템플릿 렌더링 시 승인 문구를 반환한다`() {
+        val rendered = renderer.render(
+            template = registry.getTemplateByType(NotificationTemplateType.OWNER_CLOSE_REQUEST_APPROVED),
+            variables = mapOf(
+                "상품명" to "소금빵"
+            )
+        )
+
+        assertEquals("마감 요청이 승인됐어요.", rendered.title)
+        assertEquals("소금빵 공구 마감 요청이 승인됐어요.", rendered.body)
+        assertEquals(NotificationDeeplinkType.GROUPBUY_DETAIL, rendered.deeplinkType)
+    }
+
+    @Test
+    fun `사장님 마감 요청 반려 템플릿 렌더링 시 반려 문구를 반환한다`() {
+        val rendered = renderer.render(
+            template = registry.getTemplateByType(NotificationTemplateType.OWNER_CLOSE_REQUEST_REJECTED),
+            variables = mapOf(
+                "상품명" to "소금빵"
+            )
+        )
+
+        assertEquals("마감 요청이 반려됐어요.", rendered.title)
+        assertEquals("소금빵 공구 마감 요청이 반려됐어요. 자세한 내용을 확인해주세요.", rendered.body)
+        assertEquals(NotificationDeeplinkType.GROUPBUY_DETAIL, rendered.deeplinkType)
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyCloseRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/AdminOwnerGroupBuyCloseRequestServiceTest.kt
@@ -1,0 +1,125 @@
+package com.moongchijang.domain.owner.application
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
+import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.support.GroupBuyFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Optional
+
+@ExtendWith(MockitoExtension::class)
+class AdminOwnerGroupBuyCloseRequestServiceTest {
+
+    @Mock
+    private lateinit var groupBuyRepository: GroupBuyRepository
+
+    @Mock
+    private lateinit var storeStaffRepository: StoreStaffRepository
+
+    @Mock
+    private lateinit var notificationEventPublisher: NotificationEventPublisher
+
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-06-03T03:00:00Z"), ZoneId.of("Asia/Seoul"))
+
+    private lateinit var service: AdminOwnerGroupBuyCloseRequestService
+
+    @BeforeEach
+    fun setUp() {
+        service = AdminOwnerGroupBuyCloseRequestService(
+            groupBuyRepository = groupBuyRepository,
+            storeStaffRepository = storeStaffRepository,
+            notificationEventPublisher = notificationEventPublisher,
+            clock = clock
+        )
+    }
+
+    @Test
+    fun `기타 사유 마감 요청을 승인하면 공구를 닫고 승인 알림을 발송한다`() {
+        val groupBuy = pendingCloseReviewGroupBuy(id = 21L, status = GroupBuyStatus.IN_PROGRESS)
+        `when`(groupBuyRepository.findWithLockById(21L)).thenReturn(Optional.of(groupBuy))
+        `when`(storeStaffRepository.findUserIdsByStoreId(groupBuy.store.id)).thenReturn(listOf(91L))
+
+        val result = service.approve(21L)
+
+        assertEquals(GroupBuyCloseRequestReviewStatus.APPROVED, result.reviewStatus)
+        assertEquals(GroupBuyStatus.CLOSED, result.groupBuyStatus)
+        assertEquals(GroupBuyStatus.CLOSED, groupBuy.status)
+        assertEquals(LocalDateTime.of(2026, 6, 3, 12, 0), groupBuy.closeReviewedAt)
+        verify(notificationEventPublisher).publishOwnerCloseRequestApproved(
+            21L,
+            listOf(91L),
+            LocalDateTime.of(2026, 6, 3, 12, 0)
+        )
+    }
+
+    @Test
+    fun `기타 사유 마감 요청을 반려하면 공구 상태는 유지하고 반려 사유를 저장한다`() {
+        val groupBuy = pendingCloseReviewGroupBuy(id = 22L, status = GroupBuyStatus.ACHIEVED)
+        `when`(groupBuyRepository.findWithLockById(22L)).thenReturn(Optional.of(groupBuy))
+        `when`(storeStaffRepository.findUserIdsByStoreId(groupBuy.store.id)).thenReturn(listOf(91L))
+
+        val result = service.reject(22L, AdminOwnerGroupBuyCloseRequestRejectRequest("  사유가 불충분합니다  "))
+
+        assertEquals(GroupBuyCloseRequestReviewStatus.REJECTED, result.reviewStatus)
+        assertEquals(GroupBuyStatus.ACHIEVED, result.groupBuyStatus)
+        assertEquals(GroupBuyStatus.ACHIEVED, groupBuy.status)
+        assertEquals("사유가 불충분합니다", groupBuy.closeRequestRejectionReason)
+        assertEquals(LocalDateTime.of(2026, 6, 3, 12, 0), groupBuy.closeReviewedAt)
+        assertNull(groupBuy.closedByType)
+        verify(notificationEventPublisher).publishOwnerCloseRequestRejected(
+            22L,
+            listOf(91L),
+            LocalDateTime.of(2026, 6, 3, 12, 0)
+        )
+    }
+
+    @Test
+    fun `검토 대기 상태가 아니면 승인할 수 없다`() {
+        val groupBuy = pendingCloseReviewGroupBuy(id = 23L, status = GroupBuyStatus.IN_PROGRESS).apply {
+            closeRequestReviewStatus = GroupBuyCloseRequestReviewStatus.REJECTED
+        }
+        `when`(groupBuyRepository.findWithLockById(23L)).thenReturn(Optional.of(groupBuy))
+
+        val ex = assertThrows<CustomException> {
+            service.approve(23L)
+        }
+
+        assertEquals(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION, ex.errorCode)
+        verify(notificationEventPublisher, never()).publishOwnerCloseRequestApproved(23L, listOf(91L), LocalDateTime.of(2026, 6, 3, 12, 0))
+    }
+
+    private fun pendingCloseReviewGroupBuy(
+        id: Long,
+        status: GroupBuyStatus
+    ) = GroupBuyFixture.createGroupBuy(
+        id = id,
+        status = status,
+        deadline = LocalDateTime.of(2026, 6, 5, 23, 59),
+    ).apply {
+        store.id = 301L
+        closeReason = GroupBuyCloseReason.OTHER
+        closeReasonDetail = "운영 사정으로 검토 요청"
+        closeRequestedAt = LocalDateTime.of(2026, 6, 3, 9, 0)
+        closeRequestReviewStatus = GroupBuyCloseRequestReviewStatus.PENDING
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.owner.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyClosedByType
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
@@ -314,8 +315,14 @@ class OwnerGroupBuyServiceTest {
         assertEquals(GroupBuyStatus.CLOSED, groupBuy.status)
         assertEquals(GroupBuyCloseReason.STORE_CONDITION, groupBuy.closeReason)
         assertEquals(GroupBuyClosedByType.OWNER, groupBuy.closedByType)
+        assertEquals(GroupBuyCloseRequestReviewStatus.APPROVED, groupBuy.closeRequestReviewStatus)
         assertNull(groupBuy.closeReasonDetail)
         verify(groupBuyRepository).save(groupBuy)
+        verify(notificationEventPublisher).publishOwnerCloseRequestApproved(
+            groupBuyId = groupBuy.id,
+            ownerUserIds = listOf(owner.id!!),
+            occurredAt = groupBuy.closeReviewedAt!!
+        )
     }
 
     @Test
@@ -342,6 +349,41 @@ class OwnerGroupBuyServiceTest {
         }
 
         assertEquals(ErrorCode.INVALID_INPUT, ex.errorCode)
+    }
+
+    @Test
+    fun `사장님 공구 마감 요청에서 기타 사유는 검토 대기로 전환한다`() {
+        val owner = seller()
+        val groupBuy = groupBuy(
+            id = 14L,
+            status = GroupBuyStatus.IN_PROGRESS,
+            currentQuantity = 12,
+            targetQuantity = 20,
+            price = 9900
+        )
+        val request = OwnerGroupBuyCloseRequest(
+            reason = OwnerGroupBuyCloseReasonType.OTHER,
+            reasonDetail = "운영 사정으로 검토가 필요합니다."
+        )
+
+        `when`(userRepository.findByIdAndDeletedAtIsNull(owner.id!!)).thenReturn(owner)
+        `when`(storeStaffRepository.findStoreIdsByUserId(owner.id!!)).thenReturn(listOf(1L))
+        `when`(groupBuyRepository.findWithStoreById(groupBuy.id)).thenReturn(Optional.of(groupBuy))
+
+        service.requestGroupBuyClose(owner.id!!, groupBuy.id, request)
+
+        assertEquals(GroupBuyStatus.IN_PROGRESS, groupBuy.status)
+        assertEquals(GroupBuyCloseReason.OTHER, groupBuy.closeReason)
+        assertEquals("운영 사정으로 검토가 필요합니다.", groupBuy.closeReasonDetail)
+        assertEquals(GroupBuyCloseRequestReviewStatus.PENDING, groupBuy.closeRequestReviewStatus)
+        assertNull(groupBuy.closedByType)
+        assertNull(groupBuy.closeReviewedAt)
+        verify(groupBuyRepository).save(groupBuy)
+        verify(notificationEventPublisher, never()).publishOwnerCloseRequestApproved(
+            groupBuyId = groupBuy.id,
+            ownerUserIds = listOf(owner.id!!),
+            occurredAt = groupBuy.closeRequestedAt!!
+        )
     }
 
     private fun seller() = UserFixture.createKakaoUser(id = 1L).apply {

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestControllerTest.kt
@@ -18,7 +18,7 @@ class AdminOwnerGroupBuyCloseRequestControllerTest {
     private val controller = AdminOwnerGroupBuyCloseRequestController(service)
 
     @Test
-    fun `사장님 공구 마감 요청 승인 시 201과 CLOSED 상태를 반환한다`() {
+    fun `사장님 공구 마감 요청 승인 시 200과 CLOSED 상태를 반환한다`() {
         val response = AdminOwnerGroupBuyCloseRequestActionResponse(
             groupBuyId = 21L,
             reviewStatus = GroupBuyCloseRequestReviewStatus.APPROVED,
@@ -28,7 +28,7 @@ class AdminOwnerGroupBuyCloseRequestControllerTest {
 
         val result = controller.approve(21L)
 
-        assertEquals(HttpStatus.CREATED, result.statusCode)
+        assertEquals(HttpStatus.OK, result.statusCode)
         assertEquals(response, result.body?.data)
         verify(service).approve(21L)
     }

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/AdminOwnerGroupBuyCloseRequestControllerTest.kt
@@ -1,0 +1,52 @@
+package com.moongchijang.domain.owner.presentation
+
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyCloseRequestService
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
+import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.http.HttpStatus
+
+class AdminOwnerGroupBuyCloseRequestControllerTest {
+
+    private val service: AdminOwnerGroupBuyCloseRequestService = mock(AdminOwnerGroupBuyCloseRequestService::class.java)
+    private val controller = AdminOwnerGroupBuyCloseRequestController(service)
+
+    @Test
+    fun `사장님 공구 마감 요청 승인 시 201과 CLOSED 상태를 반환한다`() {
+        val response = AdminOwnerGroupBuyCloseRequestActionResponse(
+            groupBuyId = 21L,
+            reviewStatus = GroupBuyCloseRequestReviewStatus.APPROVED,
+            groupBuyStatus = GroupBuyStatus.CLOSED
+        )
+        `when`(service.approve(21L)).thenReturn(response)
+
+        val result = controller.approve(21L)
+
+        assertEquals(HttpStatus.CREATED, result.statusCode)
+        assertEquals(response, result.body?.data)
+        verify(service).approve(21L)
+    }
+
+    @Test
+    fun `사장님 공구 마감 요청 반려 시 REJECTED 상태를 반환한다`() {
+        val request = AdminOwnerGroupBuyCloseRequestRejectRequest("사유가 불충분합니다")
+        val response = AdminOwnerGroupBuyCloseRequestActionResponse(
+            groupBuyId = 22L,
+            reviewStatus = GroupBuyCloseRequestReviewStatus.REJECTED,
+            groupBuyStatus = GroupBuyStatus.ACHIEVED
+        )
+        `when`(service.reject(22L, request)).thenReturn(response)
+
+        val result = controller.reject(22L, request)
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(response, result.body?.data)
+        verify(service).reject(22L, request)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 공구 마감 요청에 `기타(OTHER)` 사유 분기 처리를 추가했습니다.
- `기타` 사유 요청은 즉시 마감하지 않고, 검토 대기 상태로 저장되도록 변경했습니다.
- 공구 마감 요청 검토 상태 저장 필드를 추가했습니다.
  - `closeRequestReviewStatus`
  - `closeRequestRejectionReason`
  - `closeReviewedAt`
- 운영자 마감 요청 승인/반려 처리 API 및 서비스 로직을 추가했습니다.
  - `POST /api/v1/admin/owner-group-buys/{groupBuyId}/close-requests/approve`
  - `POST /api/v1/admin/owner-group-buys/{groupBuyId}/close-requests/reject`
- 운영자 승인 시 공구를 실제로 마감 처리하도록 연결했습니다.
- 운영자 반려 시 공구 상태는 유지하고 반려 사유를 저장하도록 반영했습니다.
- 사장님 마감 요청 승인/반려 알림 발송을 연결했습니다.
- 관련 DTO를 분리하고 스키마 설명을 추가했습니다.
- 관련 테스트와 OpenAPI 명세를 업데이트했습니다.

## 🔍 참고 사항
- `SOLD_OUT`, `STORE_CONDITION` 등 기존 사유는 기존처럼 즉시 마감 처리됩니다.
- `OTHER`만 운영자 검토 대상으로 분기됩니다.
- 승인/반려 알림은 기존 사장님 알림 템플릿을 재사용하며, `targetId`는 `groupBuyId`, 딥링크는 `GROUPBUY_DETAIL` 기준으로 연결됩니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #306 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인