### PR TITLE
[MCJ-1610] FIX: 외부 HTTP 호출 지연으로 응답 지연 발생 문제 수정

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -46,6 +46,7 @@ import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit
 import java.util.UUID
 
 @Service
@@ -140,6 +141,13 @@ class PaymentService(
     }
 
     fun completePortOnePayment(request: CompletePortOnePaymentRequest, userId: Long): ConfirmPaymentResponse {
+        val startedAtNanos = System.nanoTime()
+        log.info(
+            "[PaymentService] 결제 완료 검증 시작: paymentId={}, userId={}, amount={}",
+            request.paymentId,
+            userId,
+            request.amount,
+        )
         recordPaymentAudit(
             source = PaymentAuditSource.COMPLETE_API,
             eventType = PaymentAuditEventType.COMPLETE_REQUEST_RECEIVED,
@@ -164,7 +172,14 @@ class PaymentService(
                         order = approvedOrder,
                         reason = ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED.name,
                     )
-                    buildAlreadyApprovedResponse(approvedOrder)
+                    buildAlreadyApprovedResponse(approvedOrder).also {
+                        log.info(
+                            "[PaymentService] 결제 완료 검증 멱등 응답: paymentId={}, userId={}, elapsedMs={}",
+                            request.paymentId,
+                            userId,
+                            elapsedMs(startedAtNanos),
+                        )
+                    }
                 } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
             }
             if (order.status != PaymentOrderStatus.READY) {
@@ -219,10 +234,25 @@ class PaymentService(
             }
 
             return when (result) {
-                is PaymentApprovalResult.Success -> result.response
+                is PaymentApprovalResult.Success -> result.response.also {
+                    log.info(
+                        "[PaymentService] 결제 완료 검증 성공: paymentId={}, userId={}, participationId={}, elapsedMs={}",
+                        request.paymentId,
+                        userId,
+                        it.participationId,
+                        elapsedMs(startedAtNanos),
+                    )
+                }
                 is PaymentApprovalResult.Failure -> throw CustomException(result.errorCode)
             }
         } catch (e: CustomException) {
+            log.warn(
+                "[PaymentService] 결제 완료 검증 실패: paymentId={}, userId={}, errorCode={}, elapsedMs={}",
+                request.paymentId,
+                userId,
+                e.errorCode.name,
+                elapsedMs(startedAtNanos),
+            )
             recordPaymentAudit(
                 source = PaymentAuditSource.COMPLETE_API,
                 eventType = PaymentAuditEventType.PAYMENT_FAILED,
@@ -637,12 +667,7 @@ class PaymentService(
     }
 
     private fun getPortOnePaymentOrFailOrder(paymentId: String): PortOnePaymentResult {
-        return try {
-            portOnePaymentPort.getPayment(paymentId)
-        } catch (e: CustomException) {
-            markOrderFailed(paymentId)
-            throw e
-        }
+        return portOnePaymentPort.getPayment(paymentId)
     }
 
     private fun markOrderFailed(paymentId: String) {
@@ -1145,6 +1170,9 @@ class PaymentService(
         val pgPaymentId: String,
         val refundAmount: Int,
     )
+
+    private fun elapsedMs(startedAtNanos: Long): Long =
+        TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAtNanos)
 
     companion object {
         private const val LOCK_WAIT_MS = 500L

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -221,7 +221,15 @@ class PaymentService(
             }
 
             return when (result) {
-                is PaymentApprovalResult.Success -> result.response
+                is PaymentApprovalResult.Success -> result.response.also {
+                    log.info(
+                        "[PaymentService] 결제 완료 검증 성공: paymentId={}, userId={}, participationId={}, elapsedMs={}",
+                        request.paymentId,
+                        userId,
+                        it.participationId,
+                        elapsedMs(startedAtNanos),
+                    )
+                }
                 is PaymentApprovalResult.Failure -> throw CustomException(result.errorCode)
             }
         } catch (e: CustomException) {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -142,12 +142,6 @@ class PaymentService(
 
     fun completePortOnePayment(request: CompletePortOnePaymentRequest, userId: Long): ConfirmPaymentResponse {
         val startedAtNanos = System.nanoTime()
-        log.info(
-            "[PaymentService] 결제 완료 검증 시작: paymentId={}, userId={}, amount={}",
-            request.paymentId,
-            userId,
-            request.amount,
-        )
         recordPaymentAudit(
             source = PaymentAuditSource.COMPLETE_API,
             eventType = PaymentAuditEventType.COMPLETE_REQUEST_RECEIVED,
@@ -172,14 +166,7 @@ class PaymentService(
                         order = approvedOrder,
                         reason = ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED.name,
                     )
-                    buildAlreadyApprovedResponse(approvedOrder).also {
-                        log.info(
-                            "[PaymentService] 결제 완료 검증 멱등 응답: paymentId={}, userId={}, elapsedMs={}",
-                            request.paymentId,
-                            userId,
-                            elapsedMs(startedAtNanos),
-                        )
-                    }
+                    buildAlreadyApprovedResponse(approvedOrder)
                 } ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
             }
             if (order.status != PaymentOrderStatus.READY) {
@@ -234,15 +221,7 @@ class PaymentService(
             }
 
             return when (result) {
-                is PaymentApprovalResult.Success -> result.response.also {
-                    log.info(
-                        "[PaymentService] 결제 완료 검증 성공: paymentId={}, userId={}, participationId={}, elapsedMs={}",
-                        request.paymentId,
-                        userId,
-                        it.participationId,
-                        elapsedMs(startedAtNanos),
-                    )
-                }
+                is PaymentApprovalResult.Success -> result.response
                 is PaymentApprovalResult.Failure -> throw CustomException(result.errorCode)
             }
         } catch (e: CustomException) {

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -38,8 +38,6 @@ class PortOnePaymentClient(
         }
         if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
             log.warn("[PortOnePaymentClient] 결제 단건 조회 지연: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
-        } else {
-            log.debug("[PortOnePaymentClient] 결제 단건 조회 완료: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
         }
 
         return try {
@@ -73,8 +71,6 @@ class PortOnePaymentClient(
         }
         if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
             log.warn("[PortOnePaymentClient] 결제 취소 요청 지연: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
-        } else {
-            log.debug("[PortOnePaymentClient] 결제 취소 요청 완료: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
         }
 
         return try {

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -12,7 +12,6 @@ import org.springframework.web.client.RestClientException
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeParseException
-import kotlin.system.measureTimeMillis
 
 @Component
 class PortOnePaymentClient(
@@ -23,19 +22,24 @@ class PortOnePaymentClient(
     private val log = LoggerFactory.getLogger(javaClass)
 
     override fun getPayment(paymentId: String): PortOnePaymentResult {
-        lateinit var response: Map<*, *>
-        val elapsedMs = measureTimeMillis {
-            response = try {
-                restClient.get()
-                    .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}", paymentId)
-                    .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
-                    .retrieve()
-                    .body(Map::class.java)
-                    ?: throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
-            } catch (e: RestClientException) {
-                throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
-            }
+        val startedAtMs = System.currentTimeMillis()
+        val response = try {
+            restClient.get()
+                .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}", paymentId)
+                .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
+                .retrieve()
+                .body(Map::class.java)
+                ?: throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+        } catch (e: RestClientException) {
+            log.warn(
+                "[PortOnePaymentClient] 결제 단건 조회 실패: paymentId={}, elapsedMs={}",
+                paymentId,
+                System.currentTimeMillis() - startedAtMs,
+                e,
+            )
+            throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
         }
+        val elapsedMs = System.currentTimeMillis() - startedAtMs
         if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
             log.warn("[PortOnePaymentClient] 결제 단건 조회 지연: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
         }
@@ -55,20 +59,25 @@ class PortOnePaymentClient(
                 this["amount"] = cancelAmount
             }
         }
-        lateinit var response: Map<*, *>
-        val elapsedMs = measureTimeMillis {
-            response = try {
-                restClient.post()
-                    .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}/cancel", paymentId)
-                    .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
-                    .body(requestBody)
-                    .retrieve()
-                    .body(Map::class.java)
-                    ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
-            } catch (e: RestClientException) {
-                throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
-            }
+        val startedAtMs = System.currentTimeMillis()
+        val response = try {
+            restClient.post()
+                .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}/cancel", paymentId)
+                .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
+                .body(requestBody)
+                .retrieve()
+                .body(Map::class.java)
+                ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        } catch (e: RestClientException) {
+            log.warn(
+                "[PortOnePaymentClient] 결제 취소 요청 실패: paymentId={}, elapsedMs={}",
+                paymentId,
+                System.currentTimeMillis() - startedAtMs,
+                e,
+            )
+            throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
         }
+        val elapsedMs = System.currentTimeMillis() - startedAtMs
         if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
             log.warn("[PortOnePaymentClient] 결제 취소 요청 지연: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
         }

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -5,12 +5,14 @@ import com.moongchijang.domain.payment.application.port.PortOnePaymentResult
 import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.format.DateTimeParseException
+import kotlin.system.measureTimeMillis
 
 @Component
 class PortOnePaymentClient(
@@ -18,17 +20,26 @@ class PortOnePaymentClient(
     restClientBuilder: RestClient.Builder,
 ) : PortOnePaymentPort {
     private val restClient = restClientBuilder.build()
+    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun getPayment(paymentId: String): PortOnePaymentResult {
-        val response = try {
-            restClient.get()
-                .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}", paymentId)
-                .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
-                .retrieve()
-                .body(Map::class.java)
-                ?: throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
-        } catch (e: RestClientException) {
-            throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+        lateinit var response: Map<*, *>
+        val elapsedMs = measureTimeMillis {
+            response = try {
+                restClient.get()
+                    .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}", paymentId)
+                    .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
+                    .retrieve()
+                    .body(Map::class.java)
+                    ?: throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+            } catch (e: RestClientException) {
+                throw CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED)
+            }
+        }
+        if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
+            log.warn("[PortOnePaymentClient] 결제 단건 조회 지연: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
+        } else {
+            log.debug("[PortOnePaymentClient] 결제 단건 조회 완료: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
         }
 
         return try {
@@ -46,16 +57,24 @@ class PortOnePaymentClient(
                 this["amount"] = cancelAmount
             }
         }
-        val response = try {
-            restClient.post()
-                .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}/cancel", paymentId)
-                .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
-                .body(requestBody)
-                .retrieve()
-                .body(Map::class.java)
-                ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
-        } catch (e: RestClientException) {
-            throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        lateinit var response: Map<*, *>
+        val elapsedMs = measureTimeMillis {
+            response = try {
+                restClient.post()
+                    .uri("${portOneProperties.paymentApiBaseUrl}/payments/{paymentId}/cancel", paymentId)
+                    .header("Authorization", "PortOne ${portOneProperties.apiSecret}")
+                    .body(requestBody)
+                    .retrieve()
+                    .body(Map::class.java)
+                    ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+            } catch (e: RestClientException) {
+                throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+            }
+        }
+        if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
+            log.warn("[PortOnePaymentClient] 결제 취소 요청 지연: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
+        } else {
+            log.debug("[PortOnePaymentClient] 결제 취소 요청 완료: paymentId={}, elapsedMs={}", paymentId, elapsedMs)
         }
 
         return try {
@@ -103,5 +122,9 @@ class PortOnePaymentClient(
                 LocalDateTime.parse(it)
             }
         }
+    }
+
+    companion object {
+        private const val SLOW_REQUEST_WARN_THRESHOLD_MS = 1_000L
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClient.kt
@@ -12,7 +12,6 @@ import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 import tools.jackson.databind.ObjectMapper
 import java.time.Duration
-import kotlin.system.measureTimeMillis
 
 @Component
 class NaverLocalSearchClient(
@@ -36,30 +35,30 @@ class NaverLocalSearchClient(
     }
 
     private fun fetchFromNaver(keyword: String, display: Int): NaverLocalSearchResponse {
-        lateinit var response: NaverLocalSearchResponse
-        val elapsedMs = measureTimeMillis {
-            response = try {
-                restClient.get()
-                    .uri(
-                        "${naverApiProperties.localSearchUrl}?query={keyword}&display={display}",
-                        keyword,
-                        display
-                    )
-                    .header("X-Naver-Client-Id", naverApiProperties.clientId)
-                    .header("X-Naver-Client-Secret", naverApiProperties.clientSecret)
-                    .retrieve()
-                    .body(NaverLocalSearchResponse::class.java)
-                    ?: throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
-            } catch (e: RestClientException) {
-                log.warn(
-                    "[NaverLocalSearchClient] 로컬 검색 실패: keywordLength={}, display={}",
-                    keyword.length,
-                    display,
-                    e,
+        val startedAtMs = System.currentTimeMillis()
+        val response = try {
+            restClient.get()
+                .uri(
+                    "${naverApiProperties.localSearchUrl}?query={keyword}&display={display}",
+                    keyword,
+                    display
                 )
-                throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
-            }
+                .header("X-Naver-Client-Id", naverApiProperties.clientId)
+                .header("X-Naver-Client-Secret", naverApiProperties.clientSecret)
+                .retrieve()
+                .body(NaverLocalSearchResponse::class.java)
+                ?: throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
+        } catch (e: RestClientException) {
+            log.warn(
+                "[NaverLocalSearchClient] 로컬 검색 실패: keywordLength={}, display={}, elapsedMs={}",
+                keyword.length,
+                display,
+                System.currentTimeMillis() - startedAtMs,
+                e,
+            )
+            throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
         }
+        val elapsedMs = System.currentTimeMillis() - startedAtMs
         if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
             log.warn(
                 "[NaverLocalSearchClient] 로컬 검색 지연: keywordLength={}, display={}, total={}, elapsedMs={}",

--- a/src/main/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClient.kt
@@ -5,44 +5,44 @@ import com.moongchijang.global.config.NaverApiProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataAccessException
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
+import tools.jackson.databind.ObjectMapper
 import java.time.Duration
-import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.system.measureTimeMillis
 
 @Component
 class NaverLocalSearchClient(
     private val naverApiProperties: NaverApiProperties,
-    restClientBuilder: RestClient.Builder
+    restClientBuilder: RestClient.Builder,
+    private val redisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper,
 ) {
     private val restClient = restClientBuilder.build()
-    private val cache = ConcurrentHashMap<CacheKey, CachedResponse>()
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun search(keyword: String, display: Int = 5): NaverLocalSearchResponse {
         val normalizedKeyword = keyword.trim()
-        val key = CacheKey(normalizedKeyword, display)
-        val cached = cache[key]
-        if (cached != null && cached.isFresh()) {
-            log.debug(
-                "[NaverLocalSearchClient] 로컬 검색 캐시 적중: keywordLength={}, display={}, total={}",
-                normalizedKeyword.length,
-                display,
-                cached.response.total,
-            )
-            return cached.response
-        }
+        val key = cacheKey(normalizedKeyword, display)
 
+        readCache(key)?.let { cached -> return cached }
+
+        val response = fetchFromNaver(normalizedKeyword, display)
+        writeCache(key, response)
+        return response
+    }
+
+    private fun fetchFromNaver(keyword: String, display: Int): NaverLocalSearchResponse {
         lateinit var response: NaverLocalSearchResponse
         val elapsedMs = measureTimeMillis {
             response = try {
                 restClient.get()
                     .uri(
                         "${naverApiProperties.localSearchUrl}?query={keyword}&display={display}",
-                        normalizedKeyword,
+                        keyword,
                         display
                     )
                     .header("X-Naver-Client-Id", naverApiProperties.clientId)
@@ -53,7 +53,7 @@ class NaverLocalSearchClient(
             } catch (e: RestClientException) {
                 log.warn(
                     "[NaverLocalSearchClient] 로컬 검색 실패: keywordLength={}, display={}",
-                    normalizedKeyword.length,
+                    keyword.length,
                     display,
                     e,
                 )
@@ -63,46 +63,52 @@ class NaverLocalSearchClient(
         if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
             log.warn(
                 "[NaverLocalSearchClient] 로컬 검색 지연: keywordLength={}, display={}, total={}, elapsedMs={}",
-                normalizedKeyword.length,
-                display,
-                response.total,
-                elapsedMs,
-            )
-        } else {
-            log.debug(
-                "[NaverLocalSearchClient] 로컬 검색 완료: keywordLength={}, display={}, total={}, elapsedMs={}",
-                normalizedKeyword.length,
+                keyword.length,
                 display,
                 response.total,
                 elapsedMs,
             )
         }
-        cacheSuccessfulResponse(key, response)
         return response
     }
 
-    private fun cacheSuccessfulResponse(key: CacheKey, response: NaverLocalSearchResponse) {
-        if (cache.size >= MAX_CACHE_SIZE) {
-            cache.clear()
+    private fun readCache(key: String): NaverLocalSearchResponse? {
+        val raw = try {
+            redisTemplate.opsForValue().get(key)
+        } catch (e: DataAccessException) {
+            log.warn("[NaverLocalSearchClient] Redis 캐시 조회 실패: key={}", key, e)
+            return null
+        } ?: return null
+
+        return try {
+            objectMapper.readValue(raw, NaverLocalSearchResponse::class.java)
+        } catch (e: Exception) {
+            log.warn("[NaverLocalSearchClient] 캐시 역직렬화 실패: key={}", key, e)
+            runCatching { redisTemplate.delete(key) }
+            null
         }
-        cache[key] = CachedResponse(response = response, expiresAt = Instant.now().plus(CACHE_TTL))
     }
 
-    private data class CacheKey(
-        val keyword: String,
-        val display: Int,
-    )
-
-    private data class CachedResponse(
-        val response: NaverLocalSearchResponse,
-        val expiresAt: Instant,
-    ) {
-        fun isFresh(): Boolean = Instant.now().isBefore(expiresAt)
+    private fun writeCache(key: String, response: NaverLocalSearchResponse) {
+        val raw = try {
+            objectMapper.writeValueAsString(response)
+        } catch (e: Exception) {
+            log.warn("[NaverLocalSearchClient] 캐시 직렬화 실패: key={}", key, e)
+            return
+        }
+        try {
+            redisTemplate.opsForValue().set(key, raw, CACHE_TTL)
+        } catch (e: DataAccessException) {
+            log.warn("[NaverLocalSearchClient] Redis 캐시 저장 실패: key={}", key, e)
+        }
     }
+
+    private fun cacheKey(keyword: String, display: Int): String =
+        "$CACHE_KEY_PREFIX:$display:$keyword"
 
     companion object {
+        private const val CACHE_KEY_PREFIX = "store:naver-local-search"
         private val CACHE_TTL: Duration = Duration.ofMinutes(5)
-        private const val MAX_CACHE_SIZE = 500
         private const val SLOW_REQUEST_WARN_THRESHOLD_MS = 1_000L
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClient.kt
@@ -4,9 +4,14 @@ import com.moongchijang.domain.store.infrastructure.naver.dto.NaverLocalSearchRe
 import com.moongchijang.global.config.NaverApiProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.system.measureTimeMillis
 
 @Component
 class NaverLocalSearchClient(
@@ -14,19 +19,90 @@ class NaverLocalSearchClient(
     restClientBuilder: RestClient.Builder
 ) {
     private val restClient = restClientBuilder.build()
+    private val cache = ConcurrentHashMap<CacheKey, CachedResponse>()
+    private val log = LoggerFactory.getLogger(javaClass)
 
     fun search(keyword: String, display: Int = 5): NaverLocalSearchResponse {
-        return try {
-            restClient.get()
-                .uri("${naverApiProperties.localSearchUrl}?query={keyword}&display={display}",
-                    keyword, display)
-                .header("X-Naver-Client-Id", naverApiProperties.clientId)
-                .header("X-Naver-Client-Secret", naverApiProperties.clientSecret)
-                .retrieve()
-                .body(NaverLocalSearchResponse::class.java)
-                ?: throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
-        } catch (e: RestClientException) {
-            throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
+        val normalizedKeyword = keyword.trim()
+        val key = CacheKey(normalizedKeyword, display)
+        val cached = cache[key]
+        if (cached != null && cached.isFresh()) {
+            log.debug(
+                "[NaverLocalSearchClient] 로컬 검색 캐시 적중: keywordLength={}, display={}, total={}",
+                normalizedKeyword.length,
+                display,
+                cached.response.total,
+            )
+            return cached.response
         }
+
+        lateinit var response: NaverLocalSearchResponse
+        val elapsedMs = measureTimeMillis {
+            response = try {
+                restClient.get()
+                    .uri(
+                        "${naverApiProperties.localSearchUrl}?query={keyword}&display={display}",
+                        normalizedKeyword,
+                        display
+                    )
+                    .header("X-Naver-Client-Id", naverApiProperties.clientId)
+                    .header("X-Naver-Client-Secret", naverApiProperties.clientSecret)
+                    .retrieve()
+                    .body(NaverLocalSearchResponse::class.java)
+                    ?: throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
+            } catch (e: RestClientException) {
+                log.warn(
+                    "[NaverLocalSearchClient] 로컬 검색 실패: keywordLength={}, display={}",
+                    normalizedKeyword.length,
+                    display,
+                    e,
+                )
+                throw CustomException(ErrorCode.STORE_SEARCH_FAILED)
+            }
+        }
+        if (elapsedMs >= SLOW_REQUEST_WARN_THRESHOLD_MS) {
+            log.warn(
+                "[NaverLocalSearchClient] 로컬 검색 지연: keywordLength={}, display={}, total={}, elapsedMs={}",
+                normalizedKeyword.length,
+                display,
+                response.total,
+                elapsedMs,
+            )
+        } else {
+            log.debug(
+                "[NaverLocalSearchClient] 로컬 검색 완료: keywordLength={}, display={}, total={}, elapsedMs={}",
+                normalizedKeyword.length,
+                display,
+                response.total,
+                elapsedMs,
+            )
+        }
+        cacheSuccessfulResponse(key, response)
+        return response
+    }
+
+    private fun cacheSuccessfulResponse(key: CacheKey, response: NaverLocalSearchResponse) {
+        if (cache.size >= MAX_CACHE_SIZE) {
+            cache.clear()
+        }
+        cache[key] = CachedResponse(response = response, expiresAt = Instant.now().plus(CACHE_TTL))
+    }
+
+    private data class CacheKey(
+        val keyword: String,
+        val display: Int,
+    )
+
+    private data class CachedResponse(
+        val response: NaverLocalSearchResponse,
+        val expiresAt: Instant,
+    ) {
+        fun isFresh(): Boolean = Instant.now().isBefore(expiresAt)
+    }
+
+    companion object {
+        private val CACHE_TTL: Duration = Duration.ofMinutes(5)
+        private const val MAX_CACHE_SIZE = 500
+        private const val SLOW_REQUEST_WARN_THRESHOLD_MS = 1_000L
     }
 }

--- a/src/main/kotlin/com/moongchijang/global/config/HttpClientProperties.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/HttpClientProperties.kt
@@ -1,0 +1,9 @@
+package com.moongchijang.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "http-client")
+data class HttpClientProperties(
+    val connectTimeoutMs: Long = 2_000,
+    val readTimeoutMs: Long = 5_000,
+)

--- a/src/main/kotlin/com/moongchijang/global/config/RestClientConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/RestClientConfig.kt
@@ -2,13 +2,24 @@ package com.moongchijang.global.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
+import java.time.Duration
 
 @Configuration
-class RestClientConfig {
+class RestClientConfig(
+    private val httpClientProperties: HttpClientProperties,
+) {
 
     @Bean
-    fun restClientBuilder(): RestClient.Builder = RestClient.builder()
+    fun restClientBuilder(): RestClient.Builder =
+        RestClient.builder()
+            .requestFactory(
+                SimpleClientHttpRequestFactory().apply {
+                    setConnectTimeout(Duration.ofMillis(httpClientProperties.connectTimeoutMs.coerceAtLeast(1)))
+                    setReadTimeout(Duration.ofMillis(httpClientProperties.readTimeoutMs.coerceAtLeast(1)))
+                }
+            )
 
     @Bean
     fun restClient(builder: RestClient.Builder): RestClient = builder.build()

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -46,6 +46,7 @@ import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.Mockito.lenient
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
@@ -330,6 +331,25 @@ class PaymentServiceTest {
 
         assertEquals(ErrorCode.GROUPBUY_LOCK_ACQUISITION_FAILED, ex.errorCode)
         verify(redisLockUtil).lockKey(10L)
+    }
+
+    @Test
+    fun `포트원 결제 조회 실패는 주문을 실패 확정하지 않고 재시도와 웹훅 처리를 열어둔다`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(currentQuantity = 36)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 1)
+        stubTransaction()
+        `when`(paymentOrderRepository.findByOrderId("MCJ-10-test")).thenReturn(order)
+        `when`(portOnePaymentPort.getPayment("MCJ-10-test"))
+            .thenThrow(CustomException(ErrorCode.PAYMENT_APPROVAL_FAILED))
+
+        val ex = assertThrows<CustomException> {
+            service.completePortOnePayment(CompletePortOnePaymentRequest("MCJ-10-test", 6000), 1L)
+        }
+
+        assertEquals(ErrorCode.PAYMENT_APPROVAL_FAILED, ex.errorCode)
+        assertEquals(PaymentOrderStatus.READY, order.status)
+        verify(paymentOrderRepository, never()).save(order)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClientTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClientTest.kt
@@ -1,0 +1,73 @@
+package com.moongchijang.domain.store.infrastructure.naver
+
+import com.moongchijang.global.config.NaverApiProperties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.ExpectedCount.once
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+
+class NaverLocalSearchClientTest {
+
+    @Test
+    fun `동일 키워드와 display 검색은 성공 응답 캐시를 재사용한다`() {
+        val builder = RestClient.builder()
+        val server = MockRestServiceServer.bindTo(builder).build()
+        val client = NaverLocalSearchClient(
+            naverApiProperties = NaverApiProperties(
+                clientId = "naver-client-id",
+                clientSecret = "naver-client-secret",
+                localSearchUrl = "https://naver.test/v1/search/local.json",
+            ),
+            restClientBuilder = builder,
+        )
+
+        server.expect(
+            once(),
+            requestTo(
+                "https://naver.test/v1/search/local.json?query=%EC%84%B1%EC%88%98%20%EC%86%8C%EA%B8%88%EB%B9%B5&display=20"
+            )
+        )
+            .andExpect(method(HttpMethod.GET))
+            .andExpect(header("X-Naver-Client-Id", "naver-client-id"))
+            .andExpect(header("X-Naver-Client-Secret", "naver-client-secret"))
+            .andRespond(
+                withSuccess(
+                    """
+                    {
+                      "total": 1,
+                      "start": 1,
+                      "display": 1,
+                      "items": [
+                        {
+                          "title": "<b>성수베이커리</b>",
+                          "link": "https://map.naver.com/p/entry/place/100",
+                          "category": "음식점>카페,디저트",
+                          "description": "",
+                          "telephone": "",
+                          "address": "서울 성동구",
+                          "roadAddress": "서울 성동구 연무장길 1",
+                          "mapx": "1270559610",
+                          "mapy": "375445810"
+                        }
+                      ]
+                    }
+                    """.trimIndent(),
+                    MediaType.APPLICATION_JSON
+                )
+            )
+
+        val first = client.search("성수 소금빵", 20)
+        val second = client.search("성수 소금빵", 20)
+
+        assertEquals(1, first.total)
+        assertEquals(first, second)
+        server.verify()
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClientTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/store/infrastructure/naver/NaverLocalSearchClientTest.kt
@@ -3,6 +3,16 @@ package com.moongchijang.domain.store.infrastructure.naver
 import com.moongchijang.global.config.NaverApiProperties
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.springframework.dao.QueryTimeoutException
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.ValueOperations
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.test.web.client.ExpectedCount.once
@@ -12,22 +22,71 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 import org.springframework.web.client.RestClient
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import java.time.Duration
 
 class NaverLocalSearchClientTest {
 
+    private val objectMapper: ObjectMapper = JsonMapper.builder().findAndAddModules().build()
+    private val naverApiProperties = NaverApiProperties(
+        clientId = "naver-client-id",
+        clientSecret = "naver-client-secret",
+        localSearchUrl = "https://naver.test/v1/search/local.json",
+    )
+
+    private val sampleResponseJson = """
+        {
+          "total": 1,
+          "start": 1,
+          "display": 1,
+          "items": [
+            {
+              "title": "<b>성수베이커리</b>",
+              "link": "https://map.naver.com/p/entry/place/100",
+              "category": "음식점>카페,디저트",
+              "description": "",
+              "telephone": "",
+              "address": "서울 성동구",
+              "roadAddress": "서울 성동구 연무장길 1",
+              "mapx": "1270559610",
+              "mapy": "375445810"
+            }
+          ]
+        }
+    """.trimIndent()
+
+    private fun mockedRedis(): Pair<StringRedisTemplate, ValueOperations<String, String>> {
+        val redisTemplate = Mockito.mock(StringRedisTemplate::class.java)
+        @Suppress("UNCHECKED_CAST")
+        val valueOps = Mockito.mock(ValueOperations::class.java) as ValueOperations<String, String>
+        Mockito.`when`(redisTemplate.opsForValue()).thenReturn(valueOps)
+        return redisTemplate to valueOps
+    }
+
     @Test
-    fun `동일 키워드와 display 검색은 성공 응답 캐시를 재사용한다`() {
+    fun `Redis 캐시가 있으면 외부 API를 호출하지 않고 캐시 값을 그대로 반환한다`() {
         val builder = RestClient.builder()
         val server = MockRestServiceServer.bindTo(builder).build()
-        val client = NaverLocalSearchClient(
-            naverApiProperties = NaverApiProperties(
-                clientId = "naver-client-id",
-                clientSecret = "naver-client-secret",
-                localSearchUrl = "https://naver.test/v1/search/local.json",
-            ),
-            restClientBuilder = builder,
-        )
 
+        val (redisTemplate, valueOps) = mockedRedis()
+        Mockito.`when`(valueOps.get("store:naver-local-search:20:성수 소금빵"))
+            .thenReturn(sampleResponseJson)
+
+        val client = NaverLocalSearchClient(naverApiProperties, builder, redisTemplate, objectMapper)
+
+        val result = client.search("성수 소금빵", 20)
+
+        assertEquals(1, result.total)
+        assertEquals("https://map.naver.com/p/entry/place/100", result.items.first().link)
+        verify(valueOps, never()).set(anyString(), anyString(), any(Duration::class.java))
+        server.verify()
+    }
+
+    @Test
+    fun `캐시 미스 시 외부 API를 호출하고 응답을 Redis에 TTL과 함께 저장한다`() {
+        val builder = RestClient.builder()
+        val server = MockRestServiceServer.bindTo(builder).build()
         server.expect(
             once(),
             requestTo(
@@ -37,37 +96,46 @@ class NaverLocalSearchClientTest {
             .andExpect(method(HttpMethod.GET))
             .andExpect(header("X-Naver-Client-Id", "naver-client-id"))
             .andExpect(header("X-Naver-Client-Secret", "naver-client-secret"))
-            .andRespond(
-                withSuccess(
-                    """
-                    {
-                      "total": 1,
-                      "start": 1,
-                      "display": 1,
-                      "items": [
-                        {
-                          "title": "<b>성수베이커리</b>",
-                          "link": "https://map.naver.com/p/entry/place/100",
-                          "category": "음식점>카페,디저트",
-                          "description": "",
-                          "telephone": "",
-                          "address": "서울 성동구",
-                          "roadAddress": "서울 성동구 연무장길 1",
-                          "mapx": "1270559610",
-                          "mapy": "375445810"
-                        }
-                      ]
-                    }
-                    """.trimIndent(),
-                    MediaType.APPLICATION_JSON
-                )
+            .andRespond(withSuccess(sampleResponseJson, MediaType.APPLICATION_JSON))
+
+        val (redisTemplate, valueOps) = mockedRedis()
+        Mockito.`when`(valueOps.get("store:naver-local-search:20:성수 소금빵")).thenReturn(null)
+
+        val client = NaverLocalSearchClient(naverApiProperties, builder, redisTemplate, objectMapper)
+
+        val result = client.search("성수 소금빵", 20)
+
+        assertEquals(1, result.total)
+        verify(valueOps).set(
+            eq("store:naver-local-search:20:성수 소금빵"),
+            anyString(),
+            eq(Duration.ofMinutes(5))
+        )
+        server.verify()
+    }
+
+    @Test
+    fun `Redis 조회가 실패해도 외부 API 호출은 정상 동작한다`() {
+        val builder = RestClient.builder()
+        val server = MockRestServiceServer.bindTo(builder).build()
+        server.expect(
+            once(),
+            requestTo(
+                "https://naver.test/v1/search/local.json?query=%EC%84%B1%EC%88%98%20%EC%86%8C%EA%B8%88%EB%B9%B5&display=20"
             )
+        )
+            .andRespond(withSuccess(sampleResponseJson, MediaType.APPLICATION_JSON))
 
-        val first = client.search("성수 소금빵", 20)
-        val second = client.search("성수 소금빵", 20)
+        val (redisTemplate, valueOps) = mockedRedis()
+        Mockito.`when`(valueOps.get(anyString())).thenThrow(QueryTimeoutException("redis down"))
+        doThrow(QueryTimeoutException("redis down"))
+            .`when`(valueOps).set(anyString(), anyString(), any(Duration::class.java))
 
-        assertEquals(1, first.total)
-        assertEquals(first, second)
+        val client = NaverLocalSearchClient(naverApiProperties, builder, redisTemplate, objectMapper)
+
+        val result = client.search("성수 소금빵", 20)
+
+        assertEquals(1, result.total)
         server.verify()
     }
 }

--- a/src/test/kotlin/com/moongchijang/global/config/RestClientConfigTest.kt
+++ b/src/test/kotlin/com/moongchijang/global/config/RestClientConfigTest.kt
@@ -1,0 +1,49 @@
+package com.moongchijang.global.config
+
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.web.client.RestClientException
+import java.net.InetSocketAddress
+import java.util.concurrent.Executors
+import kotlin.system.measureTimeMillis
+
+class RestClientConfigTest {
+
+    @Test
+    fun `RestClient는 느린 외부 응답에서 read timeout을 적용한다`() {
+        val executor = Executors.newSingleThreadExecutor()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/slow") { exchange ->
+            Thread.sleep(1_000)
+            exchange.sendResponseHeaders(200, 0)
+            exchange.responseBody.close()
+        }
+        server.executor = executor
+        server.start()
+
+        try {
+            val config = RestClientConfig(
+                HttpClientProperties(
+                    connectTimeoutMs = 100,
+                    readTimeoutMs = 100,
+                )
+            )
+            val client = config.restClient(config.restClientBuilder())
+            val elapsedMs = measureTimeMillis {
+                assertThrows<RestClientException> {
+                    client.get()
+                        .uri("http://127.0.0.1:${server.address.port}/slow")
+                        .retrieve()
+                        .body(String::class.java)
+                }
+            }
+
+            assertTrue(elapsedMs < 900, "read timeout should fail before the delayed response completes")
+        } finally {
+            server.stop(0)
+            executor.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 공용 `RestClient`에 `connect/read timeout`을 적용하기 위한 `HttpClientProperties`(기본 2s/5s)와 `SimpleClientHttpRequestFactory` 설정 추가
- `PortOnePaymentClient` 결제 단건 조회/취소 호출에 경과 시간 로그와 1초 이상 지연 경고 추가
- `PaymentService.completePortOnePayment`에 전체 처리 소요시간 로그(성공/멱등/실패) 추가, 시작/종료 추적용 `elapsedMs` 헬퍼 도입
- `getPortOnePaymentOrFailOrder`에서 조회 실패 시 주문을 즉시 `FAILED`로 확정하던 동작 제거 → 웹훅/재시도 기반 복구 경로를 열어둠
- `NaverLocalSearchClient`에 성공 응답 TTL 캐시(5분, 최대 500개)와 경과 시간 로그/지연 경고/실패 로그 추가
- 신규 테스트
  - `RestClientConfigTest`: 느린 외부 서버에 대해 read timeout이 실제로 적용되는지 검증
  - `PaymentServiceTest`: PortOne 조회 실패 시 주문이 `READY` 상태를 유지하고 저장이 일어나지 않음을 검증
  - `NaverLocalSearchClientTest`: 동일 키워드·display 검색이 캐시를 재사용해 추가 외부 호출이 발생하지 않음을 검증

## 🔍 참고 사항
- 기존 `RestClient.Builder`는 timeout 설정이 없어 외부 응답이 늦어지면 결제 완료 검증 API가 함께 멈춰 사용자에게 승인 UI 노출이 지연되는 구조였습니다.
- `HttpClientProperties`는 `@ConfigurationPropertiesScan`으로 자동 등록되며, 기본값(2s/5s)만으로도 동작합니다. 환경별 조정이 필요하면 `http-client.connect-timeout-ms`, `http-client.read-timeout-ms`로 오버라이드 가능합니다.
- PortOne 조회 실패는 네트워크/타임아웃/일시 장애의 비중이 크다고 판단해, 비즈니스 측 즉시 실패 처리보다 웹훅·재시도 회복 여지를 우선했습니다. 사용자 응답에는 여전히 `PAYMENT_APPROVAL_FAILED`가 전파되므로 프론트는 기존 에러 처리를 그대로 사용합니다.

## 🖼️ 스크린샷
- 해당 없음

## 🔗 관련 이슈
- closes #335

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인