### PR TITLE
[MCJ-1596] feat: 검색 보정 fallback 추가

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -8,6 +8,7 @@ import com.moongchijang.domain.search.application.dto.SearchCase
 import com.moongchijang.domain.search.application.dto.SearchResponse
 import com.moongchijang.domain.search.domain.SearchUiState
 import com.moongchijang.global.util.S3ImageReferenceResolver
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -19,14 +20,18 @@ import java.time.LocalDateTime
  *
  * 1차: strict AND 쿼리(`+token*`)로 정확 매칭 우선.
  * 2차: 1차에서 양쪽 인덱스 모두 0건이면 fallback OR 쿼리로 재조회. 합성어/부분 매칭 케이스를 잡는다.
+ * 3차: 1·2차 모두 0건이면 correction dictionary 로 보정한 검색어를 한 번 더 조회한다.
  *
- * 1·2차 모두 0건이거나 사용자 입력이 빈 토큰뿐이면 [emptyResponse] 를 반환한다.
+ * 모든 단계가 0건이거나 사용자 입력이 빈 토큰뿐이면 [emptyResponse] 를 반환한다.
  */
 @Component
 class FullTextSearchEngine(
     private val groupBuyRepository: GroupBuyRepository,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
+    private val searchCorrectionService: SearchCorrectionService,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
         private const val DEFAULT_LIMIT = 50
         private const val CONFIDENCE_BOTH = 1.0
@@ -35,8 +40,30 @@ class FullTextSearchEngine(
     }
 
     fun search(query: String): SearchResponse {
+        val startedAt = System.nanoTime()
         val now = LocalDateTime.now()
+        val response = searchByFullText(query, now)
+        if (response.totalCount > 0) {
+            return response
+        }
 
+        val correctedQuery = searchCorrectionService.correct(query)
+            ?.takeIf { it != SearchQueryNormalizer.normalize(query) }
+            ?: return response.also { logEmptyResult(query, correctedQuery = null, startedAt = startedAt) }
+
+        val correctedResponse = searchByFullText(correctedQuery, now)
+        log.info(
+            "search_correction fallback=true originalQuery={} normalizedQuery={} correctedQuery={} resultCount={} latencyMs={}",
+            query,
+            SearchQueryNormalizer.normalize(query),
+            correctedQuery,
+            correctedResponse.totalCount,
+            elapsedMillis(startedAt)
+        )
+        return correctedResponse
+    }
+
+    private fun searchByFullText(query: String, now: LocalDateTime): SearchResponse {
         val (strictQuery, fallbackQuery) = FullTextQueryBuilder.buildQueries(query)
         if (strictQuery.isEmpty()) {
             return emptyResponse()
@@ -114,6 +141,19 @@ class FullTextSearchEngine(
         productHit || storeHit -> CONFIDENCE_SINGLE
         else -> CONFIDENCE_NONE
     }
+
+    private fun logEmptyResult(query: String, correctedQuery: String?, startedAt: Long) {
+        log.info(
+            "search_correction fallback=false originalQuery={} normalizedQuery={} correctedQuery={} resultCount=0 latencyMs={}",
+            query,
+            SearchQueryNormalizer.normalize(query),
+            correctedQuery,
+            elapsedMillis(startedAt)
+        )
+    }
+
+    private fun elapsedMillis(startedAt: Long): Long =
+        (System.nanoTime() - startedAt) / 1_000_000
 
     private fun emptyResponse() = SearchResponse(
         searchCase = SearchCase.NONE_DETECTED,

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -47,15 +47,23 @@ class FullTextSearchEngine(
             return response
         }
 
+        val normalizedQuery = SearchQueryNormalizer.normalize(query)
         val correctedQuery = searchCorrectionService.correct(query)
-            ?.takeIf { it != SearchQueryNormalizer.normalize(query) }
-            ?: return response.also { logEmptyResult(query, correctedQuery = null, startedAt = startedAt) }
+            ?.takeIf { it != normalizedQuery }
+            ?: return response.also {
+                logEmptyResult(
+                    query = query,
+                    normalizedQuery = normalizedQuery,
+                    correctedQuery = null,
+                    startedAt = startedAt,
+                )
+            }
 
         val correctedResponse = searchByFullText(correctedQuery, now)
         log.info(
             "search_correction fallback=true originalQuery={} normalizedQuery={} correctedQuery={} resultCount={} latencyMs={}",
             query,
-            SearchQueryNormalizer.normalize(query),
+            normalizedQuery,
             correctedQuery,
             correctedResponse.totalCount,
             elapsedMillis(startedAt)
@@ -142,11 +150,16 @@ class FullTextSearchEngine(
         else -> CONFIDENCE_NONE
     }
 
-    private fun logEmptyResult(query: String, correctedQuery: String?, startedAt: Long) {
+    private fun logEmptyResult(
+        query: String,
+        normalizedQuery: String,
+        correctedQuery: String?,
+        startedAt: Long,
+    ) {
         log.info(
             "search_correction fallback=false originalQuery={} normalizedQuery={} correctedQuery={} resultCount=0 latencyMs={}",
             query,
-            SearchQueryNormalizer.normalize(query),
+            normalizedQuery,
             correctedQuery,
             elapsedMillis(startedAt)
         )

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
@@ -2,23 +2,19 @@ package com.moongchijang.domain.search.application
 
 import com.moongchijang.domain.search.domain.repository.SearchCorrectionRepository
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SearchCorrectionService(
     private val searchCorrectionRepository: SearchCorrectionRepository,
 ) {
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional(readOnly = true)
     fun correct(query: String): String? {
         val normalized = SearchQueryNormalizer.normalize(query)
         if (normalized.isBlank()) {
             return null
         }
 
-        val correction = searchCorrectionRepository.findBySourceKeywordAndEnabledTrue(normalized)
-            ?: return null
-        correction.recordHit()
-        return correction.targetKeyword
+        return searchCorrectionRepository.findBySourceKeywordAndEnabledTrue(normalized)?.targetKeyword
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
@@ -1,0 +1,24 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.domain.repository.SearchCorrectionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SearchCorrectionService(
+    private val searchCorrectionRepository: SearchCorrectionRepository,
+) {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun correct(query: String): String? {
+        val normalized = SearchQueryNormalizer.normalize(query)
+        if (normalized.isBlank()) {
+            return null
+        }
+
+        val correction = searchCorrectionRepository.findBySourceKeywordAndEnabledTrue(normalized)
+            ?: return null
+        correction.recordHit()
+        return correction.targetKeyword
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchQueryNormalizer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchQueryNormalizer.kt
@@ -1,0 +1,12 @@
+package com.moongchijang.domain.search.application
+
+object SearchQueryNormalizer {
+    private val SEPARATORS = Regex("""[\s\-_]+""")
+    private val SPECIAL_CHARS = Regex("""[^\p{L}\p{N}]""")
+
+    fun normalize(query: String): String =
+        query.trim()
+            .replace(SEPARATORS, "")
+            .replace(SPECIAL_CHARS, "")
+            .lowercase()
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchQueryNormalizer.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchQueryNormalizer.kt
@@ -1,12 +1,10 @@
 package com.moongchijang.domain.search.application
 
 object SearchQueryNormalizer {
-    private val SEPARATORS = Regex("""[\s\-_]+""")
     private val SPECIAL_CHARS = Regex("""[^\p{L}\p{N}]""")
 
     fun normalize(query: String): String =
         query.trim()
-            .replace(SEPARATORS, "")
             .replace(SPECIAL_CHARS, "")
             .lowercase()
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/domain/SearchCorrection.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/domain/SearchCorrection.kt
@@ -1,0 +1,48 @@
+package com.moongchijang.domain.search.domain
+
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "search_corrections",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_search_corrections_source_keyword",
+            columnNames = ["source_keyword"]
+        )
+    ]
+)
+class SearchCorrection(
+    @Column(name = "source_keyword", nullable = false, length = 100)
+    val sourceKeyword: String,
+
+    @Column(name = "target_keyword", nullable = false, length = 100)
+    val targetKeyword: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    val type: SearchCorrectionType,
+
+    @Column(nullable = false)
+    var enabled: Boolean = true,
+
+    @Column(name = "hit_count", nullable = false)
+    var hitCount: Long = 0L,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L,
+) : BaseEntity() {
+    fun recordHit() {
+        hitCount += 1
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/domain/SearchCorrectionType.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/domain/SearchCorrectionType.kt
@@ -1,0 +1,7 @@
+package com.moongchijang.domain.search.domain
+
+enum class SearchCorrectionType {
+    TYPO,
+    ALIAS,
+    SYNONYM,
+}

--- a/src/main/kotlin/com/moongchijang/domain/search/domain/repository/SearchCorrectionRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/domain/repository/SearchCorrectionRepository.kt
@@ -1,0 +1,8 @@
+package com.moongchijang.domain.search.domain.repository
+
+import com.moongchijang.domain.search.domain.SearchCorrection
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SearchCorrectionRepository : JpaRepository<SearchCorrection, Long> {
+    fun findBySourceKeywordAndEnabledTrue(sourceKeyword: String): SearchCorrection?
+}

--- a/src/main/resources/db/migration/V40__create_search_corrections_table.sql
+++ b/src/main/resources/db/migration/V40__create_search_corrections_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE search_corrections
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    source_keyword VARCHAR(100) NOT NULL,
+    target_keyword VARCHAR(100) NOT NULL,
+    type           VARCHAR(20)  NOT NULL,
+    enabled        BOOLEAN      NOT NULL DEFAULT TRUE,
+    hit_count      BIGINT       NOT NULL DEFAULT 0,
+    created_at     DATETIME     NOT NULL,
+    updated_at     DATETIME     NOT NULL,
+    CONSTRAINT uk_search_corrections_source_keyword UNIQUE (source_keyword)
+);
+
+INSERT INTO search_corrections (source_keyword, target_keyword, type, enabled, hit_count, created_at, updated_at)
+VALUES ('카래', '카레', 'TYPO', TRUE, 0, NOW(), NOW()),
+       ('소굼빵', '소금빵', 'TYPO', TRUE, 0, NOW(), NOW()),
+       ('시오빵', '소금빵', 'ALIAS', TRUE, 0, NOW(), NOW()),
+       ('부대찌게', '부대찌개', 'TYPO', TRUE, 0, NOW(), NOW()),
+       ('떡복이', '떡볶이', 'TYPO', TRUE, 0, NOW(), NOW());

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -20,7 +20,8 @@ class FullTextSearchEngineTest {
 
     private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
     private val s3ImageReferenceResolver: S3ImageReferenceResolver = Mockito.mock(S3ImageReferenceResolver::class.java)
-    private val engine = FullTextSearchEngine(groupBuyRepository, s3ImageReferenceResolver)
+    private val searchCorrectionService: SearchCorrectionService = Mockito.mock(SearchCorrectionService::class.java)
+    private val engine = FullTextSearchEngine(groupBuyRepository, s3ImageReferenceResolver, searchCorrectionService)
 
     private fun stubProductIds(vararg sequentialReturns: List<Long>) {
         val stubbing = Mockito.`when`(
@@ -70,6 +71,7 @@ class FullTextSearchEngineTest {
         assertThat(response.confidence).isEqualTo(0.5)
         assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
         assertThat(response.results.map { it.id }).containsExactly(10L)
+        Mockito.verifyNoInteractions(searchCorrectionService)
     }
 
     @Test
@@ -88,6 +90,7 @@ class FullTextSearchEngineTest {
         assertThat(response.confidence).isEqualTo(0.5)
         assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
         assertThat(response.results.map { it.id }).containsExactly(20L)
+        Mockito.verifyNoInteractions(searchCorrectionService)
     }
 
     @Test
@@ -117,6 +120,7 @@ class FullTextSearchEngineTest {
         assertThat(response.totalCount).isEqualTo(2)
         // deadline ASC 정렬 검증 (saltBread = +1일, seongsuBagel = +2일)
         assertThat(response.results.map { it.id }).containsExactly(10L, 20L)
+        Mockito.verifyNoInteractions(searchCorrectionService)
     }
 
     @Test
@@ -184,5 +188,44 @@ class FullTextSearchEngineTest {
             .searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
         Mockito.verify(groupBuyRepository, Mockito.times(2))
             .searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        Mockito.verifyNoInteractions(searchCorrectionService)
+    }
+
+    @Test
+    @DisplayName("strict/fallback 검색 결과가 0건이면 보정어로 한 번 더 FULLTEXT 검색한다")
+    fun `empty first pass searches once more with corrected query`() {
+        val groupBuy = SearchTestFixtures.groupBuy(id = 30L, productName = "카레라면")
+        stubProductIds(emptyList(), emptyList(), listOf(30L))
+        stubStoreIds(emptyList(), emptyList(), emptyList())
+        Mockito.`when`(searchCorrectionService.correct("카래")).thenReturn("카레")
+        stubFetch(listOf(groupBuy))
+
+        val response = engine.search("카래")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.RESULTS)
+        assertThat(response.searchCase).isEqualTo(SearchCase.PRODUCT_ONLY)
+        assertThat(response.detectedProduct).isEqualTo("카레")
+        assertThat(response.totalCount).isEqualTo(1)
+        assertThat(response.results.map { it.productName }).containsExactly("카레라면")
+        Mockito.verify(searchCorrectionService).correct("카래")
+        Mockito.verify(groupBuyRepository, Mockito.times(3))
+            .searchProductIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+        Mockito.verify(groupBuyRepository, Mockito.times(3))
+            .searchStoreIdsByFullText(anyString(), anyString(), anyLocalDateTime(), anyInt())
+    }
+
+    @Test
+    @DisplayName("보정어가 없으면 EMPTY_CAN_REQUEST 응답을 그대로 반환한다")
+    fun `empty first pass without correction remains empty`() {
+        stubProductIds(emptyList(), emptyList())
+        stubStoreIds(emptyList(), emptyList())
+        Mockito.`when`(searchCorrectionService.correct("없는상품")).thenReturn(null)
+
+        val response = engine.search("없는상품")
+
+        assertThat(response.uiState).isEqualTo(SearchUiState.EMPTY_CAN_REQUEST)
+        assertThat(response.totalCount).isZero
+        Mockito.verify(searchCorrectionService).correct("없는상품")
+        Mockito.verify(groupBuyRepository, Mockito.never()).findAllWithStoreByIdIn(anyLongList())
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
@@ -13,8 +13,8 @@ class SearchCorrectionServiceTest {
     private val service = SearchCorrectionService(searchCorrectionRepository)
 
     @Test
-    @DisplayName("검색어를 정규화한 뒤 보정 사전을 조회하고 hit count를 증가시킨다")
-    fun `correct normalizes source keyword and records hit`() {
+    @DisplayName("검색어를 정규화한 뒤 보정 사전을 조회하고 target keyword를 반환한다")
+    fun `correct normalizes source keyword and returns target keyword`() {
         val correction = SearchCorrection(
             sourceKeyword = "카래",
             targetKeyword = "카레",
@@ -26,7 +26,7 @@ class SearchCorrectionServiceTest {
         val corrected = service.correct(" 카-래 ")
 
         assertThat(corrected).isEqualTo("카레")
-        assertThat(correction.hitCount).isEqualTo(1)
+        assertThat(correction.hitCount).isZero
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
@@ -1,0 +1,40 @@
+package com.moongchijang.domain.search.application
+
+import com.moongchijang.domain.search.domain.SearchCorrection
+import com.moongchijang.domain.search.domain.SearchCorrectionType
+import com.moongchijang.domain.search.domain.repository.SearchCorrectionRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+class SearchCorrectionServiceTest {
+    private val searchCorrectionRepository: SearchCorrectionRepository = Mockito.mock(SearchCorrectionRepository::class.java)
+    private val service = SearchCorrectionService(searchCorrectionRepository)
+
+    @Test
+    @DisplayName("검색어를 정규화한 뒤 보정 사전을 조회하고 hit count를 증가시킨다")
+    fun `correct normalizes source keyword and records hit`() {
+        val correction = SearchCorrection(
+            sourceKeyword = "카래",
+            targetKeyword = "카레",
+            type = SearchCorrectionType.TYPO,
+        )
+        Mockito.`when`(searchCorrectionRepository.findBySourceKeywordAndEnabledTrue("카래"))
+            .thenReturn(correction)
+
+        val corrected = service.correct(" 카-래 ")
+
+        assertThat(corrected).isEqualTo("카레")
+        assertThat(correction.hitCount).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("정규화 후 검색어가 비어 있으면 사전을 조회하지 않는다")
+    fun `blank normalized query skips repository`() {
+        val corrected = service.correct(" - _ ")
+
+        assertThat(corrected).isNull()
+        Mockito.verifyNoInteractions(searchCorrectionRepository)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 검색 결과 0건일 때만 동작하는 검색어 보정 fallback을 추가했습니다.
- 검색어 정규화 후 `search_corrections` 사전에서 보정어를 조회하고, 보정어로 FULLTEXT 검색을 1회 재시도합니다.
- `카래 -> 카레`, `소굼빵 -> 소금빵`, `시오빵 -> 소금빵` 등 초기 seed correction 데이터를 Flyway로 추가했습니다.
- fallback 사용 여부, 원본/정규화/보정 검색어, 결과 수, latency를 로그로 남기도록 보강했습니다.
- 정상 검색 경로에서는 correction dictionary를 조회하지 않는 테스트와 `카래 -> 카레` fallback 테스트를 추가했습니다.

## 🔍 참고 사항
- 기존 Redis 캐시, 검색 이력 저장, Naver Local 추천 보강 흐름은 변경하지 않았습니다.
- `FullTextSearchEngine` 내부에서 `strict/fallback` FULLTEXT 검색이 모두 0건일 때만 correction fallback을 실행합니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- closes #313

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
