### PR TITLE
[MCJ-1624] FEAT: 관리자 로그인 API 분리

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/application/AuthService.kt
@@ -194,13 +194,7 @@ class AuthService(
             val normalizedEmail = request.email.trim().lowercase()
             log.info("[AuthService] 이메일 로그인 처리 시작: email={}", maskEmail(normalizedEmail))
 
-            val user = userService.findActiveEmailUser(normalizedEmail)
-                ?: throw CustomException(ErrorCode.INVALID_CREDENTIALS)
-
-            val passwordHash = user.passwordHash ?: throw CustomException(ErrorCode.INVALID_CREDENTIALS)
-            if (!passwordEncoder.matches(request.password, passwordHash)) {
-                throw CustomException(ErrorCode.INVALID_CREDENTIALS)
-            }
+            val user = authenticateEmailUser(normalizedEmail, request.password)
 
             val accessToken = jwtTokenProvider.generateAccessToken(user.id!!)
             val refreshToken = tokenService.issueRefreshToken(user.id!!)
@@ -227,8 +221,59 @@ class AuthService(
         }
     }
 
+    @Transactional
+    fun loginAdminWithEmail(request: EmailLoginRequest): AuthLoginResult {
+        return runCatching {
+            val normalizedEmail = request.email.trim().lowercase()
+            log.info("[AuthService] 관리자 이메일 로그인 처리 시작: email={}", maskEmail(normalizedEmail))
+
+            val user = authenticateEmailUser(normalizedEmail, request.password)
+            if (!user.hasRole(UserRole.ADMIN)) {
+                throw CustomException(ErrorCode.FORBIDDEN)
+            }
+
+            user.role = UserRole.ADMIN
+            user.saveLastRole(UserRole.ADMIN)
+
+            val accessToken = jwtTokenProvider.generateAccessToken(user.id!!)
+            val refreshToken = tokenService.issueRefreshToken(user.id!!)
+            val expiresIn = jwtTokenProvider.getAccessTokenExpiresInSeconds()
+
+            val response = AuthLoginResponse(
+                accessToken = accessToken,
+                tokenType = "Bearer",
+                expiresIn = expiresIn,
+                isNewUser = false,
+                user = toAuthUserResponse(user),
+            )
+
+            log.info("[AuthService] 관리자 이메일 로그인 처리 완료: userId={}", user.id)
+            recordAfterCommit { authMetricsRecorder.recordLogin(provider = "admin-email", result = "success") }
+
+            AuthLoginResult(
+                response = response,
+                refreshToken = refreshToken,
+            )
+        }.getOrElse { throwable ->
+            authMetricsRecorder.recordLogin(provider = "admin-email", result = "failure")
+            throw throwable
+        }
+    }
+
     companion object {
         private val PASSWORD_REGEX = Regex("^(?=.*[A-Za-z])(?=.*[0-9]).{8,20}$")
+    }
+
+    private fun authenticateEmailUser(email: String, rawPassword: String): User {
+        val user = userService.findActiveEmailUser(email)
+            ?: throw CustomException(ErrorCode.INVALID_CREDENTIALS)
+
+        val passwordHash = user.passwordHash ?: throw CustomException(ErrorCode.INVALID_CREDENTIALS)
+        if (!passwordEncoder.matches(rawPassword, passwordHash)) {
+            throw CustomException(ErrorCode.INVALID_CREDENTIALS)
+        }
+
+        return user
     }
 
     private fun toAuthUserResponse(user: User): AuthUserResponse =

