### PR TITLE
[MCJ-1601] FEAT: 피드 검색 후보 기반 오탈자 보정 강화

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -179,35 +179,45 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
      * 검색 보정 fallback 에서 사용할 현재 피드 검색 후보를 반환한다.
      *
      * FULLTEXT 검색 대상과 동일하게 진행 중이고 마감 전인 공구의 상품명, 매장명, 주소를 후보로 제한한다.
+     * 후보 전체 로딩을 피하기 위해 호출 측에서 limit 을 지정한다.
      */
     @Query(
         value = """
-            SELECT DISTINCT gb.product_name AS keyword
-            FROM group_buys gb
-            WHERE gb.status = :status
-              AND gb.deadline > CURRENT_TIMESTAMP
-              AND gb.product_name IS NOT NULL
-              AND gb.product_name <> ''
-            UNION
-            SELECT DISTINCT s.name AS keyword
-            FROM group_buys gb
-            JOIN stores s ON gb.store_id = s.id
-            WHERE gb.status = :status
-              AND gb.deadline > CURRENT_TIMESTAMP
-              AND s.name IS NOT NULL
-              AND s.name <> ''
-            UNION
-            SELECT DISTINCT s.address AS keyword
-            FROM group_buys gb
-            JOIN stores s ON gb.store_id = s.id
-            WHERE gb.status = :status
-              AND gb.deadline > CURRENT_TIMESTAMP
-              AND s.address IS NOT NULL
-              AND s.address <> ''
+            SELECT keyword
+            FROM (
+                SELECT gb.product_name AS keyword, gb.deadline AS deadline
+                FROM group_buys gb
+                WHERE gb.status = :status
+                  AND gb.deadline > CURRENT_TIMESTAMP
+                  AND gb.product_name IS NOT NULL
+                  AND gb.product_name <> ''
+                UNION ALL
+                SELECT s.name AS keyword, gb.deadline AS deadline
+                FROM group_buys gb
+                JOIN stores s ON gb.store_id = s.id
+                WHERE gb.status = :status
+                  AND gb.deadline > CURRENT_TIMESTAMP
+                  AND s.name IS NOT NULL
+                  AND s.name <> ''
+                UNION ALL
+                SELECT s.address AS keyword, gb.deadline AS deadline
+                FROM group_buys gb
+                JOIN stores s ON gb.store_id = s.id
+                WHERE gb.status = :status
+                  AND gb.deadline > CURRENT_TIMESTAMP
+                  AND s.address IS NOT NULL
+                  AND s.address <> ''
+            ) active_keywords
+            GROUP BY keyword
+            ORDER BY MIN(deadline) ASC
+            LIMIT :limit
         """,
         nativeQuery = true
     )
-    fun findActiveSearchKeywords(@Param("status") status: String): List<String>
+    fun findActiveSearchKeywords(
+        @Param("status") status: String,
+        @Param("limit") limit: Int,
+    ): List<String>
 
     /**
      * 주어진 id 목록의 GroupBuy 를 store 와 함께 한 번에 로드한다.

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepository.kt
@@ -176,6 +176,40 @@ interface GroupBuyRepository : JpaRepository<GroupBuy, Long>, GroupBuyRepository
     ): List<Long>
 
     /**
+     * 검색 보정 fallback 에서 사용할 현재 피드 검색 후보를 반환한다.
+     *
+     * FULLTEXT 검색 대상과 동일하게 진행 중이고 마감 전인 공구의 상품명, 매장명, 주소를 후보로 제한한다.
+     */
+    @Query(
+        value = """
+            SELECT DISTINCT gb.product_name AS keyword
+            FROM group_buys gb
+            WHERE gb.status = :status
+              AND gb.deadline > CURRENT_TIMESTAMP
+              AND gb.product_name IS NOT NULL
+              AND gb.product_name <> ''
+            UNION
+            SELECT DISTINCT s.name AS keyword
+            FROM group_buys gb
+            JOIN stores s ON gb.store_id = s.id
+            WHERE gb.status = :status
+              AND gb.deadline > CURRENT_TIMESTAMP
+              AND s.name IS NOT NULL
+              AND s.name <> ''
+            UNION
+            SELECT DISTINCT s.address AS keyword
+            FROM group_buys gb
+            JOIN stores s ON gb.store_id = s.id
+            WHERE gb.status = :status
+              AND gb.deadline > CURRENT_TIMESTAMP
+              AND s.address IS NOT NULL
+              AND s.address <> ''
+        """,
+        nativeQuery = true
+    )
+    fun findActiveSearchKeywords(@Param("status") status: String): List<String>
+
+    /**
      * 주어진 id 목록의 GroupBuy 를 store 와 함께 한 번에 로드한다.
      * [searchIdsByFullText] 후속 호출 용도. 빈 id 목록은 호출자가 가드한다.
      */

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
@@ -1,5 +1,7 @@
 package com.moongchijang.domain.search.application
 
