### PR TITLE
[MCJ-1599] REFACTOR: 서버 시간 처리 기준을 UTC 저장 / KST 계산 정책으로 정비

### DIFF
--- a/src/main/kotlin/com/moongchijang/MoongchijangApplication.kt
+++ b/src/main/kotlin/com/moongchijang/MoongchijangApplication.kt
@@ -9,7 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 @EnableAsync
 @EnableScheduling
 class MoongchijangApplication

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminCsTicketService.kt
@@ -7,6 +7,7 @@ import com.moongchijang.domain.admin.application.dto.csticket.AdminCsTicketUpdat
 import com.moongchijang.domain.csticket.domain.repository.CsTicketRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.kstNow
 import com.moongchijang.security.crypto.PersonalInfoManager
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
@@ -43,7 +44,7 @@ class AdminCsTicketService(
             pageable = pageable
         )
 
-        val response = AdminCsTicketPageResponse.from(page, LocalDateTime.now(clock))
+        val response = AdminCsTicketPageResponse.from(page, clock.kstNow())
         log.info("[AdminCsTicketService] CS 티켓 목록 조회 완료: status={}, totalElements={}", status, response.totalElements)
         return response
     }
@@ -55,7 +56,7 @@ class AdminCsTicketService(
 
         val response = AdminCsTicketDetailResponse.from(
             ticket,
-            LocalDateTime.now(clock),
+            clock.kstNow(),
             consumerEmail = personalInfoManager.decryptIfNeeded(ticket.consumer?.email),
             consumerPhoneNumber = personalInfoManager.decryptIfNeeded(ticket.consumer?.phoneNumber),
         )
@@ -69,7 +70,7 @@ class AdminCsTicketService(
         request: AdminCsTicketUpdateRequest,
     ): AdminCsTicketDetailResponse {
         log.info("[AdminCsTicketService] CS 티켓 수정 시작: ticketId={}, status={}", ticketId, request.status)
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val ticket = csTicketRepository.findAdminDetailById(ticketId)
             .orElseThrow { CustomException(ErrorCode.CS_TICKET_NOT_FOUND) }
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
@@ -5,7 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
-import com.moongchijang.global.time.kstNow
+import com.moongchijang.global.time.utcNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -28,7 +28,7 @@ class AdminDashboardOrderMonitoringService(
             pageable.pageNumber,
             pageable.pageSize,
         )
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val overdueBefore = now.minusHours(48)
         val page = groupBuyRepository.findAdminOrderPage(
             groupBuyStatus = GroupBuyStatus.ACHIEVED,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringService.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -27,7 +28,7 @@ class AdminDashboardOrderMonitoringService(
             pageable.pageNumber,
             pageable.pageSize,
         )
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val overdueBefore = now.minusHours(48)
         val page = groupBuyRepository.findAdminOrderPage(
             groupBuyStatus = GroupBuyStatus.ACHIEVED,

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
@@ -9,6 +9,8 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestReposit
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.time.kstNow
+import com.moongchijang.global.time.kstToday
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,8 +32,8 @@ class AdminDashboardSummaryService(
 
     fun getSummary(): AdminDashboardSummaryResponse {
         log.info("[AdminDashboardSummaryService] 관리자 대시보드 요약 조회 시작")
-        val now = LocalDateTime.now(clock)
-        val today = LocalDate.now(clock)
+        val now = clock.kstNow()
+        val today = clock.kstToday()
         val todayRange = today.toRange()
         val yesterdayRange = today.minusDays(1).toRange()
         val pendingApprovalStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryService.kt
@@ -9,8 +9,9 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestReposit
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusHistoryRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
-import com.moongchijang.global.time.kstNow
 import com.moongchijang.global.time.kstToday
+import com.moongchijang.global.time.utcNow
+import com.moongchijang.global.time.TimePolicy
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,10 +33,10 @@ class AdminDashboardSummaryService(
 
     fun getSummary(): AdminDashboardSummaryResponse {
         log.info("[AdminDashboardSummaryService] 관리자 대시보드 요약 조회 시작")
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val today = clock.kstToday()
-        val todayRange = today.toRange()
-        val yesterdayRange = today.minusDays(1).toRange()
+        val todayRange = today.toStorageRange()
+        val yesterdayRange = today.minusDays(1).toStorageRange()
         val pendingApprovalStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
         val completedApprovalStatuses = listOf(GroupBuyRequestStatus.OPENED, GroupBuyRequestStatus.REJECTED)
         val orderOverdueBefore = now.minusHours(48)
@@ -119,10 +120,10 @@ class AdminDashboardSummaryService(
         return (current - previous) * 100.0 / previous
     }
 
-    private fun LocalDate.toRange(): DateTimeRange =
+    private fun LocalDate.toStorageRange(): DateTimeRange =
         DateTimeRange(
-            start = atStartOfDay(),
-            end = plusDays(1).atStartOfDay()
+            start = atStartOfDay(TimePolicy.BUSINESS_ZONE_ID).withZoneSameInstant(TimePolicy.STORAGE_ZONE_ID).toLocalDateTime(),
+            end = plusDays(1).atStartOfDay(TimePolicy.BUSINESS_ZONE_ID).withZoneSameInstant(TimePolicy.STORAGE_ZONE_ID).toLocalDateTime(),
         )
 
     private data class DateTimeRange(

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundService.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundI
 import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundResponse
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -20,7 +21,7 @@ class AdminDashboardUrgentRefundService(
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun getUrgentRefunds(pageable: Pageable): AdminDashboardUrgentRefundResponse {
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val requestedBefore = now.minusHours(URGENT_REFUND_THRESHOLD_HOURS)
         log.info(
             "[AdminDashboardUrgentRefundService] 긴급 환불 요청 조회 시작: requestedBefore={}, page={}, size={}",

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundService.kt
@@ -4,7 +4,7 @@ import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundI
 import com.moongchijang.domain.admin.application.dto.AdminDashboardUrgentRefundResponse
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
-import com.moongchijang.global.time.kstNow
+import com.moongchijang.global.time.utcNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -21,7 +21,7 @@ class AdminDashboardUrgentRefundService(
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun getUrgentRefunds(pageable: Pageable): AdminDashboardUrgentRefundResponse {
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val requestedBefore = now.minusHours(URGENT_REFUND_THRESHOLD_HOURS)
         log.info(
             "[AdminDashboardUrgentRefundService] 긴급 환불 요청 조회 시작: requestedBefore={}, page={}, size={}",

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -13,7 +13,7 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
-import com.moongchijang.global.time.kstNow
+import com.moongchijang.global.time.utcNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -42,7 +42,7 @@ class AdminOrderService(
             pageable.pageNumber,
             pageable.pageSize,
         )
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val page = groupBuyRepository.findAdminOrderPage(
             groupBuyStatus = GroupBuyStatus.ACHIEVED,
             orderStatuses = status.toOrderStatuses(),
@@ -64,7 +64,7 @@ class AdminOrderService(
 
     fun getOrderDetail(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 상세 조회 시작: orderId={}", orderId)
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val groupBuy = groupBuyRepository.findAdminOrderDetailById(orderId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
 
@@ -80,7 +80,7 @@ class AdminOrderService(
     @Transactional
     fun markOwnerContacted(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 사장님연락 상태 변경 시작: orderId={}", orderId)
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.markOrderOwnerContacted(now)
@@ -93,7 +93,7 @@ class AdminOrderService(
     @Transactional
     fun confirmOrder(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 확정 시작: orderId={}", orderId)
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.confirmOrder(now)
@@ -106,7 +106,7 @@ class AdminOrderService(
     @Transactional
     fun cancelOrder(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 취소 시작: orderId={}", orderId)
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.cancelOrder(now)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -13,6 +13,7 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -41,7 +42,7 @@ class AdminOrderService(
             pageable.pageNumber,
             pageable.pageSize,
         )
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val page = groupBuyRepository.findAdminOrderPage(
             groupBuyStatus = GroupBuyStatus.ACHIEVED,
             orderStatuses = status.toOrderStatuses(),
@@ -63,7 +64,7 @@ class AdminOrderService(
 
     fun getOrderDetail(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 상세 조회 시작: orderId={}", orderId)
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val groupBuy = groupBuyRepository.findAdminOrderDetailById(orderId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
 
@@ -79,7 +80,7 @@ class AdminOrderService(
     @Transactional
     fun markOwnerContacted(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 사장님연락 상태 변경 시작: orderId={}", orderId)
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.markOrderOwnerContacted(now)
@@ -92,7 +93,7 @@ class AdminOrderService(
     @Transactional
     fun confirmOrder(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 확정 시작: orderId={}", orderId)
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.confirmOrder(now)
@@ -105,7 +106,7 @@ class AdminOrderService(
     @Transactional
     fun cancelOrder(orderId: Long): AdminOrderDetailResponse {
         log.info("[AdminOrderService] 주문 취소 시작: orderId={}", orderId)
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val groupBuy = findOrderForUpdate(orderId)
         validatePendingOrder(groupBuy)
         groupBuy.cancelOrder(now)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyCloseRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyCloseRequestService.kt
@@ -11,6 +11,7 @@ import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyCloseRequ
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -32,7 +33,7 @@ class AdminOwnerGroupBuyCloseRequestService(
         val groupBuy = findGroupBuyForReview(groupBuyId)
         validatePendingReview(groupBuy)
 
-        val reviewedAt = LocalDateTime.now(clock)
+        val reviewedAt = clock.kstNow()
         groupBuy.approveCloseReview(reviewedAt)
         publishApproved(groupBuy, reviewedAt)
 
@@ -60,7 +61,7 @@ class AdminOwnerGroupBuyCloseRequestService(
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_REJECTION_REASON_REQUIRED)
         }
 
-        val reviewedAt = LocalDateTime.now(clock)
+        val reviewedAt = clock.kstNow()
         groupBuy.rejectCloseReview(reason, reviewedAt)
         publishRejected(groupBuy, reviewedAt)
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestService.kt
@@ -17,6 +17,7 @@ import com.moongchijang.domain.owner.domain.repository.OwnerGroupBuyRequestRepos
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.util.S3ImageReferenceResolver
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -57,7 +58,7 @@ class AdminOwnerGroupBuyRequestService(
             keyword = normalizedKeyword,
             pageable = pageable
         )
-        val response = AdminOwnerGroupBuyRequestPageResponse.from(page, LocalDateTime.now(clock))
+        val response = AdminOwnerGroupBuyRequestPageResponse.from(page, clock.kstNow())
         log.info(
             "[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 목록 조회 완료: totalElements={}",
             response.totalElements,
@@ -86,7 +87,7 @@ class AdminOwnerGroupBuyRequestService(
         validatePending(request)
         validateApprovalSource(request)
 
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val groupBuy = groupBuyRepository.save(
             GroupBuy(
                 store = request.store,
@@ -157,7 +158,7 @@ class AdminOwnerGroupBuyRequestService(
 
         request.status = OwnerGroupBuyRequestStatus.REJECTED
         request.rejectionReason = reason
-        val reviewedAt = LocalDateTime.now(clock)
+        val reviewedAt = clock.kstNow()
         request.reviewedAt = reviewedAt
         request.approvedGroupBuy = null
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -19,6 +19,7 @@ import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.security.crypto.PersonalInfoManager
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -44,7 +45,7 @@ class AdminRefundRequestService(
         keyword: String?,
         pageable: Pageable,
     ): AdminRefundRequestPageResponse {
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
         val statuses = tab.toParticipationStatuses()
         val reviewStatuses = tab.toOwnerReviewStatuses()
@@ -85,7 +86,7 @@ class AdminRefundRequestService(
 
     fun getRefundRequestDetail(requestId: Long): AdminRefundRequestDetailResponse {
         log.info("[AdminRefundRequestService] 환불 요청 상세 조회 시작: requestId={}", requestId)
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val participation = participationRepository.findPickupDetailById(requestId)
             ?: throw CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
         val paymentOrder = paymentOrderRepository.findByUserIdAndGroupBuyId(
@@ -115,7 +116,7 @@ class AdminRefundRequestService(
             requestId,
             request.refundAmount
         )
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val participation = participationRepository.findByIdForUpdate(requestId)
             .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
 
@@ -186,7 +187,7 @@ class AdminRefundRequestService(
             requestId,
             rejectionReason.length
         )
-        val now = LocalDateTime.now(clock)
+        val now = clock.kstNow()
         val participation = participationRepository.findByIdForUpdate(requestId)
             .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestService.kt
@@ -19,7 +19,7 @@ import com.moongchijang.domain.refund.application.RefundRequestSyncService
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.security.crypto.PersonalInfoManager
-import com.moongchijang.global.time.kstNow
+import com.moongchijang.global.time.utcNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -45,7 +45,7 @@ class AdminRefundRequestService(
         keyword: String?,
         pageable: Pageable,
     ): AdminRefundRequestPageResponse {
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val normalizedKeyword = keyword?.trim()?.takeIf { it.isNotBlank() }
         val statuses = tab.toParticipationStatuses()
         val reviewStatuses = tab.toOwnerReviewStatuses()
@@ -86,7 +86,7 @@ class AdminRefundRequestService(
 
     fun getRefundRequestDetail(requestId: Long): AdminRefundRequestDetailResponse {
         log.info("[AdminRefundRequestService] 환불 요청 상세 조회 시작: requestId={}", requestId)
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val participation = participationRepository.findPickupDetailById(requestId)
             ?: throw CustomException(ErrorCode.PARTICIPATION_NOT_FOUND)
         val paymentOrder = paymentOrderRepository.findByUserIdAndGroupBuyId(
@@ -116,7 +116,7 @@ class AdminRefundRequestService(
             requestId,
             request.refundAmount
         )
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val participation = participationRepository.findByIdForUpdate(requestId)
             .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
 
@@ -187,7 +187,7 @@ class AdminRefundRequestService(
             requestId,
             rejectionReason.length
         )
-        val now = clock.kstNow()
+        val now = clock.utcNow()
         val participation = participationRepository.findByIdForUpdate(requestId)
             .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
@@ -15,6 +15,7 @@ import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.kstToday
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -37,7 +38,7 @@ class AdminSettlementService(
     ): AdminSettlementDashboardResponse {
         log.info("[AdminSettlementService] 정산 대시보드 조회 시작: year={}, month={}", year, month)
         val yearMonth = validateYearMonth(year, month)
-        val today = LocalDate.now(clock)
+        val today = clock.kstToday()
         val range = yearMonth.toDateRange()
         val aggregations = participationRepository.findAdminSettlementAggregations(
             groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,
@@ -79,7 +80,7 @@ class AdminSettlementService(
             pageable.pageSize,
         )
         val yearMonth = validateYearMonth(year, month)
-        val today = LocalDate.now(clock)
+        val today = clock.kstToday()
         val range = yearMonth.toDateRange().filterByStatus(status, today)
         val page = participationRepository.findAdminSettlementPage(
             groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,
@@ -104,7 +105,7 @@ class AdminSettlementService(
 
     fun getSettlementDetail(settlementId: Long): AdminSettlementDetailResponse {
         log.info("[AdminSettlementService] 정산 상세 조회 시작: settlementId={}", settlementId)
-        val today = LocalDate.now(clock)
+        val today = clock.kstToday()
         val aggregation = participationRepository.findAdminSettlementDetail(
             groupBuyId = settlementId,
             groupBuyStatuses = SETTLEMENT_GROUP_BUY_STATUSES,

--- a/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/store/RedisEmailVerificationStore.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/infrastructure/email/store/RedisEmailVerificationStore.kt
@@ -1,11 +1,11 @@
 package com.moongchijang.domain.auth.infrastructure.email.store
 
 import com.moongchijang.domain.auth.application.port.EmailVerificationStore
+import com.moongchijang.global.time.TimePolicy
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Component
 import java.time.Duration
 import java.time.LocalDate
-import java.time.ZoneId
 
 @Component
 class RedisEmailVerificationStore(
@@ -48,7 +48,7 @@ class RedisEmailVerificationStore(
     private fun cooldownKey(email: String): String = "auth:email:verification:cooldown:$email"
 
     private fun dailyCountKey(email: String): String {
-        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val today = LocalDate.now(TimePolicy.BUSINESS_ZONE_ID)
         return "auth:email:verification:daily:$today:$email"
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryService.kt
@@ -4,17 +4,20 @@ import com.moongchijang.domain.favorite.application.dto.WishFilterType
 import com.moongchijang.domain.favorite.application.dto.WishSortType
 import com.moongchijang.domain.favorite.application.dto.WishlistPageResponse
 import com.moongchijang.domain.favorite.domain.repository.FavoriteRepository
+import com.moongchijang.global.time.kstNow
 import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Service
 class WishlistQueryService(
     private val favoriteRepository: FavoriteRepository,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -25,7 +28,7 @@ class WishlistQueryService(
         excludeClosed: Boolean,
         sort: WishSortType,
         pageable: Pageable,
-        now: LocalDateTime = LocalDateTime.now(),
+        now: LocalDateTime = clock.kstNow(),
     ): WishlistPageResponse {
         log.info(
             "[WishlistQueryService] 찜 목록 조회 시작: userId={}, filter={}, excludeClosed={}, sort={}, page={}, size={}",

--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistItemResponse.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.favorite.application.dto
 
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -65,7 +66,7 @@ data class WishlistItemResponse(
         fun from(
             groupBuy: GroupBuy,
             thumbnailUrl: String?,
-            now: LocalDateTime = LocalDateTime.now()
+            now: LocalDateTime = LocalDateTime.now(TimePolicy.BUSINESS_ZONE_ID)
         ): WishlistItemResponse {
             val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()
             val achievementRate = GroupBuyProgressCalculator.achievementRate(

--- a/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistPageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/favorite/application/dto/WishlistPageResponse.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.favorite.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.data.domain.Page
 import java.time.LocalDateTime
@@ -30,7 +31,7 @@ data class WishlistPageResponse(
         fun from(
             page: Page<GroupBuy>,
             thumbnailUrlResolver: (GroupBuy) -> String?,
-            now: LocalDateTime = LocalDateTime.now(),
+            now: LocalDateTime = LocalDateTime.now(TimePolicy.BUSINESS_ZONE_ID),
             urgentCount: Int,
         ): WishlistPageResponse {
             return WishlistPageResponse(

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/AdminGroupBuyRequestActionService.kt
@@ -18,6 +18,8 @@ import com.moongchijang.domain.store.domain.repository.StoreRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.util.S3ImageReferenceResolver
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -34,6 +36,7 @@ class AdminGroupBuyRequestActionService(
     private val storeRepository: StoreRepository,
     private val eventPublisher: ApplicationEventPublisher,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(AdminGroupBuyRequestActionService::class.java)
 
@@ -199,7 +202,7 @@ class AdminGroupBuyRequestActionService(
             GroupBuyRequestStatusHistory(
                 groupBuyRequest = groupBuyRequest,
                 status = status,
-                changedAt = LocalDateTime.now()
+                changedAt = clock.utcNow()
             )
         )
     }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyOpenRequestService.kt
@@ -21,6 +21,8 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.security.crypto.PersonalInfoManager
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
@@ -40,6 +42,7 @@ class GroupBuyOpenRequestService(
     private val notificationEventPublisher: NotificationEventPublisher,
     private val recommendedStoreImageService: RecommendedStoreImageService,
     private val personalInfoManager: PersonalInfoManager,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -85,7 +88,7 @@ class GroupBuyOpenRequestService(
             notificationEventPublisher.publishRequestOpened(
                 requestId = requestId,
                 requesterUserIds = result.targetUserIds,
-                occurredAt = java.time.LocalDateTime.now()
+                occurredAt = clock.utcNow()
             )
         }
         return result

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -21,6 +21,7 @@ import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.time.kstNow
 import com.moongchijang.global.time.kstToday
+import com.moongchijang.global.time.utcNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -78,7 +79,7 @@ class GroupBuyRequestService(
             GroupBuyRequestStatusHistory(
                 groupBuyRequest = saved,
                 status = GroupBuyRequestStatus.IN_REVIEW,
-                changedAt = saved.createdAt ?: LocalDateTime.now()
+                changedAt = saved.createdAt ?: clock.utcNow()
             )
         )
         adminDiscordAlertService.sendNewGroupBuyRequest(saved)
@@ -212,7 +213,7 @@ class GroupBuyRequestService(
             GroupBuyRequestStatusHistory(
                 groupBuyRequest = groupBuyRequest,
                 status = request.targetStatus,
-                changedAt = LocalDateTime.now()
+                changedAt = clock.utcNow()
             )
         )
         openedGroupBuyForNotification?.let { notifyOpenedAfterCommit(it) }

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestService.kt
@@ -19,6 +19,8 @@ import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.kstNow
+import com.moongchijang.global.time.kstToday
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -44,7 +46,7 @@ class GroupBuyRequestService(
 
     fun create(userId: Long, request: GroupBuyRequestCreateRequest): GroupBuyRequestIdResponse {
         log.info("[GroupBuyRequestService] 공구요청 생성 시작: userId={}", userId)
-        if (!request.desiredPickupDate.isAfter(LocalDate.now(clock))) {
+        if (!request.desiredPickupDate.isAfter(clock.kstToday())) {
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_INVALID_DATE)
         }
 
@@ -142,7 +144,7 @@ class GroupBuyRequestService(
 
         val groupBuysById = findOpenedGroupBuys(page.content)
 
-        val response = AdminGroupBuyRequestPageResponse.from(page, groupBuysById, LocalDateTime.now(clock))
+        val response = AdminGroupBuyRequestPageResponse.from(page, groupBuysById, clock.kstNow())
         log.info(
             "[GroupBuyRequestService] 관리자 공구요청 목록 조회 완료: status={}, totalElements={}",
             status,

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandService.kt
@@ -7,9 +7,11 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRequestStatusH
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.utcNow
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Service
@@ -17,6 +19,7 @@ class GroupBuyRequestStatusCommandService(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
     private val groupBuyRequestStatusHistoryRepository: GroupBuyRequestStatusHistoryRepository,
     private val notificationEventPublisher: NotificationEventPublisher,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -24,8 +27,9 @@ class GroupBuyRequestStatusCommandService(
     fun rejectRequest(
         requestId: Long,
         reason: String?,
-        changedAt: LocalDateTime = LocalDateTime.now()
+        changedAt: LocalDateTime? = null
     ) {
+        val effectiveChangedAt = changedAt ?: clock.utcNow()
         val request = groupBuyRequestRepository.findById(requestId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_REQUEST_NOT_FOUND) }
 
@@ -34,14 +38,14 @@ class GroupBuyRequestStatusCommandService(
             GroupBuyRequestStatusHistory(
                 groupBuyRequest = request,
                 status = GroupBuyRequestStatus.REJECTED,
-                changedAt = changedAt
+                changedAt = effectiveChangedAt
             )
         )
 
         notificationEventPublisher.publishRequestRejected(
             requestId = request.id,
             requesterUserId = requireNotNull(request.user.id) { "GroupBuyRequest.user.id must not be null" },
-            occurredAt = changedAt
+            occurredAt = effectiveChangedAt
         )
         log.info(
             "[GroupBuyRequestStatusCommandService] 요청공구 거절 처리 및 알림 트리거 발행: requestId={}, requesterUserId={}",

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyService.kt
@@ -16,12 +16,14 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.kstNow
 import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Service
@@ -31,6 +33,7 @@ class GroupBuyService(
     private val favoriteRepository: FavoriteRepository,
     private val participationRepository: ParticipationRepository,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
+    private val clock: Clock,
     @Value("\${app.share.base-url}") private val shareBaseUrl: String,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -70,10 +73,12 @@ class GroupBuyService(
             resultPage.totalElements, resultPage.totalPages, resultPage.number + 1
         )
 
+        val now = clock.kstNow()
         return GroupBuyFeedPageResponse.from(
             resultPage.map {
                 GroupBuyFeedItemResponse.from(
                     groupBuy = it,
+                    now = now,
                     thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.thumbnailKey),
                 )
             },
@@ -99,7 +104,7 @@ class GroupBuyService(
         } ?: false
 
         val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy)
-        val now = LocalDateTime.now()
+        val now = clock.kstNow()
         val canParticipate = !isParticipated &&
             !isClosed &&
             groupBuy.deadline.isAfter(now) &&
@@ -118,7 +123,8 @@ class GroupBuyService(
                 .mapNotNull { s3ImageReferenceResolver.resolveForRead(it.imageKey) },
             isWishlisted = isWishlisted,
             isParticipated = isParticipated,
-            canParticipate = canParticipate
+            canParticipate = canParticipate,
+            now = now,
         )
     }
 
@@ -167,7 +173,7 @@ class GroupBuyService(
             return emptyList()
         }
 
-        val now = LocalDateTime.now()
+        val now = clock.kstNow()
         val groupBuysById = groupBuyRepository.findAllById(groupBuyIds).associateBy { it.id }
 
         val response = groupBuyIds.mapNotNull { id ->

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
@@ -10,7 +10,7 @@ import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
-import com.moongchijang.global.time.utcNow
+import com.moongchijang.global.time.kstNow
 import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -34,7 +34,7 @@ class GroupBuyStatusTransitionService(
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun transitionExpiredGroupBuys() {
-        transitionExpiredGroupBuysAt(clock.utcNow())
+        transitionExpiredGroupBuysAt(clock.kstNow())
     }
 
     fun transitionExpiredGroupBuysAt(now: LocalDateTime) {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyStatusTransitionService.kt
@@ -10,6 +10,8 @@ import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
@@ -25,13 +27,14 @@ class GroupBuyStatusTransitionService(
     private val notificationEventPublisher: NotificationEventPublisher,
     private val adminDiscordAlertService: AdminDiscordAlertService,
     private val transactionManager: PlatformTransactionManager,
+    private val clock: Clock,
     @Value("\${groupbuy.status-transition.batch-size:500}")
     private val batchSize: Int
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     fun transitionExpiredGroupBuys() {
-        transitionExpiredGroupBuysAt(LocalDateTime.now())
+        transitionExpiredGroupBuysAt(clock.utcNow())
     }
 
     fun transitionExpiredGroupBuysAt(now: LocalDateTime) {

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyDetailResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyDetailResponse.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.groupbuy.application.dto
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -113,7 +114,7 @@ data class GroupBuyDetailResponse(
             isWishlisted: Boolean,
             isParticipated: Boolean,
             canParticipate: Boolean,
-            now: LocalDateTime = LocalDateTime.now()
+            now: LocalDateTime = LocalDateTime.now(TimePolicy.BUSINESS_ZONE_ID)
         ): GroupBuyDetailResponse {
             val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()
             val pickupDateLabel = formatPickupLabel(groupBuy.pickupDate)

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponse.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.groupbuy.application.dto
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.domain.store.domain.entity.RegionType
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -64,7 +65,7 @@ data class GroupBuyFeedItemResponse(
     companion object {
         fun from(
             groupBuy: GroupBuy,
-            now: LocalDateTime = LocalDateTime.now(),
+            now: LocalDateTime = LocalDateTime.now(TimePolicy.BUSINESS_ZONE_ID),
             thumbnailUrl: String?,
         ): GroupBuyFeedItemResponse {
             val dDay = ChronoUnit.DAYS.between(now.toLocalDate(), groupBuy.deadline.toLocalDate()).toInt()

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressItem.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressItem.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.groupbuy.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -23,7 +24,7 @@ data class GroupBuyProgressItem(
     val isClosed: Boolean
 ) {
     companion object {
-        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyProgressItem {
+        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now(TimePolicy.BUSINESS_ZONE_ID)): GroupBuyProgressItem {
             val achievementRate = GroupBuyProgressCalculator.achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
             val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy)
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyProgressResponse.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.groupbuy.application.dto
 
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
@@ -23,7 +24,7 @@ data class GroupBuyProgressResponse(
     val isClosed: Boolean
 ) {
     companion object {
-        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now()): GroupBuyProgressResponse {
+        fun from(groupBuy: GroupBuy, now: LocalDateTime = LocalDateTime.now(TimePolicy.BUSINESS_ZONE_ID)): GroupBuyProgressResponse {
             val achievementRate = GroupBuyProgressCalculator.achievementRate(groupBuy.currentQuantity, groupBuy.targetQuantity)
             val isClosed = GroupBuyProgressCalculator.isClosed(groupBuy)
 

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuy.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.groupbuy.domain.entity
 
 import com.moongchijang.domain.store.domain.entity.Store
 import com.moongchijang.global.entity.BaseEntity
+import com.moongchijang.global.time.TimePolicy
 import jakarta.persistence.*
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -120,25 +121,25 @@ class GroupBuy(
 
 ) : BaseEntity()
 {
-    fun transitionToAchieved(achievedAt: LocalDateTime = LocalDateTime.now()) {
+    fun transitionToAchieved(achievedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)) {
         requireStatus(GroupBuyStatus.IN_PROGRESS)
         status = GroupBuyStatus.ACHIEVED
         this.achievedAt = achievedAt
     }
 
-    fun markOrderOwnerContacted(contactedAt: LocalDateTime = LocalDateTime.now()) {
+    fun markOrderOwnerContacted(contactedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)) {
         requireStatus(GroupBuyStatus.ACHIEVED)
         orderOwnerContactedAt = contactedAt
     }
 
-    fun confirmOrder(confirmedAt: LocalDateTime = LocalDateTime.now()) {
+    fun confirmOrder(confirmedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)) {
         requireStatus(GroupBuyStatus.ACHIEVED)
         orderStatus = GroupBuyOrderStatus.CONFIRMED
         orderConfirmedAt = confirmedAt
         orderCancelledAt = null
     }
 
-    fun cancelOrder(cancelledAt: LocalDateTime = LocalDateTime.now()) {
+    fun cancelOrder(cancelledAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)) {
         requireStatus(GroupBuyStatus.ACHIEVED)
         orderStatus = GroupBuyOrderStatus.CANCELLED
         orderCancelledAt = cancelledAt
@@ -176,7 +177,7 @@ class GroupBuy(
     fun closeByOwner(
         reason: GroupBuyCloseReason,
         reasonDetail: String?,
-        requestedAt: LocalDateTime = LocalDateTime.now()
+        requestedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)
     ) {
         closeReason = reason
         closeReasonDetail = reasonDetail
@@ -191,7 +192,7 @@ class GroupBuy(
     fun requestCloseReview(
         reason: GroupBuyCloseReason,
         reasonDetail: String?,
-        requestedAt: LocalDateTime = LocalDateTime.now()
+        requestedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)
     ) {
         require(status == GroupBuyStatus.IN_PROGRESS || status == GroupBuyStatus.ACHIEVED) {
             "IN_PROGRESS 또는 ACHIEVED 상태에서만 마감 요청을 할 수 있습니다."
@@ -211,7 +212,7 @@ class GroupBuy(
         closedByType = null
     }
 
-    fun approveCloseReview(reviewedAt: LocalDateTime = LocalDateTime.now()) {
+    fun approveCloseReview(reviewedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)) {
         require(closeRequestReviewStatus == GroupBuyCloseRequestReviewStatus.PENDING) {
             "PENDING 상태의 마감 요청만 승인할 수 있습니다."
         }
@@ -224,7 +225,7 @@ class GroupBuy(
 
     fun rejectCloseReview(
         rejectionReason: String,
-        reviewedAt: LocalDateTime = LocalDateTime.now()
+        reviewedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)
     ) {
         require(closeRequestReviewStatus == GroupBuyCloseRequestReviewStatus.PENDING) {
             "PENDING 상태의 마감 요청만 반려할 수 있습니다."

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequestStatusHistory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/entity/GroupBuyRequestStatusHistory.kt
@@ -1,5 +1,6 @@
 package com.moongchijang.domain.groupbuy.domain.entity
 
+import com.moongchijang.global.time.TimePolicy
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
@@ -16,7 +17,7 @@ class GroupBuyRequestStatusHistory(
     val status: GroupBuyRequestStatus,
 
     @Column(nullable = false)
-    val changedAt: LocalDateTime = LocalDateTime.now(),
+    val changedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID),
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L

--- a/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
+++ b/src/main/kotlin/com/moongchijang/domain/groupbuy/domain/repository/GroupBuyRepositoryImpl.kt
@@ -18,16 +18,19 @@ import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.NumberExpression
 import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.moongchijang.global.time.kstNow
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Repository
 class GroupBuyRepositoryImpl(
-    private val queryFactory: JPAQueryFactory
+    private val queryFactory: JPAQueryFactory,
+    private val clock: Clock,
 ) : GroupBuyRepositoryCustom {
 
     override fun searchFeed(
@@ -36,7 +39,7 @@ class GroupBuyRepositoryImpl(
         pageable: Pageable,
         sortMode: FeedSortMode,
     ): Page<GroupBuy> {
-        val now = LocalDateTime.now()
+        val now = clock.kstNow()
         val where = buildWhere(filter, districtFilters, now)
         val orderSpecifiers = buildOrderSpecifiers(sortMode)
 

--- a/src/main/kotlin/com/moongchijang/domain/image/application/S3ImageUploadService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/image/application/S3ImageUploadService.kt
@@ -9,6 +9,7 @@ import com.moongchijang.domain.image.application.dto.ImageDeleteResponse
 import com.moongchijang.global.config.AppS3Properties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.TimePolicy
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3Client
@@ -20,7 +21,6 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import java.time.Duration
 import java.time.LocalDate
-import java.time.ZoneId
 import java.util.UUID
 
 @Service
@@ -93,7 +93,7 @@ class S3ImageUploadService(
 
         val extension = extensionFrom(file.fileName)
         val folder = if (file.category == ImageUploadCategory.THUMBNAIL) "thumbnail" else "products"
-        val datePartition = LocalDate.now(ZoneId.of("Asia/Seoul")).toString().replace("-", "")
+        val datePartition = LocalDate.now(TimePolicy.BUSINESS_ZONE_ID).toString().replace("-", "")
         val subject = groupBuyId?.toString() ?: "pending/$userId/$datePartition"
         val prefix = appS3Properties.prefix.trim('/')
         val prefixSegment = if (prefix.isBlank()) "" else "$prefix/"

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryService.kt
@@ -7,15 +7,18 @@ import com.moongchijang.domain.participation.application.dto.PickupWaitingPartic
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 import java.time.LocalDateTime
 
 @Service
 class MyPageParticipationQueryService(
-    private val participationRepository: ParticipationRepository
+    private val participationRepository: ParticipationRepository,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -42,7 +45,7 @@ class MyPageParticipationQueryService(
             page.totalPages
         )
 
-        val now = LocalDateTime.now()
+        val now = clock.kstNow()
         val mapped = page.map { participation -> InProgressParticipationItemResponse.from(participation, now) }
         return InProgressParticipationPageResponse.from(mapped)
     }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/MypageService.kt
@@ -13,10 +13,12 @@ import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
+import com.moongchijang.global.time.kstToday
 import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
 
 @Service
 @Transactional(readOnly = true)
@@ -25,6 +27,7 @@ class MypageService(
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
     private val paymentOrderRepository: PaymentOrderRepository,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(MypageService::class.java)
 
@@ -104,12 +107,14 @@ class MypageService(
             .filter { it.isApproved }
             .map { it.groupBuyId }
             .toSet()
+        val today = clock.kstToday()
         return participations.map {
             MypageParticipationResponse.from(
                 participation = it,
                 thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.groupBuy.thumbnailKey),
                 approvedPaymentGroupBuyIds = cancellableGroupBuyIds,
-                paymentInfo = paymentInfoByParticipationId[it.id]
+                paymentInfo = paymentInfoByParticipationId[it.id],
+                today = today,
             )
         }
     }
@@ -148,11 +153,13 @@ class MypageService(
 
     private fun withPaymentInfo(participations: List<Participation>): List<MypageParticipationResponse> {
         val paymentInfoByParticipationId = paymentInfoByParticipationId(participations)
+        val today = clock.kstToday()
         return participations.map {
             MypageParticipationResponse.from(
                 participation = it,
                 thumbnailUrl = s3ImageReferenceResolver.resolveForRead(it.groupBuy.thumbnailKey),
-                paymentInfo = paymentInfoByParticipationId[it.id]
+                paymentInfo = paymentInfoByParticipationId[it.id],
+                today = today,
             )
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/mypage/application/dto/MypageResponse.kt
@@ -4,6 +4,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyRequest
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.global.time.TimePolicy
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -100,7 +101,8 @@ data class MypageParticipationResponse(
             participation: Participation,
             thumbnailUrl: String?,
             approvedPaymentGroupBuyIds: Set<Long> = emptySet(),
-            paymentInfo: MypageParticipationPaymentInfo? = null
+            paymentInfo: MypageParticipationPaymentInfo? = null,
+            today: LocalDate = LocalDate.now(TimePolicy.BUSINESS_ZONE_ID),
         ): MypageParticipationResponse {
             val groupBuy = participation.groupBuy
             val canViewPickupOrQr = participation.status == ParticipationStatus.CONFIRMED &&
@@ -125,14 +127,14 @@ data class MypageParticipationResponse(
                 paymentMethod = paymentInfo?.paymentMethod,
                 quantity = participation.quantity,
                 pickupStatus = participation.pickupStatus.name,
-                dDay = ChronoUnit.DAYS.between(LocalDate.now(), groupBuy.deadline.toLocalDate())
+                dDay = ChronoUnit.DAYS.between(today, groupBuy.deadline.toLocalDate())
                     .toInt()
                     .coerceAtLeast(0),
                 canCancel = participation.status == ParticipationStatus.PAID_WAITING_GOAL &&
                     groupBuy.id in approvedPaymentGroupBuyIds,
                 canViewPickup = canViewPickupOrQr,
                 canViewQr = canViewPickupOrQr,
-                qrAvailability = qrAvailability(participation)
+                qrAvailability = qrAvailability(participation, today)
             )
         }
 
@@ -157,11 +159,11 @@ data class MypageParticipationResponse(
                 else -> status.name
             }
 
-        private fun qrAvailability(participation: Participation): String =
+        private fun qrAvailability(participation: Participation, today: LocalDate): String =
             when {
                 participation.pickupStatus == PickupStatus.PICKED_UP -> "PICKED_UP"
                 participation.status != ParticipationStatus.CONFIRMED -> "UNAVAILABLE"
-                LocalDate.now().isBefore(participation.groupBuy.pickupDate) -> "LOCKED"
+                today.isBefore(participation.groupBuy.pickupDate) -> "LOCKED"
                 else -> "AVAILABLE"
             }
     }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationImmediateDispatchService.kt
@@ -18,13 +18,14 @@ import com.moongchijang.domain.notification.domain.repository.NotificationReposi
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.TimePolicy
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.time.DayOfWeek
 
 @Service
 class NotificationImmediateDispatchService(
@@ -44,7 +45,7 @@ class NotificationImmediateDispatchService(
     }
 
     private val log = LoggerFactory.getLogger(javaClass)
-    private val zoneId: ZoneId = ZoneId.of("Asia/Seoul")
+    private val zoneId: ZoneId = TimePolicy.BUSINESS_ZONE_ID
 
     @Transactional
     fun dispatch(event: NotificationImmediateTriggerEvent) {

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationQueryService.kt
@@ -9,12 +9,12 @@ import com.moongchijang.domain.notification.domain.repository.NotificationReposi
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.TimePolicy
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.time.ZoneId
 
 @Service
 class NotificationQueryService(
@@ -67,7 +67,7 @@ class NotificationQueryService(
 
         val hasNext = notifications.size > safeLimit
         val content = if (hasNext) notifications.dropLast(1) else notifications
-        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val today = LocalDate.now(TimePolicy.BUSINESS_ZONE_ID)
         val items = content.map { NotificationItemResponse.from(it, today) }
         val nextCursor = content.lastOrNull()?.let { NotificationCursor(it.occurredAt, it.id).encode() }
         log.info(

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerScheduler.kt
@@ -10,12 +10,14 @@ import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.entity.PickupStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
+import com.moongchijang.global.time.TimePolicy
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 @Component
 class NotificationTriggerScheduler(
@@ -26,6 +28,7 @@ class NotificationTriggerScheduler(
     private val favoriteRepository: FavoriteRepository,
     private val groupBuyRequestRepository: GroupBuyRequestRepository,
     private val storeStaffRepository: StoreStaffRepository,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -252,7 +255,7 @@ class NotificationTriggerScheduler(
         )
     }
 
-    private fun nowKst(): LocalDateTime = LocalDateTime.now(ZoneId.of(KST_ZONE_ID))
+    private fun nowKst(): LocalDateTime = clock.kstNow()
 
     private enum class ReminderOffset(
         val hours: Long,
@@ -264,7 +267,7 @@ class NotificationTriggerScheduler(
     }
 
     companion object {
-        private const val KST_ZONE_ID = "Asia/Seoul"
+        private const val KST_ZONE_ID = TimePolicy.BUSINESS_TIME_ZONE_ID
         private const val WINDOW_MINUTES = 10
         private val OWNER_PICKUP_GROUP_BUY_STATUSES = listOf(GroupBuyStatus.ACHIEVED, GroupBuyStatus.COMPLETED)
     }

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/dto/NotificationItemResponse.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.notification.domain.entity.Notification
 import com.moongchijang.domain.notification.domain.entity.NotificationDeeplinkType
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import com.moongchijang.domain.notification.domain.entity.NotificationType
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -64,7 +65,12 @@ data class NotificationItemResponse(
                 deeplinkType = notification.deeplinkType,
                 triggerType = notification.triggerType,
                 deeplinkParams = NotificationDeeplinkSchema.toParams(notification.deeplinkType, notification.targetId),
-                section = resolveSection(notification.occurredAt.toLocalDate(), today)
+                section = resolveSection(
+                    notification.occurredAt.atZone(TimePolicy.STORAGE_ZONE_ID)
+                        .withZoneSameInstant(TimePolicy.BUSINESS_ZONE_ID)
+                        .toLocalDate(),
+                    today
+                )
             )
         }
 

--- a/src/main/kotlin/com/moongchijang/domain/notification/application/event/NotificationImmediateTriggerEvent.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/application/event/NotificationImmediateTriggerEvent.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.notification.application.event
 
 import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.global.time.TimePolicy
 import java.time.LocalDateTime
 
 data class NotificationImmediateTriggerEvent(
@@ -8,5 +9,5 @@ data class NotificationImmediateTriggerEvent(
     val targetId: Long,
     val userIds: List<Long>,
     val scheduleKey: String,
-    val occurredAt: LocalDateTime = LocalDateTime.now(),
+    val occurredAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID),
 )

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchHistory.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/entity/NotificationDispatchHistory.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.notification.domain.entity
 
 import com.moongchijang.global.entity.BaseEntity
+import com.moongchijang.global.time.TimePolicy
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -68,7 +69,7 @@ class NotificationDispatchHistory(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0L
 ) : BaseEntity() {
-    fun markSuccess(processedAt: LocalDateTime = LocalDateTime.now()): NotificationDispatchHistory {
+    fun markSuccess(processedAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)): NotificationDispatchHistory {
         status = NotificationDispatchStatus.SUCCESS
         this.processedAt = processedAt
         nextRetryAt = null

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyRequestService.kt
@@ -16,6 +16,7 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.util.S3ImageReferenceResolver
+import com.moongchijang.global.time.kstNow
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -171,7 +172,7 @@ class OwnerGroupBuyRequestService(
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
     private fun validateRequest(request: OwnerGroupBuyRequestCreateRequest) {
-        if (request.deadline.isBefore(LocalDateTime.now(clock).plusDays(MIN_RECRUITING_DAYS))) {
+        if (request.deadline.isBefore(clock.kstNow().plusDays(MIN_RECRUITING_DAYS))) {
             throw CustomException(ErrorCode.OWNER_GROUPBUY_REQUEST_INVALID_DEADLINE)
         }
 

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerGroupBuyService.kt
@@ -28,6 +28,7 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.TimePolicy
 import com.moongchijang.security.crypto.PersonalInfoManager
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -439,6 +440,6 @@ class OwnerGroupBuyService(
         val DETAIL_PARTICIPATION_STATUSES = listOf(ParticipationStatus.PAID_WAITING_GOAL, ParticipationStatus.CONFIRMED)
         const val UNKNOWN_PAYMENT_METHOD = "UNKNOWN"
         const val UNKNOWN_PAYMENT_STATUS = "UNKNOWN"
-        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+        val SEOUL_ZONE_ID: ZoneId = TimePolicy.BUSINESS_ZONE_ID
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -29,6 +29,8 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.time.TimePolicy
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -44,6 +46,7 @@ class OwnerSettlementService(
     private val groupBuyRepository: GroupBuyRepository,
     private val participationRepository: ParticipationRepository,
     private val refundRequestSyncService: RefundRequestSyncService,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -221,7 +224,7 @@ class OwnerSettlementService(
             groupBuyId = participation.groupBuy.id,
             productName = participation.groupBuy.productName,
             requesterName = participation.user.nickname ?: "",
-            requestedDate = (participation.cancelledAt ?: participation.createdAt ?: java.time.LocalDateTime.now()).toLocalDate(),
+            requestedDate = (participation.cancelledAt ?: participation.createdAt ?: clock.utcNow()).toLocalDate(),
             paymentAmount = participation.totalAmount,
             penaltyAmount = penaltyAmount,
             refundExpectedAmount = refundExpectedAmount,
@@ -263,7 +266,7 @@ class OwnerSettlementService(
             throw CustomException(ErrorCode.OWNER_REFUND_REVIEW_ALREADY_PROCESSED)
         }
 
-        val now = java.time.LocalDateTime.now()
+        val now = clock.utcNow()
         participation.ownerRefundReviewedAt = now
 
         when (request.action) {
@@ -308,7 +311,7 @@ class OwnerSettlementService(
     }
 
     private fun toRefundListItem(participation: Participation): OwnerRefundRequestListItemResponse {
-        val requestedAt = participation.cancelledAt ?: participation.createdAt ?: java.time.LocalDateTime.now()
+        val requestedAt = participation.cancelledAt ?: participation.createdAt ?: clock.utcNow()
         return OwnerRefundRequestListItemResponse(
             participationId = participation.id,
             groupBuyId = participation.groupBuy.id,
@@ -320,7 +323,7 @@ class OwnerSettlementService(
             requestedDate = requestedAt.toLocalDate(),
             status = toRefundStatus(participation.status),
             exceeded24Hours = participation.status == ParticipationStatus.REFUND_PENDING &&
-                requestedAt.isBefore(java.time.LocalDateTime.now().minusHours(24)),
+                requestedAt.isBefore(clock.utcNow().minusHours(24)),
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -29,6 +29,7 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.time.TimePolicy
+import com.moongchijang.global.time.kstToday
 import com.moongchijang.global.time.utcNow
 import java.time.Clock
 import org.slf4j.LoggerFactory
@@ -36,7 +37,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.YearMonth
-import java.time.ZoneId
 
 @Service
 @Transactional(readOnly = true)
@@ -182,7 +182,7 @@ class OwnerSettlementService(
         val allRequests = participationRepository.findRefundRequestsByStoreIdsAndStatuses(
             storeIds = storeIds,
             statuses = REFUND_STATUSES,
-            fromDateTime = LocalDate.now(SEOUL_ZONE_ID).minusMonths(REFUND_LIST_LOOKBACK_MONTHS).atStartOfDay(),
+            fromDateTime = clock.kstToday().minusMonths(REFUND_LIST_LOOKBACK_MONTHS).atStartOfDay(),
         )
 
         val pendingCount = allRequests.count { request -> isReviewPending(request) }
@@ -224,7 +224,7 @@ class OwnerSettlementService(
             groupBuyId = participation.groupBuy.id,
             productName = participation.groupBuy.productName,
             requesterName = participation.user.nickname ?: "",
-            requestedDate = (participation.cancelledAt ?: participation.createdAt ?: clock.utcNow()).toLocalDate(),
+            requestedDate = toBusinessDate(participation.cancelledAt ?: participation.createdAt ?: clock.utcNow()),
             paymentAmount = participation.totalAmount,
             penaltyAmount = penaltyAmount,
             refundExpectedAmount = refundExpectedAmount,
@@ -320,12 +320,17 @@ class OwnerSettlementService(
             requesterName = participation.user.nickname ?: "",
             requesterCode = "P${participation.id.toString().padStart(3, '0')}",
             refundReasonLabel = toRefundReasonLabel(participation.cancelReason),
-            requestedDate = requestedAt.toLocalDate(),
+            requestedDate = toBusinessDate(requestedAt),
             status = toRefundStatus(participation.status),
             exceeded24Hours = participation.status == ParticipationStatus.REFUND_PENDING &&
                 requestedAt.isBefore(clock.utcNow().minusHours(24)),
         )
     }
+
+    private fun toBusinessDate(dateTime: java.time.LocalDateTime): LocalDate =
+        dateTime.atZone(TimePolicy.STORAGE_ZONE_ID)
+            .withZoneSameInstant(TimePolicy.BUSINESS_ZONE_ID)
+            .toLocalDate()
 
     private fun toRefundStatus(status: ParticipationStatus): OwnerRefundRequestStatus {
         return if (status == ParticipationStatus.REFUNDED) {
@@ -357,7 +362,7 @@ class OwnerSettlementService(
             return OwnerSettlementStatus.REFUND_PROCESSING
         }
 
-        return if (aggregation.pickupCompletedDate.plusDays(OWNER_SETTLEMENT_DELAY_DAYS).isAfter(LocalDate.now(SEOUL_ZONE_ID))) {
+        return if (aggregation.pickupCompletedDate.plusDays(OWNER_SETTLEMENT_DELAY_DAYS).isAfter(clock.kstToday())) {
             OwnerSettlementStatus.SETTLEMENT_PENDING
         } else {
             OwnerSettlementStatus.SETTLEMENT_COMPLETED
@@ -398,7 +403,7 @@ class OwnerSettlementService(
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
         val requested = YearMonth.of(year, month)
-        if (requested.isAfter(YearMonth.from(LocalDate.now(SEOUL_ZONE_ID)))) {
+        if (requested.isAfter(YearMonth.from(clock.kstToday()))) {
             throw CustomException(ErrorCode.INVALID_INPUT)
         }
     }
@@ -421,7 +426,6 @@ class OwnerSettlementService(
             ParticipationStatus.REFUNDED,
         )
         val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
-        val SEOUL_ZONE_ID: ZoneId = TimePolicy.BUSINESS_ZONE_ID
         const val OWNER_SETTLEMENT_DELAY_DAYS: Long = 3
         const val REFUND_LIST_LOOKBACK_MONTHS: Long = 6
     }

--- a/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementService.kt
@@ -28,6 +28,7 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.TimePolicy
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -417,7 +418,7 @@ class OwnerSettlementService(
             ParticipationStatus.REFUNDED,
         )
         val REFUND_STATUSES = listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED)
-        val SEOUL_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+        val SEOUL_ZONE_ID: ZoneId = TimePolicy.BUSINESS_ZONE_ID
         const val OWNER_SETTLEMENT_DELAY_DAYS: Long = 3
         const val REFUND_LIST_LOOKBACK_MONTHS: Long = 6
     }

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandService.kt
@@ -4,6 +4,8 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,11 +15,12 @@ import java.time.LocalDateTime
 class ParticipationPickupCommandService(
     private val participationRepository: ParticipationRepository,
     private val userRepository: UserRepository,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
-    fun completePickup(participationId: Long, processedByUserId: Long, pickedUpAt: LocalDateTime = LocalDateTime.now()) {
+    fun completePickup(participationId: Long, processedByUserId: Long, pickedUpAt: LocalDateTime = clock.utcNow()) {
         val participation = participationRepository.findByIdForUpdate(participationId)
             .orElseThrow { CustomException(ErrorCode.PARTICIPATION_NOT_FOUND) }
         val processor = userRepository.findByIdAndDeletedAtIsNull(processedByUserId)

--- a/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/application/dto/InProgressParticipationItemResponse.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.participation.application.dto
 
 import com.moongchijang.domain.groupbuy.application.dto.GroupBuyProgressCalculator
 import com.moongchijang.domain.participation.domain.entity.Participation
+import com.moongchijang.global.time.TimePolicy
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -40,7 +41,10 @@ data class InProgressParticipationItemResponse(
     val participatedAt: LocalDateTime
 ) {
     companion object {
-        fun from(participation: Participation, now: LocalDateTime = LocalDateTime.now()): InProgressParticipationItemResponse {
+        fun from(
+            participation: Participation,
+            now: LocalDateTime = LocalDateTime.now(TimePolicy.BUSINESS_ZONE_ID)
+        ): InProgressParticipationItemResponse {
             val groupBuy = participation.groupBuy
             val dDay = ChronoUnit.DAYS.between(
                 now.toLocalDate(),

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/entity/Participation.kt
@@ -3,6 +3,7 @@ package com.moongchijang.domain.participation.domain.entity
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.global.entity.BaseEntity
+import com.moongchijang.global.time.TimePolicy
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -108,7 +109,7 @@ class Participation(
 ) : BaseEntity() {
     fun markPickedUp(
         processedBy: User,
-        pickedUpAt: LocalDateTime = LocalDateTime.now()
+        pickedUpAt: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID)
     ) {
         pickupProcessedBy = processedBy
         pickupStatus = PickupStatus.PICKED_UP

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -37,6 +37,8 @@ import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.util.S3ImageReferenceResolver
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -67,6 +69,7 @@ class PaymentService(
     private val adminDiscordAlertService: AdminDiscordAlertService,
     private val refundRequestSyncService: RefundRequestSyncService,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -336,7 +339,7 @@ class PaymentService(
             val lockedOrder = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
             if (paymentResult.status == PORTONE_STATUS_FAILED && lockedOrder.status == PaymentOrderStatus.READY) {
                 val previousStatus = lockedOrder.status
-                lockedOrder.fail(LocalDateTime.now())
+                lockedOrder.fail(clock.utcNow())
                 paymentOrderRepository.save(lockedOrder)
                 recordPaymentAudit(
                     source = PaymentAuditSource.WEBHOOK,
@@ -381,7 +384,7 @@ class PaymentService(
                 applyParticipationCancellation(
                     target = target,
                     request = request,
-                    cancelledAt = paymentResult.cancelledAt ?: LocalDateTime.now(),
+                    cancelledAt = paymentResult.cancelledAt ?: clock.utcNow(),
                 )
             } ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
         }
@@ -443,7 +446,7 @@ class PaymentService(
         }
         if (paymentResult.totalAmount != order.totalAmount) {
             val previousStatus = order.status
-            order.fail(LocalDateTime.now())
+            order.fail(clock.utcNow())
             paymentOrderRepository.save(order)
             recordPaymentFailure(
                 source = source,
@@ -457,7 +460,7 @@ class PaymentService(
         }
         if (paymentResult.paymentId != order.orderId) {
             val previousStatus = order.status
-            order.fail(LocalDateTime.now())
+            order.fail(clock.utcNow())
             paymentOrderRepository.save(order)
             recordPaymentFailure(
                 source = source,
@@ -480,7 +483,7 @@ class PaymentService(
                 order.groupBuy.id, order.quantity, order.orderId
             )
             val previousStatus = order.status
-            order.fail(LocalDateTime.now())
+            order.fail(clock.utcNow())
             paymentOrderRepository.save(order)
             recordPaymentFailure(
                 source = source,
@@ -520,7 +523,7 @@ class PaymentService(
         if (groupBuy.status == GroupBuyStatus.ACHIEVED && groupBuy.currentQuantity >= groupBuy.maxQuantity) {
             groupBuy.transitionToCompletedWhenMaxQuantityReached()
         }
-        val approvedAt = paymentResult.paidAt ?: LocalDateTime.now()
+        val approvedAt = paymentResult.paidAt ?: clock.utcNow()
         val previousStatus = order.status
         order.approve(approvedAt)
         val approvedOrder = paymentOrderRepository.save(order)
@@ -661,7 +664,7 @@ class PaymentService(
             val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
             if (order.status == PaymentOrderStatus.READY) {
                 val previousStatus = order.status
-                order.fail(LocalDateTime.now())
+                order.fail(clock.utcNow())
                 paymentOrderRepository.save(order)
                 recordPaymentAudit(
                     source = PaymentAuditSource.COMPLETE_API,
@@ -681,9 +684,9 @@ class PaymentService(
             val order = paymentOrderRepository.findByOrderIdForUpdate(paymentId) ?: return@execute
             val previousStatus = order.status
             when (paymentResult.status) {
-                PORTONE_STATUS_CANCELLED -> order.cancel(paymentResult.cancelledAt ?: LocalDateTime.now())
-                PORTONE_STATUS_PARTIAL_CANCELLED -> order.partialCancel(paymentResult.cancelledAt ?: LocalDateTime.now())
-                else -> order.fail(LocalDateTime.now())
+                PORTONE_STATUS_CANCELLED -> order.cancel(paymentResult.cancelledAt ?: clock.utcNow())
+                PORTONE_STATUS_PARTIAL_CANCELLED -> order.partialCancel(paymentResult.cancelledAt ?: clock.utcNow())
+                else -> order.fail(clock.utcNow())
             }
             paymentOrderRepository.save(order)
             val eventType = when (paymentResult.status) {
@@ -705,7 +708,7 @@ class PaymentService(
     }
 
     private fun cancelPayment(order: PaymentOrder, paymentResult: PortOnePaymentResult, partial: Boolean) {
-        val cancelledAt = paymentResult.cancelledAt ?: LocalDateTime.now()
+        val cancelledAt = paymentResult.cancelledAt ?: clock.utcNow()
         val payment = paymentRepository.findByPaymentOrderOrderId(order.orderId)
             ?: throw CustomException(ErrorCode.PAYMENT_ORDER_ALREADY_PROCESSED)
 
@@ -880,7 +883,7 @@ class PaymentService(
         return transactionTemplate().execute {
             applyPendingRefundCompletion(
                 target = target,
-                refundedAt = paymentResult.cancelledAt ?: LocalDateTime.now()
+                refundedAt = paymentResult.cancelledAt ?: clock.utcNow()
             )
             true
         } ?: false
@@ -973,7 +976,7 @@ class PaymentService(
             displayStatus = displayStatus(participation.status),
             amount = order.totalAmount,
             method = payment?.method,
-            approvedAt = order.approvedAt ?: LocalDateTime.now(),
+            approvedAt = order.approvedAt ?: clock.utcNow(),
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/pickup/application/PickupService.kt
@@ -16,6 +16,7 @@ import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.TimePolicy
 import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -249,6 +250,6 @@ class PickupService(
 
     companion object {
         private const val TOKEN_GENERATION_ATTEMPTS = 5
-        private val KST_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
+        private val KST_ZONE: ZoneId = TimePolicy.BUSINESS_ZONE_ID
     }
 }

--- a/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
+++ b/src/main/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngine.kt
@@ -7,9 +7,11 @@ import com.moongchijang.domain.groupbuy.infrastructure.search.FullTextQueryBuild
 import com.moongchijang.domain.search.application.dto.SearchCase
 import com.moongchijang.domain.search.application.dto.SearchResponse
 import com.moongchijang.domain.search.domain.SearchUiState
+import com.moongchijang.global.time.kstNow
 import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import java.time.Clock
 import java.time.LocalDateTime
 
 /**
@@ -29,6 +31,7 @@ class FullTextSearchEngine(
     private val groupBuyRepository: GroupBuyRepository,
     private val s3ImageReferenceResolver: S3ImageReferenceResolver,
     private val searchCorrectionService: SearchCorrectionService,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -41,7 +44,7 @@ class FullTextSearchEngine(
 
     fun search(query: String): SearchResponse {
         val startedAt = System.nanoTime()
-        val now = LocalDateTime.now()
+        val now = clock.kstNow()
         val response = searchByFullText(query, now)
         if (response.totalCount > 0) {
             return response

--- a/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/UserService.kt
@@ -43,6 +43,8 @@ import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import com.moongchijang.global.util.MaskingUtils.maskEmail
 import com.moongchijang.security.crypto.PersonalInfoManager
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -68,6 +70,7 @@ class UserService(
     private val withdrawalLegalRetentionCommandService: WithdrawalLegalRetentionCommandService,
     private val withdrawalImmediateCleanupService: WithdrawalImmediateCleanupService,
     private val personalInfoManager: PersonalInfoManager,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -579,7 +582,7 @@ class UserService(
     }
 
     private fun validateRejoinAvailable(rejoinAvailableAt: LocalDateTime) {
-        if (LocalDateTime.now().isBefore(rejoinAvailableAt)) {
+        if (clock.utcNow().isBefore(rejoinAvailableAt)) {
             throw CustomException(ErrorCode.REJOIN_NOT_AVAILABLE_YET)
         }
     }
@@ -596,7 +599,7 @@ class UserService(
 
     private fun isEmailRejoinBlocked(email: String): Boolean {
         val withdrawnAccount = findWithdrawnEmailAccount(email) ?: return false
-        return LocalDateTime.now().isBefore(withdrawnAccount.rejoinAvailableAt)
+        return clock.utcNow().isBefore(withdrawnAccount.rejoinAvailableAt)
     }
 
     private fun validateNicknameFormat(nickname: String) {

--- a/src/main/kotlin/com/moongchijang/domain/user/application/WithdrawalRetentionPurgeService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/application/WithdrawalRetentionPurgeService.kt
@@ -4,6 +4,8 @@ import com.moongchijang.domain.user.domain.repository.WithdrawnAccountRepository
 import com.moongchijang.domain.user.domain.repository.WithdrawnParticipationRepository
 import com.moongchijang.domain.user.domain.repository.WithdrawnPaymentOrderRepository
 import com.moongchijang.domain.user.domain.repository.WithdrawnRefundRequestRepository
+import com.moongchijang.global.time.utcNow
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -22,11 +24,12 @@ class WithdrawalRetentionPurgeService(
     private val withdrawnPaymentOrderRepository: WithdrawnPaymentOrderRepository,
     private val withdrawnParticipationRepository: WithdrawnParticipationRepository,
     private val withdrawnRefundRequestRepository: WithdrawnRefundRequestRepository,
+    private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
-    fun purgeExpired(now: LocalDateTime = LocalDateTime.now()): WithdrawalRetentionPurgeResult {
+    fun purgeExpired(now: LocalDateTime = clock.utcNow()): WithdrawalRetentionPurgeResult {
         val withdrawnRefundRequestsDeleted = withdrawnRefundRequestRepository.deleteByRetentionExpiresAtBefore(now)
         val withdrawnParticipationsDeleted = withdrawnParticipationRepository.deleteByRetentionExpiresAtBefore(now)
         val withdrawnPaymentOrdersDeleted = withdrawnPaymentOrderRepository.deleteByRetentionExpiresAtBefore(now)

--- a/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
+++ b/src/main/kotlin/com/moongchijang/domain/user/domain/entity/User.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.user.domain.entity
 
 import com.moongchijang.global.entity.BaseEntity
+import com.moongchijang.global.time.TimePolicy
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -106,7 +107,7 @@ class User(
     fun withdraw(
         reason: WithdrawalReason?,
         reasonDetail: String?,
-        now: LocalDateTime = LocalDateTime.now(),
+        now: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID),
     ) {
         this.withdrawalReason = reason
         this.withdrawalReasonDetail = reasonDetail
@@ -116,7 +117,7 @@ class User(
     fun withdrawAsOwner(
         reason: OwnerWithdrawalReason?,
         reasonDetail: String?,
-        now: LocalDateTime = LocalDateTime.now(),
+        now: LocalDateTime = LocalDateTime.now(TimePolicy.STORAGE_ZONE_ID),
     ) {
         this.ownerWithdrawalReason = reason
         this.ownerWithdrawalReasonDetail = reasonDetail

--- a/src/main/kotlin/com/moongchijang/global/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/OpenApiConfig.kt
@@ -18,7 +18,15 @@ class OpenApiConfig {
             .info(
                 Info()
                     .title("뭉치장 API")
-                    .description("공동구매 플랫폼 뭉치장의 API 명세입니다.")
+                    .description(
+                        """
+                        공동구매 플랫폼 뭉치장의 API 명세입니다.
+                        
+                        - 저장 시각(createdAt, updatedAt, 상태 전이 시각 등)은 UTC 기준으로 관리합니다.
+                        - 비즈니스 계산(D-day, 마감 여부, 픽업 오늘/내일 판단 등)은 KST(Asia/Seoul) 기준으로 처리합니다.
+                        - `date-time` 응답은 현재 LocalDateTime 직렬화 형식인 `yyyy-MM-dd'T'HH:mm:ss` 문자열을 사용합니다.
+                        """.trimIndent()
+                    )
                     .version("v1")
             )
             .addSecurityItem(SecurityRequirement().addList(securitySchemeName))

--- a/src/main/kotlin/com/moongchijang/global/config/TimeConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/TimeConfig.kt
@@ -2,11 +2,18 @@ package com.moongchijang.global.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.auditing.DateTimeProvider
 import java.time.Clock
+import java.util.Optional
+import com.moongchijang.global.time.utcNow
 
 @Configuration
 class TimeConfig {
 
     @Bean
     fun clock(): Clock = Clock.systemUTC()
+
+    @Bean
+    fun auditingDateTimeProvider(clock: Clock): DateTimeProvider =
+        DateTimeProvider { Optional.of(clock.utcNow()) }
 }

--- a/src/main/kotlin/com/moongchijang/global/config/TimeConfig.kt
+++ b/src/main/kotlin/com/moongchijang/global/config/TimeConfig.kt
@@ -8,5 +8,5 @@ import java.time.Clock
 class TimeConfig {
 
     @Bean
-    fun clock(): Clock = Clock.systemDefaultZone()
+    fun clock(): Clock = Clock.systemUTC()
 }

--- a/src/main/kotlin/com/moongchijang/global/time/TimePolicy.kt
+++ b/src/main/kotlin/com/moongchijang/global/time/TimePolicy.kt
@@ -1,0 +1,19 @@
+package com.moongchijang.global.time
+
+import java.time.Clock
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+object TimePolicy {
+    val STORAGE_ZONE_ID: ZoneId = ZoneOffset.UTC
+    val BUSINESS_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
+    const val BUSINESS_TIME_ZONE_ID: String = "Asia/Seoul"
+}
+
+fun Clock.kstNow(): LocalDateTime = LocalDateTime.ofInstant(instant(), TimePolicy.BUSINESS_ZONE_ID)
+
+fun Clock.kstToday(): LocalDate = instant().atZone(TimePolicy.BUSINESS_ZONE_ID).toLocalDate()
+
+fun Clock.utcNow(): LocalDateTime = LocalDateTime.ofInstant(instant(), TimePolicy.STORAGE_ZONE_ID)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,6 +16,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
     open-in-view: false
 
   flyway:

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -10,6 +10,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
     open-in-view: false
 
   data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -8,6 +8,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
     open-in-view: false
 
   data:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,6 +16,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: UTC
     open-in-view: false
 
   flyway:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -14,6 +14,12 @@ info:
     { "success": true, "data": { ... }, "error": null }
     { "success": false, "data": null, "error": { "code": "ERROR_CODE", "message": "설명", "detail": "상세" } }
     ```
+
+    ## 날짜/시간 처리 기준
+    - 서버 내부 저장 시각(`createdAt`, `updatedAt`, 상태 전이 시각 등)은 UTC 기준으로 저장합니다.
+    - 비즈니스 계산(D-day, 마감 여부, 픽업 오늘/내일 판단, 월별 집계)은 KST(`Asia/Seoul`) 기준으로 처리합니다.
+    - `format: date-time` 필드는 현재 `LocalDateTime` 직렬화 형식을 사용하므로 `yyyy-MM-dd'T'HH:mm:ss` 형태의 오프셋 없는 문자열로 응답합니다.
+    - 일정/픽업 관련 사용자 노출 시각은 KST 기준으로 해석하며, 감사/이력성 시각은 UTC 기준 저장값을 같은 형식으로 반환합니다.
   version: v1
 
 servers:
@@ -3865,12 +3871,15 @@ components:
           type: string
           format: date-time
           nullable: true
+          description: UTC 기준 삭제 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`
         createdAt:
           type: string
           format: date-time
+          description: UTC 기준 생성 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`
         updatedAt:
           type: string
           format: date-time
+          description: UTC 기준 수정 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`
 
     ApiResponseMyRegions:
       type: object
@@ -4320,8 +4329,8 @@ components:
               status:
                 type: string
                 enum: [IN_REVIEW, IN_CONTACT, OPENED, REJECTED]
-              changedAt: { type: string, format: date-time }
-        createdAt: { type: string, format: date-time }
+              changedAt: { type: string, format: date-time, description: "UTC 기준 상태 변경 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
+        createdAt: { type: string, format: date-time, description: "UTC 기준 요청 생성 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
 
     ApiResponseGroupBuyRequestList:
       type: object
@@ -4486,7 +4495,7 @@ components:
             displayStatus: { type: string, example: "참여중 / 달성 전" }
             amount: { type: integer }
             method: { type: string, nullable: true, example: CARD }
-            approvedAt: { type: string, format: date-time }
+            approvedAt: { type: string, format: date-time, description: "UTC 기준 결제 승인 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         error: { nullable: true, example: null }
 
     ApiResponseCancelParticipation:
@@ -4502,8 +4511,8 @@ components:
             status:
               type: string
               enum: [REFUNDED]
-            cancelledAt: { type: string, format: date-time }
-            refundedAt: { type: string, format: date-time }
+            cancelledAt: { type: string, format: date-time, description: "UTC 기준 참여 취소 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
+            refundedAt: { type: string, format: date-time, description: "UTC 기준 환불 완료 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         error: { nullable: true, example: null }
 
     PortOneWebhook:
@@ -4558,9 +4567,9 @@ components:
                 type: string
                 nullable: true
                 description: 취소 상세 사유
-              paidAt: { type: string, format: date-time, nullable: true, description: 결제 일시 }
+              paidAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 결제 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
               paymentMethod: { type: string, nullable: true, description: 결제 수단 }
-              refundedAt: { type: string, format: date-time, nullable: true }
+              refundedAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 환불 완료 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         error: { nullable: true, example: null }
 
     # ── Pickup & QR ────────────────────────────────────────────
@@ -4594,7 +4603,7 @@ components:
             pickupTimeEnd: { type: string, format: time }
             pickupLocation: { type: string }
             remainingMinutes: { type: integer, format: int64, nullable: true, description: "당일 픽업 종료까지 남은 분. 당일이 아니면 null" }
-            pickedUpAt: { type: string, format: date-time, nullable: true }
+            pickedUpAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 픽업 완료 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         error: { nullable: true, example: null }
 
     ApiResponseQrCode:
@@ -4625,7 +4634,7 @@ components:
             pickupTimeStart: { type: string, format: time, description: "픽업 시작 시각. 예) 13:00" }
             pickupTimeEnd: { type: string, format: time, description: "픽업 종료 시각. 예) 17:00" }
             dDay: { type: integer, format: int32, description: "KST 기준 픽업일까지 남은 날짜. 당일이면 0, 지난 픽업일이면 음수" }
-            pickedUpAt: { type: string, format: date-time, nullable: true }
+            pickedUpAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 픽업 완료 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         error: { nullable: true, example: null }
 
     ApiResponseNearestPickupQr:
@@ -5629,7 +5638,7 @@ components:
               example:
                 - https://cdn.example.com/owner-requests/1.jpg
                 - https://cdn.example.com/owner-requests/2.jpg
-            deadline: { type: string, format: date-time, example: "2026-06-02T23:59:00" }
+            deadline: { type: string, format: date-time, description: "KST 기준 모집 마감 일시. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`", example: "2026-06-02T23:59:00" }
             pickupDate: { type: string, format: date, example: "2026-06-03" }
             pickupTimeStart: { type: string, format: time, example: "12:00:00" }
             pickupTimeEnd: { type: string, format: time, example: "18:00:00" }
@@ -5640,8 +5649,8 @@ components:
               enum: [PENDING, APPROVED, REJECTED]
             rejectionReason: { type: string, nullable: true, example: 매장 사정으로 어렵습니다 }
             approvedGroupBuyId: { type: integer, format: int64, nullable: true, example: 300 }
-            reviewedAt: { type: string, format: date-time, nullable: true }
-            requestedAt: { type: string, format: date-time, nullable: true }
+            reviewedAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 검토 완료 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
+            requestedAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 요청 생성 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         error: { nullable: true, example: null }
     
     ApiResponseReservationPage:
@@ -6404,7 +6413,7 @@ components:
           example: 17
         targetQuantity: { type: integer, example: 20 }
         pickupDate: { type: string, format: date, example: "2026-06-12" }
-        requestedAt: { type: string, format: date-time, nullable: true }
+        requestedAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 요청 생성 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         reviewElapsedMinutes:
           type: integer
           format: int64
@@ -6465,8 +6474,8 @@ components:
           type: integer
           format: int64
           nullable: true
-        reviewedAt: { type: string, format: date-time, nullable: true }
-        requestedAt: { type: string, format: date-time, nullable: true }
+        reviewedAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 검토 완료 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
+        requestedAt: { type: string, format: date-time, nullable: true, description: "UTC 기준 요청 생성 시각. 응답 형식은 `yyyy-MM-dd'T'HH:mm:ss`" }
         actionable:
           type: boolean
           description: 승인/반려 작업 가능 여부
@@ -6527,11 +6536,11 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: 승인 후 생성된 공구의 모집 시작일시. 승인 전 요청은 null
+          description: 승인 후 생성된 공구의 KST 기준 모집 시작 일시. 승인 전 요청은 null
         deadline:
           type: string
           format: date-time
-          description: 모집 마감일시
+          description: KST 기준 모집 마감 일시
         pickupDate: { type: string, format: date }
         pickupTimeStart: { type: string, format: time }
         pickupTimeEnd: { type: string, format: time }

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardOrderMonitoringServiceTest.kt
@@ -18,13 +18,13 @@ import org.springframework.data.domain.PageRequest
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 
 class AdminDashboardOrderMonitoringServiceTest {
 
     private val groupBuyRepository: GroupBuyRepository = mock(GroupBuyRepository::class.java)
     private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
-    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneOffset.UTC)
     private val service = AdminDashboardOrderMonitoringService(
         groupBuyRepository = groupBuyRepository,
         participationRepository = participationRepository,
@@ -34,7 +34,7 @@ class AdminDashboardOrderMonitoringServiceTest {
     @Test
     fun `대시보드 발주 미확정 모니터링 목록과 요약을 조회한다`() {
         val pageable = PageRequest.of(0, 1)
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val overdueBefore = now.minusHours(48)
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = 41L,
@@ -80,7 +80,7 @@ class AdminDashboardOrderMonitoringServiceTest {
     @Test
     fun `목록이 비어있으면 환불 대기 집계를 생략한다`() {
         val pageable = PageRequest.of(0, 5)
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val overdueBefore = now.minusHours(48)
         `when`(
             groupBuyRepository.findAdminOrderPage(

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardSummaryServiceTest.kt
@@ -17,7 +17,7 @@ import org.mockito.Mockito.`when`
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 
 class AdminDashboardSummaryServiceTest {
 
@@ -26,7 +26,7 @@ class AdminDashboardSummaryServiceTest {
         mock(GroupBuyRequestStatusHistoryRepository::class.java)
     private val groupBuyRepository: GroupBuyRepository = mock(GroupBuyRepository::class.java)
     private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
-    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneOffset.UTC)
     private val service = AdminDashboardSummaryService(
         groupBuyRequestRepository = groupBuyRequestRepository,
         groupBuyRequestStatusHistoryRepository = groupBuyRequestStatusHistoryRepository,
@@ -37,13 +37,13 @@ class AdminDashboardSummaryServiceTest {
 
     @Test
     fun `운영 관리 요약을 현재 도메인 기준으로 집계한다`() {
-        val todayStart = LocalDateTime.of(2026, 5, 27, 0, 0)
-        val tomorrowStart = LocalDateTime.of(2026, 5, 28, 0, 0)
-        val yesterdayStart = LocalDateTime.of(2026, 5, 26, 0, 0)
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val todayStart = LocalDateTime.of(2026, 5, 26, 15, 0)
+        val tomorrowStart = LocalDateTime.of(2026, 5, 27, 15, 0)
+        val yesterdayStart = LocalDateTime.of(2026, 5, 25, 15, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val pendingStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
         val completedStatuses = listOf(GroupBuyRequestStatus.OPENED, GroupBuyRequestStatus.REJECTED)
-        val orderOverdueBefore = LocalDateTime.of(2026, 5, 25, 13, 0)
+        val orderOverdueBefore = LocalDateTime.of(2026, 5, 25, 4, 0)
 
         `when`(
             groupBuyRepository.countOverdueAdminOrders(
@@ -108,11 +108,11 @@ class AdminDashboardSummaryServiceTest {
 
     @Test
     fun `전일 값이 없으면 현재 값 존재 여부에 따라 증감률을 반환한다`() {
-        val todayStart = LocalDateTime.of(2026, 5, 27, 0, 0)
-        val tomorrowStart = LocalDateTime.of(2026, 5, 28, 0, 0)
-        val yesterdayStart = LocalDateTime.of(2026, 5, 26, 0, 0)
+        val todayStart = LocalDateTime.of(2026, 5, 26, 15, 0)
+        val tomorrowStart = LocalDateTime.of(2026, 5, 27, 15, 0)
+        val yesterdayStart = LocalDateTime.of(2026, 5, 25, 15, 0)
         val pendingStatuses = listOf(GroupBuyRequestStatus.IN_REVIEW, GroupBuyRequestStatus.IN_CONTACT)
-        val orderOverdueBefore = LocalDateTime.of(2026, 5, 25, 13, 0)
+        val orderOverdueBefore = LocalDateTime.of(2026, 5, 25, 4, 0)
 
         `when`(
             groupBuyRepository.countOverdueAdminOrders(

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminDashboardUrgentRefundServiceTest.kt
@@ -19,12 +19,12 @@ import org.springframework.data.domain.PageRequest
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 
 class AdminDashboardUrgentRefundServiceTest {
 
     private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
-    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T01:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T01:00:00Z"), ZoneOffset.UTC)
     private val service = AdminDashboardUrgentRefundService(
         participationRepository = participationRepository,
         clock = clock,
@@ -33,9 +33,9 @@ class AdminDashboardUrgentRefundServiceTest {
     @Test
     fun `1시간 초과 환불 요청을 경과 시간과 환불 예상 금액으로 반환한다`() {
         val pageable = PageRequest.of(0, 10)
-        val requestedAt = LocalDateTime.now(clock).minusHours(2).minusMinutes(10)
+        val requestedAt = LocalDateTime.of(2026, 5, 27, 22, 50)
         val participation = refundParticipation(id = 101L, cancelledAt = requestedAt)
-        val requestedBefore = LocalDateTime.now(clock).minusHours(1)
+        val requestedBefore = LocalDateTime.of(2026, 5, 28, 0, 0)
         `when`(
             participationRepository.findDashboardUrgentRefundRequests(
                 status = ParticipationStatus.REFUND_PENDING,

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
@@ -24,7 +24,7 @@ import org.springframework.data.domain.PageRequest
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.Optional
 
 class AdminOrderServiceTest {
@@ -33,7 +33,7 @@ class AdminOrderServiceTest {
     private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
     private val storeStaffRepository: StoreStaffRepository = mock(StoreStaffRepository::class.java)
     private val notificationEventPublisher: NotificationEventPublisher = mock(NotificationEventPublisher::class.java)
-    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneOffset.UTC)
     private val service = AdminOrderService(
         groupBuyRepository = groupBuyRepository,
         participationRepository = participationRepository,
@@ -45,7 +45,7 @@ class AdminOrderServiceTest {
     @Test
     fun `48시간 초과 발주 목록을 조회한다`() {
         val pageable = PageRequest.of(0, 20)
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val achievedAt = now.minusHours(50)
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = 30L,
@@ -103,7 +103,7 @@ class AdminOrderServiceTest {
 
     @Test
     fun `발주 상세를 조회한다`() {
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val achievedAt = now.minusHours(3)
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = 31L,
@@ -157,7 +157,7 @@ class AdminOrderServiceTest {
 
     @Test
     fun `사장님 연락 완료를 기록한다`() {
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = 32L,
             status = GroupBuyStatus.ACHIEVED
@@ -182,7 +182,7 @@ class AdminOrderServiceTest {
 
     @Test
     fun `발주를 확정 처리한다`() {
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = 33L,
             status = GroupBuyStatus.ACHIEVED
@@ -222,7 +222,7 @@ class AdminOrderServiceTest {
 
     @Test
     fun `발주를 취소하면 사장님 알림을 발행한다`() {
-        val now = LocalDateTime.of(2026, 5, 27, 13, 0)
+        val now = LocalDateTime.of(2026, 5, 27, 4, 0)
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = 36L,
             status = GroupBuyStatus.ACHIEVED

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminRefundRequestServiceTest.kt
@@ -36,7 +36,7 @@ import org.springframework.data.domain.PageRequest
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.Optional
 
 class AdminRefundRequestServiceTest {
@@ -45,7 +45,7 @@ class AdminRefundRequestServiceTest {
     private val paymentOrderRepository: PaymentOrderRepository = mock(PaymentOrderRepository::class.java)
     private val paymentRepository: PaymentRepository = mock(PaymentRepository::class.java)
     private val refundRequestSyncService: RefundRequestSyncService = mock(RefundRequestSyncService::class.java)
-    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T01:00:00Z"), ZoneId.of("Asia/Seoul"))
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T01:00:00Z"), ZoneOffset.UTC)
     private val personalInfoProperties = PersonalInfoEncryptionProperties(
         secretKey = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     )

--- a/src/test/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/favorite/application/WishlistQueryServiceTest.kt
@@ -17,6 +17,9 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -29,7 +32,9 @@ class WishlistQueryServiceTest {
     @Mock
     private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
 
-    private val service by lazy { WishlistQueryService(favoriteRepository, s3ImageReferenceResolver) }
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-22T01:00:00Z"), ZoneOffset.UTC)
+
+    private val service by lazy { WishlistQueryService(favoriteRepository, s3ImageReferenceResolver, clock) }
 
     @Test
     fun `찜 목록 조회 요청 시 페이지 결과 반환`() {

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/GroupBuyRequestStatusCommandServiceTest.kt
@@ -13,6 +13,9 @@ import org.mockito.Mockito.any
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDateTime
 import java.util.Optional
 
@@ -28,11 +31,14 @@ class GroupBuyRequestStatusCommandServiceTest {
     @Mock
     private lateinit var notificationEventPublisher: NotificationEventPublisher
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-23T03:00:00Z"), ZoneOffset.UTC)
+
     private val service by lazy {
         GroupBuyRequestStatusCommandService(
             groupBuyRequestRepository = groupBuyRequestRepository,
             groupBuyRequestStatusHistoryRepository = groupBuyRequestStatusHistoryRepository,
             notificationEventPublisher = notificationEventPublisher,
+            clock = clock,
         )
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/application/dto/GroupBuyFeedItemResponseTest.kt
@@ -40,6 +40,19 @@ class GroupBuyFeedItemResponseTest {
         assertEquals("D-day", response.dDayLabel)
     }
 
+    @Test
+    fun `피드 D-day는 월이 바뀌어도 KST 날짜 기준으로 계산한다`() {
+        val now = LocalDateTime.of(2026, 1, 31, 23, 50)
+        val groupBuy = createGroupBuy(
+            deadline = LocalDateTime.of(2026, 2, 1, 0, 10)
+        )
+
+        val response = GroupBuyFeedItemResponse.from(groupBuy, now, "https://example.com/image.jpg")
+
+        assertEquals(1, response.dDay)
+        assertEquals("D-1", response.dDayLabel)
+    }
+
     private fun createGroupBuy(deadline: LocalDateTime): GroupBuy {
         val store = Store(
             name = "청담 버터룸",

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/AdminGroupBuyRequestActionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/AdminGroupBuyRequestActionServiceTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.any
 import org.mockito.Mockito.lenient
@@ -33,9 +32,12 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneOffset
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -62,11 +64,22 @@ class AdminGroupBuyRequestActionServiceTest {
     @Mock
     private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
 
-    @InjectMocks
     private lateinit var service: AdminGroupBuyRequestActionService
+
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2026-06-05T00:00:00Z"), ZoneOffset.UTC)
 
     @BeforeEach
     fun setUp() {
+        service = AdminGroupBuyRequestActionService(
+            groupBuyRequestRepository = groupBuyRequestRepository,
+            groupBuyRequestStatusHistoryRepository = groupBuyRequestStatusHistoryRepository,
+            groupBuyRepository = groupBuyRepository,
+            groupBuyImageRepository = groupBuyImageRepository,
+            storeRepository = storeRepository,
+            eventPublisher = eventPublisher,
+            s3ImageReferenceResolver = s3ImageReferenceResolver,
+            clock = fixedClock,
+        )
         lenient().`when`(s3ImageReferenceResolver.resolve("https://cdn.example.com/1.jpg"))
             .thenReturn(S3ImageReferenceResolver.ResolvedImageReference("exhibition/1.jpg", "https://cdn.example.com/1.jpg"))
         lenient().`when`(s3ImageReferenceResolver.resolve("https://cdn.example.com/2.jpg"))

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyOpenRequestServiceTest.kt
@@ -44,6 +44,9 @@ import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.dao.DataIntegrityViolationException
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -75,6 +78,8 @@ class GroupBuyOpenRequestServiceTest {
     @Mock
     private lateinit var recommendedStoreImageService: RecommendedStoreImageService
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-23T03:00:00Z"), ZoneOffset.UTC)
+
     private val personalInfoProperties = PersonalInfoEncryptionProperties(
         secretKey = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
     )
@@ -97,6 +102,7 @@ class GroupBuyOpenRequestServiceTest {
             notificationEventPublisher = notificationEventPublisher,
             recommendedStoreImageService = recommendedStoreImageService,
             personalInfoManager = personalInfoManager,
+            clock = clock,
         )
         lenient().`when`(userRepository.findByIdAndDeletedAtIsNull(anyLong()))
             .thenAnswer { UserFixture.createKakaoUser(id = it.getArgument(0)) }

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyServiceTest.kt
@@ -10,6 +10,7 @@ import com.moongchijang.domain.participation.domain.repository.ParticipationRepo
 import com.moongchijang.domain.store.domain.entity.DistrictType
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.kstNow
 import com.moongchijang.global.util.S3ImageReferenceResolver
 import com.moongchijang.support.GroupBuyFixture
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -29,6 +30,9 @@ import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -52,6 +56,8 @@ class GroupBuyServiceTest {
     @Mock
     private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-22T01:00:00Z"), ZoneOffset.UTC)
+
     private lateinit var service: GroupBuyService
 
     @BeforeEach
@@ -63,6 +69,7 @@ class GroupBuyServiceTest {
             favoriteRepository = favoriteRepository,
             participationRepository = participationRepository,
             s3ImageReferenceResolver = s3ImageReferenceResolver,
+            clock = clock,
             shareBaseUrl = "https://moongchijang.com"
         )
     }
@@ -261,7 +268,7 @@ class GroupBuyServiceTest {
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = groupBuyId,
             status = GroupBuyStatus.IN_PROGRESS,
-            deadline = LocalDateTime.now().minusMinutes(1)
+            deadline = clock.kstNow().minusMinutes(1)
         )
 
         `when`(groupBuyRepository.findWithStoreById(groupBuyId)).thenReturn(Optional.of(groupBuy))
@@ -321,7 +328,7 @@ class GroupBuyServiceTest {
         val groupBuy = GroupBuyFixture.createGroupBuy(
             id = groupBuyId,
             status = GroupBuyStatus.ACHIEVED,
-            deadline = LocalDateTime.now().minusMinutes(1)
+            deadline = clock.kstNow().minusMinutes(1)
         ).apply {
             currentQuantity = 50
             maxQuantity = 100

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
@@ -23,7 +23,10 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionStatus
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 @ExtendWith(MockitoExtension::class)
 class GroupBuyStatusTransitionServiceTest {
@@ -49,6 +52,8 @@ class GroupBuyStatusTransitionServiceTest {
     @Mock
     private lateinit var storeStaffRepository: StoreStaffRepository
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-23T03:00:00Z"), ZoneOffset.UTC)
+
     private lateinit var service: GroupBuyStatusTransitionService
 
     @BeforeEach
@@ -61,6 +66,7 @@ class GroupBuyStatusTransitionServiceTest {
             notificationEventPublisher,
             adminDiscordAlertService,
             transactionManager,
+            clock,
             500
         )
     }
@@ -165,6 +171,7 @@ class GroupBuyStatusTransitionServiceTest {
             notificationEventPublisher,
             adminDiscordAlertService,
             transactionManager,
+            clock,
             2
         )
         val pageable = PageRequest.of(0, 2, Sort.by(Sort.Order.asc("deadline"), Sort.Order.asc("id")))

--- a/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/groupbuy/service/GroupBuyStatusTransitionServiceTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mock
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
@@ -120,6 +121,27 @@ class GroupBuyStatusTransitionServiceTest {
         service.transitionExpiredGroupBuysAt(now)
 
         verify(groupBuyRepository).findByStatusInAndDeadlineLessThanEqual(
+            listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED),
+            now,
+            pageable
+        )
+    }
+
+    @Test
+    fun `자동 전이 실행은 KST 기준 현재 시각으로 마감 공구를 조회한다`() {
+        val now = LocalDateTime.of(2026, 5, 23, 12, 0)
+        val pageable = PageRequest.of(0, 500, Sort.by(Sort.Order.asc("deadline"), Sort.Order.asc("id")))
+        `when`(
+            groupBuyRepository.findByStatusInAndDeadlineLessThanEqual(
+                listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED),
+                now,
+                pageable
+            )
+        ).thenReturn(emptyList())
+
+        service.transitionExpiredGroupBuys()
+
+        verify(groupBuyRepository, times(1)).findByStatusInAndDeadlineLessThanEqual(
             listOf(GroupBuyStatus.IN_PROGRESS, GroupBuyStatus.ACHIEVED),
             now,
             pageable

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MyPageParticipationQueryServiceTest.kt
@@ -15,6 +15,9 @@ import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -25,8 +28,10 @@ class MyPageParticipationQueryServiceTest {
     @Mock
     private lateinit var participationRepository: ParticipationRepository
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-04-13T01:00:00Z"), ZoneOffset.UTC)
+
     private val service by lazy {
-        MyPageParticipationQueryService(participationRepository)
+        MyPageParticipationQueryService(participationRepository, clock)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/MypageServiceTest.kt
@@ -18,11 +18,11 @@ import com.moongchijang.domain.store.domain.entity.Store
 import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.entity.UserRole
+import com.moongchijang.global.time.kstToday
 import com.moongchijang.global.util.S3ImageReferenceResolver
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.lenient
@@ -30,6 +30,9 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -49,12 +52,20 @@ class MypageServiceTest {
     @Mock
     private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
 
-    @InjectMocks
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-20T01:00:00Z"), ZoneOffset.UTC)
+
     private lateinit var mypageService: MypageService
 
     @org.junit.jupiter.api.BeforeEach
     fun setUp() {
         lenient().`when`(s3ImageReferenceResolver.resolveForRead(anyString())).thenAnswer { it.arguments[0] as String? }
+        mypageService = MypageService(
+            participationRepository = participationRepository,
+            groupBuyRequestRepository = groupBuyRequestRepository,
+            paymentOrderRepository = paymentOrderRepository,
+            s3ImageReferenceResolver = s3ImageReferenceResolver,
+            clock = clock,
+        )
     }
 
     @Test
@@ -394,8 +405,8 @@ class MypageServiceTest {
             targetQuantity = 10,
             maxQuantity = 20,
             status = com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus.IN_PROGRESS,
-            recruitmentStartAt = LocalDate.now().minusDays(1).atStartOfDay(),
-            deadline = LocalDate.now().plusDays(1).atTime(23, 59),
+            recruitmentStartAt = clock.kstToday().minusDays(1).atStartOfDay(),
+            deadline = clock.kstToday().plusDays(1).atTime(23, 59),
             pickupDate = LocalDate.of(2026, 5, 25),
             pickupTimeStart = LocalTime.of(13, 0),
             pickupTimeEnd = LocalTime.of(15, 0),

--- a/src/test/kotlin/com/moongchijang/domain/mypage/application/dto/MypageParticipationResponseTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/mypage/application/dto/MypageParticipationResponseTest.kt
@@ -1,0 +1,73 @@
+package com.moongchijang.domain.mypage.application.dto
+
+import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
+import com.moongchijang.domain.participation.domain.entity.PickupStatus
+import com.moongchijang.support.ParticipationFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class MypageParticipationResponseTest {
+
+    @Test
+    fun `KST 기준 내일 픽업 건은 QR이 잠겨 있고 D-day는 1이다`() {
+        val today = LocalDate.of(2026, 1, 31)
+        val participation = ParticipationFixture.createParticipation(
+            participationId = 1L,
+            groupBuyId = 101L,
+            quantity = 1,
+            totalAmount = 12000,
+            currentQuantity = 10,
+            targetQuantity = 20,
+            deadline = LocalDateTime.of(2026, 2, 1, 0, 10),
+            pickupDate = LocalDate.of(2026, 2, 1),
+            pickupTimeStart = LocalTime.of(12, 0),
+            createdAt = LocalDateTime.of(2026, 1, 30, 18, 0),
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatus = PickupStatus.NOT_READY,
+        )
+
+        val response = MypageParticipationResponse.from(
+            participation = participation,
+            thumbnailUrl = "https://example.com/image.jpg",
+            today = today,
+        )
+
+        assertEquals(1, response.dDay)
+        assertEquals("LOCKED", response.qrAvailability)
+        assertEquals(true, response.canViewPickup)
+        assertEquals(true, response.canViewQr)
+    }
+
+    @Test
+    fun `KST 기준 당일 픽업 건은 QR 조회가 가능하고 D-day는 0이다`() {
+        val today = LocalDate.of(2026, 2, 1)
+        val participation = ParticipationFixture.createParticipation(
+            participationId = 2L,
+            groupBuyId = 102L,
+            quantity = 1,
+            totalAmount = 12000,
+            currentQuantity = 10,
+            targetQuantity = 20,
+            deadline = LocalDateTime.of(2026, 2, 1, 0, 10),
+            pickupDate = LocalDate.of(2026, 2, 1),
+            pickupTimeStart = LocalTime.of(12, 0),
+            createdAt = LocalDateTime.of(2026, 1, 31, 23, 30),
+            participationStatus = ParticipationStatus.CONFIRMED,
+            pickupStatus = PickupStatus.NOT_READY,
+        )
+
+        val response = MypageParticipationResponse.from(
+            participation = participation,
+            thumbnailUrl = "https://example.com/image.jpg",
+            today = today,
+        )
+
+        assertEquals(0, response.dDay)
+        assertEquals("AVAILABLE", response.qrAvailability)
+        assertEquals(true, response.canViewPickup)
+        assertEquals(true, response.canViewQr)
+    }
+}

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationQueryServiceTest.kt
@@ -16,6 +16,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDate
 import org.springframework.data.domain.PageRequest
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -304,6 +305,39 @@ class NotificationQueryServiceTest {
         )
 
         assertThat(result.items.map { it.section.name }).containsExactly("TODAY", "YESTERDAY", "OLDER")
+    }
+
+    @Test
+    fun `UTC 자정 직전 알림도 KST 기준 오늘 섹션으로 분류한다`() {
+        val user = UserFixture.createEmailUser(id = 6L)
+        val kstToday = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val occurredAtUtc = kstToday.minusDays(1).atTime(23, 30)
+        val notification = NotificationFixture.createNotification(
+            user = user,
+            id = 61L,
+            occurredAt = occurredAtUtc
+        )
+
+        `when`(
+            notificationRepository.findForListByScope(
+                userId = 6L,
+                scope = NotificationScope.BUYER,
+                type = null,
+                cursorOccurredAt = null,
+                cursorId = null,
+                pageable = PageRequest.of(0, 21)
+            )
+        ).thenReturn(listOf(notification))
+
+        val result = service.getNotifications(
+            userId = 6L,
+            currentRole = UserRole.BUYER,
+            category = NotificationCategory.ALL,
+            cursor = null,
+            limit = 20
+        )
+
+        assertThat(result.items.single().section.name).isEqualTo("TODAY")
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/notification/application/NotificationTriggerSchedulerTest.kt
@@ -20,6 +20,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -48,6 +49,8 @@ class NotificationTriggerSchedulerTest {
     @Mock
     private lateinit var storeStaffRepository: StoreStaffRepository
 
+    private val clock: Clock = Clock.systemUTC()
+
     private val scheduler by lazy {
         NotificationTriggerScheduler(
             notificationEventPublisher = notificationEventPublisher,
@@ -57,6 +60,7 @@ class NotificationTriggerSchedulerTest {
             favoriteRepository = favoriteRepository,
             groupBuyRequestRepository = groupBuyRequestRepository,
             storeStaffRepository = storeStaffRepository,
+            clock = clock,
         )
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -36,7 +36,6 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.Optional
 
@@ -133,7 +132,7 @@ class OwnerSettlementServiceTest {
     @Test
     fun `정산 공구 카드 목록은 정산완료 상태를 반환한다`() {
         val owner = seller()
-        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val today = LocalDate.of(2026, 5, 28)
         val pickupDate = today.minusDays(4)
         val year = pickupDate.year
         val month = pickupDate.monthValue
@@ -172,7 +171,7 @@ class OwnerSettlementServiceTest {
     @Test
     fun `정산 공구 카드 목록은 정산대기 상태를 반환한다`() {
         val owner = seller()
-        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val today = LocalDate.of(2026, 5, 28)
         val pickupDate = today.minusDays(1)
         val year = pickupDate.year
         val month = pickupDate.monthValue
@@ -209,7 +208,7 @@ class OwnerSettlementServiceTest {
     @Test
     fun `정산 공구 카드 목록은 환불처리 상태를 우선 반환한다`() {
         val owner = seller()
-        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val today = LocalDate.of(2026, 5, 28)
         val pickupDate = today.minusDays(5)
         val year = pickupDate.year
         val month = pickupDate.monthValue
@@ -247,7 +246,7 @@ class OwnerSettlementServiceTest {
     @Test
     fun `정산 공구 카드 목록은 환불 대기 건이 있으면 정산완료보다 환불처리를 우선한다`() {
         val owner = seller()
-        val today = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        val today = LocalDate.of(2026, 5, 28)
         val pickupDate = today.minusDays(7)
         val year = pickupDate.year
         val month = pickupDate.monthValue
@@ -294,7 +293,7 @@ class OwnerSettlementServiceTest {
             participationRepository.findRefundRequestsByStoreIdsAndStatuses(
                 defaultStoreIds(),
                 listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
-                LocalDate.now(ZoneId.of("Asia/Seoul")).minusMonths(6).atStartOfDay(),
+                LocalDate.of(2026, 5, 28).minusMonths(6).atStartOfDay(),
             )
         ).thenReturn(
             listOf(
@@ -323,6 +322,40 @@ class OwnerSettlementServiceTest {
         assertEquals(24000, detail.paymentAmount)
         assertEquals(2400, detail.penaltyAmount)
         assertEquals(21600, detail.refundExpectedAmount)
+    }
+
+    @Test
+    fun `환불 요청 상세 requestedDate는 UTC 저장값을 KST 날짜로 변환한다`() {
+        val owner = seller()
+        val participation = refundParticipation(id = 1011L, status = ParticipationStatus.REFUND_PENDING).apply {
+            cancelledAt = LocalDateTime.of(2026, 5, 27, 23, 30)
+        }
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
+        `when`(participationRepository.findPickupDetailById(1011L)).thenReturn(participation)
+
+        val detail = service.getRefundRequestDetail(owner.id!!, 1011L)
+
+        assertEquals(LocalDate.of(2026, 5, 28), detail.requestedDate)
+    }
+
+    @Test
+    fun `환불 요청 목록 requestedDate는 UTC 저장값을 KST 날짜로 변환한다`() {
+        val owner = seller()
+        val participation = refundParticipation(id = 1003L, status = ParticipationStatus.REFUND_PENDING).apply {
+            cancelledAt = LocalDateTime.of(2026, 5, 27, 23, 30)
+        }
+        stubSellerAndStoreIds(owner.id!!, owner, defaultStoreIds())
+        `when`(
+            participationRepository.findRefundRequestsByStoreIdsAndStatuses(
+                defaultStoreIds(),
+                listOf(ParticipationStatus.REFUND_PENDING, ParticipationStatus.REFUNDED),
+                LocalDate.of(2026, 5, 28).minusMonths(6).atStartOfDay(),
+            )
+        ).thenReturn(listOf(participation))
+
+        val result = service.getRefundRequests(owner.id!!, OwnerRefundRequestTab.ALL)
+
+        assertEquals(LocalDate.of(2026, 5, 28), result.items.first().requestedDate)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/owner/application/OwnerSettlementServiceTest.kt
@@ -24,17 +24,20 @@ import com.moongchijang.support.UserFixture
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -55,8 +58,21 @@ class OwnerSettlementServiceTest {
     @Mock
     private lateinit var refundRequestSyncService: RefundRequestSyncService
 
-    @InjectMocks
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-28T04:00:00Z"), ZoneOffset.UTC)
+
     private lateinit var service: OwnerSettlementService
+
+    @BeforeEach
+    fun setUp() {
+        service = OwnerSettlementService(
+            userRepository = userRepository,
+            storeStaffRepository = storeStaffRepository,
+            groupBuyRepository = groupBuyRepository,
+            participationRepository = participationRepository,
+            refundRequestSyncService = refundRequestSyncService,
+            clock = clock,
+        )
+    }
 
     @Test
     fun `월별 정산 예정 금액을 조회한다`() {

--- a/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/application/ParticipationPickupCommandServiceTest.kt
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -25,10 +28,13 @@ class ParticipationPickupCommandServiceTest {
     @Mock
     private lateinit var userRepository: UserRepository
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-23T03:00:00Z"), ZoneOffset.UTC)
+
     private val service by lazy {
         ParticipationPickupCommandService(
             participationRepository = participationRepository,
-            userRepository = userRepository
+            userRepository = userRepository,
+            clock = clock
         )
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/participation/repository/ParticipationAuditingIntegrationTest.kt
@@ -12,6 +12,7 @@ import com.moongchijang.domain.user.domain.entity.AuthProvider
 import com.moongchijang.domain.user.domain.entity.User
 import com.moongchijang.domain.user.domain.entity.UserRole
 import com.moongchijang.global.config.QuerydslConfig
+import com.moongchijang.global.config.TimeConfig
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -28,7 +29,7 @@ import java.time.LocalTime
         "spring.jpa.hibernate.ddl-auto=create-drop"
     ]
 )
-@Import(QuerydslConfig::class)
+@Import(QuerydslConfig::class, TimeConfig::class)
 class ParticipationAuditingIntegrationTest {
 
     @Autowired

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -56,6 +56,9 @@ import org.springframework.data.domain.Sort
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionStatus
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -112,6 +115,8 @@ class PaymentServiceTest {
     @Mock
     private lateinit var s3ImageReferenceResolver: S3ImageReferenceResolver
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-23T03:00:00Z"), ZoneOffset.UTC)
+
     private val portOneProperties = PortOneProperties(
         storeId = "store-test",
         channelKey = "channel-test",
@@ -135,7 +140,8 @@ class PaymentServiceTest {
             notificationEventPublisher = notificationEventPublisher,
             adminDiscordAlertService = adminDiscordAlertService,
             refundRequestSyncService = refundRequestSyncService,
-            s3ImageReferenceResolver = s3ImageReferenceResolver
+            s3ImageReferenceResolver = s3ImageReferenceResolver,
+            clock = clock
         )
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/search/application/FullTextSearchEngineTest.kt
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.LocalDateTime
 
 class FullTextSearchEngineTest {
@@ -21,7 +24,8 @@ class FullTextSearchEngineTest {
     private val groupBuyRepository: GroupBuyRepository = Mockito.mock(GroupBuyRepository::class.java)
     private val s3ImageReferenceResolver: S3ImageReferenceResolver = Mockito.mock(S3ImageReferenceResolver::class.java)
     private val searchCorrectionService: SearchCorrectionService = Mockito.mock(SearchCorrectionService::class.java)
-    private val engine = FullTextSearchEngine(groupBuyRepository, s3ImageReferenceResolver, searchCorrectionService)
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-22T01:00:00Z"), ZoneOffset.UTC)
+    private val engine = FullTextSearchEngine(groupBuyRepository, s3ImageReferenceResolver, searchCorrectionService, clock)
 
     private fun stubProductIds(vararg sequentialReturns: List<Long>) {
         val stubbing = Mockito.`when`(

--- a/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/UserServiceTest.kt
@@ -30,6 +30,7 @@ import com.moongchijang.domain.user.domain.repository.UserRepository
 import com.moongchijang.domain.user.domain.repository.WithdrawnAccountRepository
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
+import com.moongchijang.global.time.utcNow
 import com.moongchijang.security.crypto.AesGcmPersonalInfoEncryptor
 import com.moongchijang.security.crypto.HmacSha256PersonalInfoHasher
 import com.moongchijang.security.crypto.PersonalInfoEncryptionProperties
@@ -41,7 +42,10 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
 import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class UserServiceTest {
 
@@ -74,6 +78,8 @@ class UserServiceTest {
         AesGcmPersonalInfoEncryptor(personalInfoProperties),
         HmacSha256PersonalInfoHasher(personalInfoProperties),
     )
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-23T03:00:00Z"), ZoneOffset.UTC)
+
     private val userService = UserService(
         userRepository,
         sellerBusinessProfileRepository,
@@ -91,6 +97,7 @@ class UserServiceTest {
         withdrawalLegalRetentionCommandService,
         withdrawalImmediateCleanupService,
         personalInfoManager,
+        clock,
     )
 
     @Test
@@ -291,7 +298,7 @@ class UserServiceTest {
             email = "restore@example.com",
             nickname = "새닉네임",
         )
-        val withdrawnAt = LocalDateTime.now().minusDays(40)
+        val withdrawnAt = clock.utcNow().minusDays(40)
         val withdrawnAccount = WithdrawnAccount(
             provider = AuthProvider.KAKAO,
             identifierHash = withdrawalIdentifierHasher.hashProviderIdentifier(AuthProvider.KAKAO, "kakao-restore"),

--- a/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawalRetentionPurgeServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawalRetentionPurgeServiceTest.kt
@@ -7,7 +7,10 @@ import com.moongchijang.domain.user.domain.repository.WithdrawnRefundRequestRepo
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import java.time.Clock
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class WithdrawalRetentionPurgeServiceTest {
 
@@ -16,11 +19,14 @@ class WithdrawalRetentionPurgeServiceTest {
     private val withdrawnParticipationRepository: WithdrawnParticipationRepository = Mockito.mock(WithdrawnParticipationRepository::class.java)
     private val withdrawnRefundRequestRepository: WithdrawnRefundRequestRepository = Mockito.mock(WithdrawnRefundRequestRepository::class.java)
 
+    private val clock: Clock = Clock.fixed(Instant.parse("2026-05-23T03:00:00Z"), ZoneOffset.UTC)
+
     private val service = WithdrawalRetentionPurgeService(
         withdrawnAccountRepository = withdrawnAccountRepository,
         withdrawnPaymentOrderRepository = withdrawnPaymentOrderRepository,
         withdrawnParticipationRepository = withdrawnParticipationRepository,
         withdrawnRefundRequestRepository = withdrawnRefundRequestRepository,
+        clock = clock,
     )
 
     @Test

--- a/src/test/kotlin/com/moongchijang/global/time/TimePolicyTest.kt
+++ b/src/test/kotlin/com/moongchijang/global/time/TimePolicyTest.kt
@@ -18,4 +18,13 @@ class TimePolicyTest {
         assertThat(clock.kstToday()).isEqualTo(LocalDate.of(2026, 6, 5))
         assertThat(clock.utcNow()).isEqualTo(LocalDateTime.of(2026, 6, 5, 0, 30))
     }
+
+    @Test
+    fun `UTC와 KST 날짜 경계가 월초로 넘어가도 올바르게 해석한다`() {
+        val clock = Clock.fixed(Instant.parse("2026-01-31T15:30:00Z"), ZoneOffset.UTC)
+
+        assertThat(clock.utcNow()).isEqualTo(LocalDateTime.of(2026, 1, 31, 15, 30))
+        assertThat(clock.kstNow()).isEqualTo(LocalDateTime.of(2026, 2, 1, 0, 30))
+        assertThat(clock.kstToday()).isEqualTo(LocalDate.of(2026, 2, 1))
+    }
 }

--- a/src/test/kotlin/com/moongchijang/global/time/TimePolicyTest.kt
+++ b/src/test/kotlin/com/moongchijang/global/time/TimePolicyTest.kt
@@ -1,0 +1,21 @@
+package com.moongchijang.global.time
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+class TimePolicyTest {
+
+    @Test
+    fun `UTC clock instant를 KST 비즈니스 시각으로 해석한다`() {
+        val clock = Clock.fixed(Instant.parse("2026-06-05T00:30:00Z"), ZoneOffset.UTC)
+
+        assertThat(clock.kstNow()).isEqualTo(LocalDateTime.of(2026, 6, 5, 9, 30))
+        assertThat(clock.kstToday()).isEqualTo(LocalDate.of(2026, 6, 5))
+        assertThat(clock.utcNow()).isEqualTo(LocalDateTime.of(2026, 6, 5, 0, 30))
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 서버 전반의 시간 처리 기준을 `UTC 저장 / KST 계산` 정책으로 정리했습니다.
- 공통 `Clock` 및 시간 유틸을 도입하고, 하드코딩된 `ZoneId.of("Asia/Seoul")` 및 직접 `now()` 호출 사용 지점을 정리했습니다.
- D-day 계산, 마감 여부 판단, 오늘/내일 픽업 판단, 피드/마이페이지/검색 등 날짜 계산 로직을 KST 기준으로 통일했습니다.
- 생성/수정/상태 전이/결제/환불/픽업 완료 등 서버 내부 저장 시각은 UTC 기준으로 정리했습니다.
- JPA 감사 시각과 Hibernate JDBC timezone 설정을 UTC 기준으로 맞췄습니다.
- OpenAPI 명세와 OpenAPI 설명 문구에 시간 필드 응답 규칙과 UTC/KST 해석 기준을 반영했습니다.
- 시간 정책 변경에 따라 영향을 받는 단위 테스트/통합 테스트를 정비하고, 월 경계/UTC-KST 날짜 경계/오늘-내일/D-day 경계 테스트를 추가했습니다.

## 🔍 참고 사항
- 현재 API 응답 시간 타입은 `LocalDateTime`을 유지하며, `yyyy-MM-dd'T'HH:mm:ss` 형식의 오프셋 없는 문자열로 응답합니다.
- 일정성 시각(모집 시작/마감, 픽업 관련 계산)은 KST 기준으로 해석하고, 감사/이력성 시각(`createdAt`, `updatedAt`, 상태 전이 시각 등)은 UTC 기준 저장값을 사용합니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #317 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인