--- a/src/main/kotlin/com/moongchijang/domain/auth/presentation/AdminAuthController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/auth/presentation/AdminAuthController.kt
@@ -1,0 +1,56 @@
+package com.moongchijang.domain.auth.presentation
+
+import com.moongchijang.domain.auth.application.AuthService
+import com.moongchijang.domain.auth.application.TokenService
+import com.moongchijang.domain.auth.application.dto.AuthLoginResponse
+import com.moongchijang.domain.auth.application.dto.EmailLoginRequest
+import com.moongchijang.global.response.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import jakarta.servlet.http.HttpServletResponse
+
+@RestController
+@RequestMapping("/api/v1/auth/admin")
+@Tag(name = "Admin Auth", description = "관리자 인증 API")
+class AdminAuthController(
+    private val authService: AuthService,
+    private val tokenService: TokenService,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/email/login")
+    @Operation(summary = "관리자 이메일 로그인", description = "이메일과 비밀번호를 검증하고 ADMIN 권한 보유 사용자만 로그인 처리합니다.")
+    @ApiResponses(
+        value = [
+            SwaggerApiResponse(responseCode = "200", description = "로그인 성공"),
+            SwaggerApiResponse(responseCode = "400", description = "요청값 검증 실패", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "401", description = "이메일 또는 비밀번호 불일치", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+            SwaggerApiResponse(responseCode = "403", description = "관리자 권한 없음", content = [Content(schema = Schema(implementation = ApiResponse::class))]),
+        ],
+    )
+    fun loginAdminWithEmail(
+        @Valid @RequestBody request: EmailLoginRequest,
+        response: HttpServletResponse,
+    ): ApiResponse<AuthLoginResponse> {
+        log.info("[AdminAuthController] 관리자 이메일 로그인 요청 수신")
+        val (authLoginResponse, refreshToken) = authService.loginAdminWithEmail(request)
+
+        tokenService.addRefreshTokenCookie(
+            response = response,
+            refreshToken = refreshToken,
+        )
+        log.info("[AdminAuthController] 관리자 이메일 로그인 응답 완료: userId={}", authLoginResponse.user.id)
+
+        return ApiResponse.success(authLoginResponse)
+    }
+}

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -44,6 +44,7 @@ class SecurityConfig(
                     "/metrics",
                     "/api/v1/auth/kakao",
                     "/api/v1/auth/refresh",
+                    "/api/v1/auth/admin/**",
                     "/api/v1/auth/email/**",
                     "/api/v1/auth/phone/verification-codes",
                     "/api/v1/auth/phone/verification-codes/verify",

--- a/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/moongchijang/security/config/SecurityConfig.kt
@@ -44,7 +44,7 @@ class SecurityConfig(
                     "/metrics",
                     "/api/v1/auth/kakao",
                     "/api/v1/auth/refresh",
-                    "/api/v1/auth/admin/**",
+                    "/api/v1/auth/admin/email/login",
                     "/api/v1/auth/email/**",
                     "/api/v1/auth/phone/verification-codes",
                     "/api/v1/auth/phone/verification-codes/verify",

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -33,6 +33,8 @@ servers:
 tags:
   - name: Auth
     description: 카카오 로그인 및 토큰 관리
+  - name: Admin Auth
+    description: 관리자 로그인 및 토큰 발급
   - name: GroupBuy
     description: 공구 피드 · 상세 · 달성률
   - name: GroupBuyRequest
@@ -645,6 +647,34 @@ paths:
                 $ref: '#/components/schemas/ApiResponseAuthLogin'
         '401':
           $ref: '#/components/responses/Unauthorized'
+
+  /api/v1/auth/admin/email/login:
+    post:
+      tags: [Admin Auth]
+      summary: 관리자 이메일 로그인
+      description: 이메일과 비밀번호를 검증하고 ADMIN 권한 보유 사용자만 로그인 처리한다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailLoginRequest'
+      responses:
+        '200':
+          description: 로그인 성공
+          headers:
+            Set-Cookie:
+              description: 환경별 cookie path로 저장되는 refreshToken HttpOnly 쿠키 (prod=`/`, dev=`/dev`)
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponseAuthLogin'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /api/v1/users/me/nickname:
     patch:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -671,6 +671,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponseAuthLogin'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/src/test/kotlin/com/moongchijang/domain/auth/application/AuthServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/auth/application/AuthServiceTest.kt
@@ -258,6 +258,63 @@ class AuthServiceTest {
     }
 
     @Test
+    fun `관리자 이메일 로그인 성공 시 활성 역할을 ADMIN으로 변경하고 토큰을 반환`() {
+        val now = LocalDateTime.of(2026, 6, 18, 12, 0)
+        val user = UserFixture.createEmailUser(
+            id = 55L,
+            email = "admin@example.com",
+            passwordHash = "hashed-password",
+            nickname = "관리자",
+        )
+        user.grantRole(UserRole.BUYER)
+        user.grantRole(UserRole.ADMIN)
+        setAuditFields(user, now, now)
+
+        Mockito.`when`(userService.findActiveEmailUser("admin@example.com")).thenReturn(user)
+        Mockito.`when`(passwordEncoder.matches("abc12345", "hashed-password")).thenReturn(true)
+        Mockito.`when`(jwtTokenProvider.generateAccessToken(55L)).thenReturn("admin-access-token")
+        Mockito.`when`(tokenService.issueRefreshToken(55L)).thenReturn("admin-refresh-token")
+        Mockito.`when`(jwtTokenProvider.getAccessTokenExpiresInSeconds()).thenReturn(3600L)
+
+        val result = authService.loginAdminWithEmail(
+            EmailLoginRequest(
+                email = "admin@example.com",
+                password = "abc12345",
+            )
+        )
+
+        Assertions.assertEquals("admin-access-token", result.response.accessToken)
+        Assertions.assertEquals("admin-refresh-token", result.refreshToken)
+        Assertions.assertEquals(UserRole.ADMIN, result.response.user.role)
+        Assertions.assertEquals(UserRole.ADMIN, user.role)
+        Assertions.assertEquals(UserRole.ADMIN, user.lastRole)
+    }
+
+    @Test
+    fun `관리자 이메일 로그인 시 ADMIN 권한이 없으면 예외`() {
+        val user = UserFixture.createEmailUser(
+            id = 56L,
+            email = "buyer@example.com",
+            passwordHash = "hashed-password",
+        )
+        user.grantRole(UserRole.BUYER)
+
+        Mockito.`when`(userService.findActiveEmailUser("buyer@example.com")).thenReturn(user)
+        Mockito.`when`(passwordEncoder.matches("abc12345", "hashed-password")).thenReturn(true)
+
+        val exception = assertThrows<CustomException> {
+            authService.loginAdminWithEmail(
+                EmailLoginRequest(
+                    email = "buyer@example.com",
+                    password = "abc12345",
+                )
+            )
+        }
+
+        Assertions.assertEquals(ErrorCode.FORBIDDEN, exception.errorCode)
+    }
+
+    @Test
     fun `이메일 회원가입 시 비밀번호 형식 불일치면 예외`() {
         Mockito.`when`(emailSignupTokenStore.isValid("new@example.com", "signup-token")).thenReturn(true)
 


### PR DESCRIPTION
## 📌 작업한 내용
- 일반 사용자 로그인과 분리된 관리자 전용 이메일 로그인 API를 추가했습니다.
- 관리자 로그인 시 기존 이메일/비밀번호 검증 이후 `ADMIN` 권한 보유 여부를 확인하도록 인증 흐름을 분리했습니다.
- 관리자 로그인 성공 시 활성 역할이 `ADMIN`으로 반영되도록 처리했습니다.
- 관리자 로그인 경로에 대한 보안 설정과 OpenAPI 명세를 함께 반영했습니다.
- 관리자 로그인 성공/권한 없음 케이스에 대한 테스트를 추가했습니다.

## 🔍 참고 사항
- 관리자 로그인 요청/응답 DTO는 기존 이메일 로그인 DTO를 재사용했습니다.
- 관리자 계정은 별도 회원가입 없이 DB에 존재하는 계정을 기준으로 로그인합니다.
- 관리자 로그인 API 경로는 `/api/v1/auth/admin/email/login` 입니다.
## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈
- Closed #355 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인