### PR TITLE
[MCJ-1624] CHORE: 프론트 codegen 트리거 전 OpenAPI readiness 확인 추가

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -101,6 +101,22 @@ jobs:
             # 태그 없는 미사용 이미지를 정리해 디스크 사용량 누적을 완화합니다.
             docker image prune -f
 
+      - name: Wait for dev OpenAPI to be ready
+        run: |
+          for i in {1..20}; do
+            status=$(curl -s -o /dev/null -w "%{http_code}" https://api.moongchijang.com/dev/openapi.yaml)
+            if [ "$status" = "200" ]; then
+              echo "Dev OpenAPI is ready"
+              exit 0
+            fi
+
+            echo "Dev OpenAPI not ready yet (status: $status), retrying..."
+            sleep 5
+          done
+
+          echo "Dev OpenAPI did not become ready in time"
+          exit 1
+
       - name: Trigger Frontend Orval Codegen
         uses: peter-evans/repository-dispatch@v3
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -125,6 +125,22 @@ jobs:
             # 태그 없는 미사용 이미지를 정리해 디스크 사용량 누적을 완화합니다.
             docker image prune -f
 
+      - name: Wait for prod OpenAPI to be ready
+        run: |
+          for i in {1..20}; do
+            status=$(curl -s -o /dev/null -w "%{http_code}" https://api.moongchijang.com/openapi.yaml)
+            if [ "$status" = "200" ]; then
+              echo "Prod OpenAPI is ready"
+              exit 0
+            fi
+
+            echo "Prod OpenAPI not ready yet (status: $status), retrying..."
+            sleep 5
+          done
+
+          echo "Prod OpenAPI did not become ready in time"
+          exit 1
+
       - name: Trigger Frontend Orval Codegen
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
## 📌 작업한 내용
- dev/prod 배포 워크플로우에 OpenAPI readiness check를 추가했습니다.
- 프론트 repository dispatch 실행 전에 각 환경의 OpenAPI 문서가 `200` 응답 가능한 상태인지 확인하도록 보완했습니다.
- dev 환경은 `/dev/openapi.yaml`, prod 환경은 `/openapi.yaml` 기준으로 readiness를 확인하도록 분기했습니다.
- readiness가 확인된 이후에만 프론트 Orval codegen 트리거가 실행되도록 흐름을 정리했습니다.

## 🔍 참고 사항
- OpenAPI 문서가 일시적으로 `502 Bad Gateway`를 반환하는 배포 직후 구간을 흡수하기 위한 변경입니다.
- readiness check는 최대 20회, 5초 간격으로 재시도합니다.
- readiness check가 끝내 성공하지 못하면 프론트 codegen dispatch는 실행되지 않도록 했습니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closed #357 

## ✅ 체크리스트
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인