### PR TITLE
[MCJ-1600] FEAT: 모집중 공구 상세 기간 정보 응답 추가 및 관리자 공구 요청 패키지 정리

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyCloseRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyCloseRequestService.kt
@@ -1,4 +1,4 @@
-package com.moongchijang.domain.owner.application
+package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
@@ -6,8 +6,8 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReview
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestService.kt
@@ -1,4 +1,4 @@
-package com.moongchijang.domain.owner.application
+package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
@@ -6,10 +6,10 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestActionResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestDetailResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestPageResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestDetailResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestPageResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestImageRepository

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyCloseRequestActionResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyCloseRequestActionResponse.kt
@@ -1,4 +1,4 @@
-package com.moongchijang.domain.owner.application.dto
+package com.moongchijang.domain.admin.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyCloseRequestRejectRequest.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyCloseRequestRejectRequest.kt
@@ -1,4 +1,4 @@
-package com.moongchijang.domain.owner.application.dto
+package com.moongchijang.domain.admin.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyRequestDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyRequestDtos.kt
@@ -1,4 +1,4 @@
-package com.moongchijang.domain.owner.application.dto
+package com.moongchijang.domain.admin.application.dto
 
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyCloseRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyCloseRequestController.kt
@@ -1,8 +1,8 @@
-package com.moongchijang.domain.owner.presentation
+package com.moongchijang.domain.admin.presentation
 
-import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyCloseRequestService
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import com.moongchijang.domain.admin.application.AdminOwnerGroupBuyCloseRequestService
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestController.kt
@@ -1,10 +1,10 @@
-package com.moongchijang.domain.owner.presentation
+package com.moongchijang.domain.admin.presentation
 
