### PR TITLE
[MCJ-1597] FIX: 사장님 공구 관리 목록 식별자 필드 정합성 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -147,7 +147,7 @@ class OwnerGroupBuyService(
                     .findByOwnerIdAndStoreIdInAndStatusOrderByCreatedAtDesc(ownerId, storeIds, OwnerGroupBuyRequestStatus.PENDING)
                     .map {
                         OwnerGroupBuyManageListItemResponse(
-                            groupBuyId = it.id,
+                            requestId = it.id,
                             productName = it.productName,
                             price = it.price,
                             pickupDate = it.pickupDate,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageListItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageListItemResponse.kt
@@ -5,8 +5,11 @@ import java.time.LocalDate
 
 @Schema(description = "사장님 공구 관리 목록 아이템 응답")
 data class OwnerGroupBuyManageListItemResponse(
-    @field:Schema(description = "공구 ID", example = "101")
-    val groupBuyId: Long,
+    @field:Schema(description = "공구 ID (실제 공구 항목일 때만 값 존재)", example = "101", nullable = true)
+    val groupBuyId: Long? = null,
+
+    @field:Schema(description = "공구 개설 요청 ID (승인대기 항목일 때만 값 존재)", example = "55", nullable = true)
+    val requestId: Long? = null,
 
     @field:Schema(description = "공구명", example = "두쫀쿠 세트")
     val productName: String,

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -5071,9 +5071,20 @@ components:
 
     OwnerGroupBuyManageListItem:
       type: object
-      required: [groupBuyId, productName, price, pickupDate, status]
+      required: [productName, price, pickupDate, status]
       properties:
-        groupBuyId: { type: integer, format: int64, example: 101 }
+        groupBuyId:
+          type: integer
+          format: int64
+          nullable: true
+          description: 실제 공구 항목일 때 사용하는 공구 ID. PENDING_APPROVAL 항목에서는 null
+          example: 101
+        requestId:
+          type: integer
+          format: int64
+          nullable: true
+          description: 승인대기(PENDING_APPROVAL) 항목일 때 사용하는 공구 개설 요청 ID. 실제 공구 항목에서는 null
+          example: 55
         productName: { type: string, example: 두쫀쿠 세트 }
         price: { type: integer, example: 9900 }
         pickupDate: { type: string, format: date, example: "2026-06-01" }

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyServiceTest.kt
@@ -12,6 +12,7 @@ import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyExtensionReque
 import com.moongchijang.domain.owner.application.dto.OwnerGroupBuyManageFilterType
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepository
+import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
@@ -221,6 +222,24 @@ class OwnerGroupBuyServiceTest {
     fun `사장님 공구 관리 승인대기 목록 조회`() {
         val owner = seller()
         val storeIds = listOf(1L)
+        val pendingRequest = OwnerGroupBuyRequest(
+            owner = owner,
+            store = groupBuy(id = 999L, status = GroupBuyStatus.IN_PROGRESS, currentQuantity = 1, targetQuantity = 10, price = 1000).store,
+            productName = "승인대기 공구",
+            productDescription = "설명",
+            price = 9900,
+            targetQuantity = 20,
+            maxQuantity = 30,
+            thumbnailKey = "owner-thumb.jpg",
+            deadline = LocalDateTime.of(2026, 6, 10, 18, 0),
+            pickupDate = LocalDate.of(2026, 6, 12),
+            pickupTimeStart = java.time.LocalTime.of(12, 0),
+            pickupTimeEnd = java.time.LocalTime.of(18, 0),
+            pickupLocation = "서울 성동구"
+        ).apply {
+            id = 55L
+            status = OwnerGroupBuyRequestStatus.PENDING
+        }
         mockSellerAndStoreIds(owner.id!!, owner, storeIds)
         `when`(
             ownerGroupBuyRequestRepository.findByOwnerIdAndStoreIdInAndStatusOrderByCreatedAtDesc(
@@ -228,11 +247,14 @@ class OwnerGroupBuyServiceTest {
                 storeIds,
                 OwnerGroupBuyRequestStatus.PENDING
             )
-        ).thenReturn(emptyList())
+        ).thenReturn(listOf(pendingRequest))
 
         val result = service.getManageGroupBuys(owner.id!!, OwnerGroupBuyManageFilterType.PENDING_APPROVAL)
 
-        assertEquals(0, result.size)
+        assertEquals(1, result.size)
+        assertNull(result[0].groupBuyId)
+        assertEquals(55L, result[0].requestId)
+        assertEquals(OwnerGroupBuyManageFilterType.PENDING_APPROVAL, result[0].status)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -101,6 +101,27 @@ class OwnerGroupBuyControllerTest {
     }
 
     @Test
+    fun `사장님 공구 관리 승인대기 목록은 requestId를 포함한다`() {
+        val principal = CustomUserPrincipal(id = 1L, email = "seller@example.com", role = UserRole.SELLER)
+        val response = listOf(
+            OwnerGroupBuyManageListItemResponse(
+                requestId = 55L,
+                productName = "승인대기 공구",
+                price = 9900,
+                pickupDate = LocalDate.of(2026, 6, 12),
+                status = OwnerGroupBuyManageFilterType.PENDING_APPROVAL
+            )
+        )
+        `when`(ownerGroupBuyService.getManageGroupBuys(1L, OwnerGroupBuyManageFilterType.PENDING_APPROVAL)).thenReturn(response)
+
+        val result = controller.getManageGroupBuys(principal, OwnerGroupBuyManageFilterType.PENDING_APPROVAL)
+
+        assertEquals(55L, result.body?.data?.first()?.requestId)
+        assertNull(result.body?.data?.first()?.groupBuyId)
+        verify(ownerGroupBuyService).getManageGroupBuys(1L, OwnerGroupBuyManageFilterType.PENDING_APPROVAL)
+    }
+
+    @Test
     fun `사장님 모집중 공구 상세를 조회한다`() {
         val principal = CustomUserPrincipal(id = 1L, email = "seller@example.com", role = UserRole.SELLER)
         val response = OwnerGroupBuyManageDetailResponse(


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 공구 관리 목록 응답의 식별자 필드를 분리했습니다.
- `OwnerGroupBuyManageListItemResponse`에 `requestId` 필드를 추가했습니다.
- `groupBuyId`는 실제 공구 항목일 때만 사용하도록 nullable로 조정했습니다.
- 승인대기(`PENDING_APPROVAL`) 항목에서는 `requestId`만 전달하도록 서비스 매핑을 수정했습니다.
- 실제 공구 항목에서는 기존처럼 `groupBuyId`를 전달하도록 유지했습니다.
- 관련 서비스/컨트롤러 테스트를 보강했습니다.
- OpenAPI 명세에 `groupBuyId` / `requestId` 필드 사용 기준을 반영했습니다.

## 🔍 참고 사항
- 승인대기 항목 상세 조회 시에는 `requestId`를 사용해야 합니다.
- 실제 공구 상세/관리 조회 시에는 `groupBuyId`를 사용해야 합니다.
- 기존처럼 승인대기 항목에서 `groupBuyId`에 request id를 담아 전달하는 동작은 제거되었습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #314 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인