### PR TITLE
FIX: 결제 취소 상태에서 중복 요청 멱등 처리 개선

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -124,7 +124,7 @@ class PortOnePaymentClient(
     }
 
     private fun isAlreadyCancelledResponse(e: HttpClientErrorException): Boolean {
-        if (e.statusCode != HttpStatus.CONFLICT) return false
+        if (!e.statusCode.isSameCodeAs(HttpStatus.CONFLICT)) return false
         return e.responseBodyAsString.contains(PORTONE_ERROR_PAYMENT_ALREADY_CANCELLED)
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClient.kt
@@ -6,7 +6,9 @@ import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 import java.time.LocalDateTime
@@ -69,6 +71,24 @@ class PortOnePaymentClient(
                 .retrieve()
                 .body(Map::class.java)
                 ?: throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
+        } catch (e: HttpClientErrorException) {
+            val elapsedMs = System.currentTimeMillis() - startedAtMs
+            if (isAlreadyCancelledResponse(e)) {
+                log.info(
+                    "[PortOnePaymentClient] PortOne 이미 취소된 결제 멱등 처리: paymentId={}, elapsedMs={}",
+                    paymentId,
+                    elapsedMs,
+                )
+                return alreadyCancelledResult(paymentId, partial, cancelAmount)
+            }
+            log.warn(
+                "[PortOnePaymentClient] 결제 취소 요청 실패: paymentId={}, elapsedMs={}, body={}",
+                paymentId,
+                elapsedMs,
+                e.responseBodyAsString,
+                e,
+            )
+            throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
         } catch (e: RestClientException) {
             log.warn(
                 "[PortOnePaymentClient] 결제 취소 요청 실패: paymentId={}, elapsedMs={}",
@@ -101,6 +121,26 @@ class PortOnePaymentClient(
             )
             throw CustomException(ErrorCode.PAYMENT_CANCEL_FAILED)
         }
+    }
+
+    private fun isAlreadyCancelledResponse(e: HttpClientErrorException): Boolean {
+        if (e.statusCode != HttpStatus.CONFLICT) return false
+        return e.responseBodyAsString.contains(PORTONE_ERROR_PAYMENT_ALREADY_CANCELLED)
+    }
+
+    private fun alreadyCancelledResult(
+        paymentId: String,
+        partial: Boolean,
+        cancelAmount: Int?,
+    ): PortOnePaymentResult {
+        return PortOnePaymentResult(
+            paymentId = paymentId,
+            status = if (partial) PORTONE_STATUS_PARTIAL_CANCELLED else PORTONE_STATUS_CANCELLED,
+            totalAmount = cancelAmount ?: 0,
+            method = null,
+            paidAt = null,
+            cancelledAt = null,
+        )
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -172,5 +212,6 @@ class PortOnePaymentClient(
         private const val PORTONE_CANCELLATION_STATUS_SUCCEEDED = "SUCCEEDED"
         private const val PORTONE_STATUS_CANCELLED = "CANCELLED"
         private const val PORTONE_STATUS_PARTIAL_CANCELLED = "PARTIAL_CANCELLED"
+        private const val PORTONE_ERROR_PAYMENT_ALREADY_CANCELLED = "PAYMENT_ALREADY_CANCELLED"
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/infrastructure/portone/PortOnePaymentClientTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.test.web.client.ExpectedCount.once
 import org.springframework.test.web.client.MockRestServiceServer
@@ -12,6 +13,7 @@ import org.springframework.test.web.client.match.MockRestRequestMatchers.content
 import org.springframework.test.web.client.match.MockRestRequestMatchers.header
 import org.springframework.test.web.client.match.MockRestRequestMatchers.method
 import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
 import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 import org.springframework.web.client.RestClient
 import java.time.LocalDateTime
@@ -144,6 +146,36 @@ class PortOnePaymentClientTest {
         assertEquals("PARTIAL_CANCELLED", result.status)
         assertEquals(5000, result.totalAmount)
         assertEquals(LocalDateTime.of(2026, 5, 20, 9, 0), result.cancelledAt)
+        server.verify()
+    }
+
+    @Test
+    fun `이미 취소된 결제는 PAYMENT_ALREADY_CANCELLED를 받아도 취소 완료로 간주한다`() {
+        val builder = RestClient.builder()
+        val server = MockRestServiceServer.bindTo(builder).build()
+        val client = PortOnePaymentClient(
+            portOneProperties = PortOneProperties(
+                storeId = "store-test",
+                channelKey = "channel-test",
+                apiSecret = "secret-test",
+                paymentApiBaseUrl = "https://api.portone.test"
+            ),
+            restClientBuilder = builder
+        )
+        val paymentId = "portone-payment-id"
+
+        server.expect(once(), requestTo("https://api.portone.test/payments/$paymentId/cancel"))
+            .andExpect(method(HttpMethod.POST))
+            .andRespond(
+                withStatus(HttpStatus.CONFLICT)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body("""{"type":"PAYMENT_ALREADY_CANCELLED","message":"payment already cancelled"}""")
+            )
+
+        val result = client.cancelPayment(paymentId, "OTHER: 시간이 맞지 않습니다")
+
+        assertEquals(paymentId, result.paymentId)
+        assertEquals("CANCELLED", result.status)
         server.verify()
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
- `PortOnePaymentClient.cancelPayment`에서 `HttpClientErrorException` 분기를 추가하고, 409 Conflict 응답 본문이 `PAYMENT_ALREADY_CANCELLED`인 경우 예외를 던지지 않고 `CANCELLED`(부분 환불일 땐 `PARTIAL_CANCELLED`) 상태의 결과를 합성해 반환gkqslek.
- 멱등 응답 시 호출자(`PaymentService.cancelParticipation`/`processPendingRefund`)가 그대로 DB를 CANCELLED로 정상화됩니다.
- 그 외 4xx 응답은 진단을 위해 응답 본문을 함께 WARN 로깅하도록 보강합니다.
- `PortOnePaymentClientTest`에 409 + `PAYMENT_ALREADY_CANCELLED` 응답을 받았을 때 CANCELLED로 반환되는지 검증하는 케이스 추가합니다.

## 🔍 참고 사항
- 사건 재현: dev 환경 카카오 사용자(userId=13)가 participation 990030 취소 시도 → PortOne `409 Conflict {"type":"PAYMENT_ALREADY_CANCELLED"}` 반환 → 502 반환
- 원인: PR #343 머지 이전 동일 결제에 대한 첫 취소가 PortOne 측에서는 SUCCEEDED 처리됐으나 백엔드 응답 파싱 버그로 502가 반환되며 `PaymentOrder.status`가 APPROVED로 남아 있었음. 사용자가 다시 누르면 PortOne은 이미 취소된 결제라 거부 → 무한 502 루프
- 이번 변경으로 사용자가 동일 화면에서 다시 취소 버튼을 누르는 것만으로 DB 상태가 CANCELLED로 정상화됨 → 별도 데이터 마이그레이션 없이 핫픽스 단독으로 회복 가능
- 부분 환불 멱등성도 동일 분기에서 처리되도록 `partial` 플래그를 그대로 사용

## 🖼 스크린샷
없음

## 🔗 관련 이슈
- 별도 이슈 없음 

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] dev 배포 후 카카오 사용자의 좀비 주문 재취소 시 200 OK 확인
- [ ] PortOne 정상 케이스(SUCCEEDED) 동작 유지 확인
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인