-import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyRequestService
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestActionResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestDetailResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestPageResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.admin.application.AdminOwnerGroupBuyRequestService
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestDetailResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestPageResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import com.moongchijang.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -51,7 +51,7 @@ class GroupBuy(
     var status: GroupBuyStatus,
 
     @Column(name = "recruitment_start_at", nullable = false)
-    var recruitmentStartAt: LocalDateTime = LocalDateTime.now(),
+    var recruitmentStartAt: LocalDateTime,
 
     @Column(nullable = false)
     var deadline: LocalDateTime,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -50,8 +50,8 @@ class GroupBuy(
     @Column(nullable = false)
     var status: GroupBuyStatus,
 
-    @Column(name = "recruitment_start_at")
-    var recruitmentStartAt: LocalDateTime? = null,
+    @Column(name = "recruitment_start_at", nullable = false)
+    var recruitmentStartAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(nullable = false)
     var deadline: LocalDateTime,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -318,6 +318,8 @@ class OwnerGroupBuyService(
         val response = OwnerGroupBuyManageDetailResponse(
             groupBuyId = groupBuy.id,
             status = toManageFilterType(groupBuy.status),
+            recruitmentStartDate = groupBuy.recruitmentStartAt.toLocalDate(),
+            recruitmentEndDate = groupBuy.deadline.toLocalDate(),
             participantSummary = OwnerGroupBuyManageParticipantSummary(
                 totalCount = totalCount,
                 completedCount = completedCount,

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/dto/OwnerGroupBuyManageDetailResponse.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.owner.application.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
 @Schema(description = "사장님 공구 관리 상세 응답")
 data class OwnerGroupBuyManageDetailResponse(
@@ -9,6 +10,12 @@ data class OwnerGroupBuyManageDetailResponse(
 
     @field:Schema(description = "공구 상태", example = "IN_PROGRESS")
     val status: OwnerGroupBuyManageFilterType,
+
+    @field:Schema(description = "공구 모집 시작일자", example = "2026-06-01")
+    val recruitmentStartDate: LocalDate,
+
+    @field:Schema(description = "공구 모집 종료일자", example = "2026-06-07")
+    val recruitmentEndDate: LocalDate,
 
     @field:Schema(description = "참여자 요약")
     val participantSummary: OwnerGroupBuyManageParticipantSummary,

--- a/src/main/resources/db/migration/V48__alter_group_buys_require_recruitment_start_at.sql
+++ b/src/main/resources/db/migration/V48__alter_group_buys_require_recruitment_start_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE group_buys
+    MODIFY COLUMN recruitment_start_at DATETIME NOT NULL;

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -5108,13 +5108,15 @@ components:
 
     OwnerGroupBuyManageDetail:
       type: object
-      required: [groupBuyId, status, participantSummary, participants]
+      required: [groupBuyId, status, recruitmentStartDate, recruitmentEndDate, participantSummary, participants]
       properties:
         groupBuyId: { type: integer, format: int64, example: 101 }
         status:
           type: string
           enum: [ALL, IN_PROGRESS, ACHIEVED, ENDED, PENDING_APPROVAL]
           example: IN_PROGRESS
+        recruitmentStartDate: { type: string, format: date, example: "2026-06-01" }
+        recruitmentEndDate: { type: string, format: date, example: "2026-06-07" }
         participantSummary:
           $ref: '#/components/schemas/OwnerGroupBuyManageParticipantSummary'
         participants:

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyCloseRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyCloseRequestServiceTest.kt
@@ -1,11 +1,11 @@
-package com.moongchijang.domain.owner.application
+package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseReason
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestServiceTest.kt
@@ -1,11 +1,11 @@
-package com.moongchijang.domain.owner.application
+package com.moongchijang.domain.admin.application
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyCloseRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyCloseRequestControllerTest.kt
@@ -1,10 +1,10 @@
-package com.moongchijang.domain.owner.presentation
+package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyCloseRequestReviewStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
-import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyCloseRequestService
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
+import com.moongchijang.domain.admin.application.AdminOwnerGroupBuyCloseRequestService
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequestRejectRequest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestControllerTest.kt
@@ -1,8 +1,8 @@
-package com.moongchijang.domain.owner.presentation
+package com.moongchijang.domain.admin.presentation
 
-import com.moongchijang.domain.owner.application.AdminOwnerGroupBuyRequestService
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestActionResponse
-import com.moongchijang.domain.owner.application.dto.AdminOwnerGroupBuyRequestRejectRequest
+import com.moongchijang.domain.admin.application.AdminOwnerGroupBuyRequestService
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/repository/FavoriteRepositoryImplIntegrationTest.kt
@@ -104,6 +104,7 @@ class FavoriteRepositoryImplIntegrationTest {
             currentQuantity = 10,
             maxQuantity = 100,
             status = GroupBuyStatus.IN_PROGRESS,
+            recruitmentStartAt = LocalDateTime.of(2026, 5, 27, 9, 0),
             deadline = LocalDateTime.of(2026, 5, 30, 21, 0),
             pickupDate = LocalDate.of(2026, 6, 1),
             pickupTimeStart = LocalTime.of(10, 0),

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
@@ -67,6 +67,7 @@ class GroupBuyFeedItemResponseTest {
             currentQuantity = 28,
             maxQuantity = 45,
             status = GroupBuyStatus.IN_PROGRESS,
+            recruitmentStartAt = deadline.minusDays(1),
             deadline = deadline,
             pickupDate = LocalDate.of(2026, 5, 26),
             pickupTimeStart = LocalTime.of(12, 0),

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/repository/GroupBuyRepositoryImplIntegrationTest.kt
@@ -257,6 +257,7 @@ class GroupBuyRepositoryImplIntegrationTest {
             currentQuantity = currentQuantity,
             maxQuantity = 200,
             status = GroupBuyStatus.IN_PROGRESS,
+            recruitmentStartAt = deadline.minusDays(1),
             deadline = deadline,
             pickupDate = LocalDate.now().plusDays(5),
             pickupTimeStart = LocalTime.of(10, 0),

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -346,6 +346,7 @@ class GroupBuyOpenRequestServiceTest {
             targetQuantity = 10,
             maxQuantity = 20,
             status = GroupBuyStatus.IN_PROGRESS,
+            recruitmentStartAt = LocalDateTime.now(),
             deadline = LocalDateTime.now().plusDays(1),
             pickupDate = LocalDate.now().plusDays(3),
             pickupTimeStart = LocalTime.of(13, 0),

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -394,6 +394,7 @@ class MypageServiceTest {
             targetQuantity = 10,
             maxQuantity = 20,
             status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.IN_PROGRESS,
+            recruitmentStartAt = LocalDate.now().minusDays(1).atStartOfDay(),
             deadline = LocalDate.now().plusDays(1).atTime(23, 59),
             pickupDate = LocalDate.of(2026, 5, 25),
             pickupTimeStart = LocalTime.of(13, 0),

--- a/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/presentation/OwnerGroupBuyControllerTest.kt
@@ -127,6 +127,8 @@ class OwnerGroupBuyControllerTest {
         val response = OwnerGroupBuyManageDetailResponse(
             groupBuyId = 101L,
             status = OwnerGroupBuyManageFilterType.IN_PROGRESS,
+            recruitmentStartDate = LocalDate.of(2026, 5, 30),
+            recruitmentEndDate = LocalDate.of(2026, 6, 1),
             participantSummary = OwnerGroupBuyManageParticipantSummary(totalCount = 20, completedCount = 8, waitingCount = 12),
             participants = emptyList()
         )
@@ -144,6 +146,8 @@ class OwnerGroupBuyControllerTest {
         val response = OwnerGroupBuyManageDetailResponse(
             groupBuyId = 102L,
             status = OwnerGroupBuyManageFilterType.ACHIEVED,
+            recruitmentStartDate = LocalDate.of(2026, 5, 30),
+            recruitmentEndDate = LocalDate.of(2026, 6, 1),
             participantSummary = OwnerGroupBuyManageParticipantSummary(totalCount = 20, completedCount = 8, waitingCount = 12),
             participants = emptyList()
         )

--- a/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
@@ -98,6 +98,7 @@ class ParticipationAuditingIntegrationTest {
             currentQuantity = 0,
             maxQuantity = 100,
             status = GroupBuyStatus.IN_PROGRESS,
+            recruitmentStartAt = LocalDateTime.now(),
             deadline = LocalDateTime.now().plusDays(3),
             pickupDate = LocalDate.now().plusDays(5),
             pickupTimeStart = LocalTime.of(14, 0),

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -991,6 +991,7 @@ class PaymentServiceTest {
             currentQuantity = currentQuantity,
             maxQuantity = maxQuantity,
             status = status,
+            recruitmentStartAt = LocalDateTime.now(),
             deadline = LocalDateTime.now().plusDays(3),
             pickupDate = LocalDate.now().plusDays(5),
             pickupTimeStart = LocalTime.of(14, 0),

--- a/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/pickup/application/PickupServiceTest.kt
@@ -441,6 +441,7 @@ class PickupServiceTest {
             currentQuantity = 50,
             maxQuantity = 100,
             status = GroupBuyStatus.ACHIEVED,
+            recruitmentStartAt = LocalDateTime.now().minusDays(2),
             deadline = LocalDateTime.now().minusDays(1),
             pickupDate = pickupDate,
             pickupTimeStart = pickupTimeStart,

--- a/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/GroupBuyFixture.kt
@@ -34,6 +34,7 @@ object GroupBuyFixture {
             currentQuantity = currentQuantity,
             maxQuantity = maxQuantity,
             status = status,
+            recruitmentStartAt = deadline.minusDays(3),
             deadline = deadline,
             pickupDate = LocalDate.now().plusDays(5),
             pickupTimeStart = LocalTime.of(14, 0),

--- a/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
+++ b/src/test/kotlin/com/moongchijang/support/ParticipationFixture.kt
@@ -88,6 +88,7 @@ object ParticipationFixture {
             currentQuantity = currentQuantity,
             maxQuantity = 100,
             status = groupBuyStatus,
+            recruitmentStartAt = deadline.minusDays(1),
             deadline = deadline,
             pickupDate = pickupDate,
             pickupTimeStart = pickupTimeStart,

--- a/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
+++ b/src/test/kotlin/com/moongchijang/support/search/SearchTestFixtures.kt
@@ -51,6 +51,7 @@ object SearchTestFixtures {
         currentQuantity = 10,
         maxQuantity = 100,
         status = status,
+        recruitmentStartAt = deadline.minusDays(1),
         deadline = deadline,
         pickupDate = LocalDate.now().plusDays(5),
         pickupTimeStart = LocalTime.of(14, 0),


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 모집중 공구 상세 조회 응답에 공구 기간 정보를 추가했습니다.
  - 모집 시작일자(`recruitmentStartDate`)
  - 모집 종료일자(`recruitmentEndDate`)
- 모집 시작일자(`recruitmentStartAt`)를 필수값으로 정리했습니다.
  - 엔티티 non-null 반영
  - DB 컬럼 `NOT NULL` 마이그레이션 추가
- 모집중 공구 상세 조회 서비스/테스트/OpenAPI에 기간 필드를 반영했습니다.
- 관리자 전용 공구 요청 관련 컨트롤러/서비스/DTO/테스트 패키지를 `domain/admin`으로 이동해 구조를 정리했습니다.

## 🔍 참고 사항
- 기간 정보는 프론트에서 기간 연장 바텀시트 진입 시 현재 공구 기간 표시 용도로 사용됩니다.
- 시작일자는 `GroupBuy.recruitmentStartAt`, 종료일자는 `GroupBuy.deadline` 기준으로 응답합니다.
- owner 도메인 엔티티/리포지토리는 그대로 두고, 관리자 유스케이스 계층만 `admin` 도메인으로 분리했습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #318 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인