### PR TITLE
[MCJ-1616] HOTFIX: Loki 설정 스키마를 수정해 로그 수집 정상화

### DIFF
--- a/docker/monitoring/loki/loki-config.yml
+++ b/docker/monitoring/loki/loki-config.yml
@@ -9,6 +9,10 @@ common:
   ring:
     kvstore:
       store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
 
 schema_config:
   configs:
@@ -19,11 +23,6 @@ schema_config:
       index:
         prefix: index_
         period: 24h
-
-storage_config:
-  filesystem:
-    chunks_directory: /loki/chunks
-    rules_directory: /loki/rules
 
 limits_config:
   allow_structured_metadata: true


### PR DESCRIPTION
## 📌 작업한 내용
- Loki 컨테이너가 재시작을 반복하던 원인을 확인하고, `loki-config.yml` 설정 구조를 Loki 3.x 스키마에 맞게 수정했습니다.
- 기존 `storage_config.filesystem`에 있던 `chunks_directory`, `rules_directory` 설정을 `common.storage.filesystem`으로 이동해 config parsing 오류를 해소했습니다.
- Docker monitoring compose 기준으로 Loki 설정 파일이 정상 해석되는 것을 확인했습니다.

## 🔍 참고 사항
- 운영 환경에서 Loki 기동 실패 로그에 `field chunks_directory not found in type local.FSConfig`, `field rules_directory not found in type local.FSConfig` 에러가 발생하고 있었습니다.
- 이번 수정은 Loki 설정 스키마 호환성 문제를 해결하는 작업이며, 적용 후에는 EC2에서 Loki 재기동 및 Grafana Explore 로그 조회까지 함께 확인하는 것이 좋습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #347 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인