### PR TITLE
FIX: 결제 감사 로그 FK 제거로 결제 승인 지연 해소

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentAuditLog.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentAuditLog.kt
@@ -2,10 +2,12 @@ package com.moongchijang.domain.payment.domain.entity
 
 import com.moongchijang.global.entity.BaseEntity
 import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -25,7 +27,10 @@ import jakarta.persistence.Table
 )
 class PaymentAuditLog(
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "payment_order_id")
+    @JoinColumn(
+        name = "payment_order_id",
+        foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
     var paymentOrder: PaymentOrder? = null,
 
     @Column(name = "order_id", length = 64)

--- a/src/main/resources/db/migration/V59__drop_payment_audit_logs_payment_order_fk.sql
+++ b/src/main/resources/db/migration/V59__drop_payment_audit_logs_payment_order_fk.sql
@@ -1,0 +1,6 @@
+-- 결제 승인 트랜잭션이 payment_orders 행에 X-lock을 잡은 상태에서
+-- REQUIRES_NEW 로 분리된 PaymentAuditLogService 가 payment_audit_logs INSERT 시
+-- FK 검증을 위해 동일 행의 S-lock 을 기다리며 자기 자신과 락 대기에 빠지는 문제 해결.
+-- payment_audit_logs.order_id (문자열) 로 추적 가능하므로 FK 강제는 불필요.
+
+ALTER TABLE payment_audit_logs DROP FOREIGN KEY fk_payment_audit_logs_payment_order_id;


### PR DESCRIPTION
## 📌 작업한 내용

- `payment_audit_logs.payment_order_id` 외래키 제약 제거 마이그레이션 추가 (`V59__drop_payment_audit_logs_payment_order_fk.sql`)

## 🔍 참고 사항

### 증상
`/api/v1/payments/portone/complete` 응답이 약 50초 걸리는 결제가 dev 환경에서 24시간 내 3건 관측되었습니다. 모두 결제 자체는 성공이지만 사용자 입장에선 \"결제 승인 UI가 한참 걸린다\"로 보였습니다.

### 근본 원인
`PaymentAuditLogService.record()` 는 `PROPAGATION_REQUIRES_NEW` 로 분리된 트랜잭션에서 `payment_audit_logs` 에 INSERT 합니다. 그런데 호출 시점에 외부 `approvePayment` 트랜잭션이 이미 `payment_orders.id = X` 행에 X-락을 잡고 있습니다. 새 트랜잭션의 INSERT 가 FK `fk_payment_audit_logs_payment_order_id` 검증을 위해 같은 행의 S-락을 요구하면서, 자기 자신과 무한 락 대기에 빠집니다. MySQL InnoDB 의 `innodb_lock_wait_timeout` 기본값 50초가 지난 뒤에야 강제 해제되면서 외부 트랜잭션이 commit 됩니다.

### 해결
따라서 `payment_audit_logs.payment_order_id` 의 FK 제약을 제거했습니다. 


## 🖼️ 스크린샷

해당 없음.

## 🔗 관련 이슈

없음. 

## ✅ 체크리스트

- [x] 로컬에서 빌드 및 테스트 완료 (\`PaymentAuditLogServiceTest\`, \`PaymentServiceTest\`)
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인