### PR TITLE
FIX: 포트원 결제 취소 응답 파싱 오류로 인한 502 차단

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -120,7 +120,7 @@ class PortOnePaymentClient(
         val totalAmount = (cancellation["totalAmount"] as? Number)?.toInt() ?: 0
         val cancelledAt = parseDateTime(cancellation["cancelledAt"] as? String)
         return PortOnePaymentResult(
-            paymentId = cancellation["id"] as? String ?: paymentId,
+            paymentId = paymentId,
             status = mappedStatus,
             totalAmount = totalAmount,
             method = null,

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -54,6 +54,7 @@ class PortOnePaymentClient(
     }
 
     override fun cancelPayment(paymentId: String, reason: String, cancelAmount: Int?): PortOnePaymentResult {
+        val partial = cancelAmount != null
         val requestBody = mutableMapOf<String, Any>("reason" to reason).apply {
             if (cancelAmount != null) {
                 this["amount"] = cancelAmount
@@ -83,12 +84,49 @@ class PortOnePaymentClient(
         }
 
         return try {
-            toPaymentResult(paymentId, response)
+            toCancellationResult(paymentId, response, partial)
         } catch (e: CustomException) {
+            log.warn(
+                "[PortOnePaymentClient] 결제 취소 응답 파싱 실패: paymentId={}, response={}",
+                paymentId,
+                response,
+            )
             throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
         } catch (e: RuntimeException) {
+            log.warn(
+                "[PortOnePaymentClient] 결제 취소 응답 파싱 실패: paymentId={}, response={}",
+                paymentId,
+                response,
+                e,
+            )
             throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
         }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun toCancellationResult(
+        paymentId: String,
+        response: Map<*, *>,
+        partial: Boolean,
+    ): PortOnePaymentResult {
+        val cancellation = response["cancellation"] as? Map<String, Any?>
+            ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        val rawStatus = cancellation["status"] as? String ?: ""
+        val mappedStatus = when (rawStatus) {
+            PORTONE_CANCELLATION_STATUS_SUCCEEDED ->
+                if (partial) PORTONE_STATUS_PARTIAL_CANCELLED else PORTONE_STATUS_CANCELLED
+            else -> rawStatus
+        }
+        val totalAmount = (cancellation["totalAmount"] as? Number)?.toInt() ?: 0
+        val cancelledAt = parseDateTime(cancellation["cancelledAt"] as? String)
+        return PortOnePaymentResult(
+            paymentId = cancellation["id"] as? String ?: paymentId,
+            status = mappedStatus,
+            totalAmount = totalAmount,
+            method = null,
+            paidAt = null,
+            cancelledAt = cancelledAt,
+        )
     }
 
     private fun toPaymentResult(paymentId: String, response: Map<*, *>): PortOnePaymentResult {
@@ -131,5 +169,8 @@ class PortOnePaymentClient(
 
     companion object {
         private const val SLOW_REQUEST_WARN_THRESHOLD_MS = 1_000L
+        private const val PORTONE_CANCELLATION_STATUS_SUCCEEDED = "SUCCEEDED"
+        private const val PORTONE_STATUS_CANCELLED = "CANCELLED"
+        private const val PORTONE_STATUS_PARTIAL_CANCELLED = "PARTIAL_CANCELLED"
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
@@ -98,7 +98,7 @@ class PortOnePaymentClientTest {
 
         val result = client.cancelPayment(paymentId, "OTHER: 시간이 맞지 않습니다")
 
-        assertEquals("cancellation-id-1", result.paymentId)
+        assertEquals(paymentId, result.paymentId)
         assertEquals("CANCELLED", result.status)
         assertEquals(12000, result.totalAmount)
         assertEquals(LocalDateTime.of(2026, 5, 19, 6, 25), result.cancelledAt)

--- a/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
@@ -62,7 +62,7 @@ class PortOnePaymentClientTest {
     }
 
     @Test
-    fun `포트원 결제 취소 요청 결과를 파싱한다`() {
+    fun `포트원 결제 취소 응답의 cancellation 래퍼를 파싱한다`() {
         val builder = RestClient.builder()
         val server = MockRestServiceServer.bindTo(builder).build()
         val client = PortOnePaymentClient(
@@ -84,12 +84,12 @@ class PortOnePaymentClientTest {
                 withSuccess(
                     """
                     {
-                      "id": "$paymentId",
-                      "status": "CANCELLED",
-                      "amount": { "total": 12000 },
-                      "method": { "card": {} },
-                      "paidAt": "2026-05-19T06:20:00",
-                      "cancelledAt": "2026-05-19T06:25:00"
+                      "cancellation": {
+                        "id": "cancellation-id-1",
+                        "status": "SUCCEEDED",
+                        "totalAmount": 12000,
+                        "cancelledAt": "2026-05-19T06:25:00"
+                      }
                     }
                     """.trimIndent(),
                     MediaType.APPLICATION_JSON
@@ -98,11 +98,52 @@ class PortOnePaymentClientTest {
 
         val result = client.cancelPayment(paymentId, "OTHER: 시간이 맞지 않습니다")
 
-        assertEquals(paymentId, result.paymentId)
+        assertEquals("cancellation-id-1", result.paymentId)
         assertEquals("CANCELLED", result.status)
         assertEquals(12000, result.totalAmount)
-        assertEquals("card", result.method)
         assertEquals(LocalDateTime.of(2026, 5, 19, 6, 25), result.cancelledAt)
+        server.verify()
+    }
+
+    @Test
+    fun `부분 취소 요청 시 cancelAmount를 본문에 담고 부분취소 상태로 매핑한다`() {
+        val builder = RestClient.builder()
+        val server = MockRestServiceServer.bindTo(builder).build()
+        val client = PortOnePaymentClient(
+            portOneProperties = PortOneProperties(
+                storeId = "store-test",
+                channelKey = "channel-test",
+                apiSecret = "secret-test",
+                paymentApiBaseUrl = "https://api.portone.test"
+            ),
+            restClientBuilder = builder
+        )
+        val paymentId = "portone-payment-id"
+
+        server.expect(once(), requestTo("https://api.portone.test/payments/$paymentId/cancel"))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(content().json("""{"reason":"환불 대기 처리","amount":5000}"""))
+            .andRespond(
+                withSuccess(
+                    """
+                    {
+                      "cancellation": {
+                        "id": "cancellation-id-2",
+                        "status": "SUCCEEDED",
+                        "totalAmount": 5000,
+                        "cancelledAt": "2026-05-20T09:00:00"
+                      }
+                    }
+                    """.trimIndent(),
+                    MediaType.APPLICATION_JSON
+                )
+            )
+
+        val result = client.cancelPayment(paymentId, "환불 대기 처리", cancelAmount = 5000)
+
+        assertEquals("PARTIAL_CANCELLED", result.status)
+        assertEquals(5000, result.totalAmount)
+        assertEquals(LocalDateTime.of(2026, 5, 20, 9, 0), result.cancelledAt)
         server.verify()
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- `PortOnePaymentClient.cancelPayment`가 GET payment 와 동일한 평면 파서를 사용해 cancel 전용 응답을 파싱하지 못하던 문제를 해결
- 전용 파서 `toCancellationResult`를 추가하고 cancel 응답의 `cancellation` 래퍼에서 `id`/`status`/`totalAmount`/`cancelledAt`을 추출
- 포트원 cancel status `SUCCEEDED` → 내부 `CANCELLED`(전체) 또는 `PARTIAL_CANCELLED`(부분)로 매핑
- 파싱 실패 시 응답 본문을 그대로 WARN 로그로 남겨 차후 진단성 확보

## 🔍 참고 사항
- `POST /participations/{id}/cancel` 호출이 502로 반환되며 ERROR 로그 없이 `PortOnePaymentClient 결제 취소 요청 지연` WARN 만 남는 현상 재현됨
- 원인: 포트원 V2 cancel API 응답이 `{"cancellation": { "status": "SUCCEEDED" | "REQUESTED" | "FAILED", "totalAmount", "cancelledAt", ... }}` 래퍼 구조인데, 기존 `toPaymentResult`는 `amount.total` 평면 키만 읽음 → `extractTotalAmount` 가 `PAYMENT_APPROVAL_FAILED` 던짐 → catch 블럭에서 `PAYMENT_CANCEL_FAILED`로 재포장 → 502
- 기존 `PortOnePaymentClientTest`의 cancel mock 도 잘못된 평면 셰이프를 흉내내 버그를 잡지 못했음 → 실제 V2 셰이프로 교체하고 부분 취소 케이스 추가
- 부분 환불(`processPendingRefund`)도 동일 경로를 타므로 함께 정상화됨

## 🖼 스크린샷
없음

## 🔗 관련 이슈
- 별도 이슈 없음 

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] dev 배포 후 모바일/PC 환경에서 참여 취소 200 OK 확인
- [ ] 환불 대기 처리(부분 취소) 정상 동작 확인
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인