+import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.search.domain.repository.SearchCorrectionRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -7,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class SearchCorrectionService(
     private val searchCorrectionRepository: SearchCorrectionRepository,
+    private val groupBuyRepository: GroupBuyRepository,
 ) {
     @Transactional(readOnly = true)
     fun correct(query: String): String? {
@@ -15,6 +18,127 @@ class SearchCorrectionService(
             return null
         }
 
-        return searchCorrectionRepository.findBySourceKeywordAndEnabledTrue(normalized)?.targetKeyword
+        searchCorrectionRepository.findBySourceKeywordAndEnabledTrue(normalized)?.let {
+            return it.targetKeyword
+        }
+
+        return findSimilarCorrection(normalized)
+    }
+
+    private fun findSimilarCorrection(normalized: String): String? {
+        if (normalized.length < MIN_SIMILARITY_QUERY_LENGTH) {
+            return null
+        }
+
+        return correctionCandidates(normalized.length)
+            .asSequence()
+            .filter { it != normalized }
+            .mapNotNull { candidate ->
+                val distance = jamoEditDistance(normalized, candidate)
+                candidate.takeIf { distance <= maxDistance(normalized.length) }
+                    ?.let { SimilarCandidate(candidate = it, distance = distance) }
+            }
+            .minWithOrNull(
+                compareBy<SimilarCandidate> { it.distance }
+                    .thenBy { kotlin.math.abs(it.candidate.length - normalized.length) }
+                    .thenBy { it.candidate.length }
+            )
+            ?.candidate
+    }
+
+    private fun correctionCandidates(queryLength: Int): List<String> {
+        val dictionaryTargets = searchCorrectionRepository.findAllByEnabledTrue()
+            .map { SearchQueryNormalizer.normalize(it.targetKeyword) }
+
+        val activeFeedTerms = groupBuyRepository.findActiveSearchKeywords(GroupBuyStatus.IN_PROGRESS.name)
+            .flatMap { extractTerms(SearchQueryNormalizer.normalize(it), queryLength) }
+
+        return (dictionaryTargets + activeFeedTerms)
+            .filter { it.length >= MIN_SIMILARITY_QUERY_LENGTH }
+            .distinct()
+    }
+
+    private fun extractTerms(productName: String, queryLength: Int): List<String> {
+        if (productName.isBlank()) {
+            return emptyList()
+        }
+
+        val windowSizes = ((queryLength - 1)..(queryLength + 1))
+            .filter { it >= MIN_SIMILARITY_QUERY_LENGTH }
+            .filter { it <= productName.length }
+
+        return buildList {
+            if (productName.length <= queryLength + 1) {
+                add(productName)
+            }
+            windowSizes.forEach { size ->
+                for (start in 0..(productName.length - size)) {
+                    add(productName.substring(start, start + size))
+                }
+            }
+        }
+    }
+
+    private fun maxDistance(queryLength: Int): Int = when {
+        queryLength <= 3 -> 1
+        queryLength <= 5 -> 2
+        else -> 3
+    }
+
+    private fun jamoEditDistance(source: String, target: String): Int {
+        val left = decomposeHangul(source)
+        val right = decomposeHangul(target)
+        val dp = Array(left.size + 1) { IntArray(right.size + 1) }
+
+        for (i in 0..left.size) {
+            dp[i][0] = i
+        }
+        for (j in 0..right.size) {
+            dp[0][j] = j
+        }
+
+        for (i in 1..left.size) {
+            for (j in 1..right.size) {
+                val cost = if (left[i - 1] == right[j - 1]) 0 else 1
+                dp[i][j] = minOf(
+                    dp[i - 1][j] + 1,
+                    dp[i][j - 1] + 1,
+                    dp[i - 1][j - 1] + cost
+                )
+            }
+        }
+
+        return dp[left.size][right.size]
+    }
+
+    private fun decomposeHangul(value: String): List<Int> = buildList {
+        value.forEach { char ->
+            val syllableIndex = char.code - HANGUL_BASE
+            if (syllableIndex in 0 until HANGUL_SYLLABLE_COUNT) {
+                add(syllableIndex / (JUNG_COUNT * JONG_COUNT))
+                add(CHO_COUNT + (syllableIndex % (JUNG_COUNT * JONG_COUNT)) / JONG_COUNT)
+                val jong = syllableIndex % JONG_COUNT
+                if (jong > 0) {
+                    add(CHO_COUNT + JUNG_COUNT + jong)
+                }
+            } else {
+                add(NON_HANGUL_OFFSET + char.code)
+            }
+        }
+    }
+
+    private data class SimilarCandidate(
+        val candidate: String,
+        val distance: Int,
+    )
+
+    companion object {
+        private const val MIN_SIMILARITY_QUERY_LENGTH = 2
+        private const val HANGUL_BASE = 0xAC00
+        private const val HANGUL_SYLLABLE_COUNT = 11172
+        private const val CHO_COUNT = 19
+        private const val JUNG_COUNT = 21
+        private const val JONG_COUNT = 28
+        private const val NON_HANGUL_OFFSET = 10_000
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/SearchCorrectionService.kt
@@ -30,13 +30,14 @@ class SearchCorrectionService(
             return null
         }
 
+        val maxDistance = maxDistance(normalized.length)
         return correctionCandidates(normalized.length)
             .asSequence()
             .filter { it != normalized }
             .mapNotNull { candidate ->
-                val distance = jamoEditDistance(normalized, candidate)
-                candidate.takeIf { distance <= maxDistance(normalized.length) }
-                    ?.let { SimilarCandidate(candidate = it, distance = distance) }
+                val distance = jamoEditDistance(normalized, candidate, maxDistance)
+                    ?: return@mapNotNull null
+                SimilarCandidate(candidate = candidate, distance = distance)
             }
             .minWithOrNull(
                 compareBy<SimilarCandidate> { it.distance }
@@ -50,12 +51,16 @@ class SearchCorrectionService(
         val dictionaryTargets = searchCorrectionRepository.findAllByEnabledTrue()
             .map { SearchQueryNormalizer.normalize(it.targetKeyword) }
 
-        val activeFeedTerms = groupBuyRepository.findActiveSearchKeywords(GroupBuyStatus.IN_PROGRESS.name)
+        val activeFeedTerms = groupBuyRepository.findActiveSearchKeywords(
+            status = GroupBuyStatus.IN_PROGRESS.name,
+            limit = ACTIVE_KEYWORD_LIMIT,
+        )
             .flatMap { extractTerms(SearchQueryNormalizer.normalize(it), queryLength) }
 
         return (dictionaryTargets + activeFeedTerms)
             .filter { it.length >= MIN_SIMILARITY_QUERY_LENGTH }
             .distinct()
+            .take(MAX_SIMILARITY_CANDIDATES)
     }
 
     private fun extractTerms(productName: String, queryLength: Int): List<String> {
@@ -67,7 +72,7 @@ class SearchCorrectionService(
             .filter { it >= MIN_SIMILARITY_QUERY_LENGTH }
             .filter { it <= productName.length }
 
-        return buildList {
+        return buildSet {
             if (productName.length <= queryLength + 1) {
                 add(productName)
             }
@@ -76,7 +81,7 @@ class SearchCorrectionService(
                     add(productName.substring(start, start + size))
                 }
             }
-        }
+        }.toList()
     }
 
     private fun maxDistance(queryLength: Int): Int = when {
@@ -85,30 +90,40 @@ class SearchCorrectionService(
         else -> 3
     }
 
-    private fun jamoEditDistance(source: String, target: String): Int {
+    private fun jamoEditDistance(source: String, target: String, maxDistance: Int): Int? {
         val left = decomposeHangul(source)
         val right = decomposeHangul(target)
-        val dp = Array(left.size + 1) { IntArray(right.size + 1) }
-
-        for (i in 0..left.size) {
-            dp[i][0] = i
+        if (kotlin.math.abs(left.size - right.size) > maxDistance) {
+            return null
         }
+
+        var previous = IntArray(right.size + 1) { it }
+        var current = IntArray(right.size + 1)
         for (j in 0..right.size) {
-            dp[0][j] = j
+            previous[j] = j
         }
 
         for (i in 1..left.size) {
+            current[0] = i
+            var rowMin = current[0]
             for (j in 1..right.size) {
                 val cost = if (left[i - 1] == right[j - 1]) 0 else 1
-                dp[i][j] = minOf(
-                    dp[i - 1][j] + 1,
-                    dp[i][j - 1] + 1,
-                    dp[i - 1][j - 1] + cost
+                current[j] = minOf(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + cost
                 )
+                rowMin = minOf(rowMin, current[j])
             }
+            if (rowMin > maxDistance) {
+                return null
+            }
+            val swap = previous
+            previous = current
+            current = swap
         }
 
-        return dp[left.size][right.size]
+        return previous[right.size].takeIf { it <= maxDistance }
     }
 
     private fun decomposeHangul(value: String): List<Int> = buildList {
@@ -134,6 +149,8 @@ class SearchCorrectionService(
 
     companion object {
         private const val MIN_SIMILARITY_QUERY_LENGTH = 2
+        private const val ACTIVE_KEYWORD_LIMIT = 500
+        private const val MAX_SIMILARITY_CANDIDATES = 2_000
         private const val HANGUL_BASE = 0xAC00
         private const val HANGUL_SYLLABLE_COUNT = 11172
         private const val CHO_COUNT = 19

--- a/src/main/kotlin/com/moongchijang/domain/search/domain/repository/SearchCorrectionRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/domain/repository/SearchCorrectionRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface SearchCorrectionRepository : JpaRepository<SearchCorrection, Long> {
     fun findBySourceKeywordAndEnabledTrue(sourceKeyword: String): SearchCorrection?
+    fun findAllByEnabledTrue(): List<SearchCorrection>
 }

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
@@ -53,7 +53,7 @@ class SearchCorrectionServiceTest {
             .thenReturn(null)
         Mockito.`when`(searchCorrectionRepository.findAllByEnabledTrue())
             .thenReturn(listOf(correction))
-        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS"))
+        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS", 500))
             .thenReturn(emptyList())
 
         val corrected = service.correct("카례")
@@ -68,7 +68,7 @@ class SearchCorrectionServiceTest {
             .thenReturn(null)
         Mockito.`when`(searchCorrectionRepository.findAllByEnabledTrue())
             .thenReturn(emptyList())
-        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS"))
+        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS", 500))
             .thenReturn(listOf("카레라면"))
 
         val corrected = service.correct("카례")
@@ -83,7 +83,7 @@ class SearchCorrectionServiceTest {
             .thenReturn(null)
         Mockito.`when`(searchCorrectionRepository.findAllByEnabledTrue())
             .thenReturn(emptyList())
-        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS"))
+        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS", 500))
             .thenReturn(listOf("양즈간루"))
 
         val corrected = service.correct("앙즈간루")

--- a/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/SearchCorrectionServiceTest.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.search.application
 
+import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.search.domain.SearchCorrection
 import com.moongchijang.domain.search.domain.SearchCorrectionType
 import com.moongchijang.domain.search.domain.repository.SearchCorrectionRepository
@@ -10,7 +11,8 @@ import org.mockito.Mockito
 
 class SearchCorrectionServiceTest {
     private val searchCorrectionRepository: SearchCorrectionRepository = Mockito.mock(SearchCorrectionRepository::class.java)
-    private val service = SearchCorrectionService(searchCorrectionRepository)
+    private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
+    private val service = SearchCorrectionService(searchCorrectionRepository, groupBuyRepository)
 
     @Test
     @DisplayName("검색어를 정규화한 뒤 보정 사전을 조회하고 target keyword를 반환한다")
@@ -36,5 +38,56 @@ class SearchCorrectionServiceTest {
 
         assertThat(corrected).isNull()
         Mockito.verifyNoInteractions(searchCorrectionRepository)
+        Mockito.verifyNoInteractions(groupBuyRepository)
+    }
+
+    @Test
+    @DisplayName("사전 source가 없어도 target keyword와 자모 유사도가 가까우면 보정한다")
+    fun `corrects by jamo similarity against dictionary targets`() {
+        val correction = SearchCorrection(
+            sourceKeyword = "카래",
+            targetKeyword = "카레",
+            type = SearchCorrectionType.TYPO,
+        )
+        Mockito.`when`(searchCorrectionRepository.findBySourceKeywordAndEnabledTrue("카례"))
+            .thenReturn(null)
+        Mockito.`when`(searchCorrectionRepository.findAllByEnabledTrue())
+            .thenReturn(listOf(correction))
+        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS"))
+            .thenReturn(emptyList())
+
+        val corrected = service.correct("카례")
+
+        assertThat(corrected).isEqualTo("카레")
+    }
+
+    @Test
+    @DisplayName("현재 피드 검색 후보 일부와 자모 유사도가 가까우면 해당 부분 검색어로 보정한다")
+    fun `corrects by jamo similarity against active feed terms`() {
+        Mockito.`when`(searchCorrectionRepository.findBySourceKeywordAndEnabledTrue("카례"))
+            .thenReturn(null)
+        Mockito.`when`(searchCorrectionRepository.findAllByEnabledTrue())
+            .thenReturn(emptyList())
+        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS"))
+            .thenReturn(listOf("카레라면"))
+
+        val corrected = service.correct("카례")
+
+        assertThat(corrected).isEqualTo("카레")
+    }
+
+    @Test
+    @DisplayName("현재 피드의 매장명과 자모 유사도가 가까우면 매장명으로 보정한다")
+    fun `corrects typo against active store name`() {
+        Mockito.`when`(searchCorrectionRepository.findBySourceKeywordAndEnabledTrue("앙즈간루"))
+            .thenReturn(null)
+        Mockito.`when`(searchCorrectionRepository.findAllByEnabledTrue())
+            .thenReturn(emptyList())
+        Mockito.`when`(groupBuyRepository.findActiveSearchKeywords("IN_PROGRESS"))
+            .thenReturn(listOf("양즈간루"))
+
+        val corrected = service.correct("앙즈간루")
+
+        assertThat(corrected).isEqualTo("양즈간루")
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용

- 검색 결과가 0건일 때 correction dictionary exact 조회 이후 자모 유사도 기반 보정 fallback을 수행하도록 확장했습니다.
- 현재 피드에 노출 중인 상품명, 매장명, 주소를 검색 후보군으로 조회해 seed 사전에 없는 근접 오탈자도 보정할 수 있도록 했습니다.
- 상품명 후보 및 매장명 후보 기반 보정 케이스 테스트를 추가했습니다.

## 🔍 참고 사항

- 정상 FULLTEXT 검색 결과가 있는 경우에는 기존처럼 보정 후보 조회를 수행하지 않습니다.
- 보정 후보는 진행 중이고 마감 전인 공구의 FULLTEXT 검색 대상 필드로 제한했습니다.

## 🖼️ 스크린샷

해당 없음

## 🔗 관련 이슈

- close #320

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

