### PR TITLE
[MCJ-1595] FEAT: PortOne 웹훅 보안 검증 및 결제 감사 이력 보강

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertService.kt
@@ -52,6 +52,23 @@ class AdminDiscordAlertService(
         eventPublisher.publishEvent(AdminDiscordAlertRequestedEvent(AdminDiscordChannel.REFUND, message))
     }
 
+    fun sendPaymentFailed(
+        orderId: String?,
+        pgPaymentId: String?,
+        pgStatus: String?,
+        reason: String?,
+    ) {
+        val message = """
+            [긴급] 결제 실패 이벤트 발생
+            주문 ID: ${orderId ?: "-"}
+            PG 결제 ID: ${pgPaymentId ?: "-"}
+            PG 상태: ${pgStatus ?: "-"}
+            사유: ${reason ?: "-"}
+            → 결제 감사 이력 확인 필요
+        """.trimIndent()
+        eventPublisher.publishEvent(AdminDiscordAlertRequestedEvent(AdminDiscordChannel.PAYMENT, message))
+    }
+
     fun sendNewSellerSignup(profile: SellerBusinessProfile) {
         val ownerName = profile.ownerName.ifBlank { "이름미입력" }
         val message = """

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordChannel.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordChannel.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.notification.application.discord
 
 enum class AdminDiscordChannel {
     REFUND,
+    PAYMENT,
     GROUPBUY,
     ONBOARDING,
 }

--- a/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordProperties.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordProperties.kt
@@ -9,6 +9,7 @@ data class DiscordProperties(
 ) {
     data class Webhook(
         val refund: String = "",
+        val payment: String = "",
         val groupbuy: String = "",
         val onboarding: String = "",
     )

--- a/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/infrastructure/discord/DiscordWebhookClient.kt
@@ -45,6 +45,7 @@ class DiscordWebhookClient(
     private fun resolveWebhookUrl(channel: AdminDiscordChannel): String =
         when (channel) {
             AdminDiscordChannel.REFUND -> discordProperties.webhook.refund
+            AdminDiscordChannel.PAYMENT -> discordProperties.webhook.payment
             AdminDiscordChannel.GROUPBUY -> discordProperties.webhook.groupbuy
             AdminDiscordChannel.ONBOARDING -> discordProperties.webhook.onboarding
         }.trim()

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
@@ -53,12 +53,20 @@ class PaymentAuditLogService(
         }
 
         if (record.notifyFailure) {
-            adminDiscordAlertService.sendPaymentFailed(
-                orderId = record.orderId ?: record.paymentOrder?.orderId,
-                pgPaymentId = record.pgPaymentId,
-                pgStatus = record.pgStatus,
-                reason = record.reason,
-            )
+            try {
+                adminDiscordAlertService.sendPaymentFailed(
+                    orderId = record.orderId ?: record.paymentOrder?.orderId,
+                    pgPaymentId = record.pgPaymentId,
+                    pgStatus = record.pgStatus,
+                    reason = record.reason,
+                )
+            } catch (e: Exception) {
+                log.warn(
+                    "[PaymentAuditLogService] 결제 실패 Discord 알림 발행 실패: orderId={}",
+                    record.orderId ?: record.paymentOrder?.orderId,
+                    e
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
@@ -1,0 +1,78 @@
+package com.moongchijang.domain.payment.application
+
+import com.moongchijang.domain.notification.application.discord.AdminDiscordAlertService
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditEventType
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditLog
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditSource
+import com.moongchijang.domain.payment.domain.entity.PaymentOrder
+import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
+import com.moongchijang.domain.payment.domain.repository.PaymentAuditLogRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.support.TransactionTemplate
+
+@Service
+class PaymentAuditLogService(
+    private val paymentAuditLogRepository: PaymentAuditLogRepository,
+    private val adminDiscordAlertService: AdminDiscordAlertService,
+    transactionManager: PlatformTransactionManager,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+    private val transactionTemplate = TransactionTemplate(transactionManager).apply {
+        propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+    }
+
+    fun record(record: PaymentAuditRecord) {
+        try {
+            transactionTemplate.execute {
+                paymentAuditLogRepository.save(
+                    PaymentAuditLog(
+                        paymentOrder = record.paymentOrder,
+                        orderId = record.orderId ?: record.paymentOrder?.orderId,
+                        pgPaymentId = record.pgPaymentId,
+                        eventType = record.eventType,
+                        source = record.source,
+                        previousOrderStatus = record.previousOrderStatus,
+                        currentOrderStatus = record.currentOrderStatus ?: record.paymentOrder?.status,
+                        pgStatus = record.pgStatus,
+                        reason = record.reason?.take(500),
+                        rawPayload = record.rawPayload,
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            log.warn(
+                "[PaymentAuditLogService] 결제 감사 이력 저장 실패: source={}, eventType={}, orderId={}",
+                record.source,
+                record.eventType,
+                record.orderId ?: record.paymentOrder?.orderId,
+                e
+            )
+        }
+
+        if (record.notifyFailure) {
+            adminDiscordAlertService.sendPaymentFailed(
+                orderId = record.orderId ?: record.paymentOrder?.orderId,
+                pgPaymentId = record.pgPaymentId,
+                pgStatus = record.pgStatus,
+                reason = record.reason,
+            )
+        }
+    }
+}
+
+data class PaymentAuditRecord(
+    val source: PaymentAuditSource,
+    val eventType: PaymentAuditEventType,
+    val paymentOrder: PaymentOrder? = null,
+    val orderId: String? = null,
+    val pgPaymentId: String? = null,
+    val previousOrderStatus: PaymentOrderStatus? = null,
+    val currentOrderStatus: PaymentOrderStatus? = null,
+    val pgStatus: String? = null,
+    val reason: String? = null,
+    val rawPayload: String? = null,
+    val notifyFailure: Boolean = false,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -23,6 +23,8 @@ import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderRespons
 import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
 import com.moongchijang.domain.payment.application.port.PortOnePaymentPort
 import com.moongchijang.domain.payment.application.port.PortOnePaymentResult
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditEventType
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditSource
 import com.moongchijang.domain.payment.domain.entity.Payment
 import com.moongchijang.domain.payment.domain.entity.PaymentOrder
 import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
@@ -55,6 +57,7 @@ class PaymentService(
     private val storeStaffRepository: StoreStaffRepository,
     private val paymentOrderRepository: PaymentOrderRepository,
     private val paymentRepository: PaymentRepository,
+    private val paymentAuditLogService: PaymentAuditLogService,
     private val portOnePaymentPort: PortOnePaymentPort,
     private val portOneProperties: PortOneProperties,
     private val transactionManager: PlatformTransactionManager,
@@ -137,46 +140,96 @@ class PaymentService(
     }
 
     fun completePortOnePayment(request: CompletePortOnePaymentRequest, userId: Long): ConfirmPaymentResponse {
-        val order = transactionTemplate().execute {
-            val foundOrder = paymentOrderRepository.findByOrderId(request.paymentId)
-                ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
-            validatePaymentOrderOwner(foundOrder, userId)
-            foundOrder
-        } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+        recordPaymentAudit(
+            source = PaymentAuditSource.COMPLETE_API,
+            eventType = PaymentAuditEventType.COMPLETE_REQUEST_RECEIVED,
+            orderId = request.paymentId,
+        )
 
-        if (order.status == PaymentOrderStatus.APPROVED) {
-            return transactionTemplate().execute {
-                val approvedOrder = paymentOrderRepository.findByOrderIdForUpdate(request.paymentId)
+        try {
+            val order = transactionTemplate().execute {
+                val foundOrder = paymentOrderRepository.findByOrderId(request.paymentId)
                     ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
-                buildAlreadyApprovedResponse(approvedOrder)
-            } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
-        }
-        if (order.status != PaymentOrderStatus.READY) {
-            throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
-        }
-        if (order.totalAmount != request.amount) {
-            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
-        }
+                validatePaymentOrderOwner(foundOrder, userId)
+                foundOrder
+            } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
 
-        val paymentResult = getPortOnePaymentOrFailOrder(order.orderId)
-        if (paymentResult.status != PORTONE_STATUS_PAID) {
-            updateOrderFromPortOneStatus(order.orderId, paymentResult)
-            throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
-        }
-        if (paymentResult.totalAmount != order.totalAmount || paymentResult.paymentId != order.orderId) {
-            markOrderFailed(order.orderId)
-            throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
-        }
+            if (order.status == PaymentOrderStatus.APPROVED) {
+                return transactionTemplate().execute {
+                    val approvedOrder = paymentOrderRepository.findByOrderIdForUpdate(request.paymentId)
+                        ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
+                    recordPaymentAudit(
+                        source = PaymentAuditSource.COMPLETE_API,
+                        eventType = PaymentAuditEventType.PAYMENT_IGNORED,
+                        order = approvedOrder,
+                        reason = ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED.name,
+                    )
+                    buildAlreadyApprovedResponse(approvedOrder)
+                } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+            }
+            if (order.status != PaymentOrderStatus.READY) {
+                throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+            }
+            if (order.totalAmount != request.amount) {
+                recordPaymentFailure(
+                    source = PaymentAuditSource.COMPLETE_API,
+                    order = order,
+                    reason = ErrorCode.PAYMENT_AMOUNT_MISMATCH.name,
+                )
+                throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+            }
 
-        val result = withGroupBuyLock(order.groupBuy.id) {
-            transactionTemplate().execute {
-                approvePayment(request.paymentId, request.amount, paymentResult)
-            } ?: PaymentApprovalResult.Failure(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
-        }
+            val paymentResult = getPortOnePaymentOrFailOrder(order.orderId)
+            recordPaymentAudit(
+                source = PaymentAuditSource.COMPLETE_API,
+                eventType = PaymentAuditEventType.PORTONE_STATUS_FETCHED,
+                order = order,
+                paymentResult = paymentResult,
+            )
+            if (paymentResult.status != PORTONE_STATUS_PAID) {
+                updateOrderFromPortOneStatus(order.orderId, paymentResult)
+                recordPaymentFailure(
+                    source = PaymentAuditSource.COMPLETE_API,
+                    order = order,
+                    paymentResult = paymentResult,
+                    reason = ErrorCode.PAYMENT_APPROVAL_FAILED.name,
+                )
+                throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+            }
+            if (paymentResult.totalAmount != order.totalAmount || paymentResult.paymentId != order.orderId) {
+                markOrderFailed(order.orderId)
+                recordPaymentFailure(
+                    source = PaymentAuditSource.COMPLETE_API,
+                    order = order,
+                    paymentResult = paymentResult,
+                    reason = ErrorCode.PAYMENT_AMOUNT_MISMATCH.name,
+                )
+                throw CustomException(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
+            }
 
-        return when (result) {
-            is PaymentApprovalResult.Success -> result.response
-            is PaymentApprovalResult.Failure -> throw CustomException(result.errorCode)
+            val result = withGroupBuyLock(order.groupBuy.id) {
+                transactionTemplate().execute {
+                    approvePayment(
+                        paymentId = request.paymentId,
+                        expectedAmount = request.amount,
+                        paymentResult = paymentResult,
+                        source = PaymentAuditSource.COMPLETE_API,
+                    )
+                } ?: PaymentApprovalResult.Failure(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
+            }
+
+            return when (result) {
+                is PaymentApprovalResult.Success -> result.response
+                is PaymentApprovalResult.Failure -> throw CustomException(result.errorCode)
+            }
+        } catch (e: CustomException) {
+            recordPaymentAudit(
+                source = PaymentAuditSource.COMPLETE_API,
+                eventType = PaymentAuditEventType.PAYMENT_FAILED,
+                orderId = request.paymentId,
+                reason = e.errorCode.name,
+            )
+            throw e
         }
     }
 
@@ -186,7 +239,13 @@ class PaymentService(
         }
     }
 
-    fun handlePortOneWebhook(request: PortOneWebhookRequest) {
+    fun handlePortOneWebhook(request: PortOneWebhookRequest, rawPayload: String? = null) {
+        recordPaymentAudit(
+            source = PaymentAuditSource.WEBHOOK,
+            eventType = PaymentAuditEventType.WEBHOOK_RECEIVED,
+            orderId = request.paymentId,
+            rawPayload = rawPayload,
+        )
         if (request.storeId != null && request.storeId != portOneProperties.storeId) {
             throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
         }
@@ -198,15 +257,45 @@ class PaymentService(
 
         val order = transactionTemplate().execute {
             paymentOrderRepository.findByOrderId(paymentId)
-        } ?: return
+        } ?: run {
+            recordPaymentAudit(
+                source = PaymentAuditSource.WEBHOOK,
+                eventType = PaymentAuditEventType.PAYMENT_IGNORED,
+                orderId = paymentId,
+                reason = ErrorCode.PAYMENT_ORDER_NOT_FOUND.name,
+                rawPayload = rawPayload,
+            )
+            return
+        }
         val paymentResult = getPortOnePaymentOrFailOrder(order.orderId)
+        recordPaymentAudit(
+            source = PaymentAuditSource.WEBHOOK,
+            eventType = PaymentAuditEventType.PORTONE_STATUS_FETCHED,
+            order = order,
+            paymentResult = paymentResult,
+            rawPayload = rawPayload,
+        )
 
         if (paymentResult.status == PORTONE_STATUS_PAID) {
             withGroupBuyLock(order.groupBuy.id) {
                 transactionTemplate().execute {
                     val lockedOrder = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
                     if (lockedOrder.status != PaymentOrderStatus.APPROVED) {
-                        approvePayment(paymentId, lockedOrder.totalAmount, paymentResult)
+                        approvePayment(
+                            paymentId = paymentId,
+                            expectedAmount = lockedOrder.totalAmount,
+                            paymentResult = paymentResult,
+                            source = PaymentAuditSource.WEBHOOK,
+                        )
+                    } else {
+                        recordPaymentAudit(
+                            source = PaymentAuditSource.WEBHOOK,
+                            eventType = PaymentAuditEventType.PAYMENT_IGNORED,
+                            order = lockedOrder,
+                            paymentResult = paymentResult,
+                            reason = ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED.name,
+                            rawPayload = rawPayload,
+                        )
                     }
                 }
             }
@@ -229,8 +318,20 @@ class PaymentService(
         transactionTemplate().execute {
             val lockedOrder = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
             if (paymentResult.status == PORTONE_STATUS_FAILED && lockedOrder.status == PaymentOrderStatus.READY) {
+                val previousStatus = lockedOrder.status
                 lockedOrder.fail(LocalDateTime.now())
                 paymentOrderRepository.save(lockedOrder)
+                recordPaymentAudit(
+                    source = PaymentAuditSource.WEBHOOK,
+                    eventType = PaymentAuditEventType.PAYMENT_FAILED,
+                    order = lockedOrder,
+                    paymentResult = paymentResult,
+                    previousOrderStatus = previousStatus,
+                    currentOrderStatus = lockedOrder.status,
+                    rawPayload = rawPayload,
+                    reason = PORTONE_STATUS_FAILED,
+                    notifyFailure = true,
+                )
             }
         }
     }
@@ -308,7 +409,8 @@ class PaymentService(
     private fun approvePayment(
         paymentId: String,
         expectedAmount: Int,
-        paymentResult: PortOnePaymentResult
+        paymentResult: PortOnePaymentResult,
+        source: PaymentAuditSource,
     ): PaymentApprovalResult {
         val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId)
             ?: throw CustomException(ErrorCode.PAYMENT_ORDER_NOT_FOUND)
@@ -323,13 +425,31 @@ class PaymentService(
             return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
         }
         if (paymentResult.totalAmount != order.totalAmount) {
+            val previousStatus = order.status
             order.fail(LocalDateTime.now())
             paymentOrderRepository.save(order)
+            recordPaymentFailure(
+                source = source,
+                order = order,
+                paymentResult = paymentResult,
+                previousOrderStatus = previousStatus,
+                currentOrderStatus = order.status,
+                reason = ErrorCode.PAYMENT_AMOUNT_MISMATCH.name,
+            )
             return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
         }
         if (paymentResult.paymentId != order.orderId) {
+            val previousStatus = order.status
             order.fail(LocalDateTime.now())
             paymentOrderRepository.save(order)
+            recordPaymentFailure(
+                source = source,
+                order = order,
+                paymentResult = paymentResult,
+                previousOrderStatus = previousStatus,
+                currentOrderStatus = order.status,
+                reason = ErrorCode.PAYMENT_AMOUNT_MISMATCH.name,
+            )
             return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_AMOUNT_MISMATCH)
         }
 
@@ -342,8 +462,17 @@ class PaymentService(
                 "[PaymentService] 조건부 수량 증가 실패: groupBuyId={}, quantity={}, orderId={}",
                 order.groupBuy.id, order.quantity, order.orderId
             )
+            val previousStatus = order.status
             order.fail(LocalDateTime.now())
             paymentOrderRepository.save(order)
+            recordPaymentFailure(
+                source = source,
+                order = order,
+                paymentResult = paymentResult,
+                previousOrderStatus = previousStatus,
+                currentOrderStatus = order.status,
+                reason = ErrorCode.PAYMENT_QUANTITY_EXCEEDED.name,
+            )
             return PaymentApprovalResult.Failure(ErrorCode.PAYMENT_QUANTITY_EXCEEDED)
         }
 
@@ -375,6 +504,7 @@ class PaymentService(
             groupBuy.transitionToCompletedWhenMaxQuantityReached()
         }
         val approvedAt = paymentResult.paidAt ?: LocalDateTime.now()
+        val previousStatus = order.status
         order.approve(approvedAt)
         val approvedOrder = paymentOrderRepository.save(order)
 
@@ -387,6 +517,15 @@ class PaymentService(
                 method = paymentResult.method,
                 approvedAt = approvedAt,
             )
+        )
+
+        recordPaymentAudit(
+            source = source,
+            eventType = PaymentAuditEventType.PAYMENT_APPROVED,
+            order = approvedOrder,
+            paymentResult = paymentResult,
+            previousOrderStatus = previousStatus,
+            currentOrderStatus = approvedOrder.status,
         )
 
         publishApplyPaymentSuccessEvent(order, approvedAt)
@@ -509,8 +648,18 @@ class PaymentService(
         requiresNewTransactionTemplate().execute {
             val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
             if (order.status == PaymentOrderStatus.READY) {
+                val previousStatus = order.status
                 order.fail(LocalDateTime.now())
                 paymentOrderRepository.save(order)
+                recordPaymentAudit(
+                    source = PaymentAuditSource.COMPLETE_API,
+                    eventType = PaymentAuditEventType.PAYMENT_FAILED,
+                    order = order,
+                    previousOrderStatus = previousStatus,
+                    currentOrderStatus = order.status,
+                    reason = ErrorCode.PAYMENT_APPROVAL_FAILED.name,
+                    notifyFailure = true,
+                )
             }
         }
     }
@@ -518,12 +667,28 @@ class PaymentService(
     private fun updateOrderFromPortOneStatus(paymentId: String, paymentResult: PortOnePaymentResult) {
         requiresNewTransactionTemplate().execute {
             val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
+            val previousStatus = order.status
             when (paymentResult.status) {
                 PORTONE_STATUS_CANCELLED -> order.cancel(paymentResult.cancelledAt ?: LocalDateTime.now())
                 PORTONE_STATUS_PARTIAL_CANCELLED -> order.partialCancel(paymentResult.cancelledAt ?: LocalDateTime.now())
                 else -> order.fail(LocalDateTime.now())
             }
             paymentOrderRepository.save(order)
+            val eventType = when (paymentResult.status) {
+                PORTONE_STATUS_CANCELLED -> PaymentAuditEventType.PAYMENT_CANCELLED
+                PORTONE_STATUS_PARTIAL_CANCELLED -> PaymentAuditEventType.PAYMENT_PARTIAL_CANCELLED
+                else -> PaymentAuditEventType.PAYMENT_FAILED
+            }
+            recordPaymentAudit(
+                source = PaymentAuditSource.COMPLETE_API,
+                eventType = eventType,
+                order = order,
+                paymentResult = paymentResult,
+                previousOrderStatus = previousStatus,
+                currentOrderStatus = order.status,
+                reason = paymentResult.status,
+                notifyFailure = eventType == PaymentAuditEventType.PAYMENT_FAILED,
+            )
         }
     }
 
@@ -536,23 +701,41 @@ class PaymentService(
             applyParticipationRefundConsistency(order, cancelledAt)
         }
 
-        updateOrderAndPaymentCancellationState(order, payment, cancelledAt, partial)
+        updateOrderAndPaymentCancellationState(order, payment, paymentResult, cancelledAt, partial)
     }
 
     private fun updateOrderAndPaymentCancellationState(
         order: PaymentOrder,
         payment: Payment,
+        paymentResult: PortOnePaymentResult,
         cancelledAt: LocalDateTime,
         partial: Boolean
     ) {
+        val previousStatus = order.status
         if (partial) {
             order.partialCancel(cancelledAt)
             payment.partialCancel(cancelledAt)
+            recordPaymentAudit(
+                source = PaymentAuditSource.WEBHOOK,
+                eventType = PaymentAuditEventType.PAYMENT_PARTIAL_CANCELLED,
+                order = order,
+                paymentResult = paymentResult,
+                previousOrderStatus = previousStatus,
+                currentOrderStatus = order.status,
+            )
             return
         }
 
         order.cancel(cancelledAt)
         payment.cancel(cancelledAt)
+        recordPaymentAudit(
+            source = PaymentAuditSource.WEBHOOK,
+            eventType = PaymentAuditEventType.PAYMENT_CANCELLED,
+            order = order,
+            paymentResult = paymentResult,
+            previousOrderStatus = previousStatus,
+            currentOrderStatus = order.status,
+        )
     }
 
     private fun applyParticipationRefundConsistency(order: PaymentOrder, cancelledAt: LocalDateTime) {
@@ -880,6 +1063,57 @@ class PaymentService(
         TransactionTemplate(transactionManager).apply {
             propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
         }
+
+    private fun recordPaymentAudit(
+        source: PaymentAuditSource,
+        eventType: PaymentAuditEventType,
+        order: PaymentOrder? = null,
+        orderId: String? = order?.orderId,
+        paymentResult: PortOnePaymentResult? = null,
+        previousOrderStatus: PaymentOrderStatus? = null,
+        currentOrderStatus: PaymentOrderStatus? = order?.status,
+        reason: String? = null,
+        rawPayload: String? = null,
+        notifyFailure: Boolean = false,
+    ) {
+        paymentAuditLogService.record(
+            PaymentAuditRecord(
+                source = source,
+                eventType = eventType,
+                paymentOrder = order,
+                orderId = orderId,
+                pgPaymentId = paymentResult?.paymentId,
+                previousOrderStatus = previousOrderStatus,
+                currentOrderStatus = currentOrderStatus,
+                pgStatus = paymentResult?.status,
+                reason = reason,
+                rawPayload = rawPayload,
+                notifyFailure = notifyFailure,
+            )
+        )
+    }
+
+    private fun recordPaymentFailure(
+        source: PaymentAuditSource,
+        order: PaymentOrder,
+        paymentResult: PortOnePaymentResult? = null,
+        previousOrderStatus: PaymentOrderStatus? = null,
+        currentOrderStatus: PaymentOrderStatus? = order.status,
+        reason: String,
+        rawPayload: String? = null,
+    ) {
+        recordPaymentAudit(
+            source = source,
+            eventType = PaymentAuditEventType.PAYMENT_FAILED,
+            order = order,
+            paymentResult = paymentResult,
+            previousOrderStatus = previousOrderStatus,
+            currentOrderStatus = currentOrderStatus,
+            reason = reason,
+            rawPayload = rawPayload,
+            notifyFailure = true,
+        )
+    }
 
     private sealed interface PaymentApprovalResult {
         data class Success(val response: ConfirmPaymentResponse) : PaymentApprovalResult

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifier.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifier.kt
@@ -18,7 +18,11 @@ class PortOneWebhookSignatureVerifier(
 ) {
 
     fun verify(headers: HttpHeaders, rawPayload: String) {
-        val secret = portOneProperties.webhookSecret?.takeIf { it.isNotBlank() } ?: return
+        if (!portOneProperties.webhookSignatureVerificationEnabled) {
+            return
+        }
+        val secret = portOneProperties.webhookSecret?.takeIf { it.isNotBlank() }
+            ?: throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
         val webhookId = headers.getFirst(WEBHOOK_ID_HEADER)
             ?: throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
         val timestamp = headers.getFirst(WEBHOOK_TIMESTAMP_HEADER)?.toLongOrNull()
@@ -45,14 +49,13 @@ class PortOneWebhookSignatureVerifier(
         signatureHeader
             .split(" ")
             .asSequence()
-            .flatMap { entry ->
-                entry.split(",")
-                    .map(String::trim)
-                    .filter(String::isNotBlank)
-                    .windowed(size = 2, step = 2, partialWindows = false)
-                    .asSequence()
-                    .filter { it[0] == SIGNATURE_VERSION }
-                    .map { it[1] }
+            .mapNotNull { entry ->
+                val parts = entry.split(",", limit = 2).map(String::trim)
+                if (parts.size == 2 && parts[0] == SIGNATURE_VERSION && parts[1].isNotBlank()) {
+                    parts[1]
+                } else {
+                    null
+                }
             }
 
     private fun hmacSha256Base64(secret: String, payload: String): String {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifier.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifier.kt
@@ -1,0 +1,89 @@
+package com.moongchijang.domain.payment.application
+
+import com.moongchijang.global.config.PortOneProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.springframework.http.HttpHeaders
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+import java.time.Clock
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class PortOneWebhookSignatureVerifier(
+    private val portOneProperties: PortOneProperties,
+    private val clock: Clock,
+) {
+
+    fun verify(headers: HttpHeaders, rawPayload: String) {
+        val secret = portOneProperties.webhookSecret?.takeIf { it.isNotBlank() } ?: return
+        val webhookId = headers.getFirst(WEBHOOK_ID_HEADER)
+            ?: throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+        val timestamp = headers.getFirst(WEBHOOK_TIMESTAMP_HEADER)?.toLongOrNull()
+            ?: throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+        val signatureHeader = headers.getFirst(WEBHOOK_SIGNATURE_HEADER)
+            ?: throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+
+        val now = clock.instant().epochSecond
+        if (kotlin.math.abs(now - timestamp) > portOneProperties.webhookTimestampToleranceSeconds) {
+            throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+        }
+
+        val signedPayload = "$webhookId.$timestamp.$rawPayload"
+        val expectedSignature = hmacSha256Base64(secret, signedPayload)
+        val matched = extractV1Signatures(signatureHeader)
+            .any { constantTimeEquals(expectedSignature, it) }
+
+        if (!matched) {
+            throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+        }
+    }
+
+    private fun extractV1Signatures(signatureHeader: String): Sequence<String> =
+        signatureHeader
+            .split(" ")
+            .asSequence()
+            .flatMap { entry ->
+                entry.split(",")
+                    .map(String::trim)
+                    .filter(String::isNotBlank)
+                    .windowed(size = 2, step = 2, partialWindows = false)
+                    .asSequence()
+                    .filter { it[0] == SIGNATURE_VERSION }
+                    .map { it[1] }
+            }
+
+    private fun hmacSha256Base64(secret: String, payload: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secretKeyBytes(secret), "HmacSHA256"))
+        return Base64.getEncoder().encodeToString(mac.doFinal(payload.toByteArray(Charsets.UTF_8)))
+    }
+
+    private fun secretKeyBytes(secret: String): ByteArray {
+        if (!secret.startsWith(WEBHOOK_SECRET_PREFIX)) {
+            return secret.toByteArray(Charsets.UTF_8)
+        }
+        val normalized = secret.removePrefix(WEBHOOK_SECRET_PREFIX)
+        return try {
+            Base64.getDecoder().decode(normalized)
+        } catch (e: IllegalArgumentException) {
+            secret.toByteArray(Charsets.UTF_8)
+        }
+    }
+
+    private fun constantTimeEquals(expected: String, actual: String): Boolean =
+        MessageDigest.isEqual(
+            expected.toByteArray(Charsets.UTF_8),
+            actual.toByteArray(Charsets.UTF_8)
+        )
+
+    companion object {
+        private const val SIGNATURE_VERSION = "v1"
+        private const val WEBHOOK_SECRET_PREFIX = "whsec_"
+        private const val WEBHOOK_ID_HEADER = "webhook-id"
+        private const val WEBHOOK_TIMESTAMP_HEADER = "webhook-timestamp"
+        private const val WEBHOOK_SIGNATURE_HEADER = "webhook-signature"
+    }
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentAuditLog.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentAuditLog.kt
@@ -1,0 +1,83 @@
+package com.moongchijang.domain.payment.domain.entity
+
+import com.moongchijang.global.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(
+    name = "payment_audit_logs",
+    indexes = [
+        Index(name = "idx_payment_audit_logs_order_id", columnList = "order_id"),
+        Index(name = "idx_payment_audit_logs_payment_order_id", columnList = "payment_order_id"),
+        Index(name = "idx_payment_audit_logs_event_created", columnList = "event_type, created_at")
+    ]
+)
+class PaymentAuditLog(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_order_id")
+    var paymentOrder: PaymentOrder? = null,
+
+    @Column(name = "order_id", length = 64)
+    var orderId: String? = null,
+
+    @Column(name = "pg_payment_id", length = 200)
+    var pgPaymentId: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 50)
+    var eventType: PaymentAuditEventType,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    var source: PaymentAuditSource,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "previous_order_status", length = 30)
+    var previousOrderStatus: PaymentOrderStatus? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_order_status", length = 30)
+    var currentOrderStatus: PaymentOrderStatus? = null,
+
+    @Column(name = "pg_status", length = 50)
+    var pgStatus: String? = null,
+
+    @Column(length = 500)
+    var reason: String? = null,
+
+    @Column(name = "raw_payload", columnDefinition = "TEXT")
+    var rawPayload: String? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0L
+) : BaseEntity()
+
+enum class PaymentAuditEventType {
+    COMPLETE_REQUEST_RECEIVED,
+    WEBHOOK_RECEIVED,
+    PORTONE_STATUS_FETCHED,
+    PAYMENT_APPROVED,
+    PAYMENT_CANCELLED,
+    PAYMENT_PARTIAL_CANCELLED,
+    PAYMENT_FAILED,
+    PAYMENT_IGNORED,
+}
+
+enum class PaymentAuditSource {
+    COMPLETE_API,
+    WEBHOOK,
+    CANCEL_API,
+    PENDING_REFUND,
+}

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentAuditLogRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/repository/PaymentAuditLogRepository.kt
@@ -1,0 +1,6 @@
+package com.moongchijang.domain.payment.domain.repository
+
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditLog
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentAuditLogRepository : JpaRepository<PaymentAuditLog, Long>

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -79,7 +79,7 @@ class PaymentController(
         } catch (e: RuntimeException) {
             throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
         }
-        paymentService.handlePortOneWebhook(request)
+        paymentService.handlePortOneWebhook(request, rawPayload)
         val response = ResponseEntity.ok(ApiResponse.success(PortOneWebhookResponse()))
         return response
     }

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -1,6 +1,8 @@
 package com.moongchijang.domain.payment.presentation
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.moongchijang.domain.payment.application.PaymentService
+import com.moongchijang.domain.payment.application.PortOneWebhookSignatureVerifier
 import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
 import com.moongchijang.domain.payment.application.dto.CancelParticipationResponse
 import com.moongchijang.domain.payment.application.dto.CheckoutInfoResponse
@@ -10,9 +12,12 @@ import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderRequest
 import com.moongchijang.domain.payment.application.dto.CreatePaymentOrderResponse
 import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
 import com.moongchijang.domain.payment.application.dto.PortOneWebhookResponse
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.response.ApiResponse
 import com.moongchijang.security.principal.CustomUserPrincipal
 import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.access.prepost.PreAuthorize
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,6 +34,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1")
 class PaymentController(
     private val paymentService: PaymentService,
+    private val portOneWebhookSignatureVerifier: PortOneWebhookSignatureVerifier,
+    private val objectMapper: ObjectMapper,
 ) {
 
     @GetMapping("/group-buys/{groupBuyId}/checkout")
@@ -62,8 +70,15 @@ class PaymentController(
 
     @PostMapping("/payments/portone/webhook")
     fun handlePortOneWebhook(
-        @RequestBody request: PortOneWebhookRequest,
+        @RequestBody rawPayload: String,
+        @RequestHeader headers: HttpHeaders,
     ): ResponseEntity<ApiResponse<PortOneWebhookResponse>> {
+        portOneWebhookSignatureVerifier.verify(headers, rawPayload)
+        val request = try {
+            objectMapper.readValue(rawPayload, PortOneWebhookRequest::class.java)
+        } catch (e: RuntimeException) {
+            throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+        }
         paymentService.handlePortOneWebhook(request)
         val response = ResponseEntity.ok(ApiResponse.success(PortOneWebhookResponse()))
         return response

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.payment.presentation
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.moongchijang.domain.payment.application.PaymentService
 import com.moongchijang.domain.payment.application.PortOneWebhookSignatureVerifier
@@ -76,7 +77,7 @@ class PaymentController(
         portOneWebhookSignatureVerifier.verify(headers, rawPayload)
         val request = try {
             objectMapper.readValue(rawPayload, PortOneWebhookRequest::class.java)
-        } catch (e: RuntimeException) {
+        } catch (e: JsonProcessingException) {
             throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
         }
         paymentService.handlePortOneWebhook(request, rawPayload)

--- a/src/main/kotlin/com/moongchijang/global/config/PortOneProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/PortOneProperties.kt
@@ -8,4 +8,6 @@ data class PortOneProperties(
     val channelKey: String,
     val apiSecret: String,
     val paymentApiBaseUrl: String = "https://api.portone.io",
+    val webhookSecret: String? = null,
+    val webhookTimestampToleranceSeconds: Long = 300,
 )

--- a/src/main/kotlin/com/moongchijang/global/config/PortOneProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/PortOneProperties.kt
@@ -8,6 +8,7 @@ data class PortOneProperties(
     val channelKey: String,
     val apiSecret: String,
     val paymentApiBaseUrl: String = "https://api.portone.io",
+    val webhookSignatureVerificationEnabled: Boolean = true,
     val webhookSecret: String? = null,
     val webhookTimestampToleranceSeconds: Long = 300,
 )

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -51,6 +51,8 @@ portone:
   channel-key: ${PORTONE_CHANNEL_KEY}
   api-secret: ${PORTONE_API_SECRET}
   payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+  webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
+  webhook-timestamp-tolerance-seconds: ${PORTONE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS:300}
 
 springdoc:
   swagger-ui:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -51,6 +51,7 @@ portone:
   channel-key: ${PORTONE_CHANNEL_KEY}
   api-secret: ${PORTONE_API_SECRET}
   payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+  webhook-signature-verification-enabled: ${PORTONE_WEBHOOK_SIGNATURE_VERIFICATION_ENABLED:true}
   webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
   webhook-timestamp-tolerance-seconds: ${PORTONE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS:300}
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -95,6 +95,7 @@ discord:
   enabled: ${DISCORD_ENABLED:false}
   webhook:
     refund: ${DISCORD_WEBHOOK_REFUND:}
+    payment: ${DISCORD_WEBHOOK_PAYMENT:}
     groupbuy: ${DISCORD_WEBHOOK_GROUPBUY:}
     onboarding: ${DISCORD_WEBHOOK_ONBOARDING:}
 

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -69,6 +69,8 @@ portone:
   channel-key: ${PORTONE_CHANNEL_KEY:channel-dummy}
   api-secret: ${PORTONE_API_SECRET:portone-api-secret-dummy}
   payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+  webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
+  webhook-timestamp-tolerance-seconds: ${PORTONE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS:300}
 
 ses:
   enabled: ${SES_ENABLED:false}

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -120,5 +120,6 @@ discord:
   enabled: ${DISCORD_ENABLED:false}
   webhook:
     refund: ${DISCORD_WEBHOOK_REFUND:}
+    payment: ${DISCORD_WEBHOOK_PAYMENT:}
     groupbuy: ${DISCORD_WEBHOOK_GROUPBUY:}
     onboarding: ${DISCORD_WEBHOOK_ONBOARDING:}

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -69,6 +69,7 @@ portone:
   channel-key: ${PORTONE_CHANNEL_KEY:channel-dummy}
   api-secret: ${PORTONE_API_SECRET:portone-api-secret-dummy}
   payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+  webhook-signature-verification-enabled: ${PORTONE_WEBHOOK_SIGNATURE_VERIFICATION_ENABLED:false}
   webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
   webhook-timestamp-tolerance-seconds: ${PORTONE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS:300}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,6 +46,7 @@ portone:
   channel-key: ${PORTONE_CHANNEL_KEY}
   api-secret: ${PORTONE_API_SECRET}
   payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+  webhook-signature-verification-enabled: ${PORTONE_WEBHOOK_SIGNATURE_VERIFICATION_ENABLED:true}
   webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
   webhook-timestamp-tolerance-seconds: ${PORTONE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS:300}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -46,6 +46,8 @@ portone:
   channel-key: ${PORTONE_CHANNEL_KEY}
   api-secret: ${PORTONE_API_SECRET}
   payment-api-base-url: ${PORTONE_PAYMENT_API_BASE_URL:https://api.portone.io}
+  webhook-secret: ${PORTONE_WEBHOOK_SECRET:}
+  webhook-timestamp-tolerance-seconds: ${PORTONE_WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS:300}
 
 oauth:
   kakao:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -85,6 +85,7 @@ discord:
   enabled: ${DISCORD_ENABLED:true}
   webhook:
     refund: ${DISCORD_WEBHOOK_REFUND:}
+    payment: ${DISCORD_WEBHOOK_PAYMENT:}
     groupbuy: ${DISCORD_WEBHOOK_GROUPBUY:}
     onboarding: ${DISCORD_WEBHOOK_ONBOARDING:}
 

--- a/src/main/resources/db/migration/V49__create_payment_audit_logs_table.sql
+++ b/src/main/resources/db/migration/V49__create_payment_audit_logs_table.sql
@@ -1,0 +1,21 @@
+CREATE TABLE payment_audit_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    payment_order_id BIGINT NULL,
+    order_id VARCHAR(64) NULL,
+    pg_payment_id VARCHAR(200) NULL,
+    event_type VARCHAR(50) NOT NULL,
+    source VARCHAR(30) NOT NULL,
+    previous_order_status VARCHAR(30) NULL,
+    current_order_status VARCHAR(30) NULL,
+    pg_status VARCHAR(50) NULL,
+    reason VARCHAR(500) NULL,
+    raw_payload TEXT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_payment_audit_logs_payment_order_id FOREIGN KEY (payment_order_id) REFERENCES payment_orders (id)
+);
+
+CREATE INDEX idx_payment_audit_logs_order_id ON payment_audit_logs (order_id);
+CREATE INDEX idx_payment_audit_logs_payment_order_id ON payment_audit_logs (payment_order_id);
+CREATE INDEX idx_payment_audit_logs_event_created ON payment_audit_logs (event_type, created_at);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1621,7 +1621,26 @@ paths:
     post:
       tags: [Participation]
       summary: PortOne 결제 웹훅 수신
-      description: 웹훅 본문만 신뢰하지 않고 서버에서 PortOne 결제 단건 조회 후 상태를 동기화한다.
+      description: 웹훅 signature를 검증한 뒤, 본문만 신뢰하지 않고 서버에서 PortOne 결제 단건 조회 후 상태를 동기화한다. signature 검증은 PORTONE_WEBHOOK_SECRET 설정 시 활성화된다.
+      parameters:
+        - name: webhook-id
+          in: header
+          required: false
+          schema:
+            type: string
+          description: PortOne 웹훅 메시지 ID. PORTONE_WEBHOOK_SECRET 설정 시 필요하다.
+        - name: webhook-timestamp
+          in: header
+          required: false
+          schema:
+            type: string
+          description: PortOne 웹훅 signature 생성 기준 시각. PORTONE_WEBHOOK_SECRET 설정 시 필요하다.
+        - name: webhook-signature
+          in: header
+          required: false
+          schema:
+            type: string
+          description: PortOne 웹훅 signature. PORTONE_WEBHOOK_SECRET 설정 시 필요하다.
       requestBody:
         required: true
         content:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1621,26 +1621,26 @@ paths:
     post:
       tags: [Participation]
       summary: PortOne 결제 웹훅 수신
-      description: 웹훅 signature를 검증한 뒤, 본문만 신뢰하지 않고 서버에서 PortOne 결제 단건 조회 후 상태를 동기화한다. signature 검증은 PORTONE_WEBHOOK_SECRET 설정 시 활성화된다.
+      description: 웹훅 signature를 검증한 뒤, 본문만 신뢰하지 않고 서버에서 PortOne 결제 단건 조회 후 상태를 동기화한다. signature 검증이 활성화된 환경에서는 PORTONE_WEBHOOK_SECRET과 웹훅 헤더가 필요하다.
       parameters:
         - name: webhook-id
           in: header
           required: false
           schema:
             type: string
-          description: PortOne 웹훅 메시지 ID. PORTONE_WEBHOOK_SECRET 설정 시 필요하다.
+          description: PortOne 웹훅 메시지 ID. signature 검증이 활성화된 환경에서 필요하다.
         - name: webhook-timestamp
           in: header
           required: false
           schema:
             type: string
-          description: PortOne 웹훅 signature 생성 기준 시각. PORTONE_WEBHOOK_SECRET 설정 시 필요하다.
+          description: PortOne 웹훅 signature 생성 기준 시각. signature 검증이 활성화된 환경에서 필요하다.
         - name: webhook-signature
           in: header
           required: false
           schema:
             type: string
-          description: PortOne 웹훅 signature. PORTONE_WEBHOOK_SECRET 설정 시 필요하다.
+          description: PortOne 웹훅 signature. signature 검증이 활성화된 환경에서 필요하다.
       requestBody:
         required: true
         content:

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/discord/AdminDiscordAlertServiceTest.kt
@@ -45,4 +45,23 @@ class AdminDiscordAlertServiceTest {
         assertEquals(AdminDiscordChannel.GROUPBUY, captor.value.channel)
         assertTrue(captor.value.message.contains("총 100,000원"))
     }
+
+    @Test
+    fun `결제 실패 알림을 보낼 때 결제 채널로 전송됨`() {
+        val publisher = mock(ApplicationEventPublisher::class.java)
+        val service = AdminDiscordAlertService(publisher)
+
+        service.sendPaymentFailed(
+            orderId = "MCJ-10-test",
+            pgPaymentId = "MCJ-10-test",
+            pgStatus = "FAILED",
+            reason = "PAYMENT_APPROVAL_FAILED",
+        )
+
+        val captor = ArgumentCaptor.forClass(AdminDiscordAlertRequestedEvent::class.java)
+        verify(publisher).publishEvent(captor.capture())
+        assertEquals(AdminDiscordChannel.PAYMENT, captor.value.channel)
+        assertTrue(captor.value.message.contains("결제 실패"))
+        assertTrue(captor.value.message.contains("MCJ-10-test"))
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -85,6 +85,9 @@ class PaymentServiceTest {
     private lateinit var paymentRepository: PaymentRepository
 
     @Mock
+    private lateinit var paymentAuditLogService: PaymentAuditLogService
+
+    @Mock
     private lateinit var portOnePaymentPort: PortOnePaymentPort
 
     @Mock
@@ -123,6 +126,7 @@ class PaymentServiceTest {
             storeStaffRepository = storeStaffRepository,
             paymentOrderRepository = paymentOrderRepository,
             paymentRepository = paymentRepository,
+            paymentAuditLogService = paymentAuditLogService,
             portOnePaymentPort = portOnePaymentPort,
             portOneProperties = portOneProperties,
             transactionManager = transactionManager,

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifierTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifierTest.kt
@@ -1,0 +1,130 @@
+package com.moongchijang.domain.payment.application
+
+import com.moongchijang.global.config.PortOneProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+class PortOneWebhookSignatureVerifierTest {
+
+    private val clock = Clock.fixed(Instant.ofEpochSecond(1_780_000_000), ZoneId.of("Asia/Seoul"))
+    private val rawPayload = """{"type":"Transaction.Paid","paymentId":"MCJ-10-test"}"""
+
+    @Test
+    fun `webhook secret이 없으면 검증을 건너뛴다`() {
+        val verifier = verifier(secret = null)
+
+        assertThatCode {
+            verifier.verify(HttpHeaders(), rawPayload)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `정상 signature면 검증에 성공한다`() {
+        val secret = "test-webhook-secret"
+        val timestamp = clock.instant().epochSecond
+        val webhookId = "evt-1"
+        val headers = HttpHeaders().apply {
+            set("webhook-id", webhookId)
+            set("webhook-timestamp", timestamp.toString())
+            set("webhook-signature", "v1,${signature(secret, webhookId, timestamp, rawPayload)}")
+        }
+
+        assertThatCode {
+            verifier(secret).verify(headers, rawPayload)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `여러 signature 중 하나가 일치하면 검증에 성공한다`() {
+        val secret = "test-webhook-secret"
+        val timestamp = clock.instant().epochSecond
+        val webhookId = "evt-1"
+        val validSignature = signature(secret, webhookId, timestamp, rawPayload)
+        val headers = HttpHeaders().apply {
+            set("webhook-id", webhookId)
+            set("webhook-timestamp", timestamp.toString())
+            set("webhook-signature", "v1,invalid v1,$validSignature")
+        }
+
+        assertThatCode {
+            verifier(secret).verify(headers, rawPayload)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `signature가 일치하지 않으면 웹훅 invalid 예외를 던진다`() {
+        val headers = HttpHeaders().apply {
+            set("webhook-id", "evt-1")
+            set("webhook-timestamp", clock.instant().epochSecond.toString())
+            set("webhook-signature", "v1,invalid")
+        }
+
+        assertThatThrownBy {
+            verifier("test-webhook-secret").verify(headers, rawPayload)
+        }.isInstanceOf(CustomException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+    }
+
+    @Test
+    fun `timestamp 허용 범위를 벗어나면 웹훅 invalid 예외를 던진다`() {
+        val secret = "test-webhook-secret"
+        val timestamp = clock.instant().epochSecond - 301
+        val webhookId = "evt-1"
+        val headers = HttpHeaders().apply {
+            set("webhook-id", webhookId)
+            set("webhook-timestamp", timestamp.toString())
+            set("webhook-signature", "v1,${signature(secret, webhookId, timestamp, rawPayload)}")
+        }
+
+        assertThatThrownBy {
+            verifier(secret).verify(headers, rawPayload)
+        }.isInstanceOf(CustomException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.PAYMENT_WEBHOOK_INVALID)
+    }
+
+    @Test
+    fun `whsec prefix가 있는 base64 secret도 검증한다`() {
+        val rawSecret = "test-webhook-secret"
+        val secret = "whsec_${Base64.getEncoder().encodeToString(rawSecret.toByteArray())}"
+        val timestamp = clock.instant().epochSecond
+        val webhookId = "evt-1"
+        val headers = HttpHeaders().apply {
+            set("webhook-id", webhookId)
+            set("webhook-timestamp", timestamp.toString())
+            set("webhook-signature", "v1,${signature(rawSecret, webhookId, timestamp, rawPayload)}")
+        }
+
+        assertThatCode {
+            verifier(secret).verify(headers, rawPayload)
+        }.doesNotThrowAnyException()
+    }
+
+    private fun verifier(secret: String?): PortOneWebhookSignatureVerifier =
+        PortOneWebhookSignatureVerifier(
+            portOneProperties = PortOneProperties(
+                storeId = "store-test",
+                channelKey = "channel-test",
+                apiSecret = "api-secret",
+                webhookSecret = secret,
+            ),
+            clock = clock,
+        )
+
+    private fun signature(secret: String, webhookId: String, timestamp: Long, payload: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return Base64.getEncoder().encodeToString(mac.doFinal("$webhookId.$timestamp.$payload".toByteArray()))
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifierTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PortOneWebhookSignatureVerifierTest.kt
@@ -20,12 +20,23 @@ class PortOneWebhookSignatureVerifierTest {
     private val rawPayload = """{"type":"Transaction.Paid","paymentId":"MCJ-10-test"}"""
 
     @Test
-    fun `webhook secret이 없으면 검증을 건너뛴다`() {
-        val verifier = verifier(secret = null)
+    fun `signature 검증이 비활성화되어 있으면 검증을 건너뛴다`() {
+        val verifier = verifier(secret = null, enabled = false)
 
         assertThatCode {
             verifier.verify(HttpHeaders(), rawPayload)
         }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `signature 검증이 활성화되어 있는데 webhook secret이 없으면 웹훅 invalid 예외를 던진다`() {
+        val verifier = verifier(secret = null)
+
+        assertThatThrownBy {
+            verifier.verify(HttpHeaders(), rawPayload)
+        }.isInstanceOf(CustomException::class.java)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.PAYMENT_WEBHOOK_INVALID)
     }
 
     @Test
@@ -111,12 +122,13 @@ class PortOneWebhookSignatureVerifierTest {
         }.doesNotThrowAnyException()
     }
 
-    private fun verifier(secret: String?): PortOneWebhookSignatureVerifier =
+    private fun verifier(secret: String?, enabled: Boolean = true): PortOneWebhookSignatureVerifier =
         PortOneWebhookSignatureVerifier(
             portOneProperties = PortOneProperties(
                 storeId = "store-test",
                 channelKey = "channel-test",
                 apiSecret = "api-secret",
+                webhookSignatureVerificationEnabled = enabled,
                 webhookSecret = secret,
             ),
             clock = clock,


### PR DESCRIPTION
## 📌 작업한 내용
- PortOne 웹훅 요청을 raw payload로 받은 뒤 signature 검증을 먼저 수행하도록 변경했습니다.
- `PORTONE_WEBHOOK_SECRET` 설정 시 `webhook-id`, `webhook-timestamp`, `webhook-signature` 헤더를 검증하도록 구성했습니다.
- 결제 상태 변경 근거를 남기는 `payment_audit_logs` 테이블과 `PaymentAuditLogService`를 추가했습니다.
- 결제 완료 API, 웹훅 수신, PortOne 상태 재조회, 승인/취소/실패 상태 변경 이벤트를 audit trail로 기록하도록 보강했습니다.
- 결제 실패 audit event 발생 시 기존 Discord 알림 인프라를 재사용해 `PAYMENT` 채널로 알림을 발행하도록 추가했습니다.

## 🔍 참고 사항
- 기존 Grafana/Prometheus/Alertmanager 모니터링과 구분하기 위해, 이번 작업은 운영 지표가 아니라 결제 건별 상태 변경 이력을 저장하는 도메인 audit trail로 분리했습니다.


## 🖼️ 스크린샷
없음

## 🔗 관련 이슈
closes #312

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
