### PR TITLE
[MCJ-1623] CHORE: dev 결제 대시보드 정합성 및 실패 관측성 보강

### DIFF
--- a/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
@@ -685,6 +685,75 @@
       ],
       "title": "사용자 결제 취소 도메인 metric",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (source, event_type, result, reason) (increase(mcj_payment_audit_events_total{job=\"app-dev\"}[10m]))",
+          "legendFormat": "{{source}} / {{event_type}} / {{result}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "결제 audit 이벤트 추적 (10m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 19,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=\"moongchijang-be\",env=\"dev\"} |= \"[payment_audit]\"",
+          "refId": "A"
+        }
+      ],
+      "title": "결제 audit 로그",
+      "type": "logs"
     }
   ],
   "refresh": "30s",
@@ -692,7 +761,7 @@
   "style": "dark",
   "tags": [
     "mcj",
-    "prod",
+    "dev",
     "monitoring"
   ],
   "templating": {

--- a/docker/monitoring/grafana/dashboards/payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/payment-monitoring.json
@@ -685,6 +685,75 @@
       ],
       "title": "사용자 결제 취소 도메인 metric",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (source, event_type, result, reason) (increase(mcj_payment_audit_events_total{job=\"app\"}[10m]))",
+          "legendFormat": "{{source}} / {{event_type}} / {{result}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "결제 audit 이벤트 추적 (10m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 19,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "expr": "{service=\"moongchijang-be\",env=\"prod\"} |= \"[payment_audit]\"",
+          "refId": "A"
+        }
+      ],
+      "title": "결제 audit 로그",
+      "type": "logs"
     }
   ],
   "refresh": "30s",

--- a/docs/monitoring-operations-guide.md
+++ b/docs/monitoring-operations-guide.md
@@ -142,6 +142,38 @@ sum by (result, reason) (increase(mcj_payment_order_created_total{job="app"}[10m
 sum by (operation, result, status) (increase(mcj_portone_api_requests_total{job="app"}[10m]))
 ```
 
+### 6.6 결제 오류 관측 절차
+- dev 결제 오류는 `MCJ Dev Payment Monitoring`에서 먼저 확인한다.
+- prod 결제 오류는 `MCJ Prod Payment Monitoring`에서 같은 패널 순서로 확인한다.
+- 결제 완료 후 오류가 발생하면 HTTP 패널만 보지 말고, audit metric과 Loki 로그를 함께 확인한다.
+
+1. `결제 완료 API 401/403 비율`, `결제 핵심 엔드포인트 5xx 비율`에서 HTTP 실패 여부를 확인한다.
+2. `결제 승인 도메인 metric`, `PortOne API 성공/실패 도메인 metric`에서 승인 조회 실패인지 내부 처리 실패인지 구분한다.
+3. `결제 audit 이벤트 추적 (10m)`에서 `source`, `event_type`, `result`, `reason` 조합을 확인한다.
+4. `결제 audit 로그`에서 같은 시간대의 `[payment_audit]` 로그를 열어 `traceId`, `orderId`, `pgPaymentId`, `pgStatus`, `reason`을 확인한다.
+
+```promql
+sum by (source, event_type, result, reason) (increase(mcj_payment_audit_events_total{job="app-dev"}[10m]))
+sum by (source, event_type, result, reason) (increase(mcj_payment_audit_events_total{job="app"}[10m]))
+```
+
+```bash
+{service="moongchijang-be",env="dev"} |= "[payment_audit]"
+{service="moongchijang-be",env="prod"} |= "[payment_audit]"
+```
+
+### 6.7 dev 결제 synthetic metric
+- synthetic metric은 실결제 전 대시보드 표시 검증이 필요할 때만 명시적으로 켠다.
+- 기본값은 OFF이며, 실제 dev 결제 테스트 중에는 켜지 않는다.
+- synthetic metric은 Micrometer counter/timer만 기록하며, 결제 주문/결제/audit log 테이블에 데이터를 쓰지 않고 Discord 알림도 발송하지 않는다.
+- prod 프로필에는 synthetic metric 설정이 없고, 컴포넌트도 `dev`, `local`, `local-demo` 프로필에서만 생성된다.
+
+```bash
+PAYMENT_SYNTHETIC_METRICS_ENABLED=true
+PAYMENT_SYNTHETIC_METRICS_FIXED_DELAY_MS=60000
+PAYMENT_SYNTHETIC_METRICS_INITIAL_DELAY_MS=10000
+```
+
 ## 7. 트러블슈팅
 
 ### 7.1 `no such service: grafana`

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
@@ -30,17 +30,19 @@ class PaymentAuditLogService(
     }
 
     fun record(record: PaymentAuditRecord) {
+        val resolvedOrderId = record.orderId ?: record.paymentOrder?.orderId
+        val resolvedCurrentOrderStatus = record.currentOrderStatus ?: record.paymentOrder?.status
         try {
             transactionTemplate.execute {
                 paymentAuditLogRepository.save(
                     PaymentAuditLog(
                         paymentOrder = record.paymentOrder,
-                        orderId = record.orderId ?: record.paymentOrder?.orderId,
+                        orderId = resolvedOrderId,
                         pgPaymentId = record.pgPaymentId,
                         eventType = record.eventType,
                         source = record.source,
                         previousOrderStatus = record.previousOrderStatus,
-                        currentOrderStatus = record.currentOrderStatus ?: record.paymentOrder?.status,
+                        currentOrderStatus = resolvedCurrentOrderStatus,
                         pgStatus = record.pgStatus,
                         reason = record.reason?.take(500),
                         rawPayload = record.rawPayload,
@@ -59,11 +61,11 @@ class PaymentAuditLogService(
                 record.source,
                 record.eventType,
                 result,
-                record.orderId ?: record.paymentOrder?.orderId,
+                resolvedOrderId,
                 record.pgPaymentId,
                 record.pgStatus,
                 record.previousOrderStatus,
-                record.currentOrderStatus ?: record.paymentOrder?.status,
+                resolvedCurrentOrderStatus,
                 record.reason,
             )
         } catch (e: Exception) {
@@ -71,13 +73,13 @@ class PaymentAuditLogService(
                 source = record.source.name,
                 eventType = record.eventType.name,
                 result = "audit_record_failure",
-                reason = record.reason ?: NONE,
+                reason = record.reason ?: record.pgStatus ?: NONE,
             )
             log.warn(
                 "[PaymentAuditLogService] 결제 감사 이력 저장 실패: source={}, eventType={}, orderId={}",
                 record.source,
                 record.eventType,
-                record.orderId ?: record.paymentOrder?.orderId,
+                resolvedOrderId,
                 e
             )
         }
@@ -85,7 +87,7 @@ class PaymentAuditLogService(
         if (record.notifyFailure) {
             try {
                 adminDiscordAlertService.sendPaymentFailed(
-                    orderId = record.orderId ?: record.paymentOrder?.orderId,
+                    orderId = resolvedOrderId,
                     pgPaymentId = record.pgPaymentId,
                     pgStatus = record.pgStatus,
                     reason = record.reason,
@@ -93,7 +95,7 @@ class PaymentAuditLogService(
             } catch (e: Exception) {
                 log.warn(
                     "[PaymentAuditLogService] 결제 실패 Discord 알림 발행 실패: orderId={}",
-                    record.orderId ?: record.paymentOrder?.orderId,
+                    resolvedOrderId,
                     e
                 )
             }
@@ -101,7 +103,7 @@ class PaymentAuditLogService(
 
         if (record.notifySuccess && discordProperties.paymentSuccessAlertEnabled) {
             val sendNotification = {
-                sendPaymentSuccessAlert(record)
+                sendPaymentSuccessAlert(record, resolvedOrderId)
             }
             if (TransactionSynchronizationManager.isActualTransactionActive()) {
                 TransactionSynchronizationManager.registerSynchronization(
@@ -117,10 +119,10 @@ class PaymentAuditLogService(
         }
     }
 
-    private fun sendPaymentSuccessAlert(record: PaymentAuditRecord) {
+    private fun sendPaymentSuccessAlert(record: PaymentAuditRecord, resolvedOrderId: String?) {
         try {
             adminDiscordAlertService.sendPaymentSucceeded(
-                orderId = record.orderId ?: record.paymentOrder?.orderId,
+                orderId = resolvedOrderId,
                 pgPaymentId = record.pgPaymentId,
                 amount = record.amount,
                 method = record.method,
@@ -128,7 +130,7 @@ class PaymentAuditLogService(
         } catch (e: Exception) {
             log.warn(
                 "[PaymentAuditLogService] 결제 성공 Discord 알림 발행 실패: orderId={}",
-                record.orderId ?: record.paymentOrder?.orderId,
+                resolvedOrderId,
                 e
             )
         }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
@@ -21,6 +21,7 @@ class PaymentAuditLogService(
     private val paymentAuditLogRepository: PaymentAuditLogRepository,
     private val adminDiscordAlertService: AdminDiscordAlertService,
     private val discordProperties: DiscordProperties,
+    private val paymentMetricsRecorder: PaymentMetricsRecorder,
     transactionManager: PlatformTransactionManager,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
@@ -46,7 +47,32 @@ class PaymentAuditLogService(
                     )
                 )
             }
+            val result = record.eventType.toAuditMetricResult()
+            paymentMetricsRecorder.recordAuditEvent(
+                source = record.source.name,
+                eventType = record.eventType.name,
+                result = result,
+                reason = record.reason ?: record.pgStatus ?: NONE,
+            )
+            log.info(
+                "[payment_audit] source={} eventType={} result={} orderId={} pgPaymentId={} pgStatus={} previousOrderStatus={} currentOrderStatus={} reason={}",
+                record.source,
+                record.eventType,
+                result,
+                record.orderId ?: record.paymentOrder?.orderId,
+                record.pgPaymentId,
+                record.pgStatus,
+                record.previousOrderStatus,
+                record.currentOrderStatus ?: record.paymentOrder?.status,
+                record.reason,
+            )
         } catch (e: Exception) {
+            paymentMetricsRecorder.recordAuditEvent(
+                source = record.source.name,
+                eventType = record.eventType.name,
+                result = "audit_record_failure",
+                reason = record.reason ?: NONE,
+            )
             log.warn(
                 "[PaymentAuditLogService] 결제 감사 이력 저장 실패: source={}, eventType={}, orderId={}",
                 record.source,
@@ -106,6 +132,24 @@ class PaymentAuditLogService(
                 e
             )
         }
+    }
+
+    private fun PaymentAuditEventType.toAuditMetricResult(): String =
+        when (this) {
+            PaymentAuditEventType.PAYMENT_APPROVED,
+            PaymentAuditEventType.PAYMENT_CANCELLED,
+            PaymentAuditEventType.PAYMENT_PARTIAL_CANCELLED,
+            -> "success"
+            PaymentAuditEventType.PAYMENT_FAILED -> "failure"
+            PaymentAuditEventType.PAYMENT_IGNORED -> "ignored"
+            PaymentAuditEventType.COMPLETE_REQUEST_RECEIVED,
+            PaymentAuditEventType.WEBHOOK_RECEIVED,
+            PaymentAuditEventType.PORTONE_STATUS_FETCHED,
+            -> "event"
+        }
+
+    companion object {
+        private const val NONE = "none"
     }
 }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentMetricsRecorder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentMetricsRecorder.kt
@@ -69,12 +69,22 @@ class PaymentMetricsRecorder(
         ).record(elapsedNanos.coerceAtLeast(0), TimeUnit.NANOSECONDS)
     }
 
+    fun recordAuditEvent(source: String, eventType: String, result: String, reason: String = NONE) {
+        counter(
+            "mcj_payment_audit_events_total",
+            "source", normalizeSource(source),
+            "event_type", normalizeAuditEventType(eventType),
+            "result", normalizeAuditResult(result),
+            "reason", normalizeReason(reason),
+        ).increment()
+    }
+
     private fun counter(name: String, vararg tags: String) =
         meterRegistry.counter(name, *tags)
 
     private fun normalizeSource(source: String): String =
         when (source.lowercase()) {
-            "complete_api", "webhook", "scheduler", "admin", "user" -> source.lowercase()
+            "complete_api", "webhook", "scheduler", "admin", "user", "cancel_api", "pending_refund" -> source.lowercase()
             else -> "other"
         }
 
@@ -90,6 +100,26 @@ class PaymentMetricsRecorder(
             "transaction.cancelled", "transaction.canceled" -> "transaction_cancelled"
             "transaction.failed" -> "transaction_failed"
             null, "" -> "unknown"
+            else -> "other"
+        }
+
+    private fun normalizeAuditEventType(eventType: String): String =
+        when (eventType.lowercase()) {
+            "complete_request_received",
+            "webhook_received",
+            "portone_status_fetched",
+            "payment_approved",
+            "payment_cancelled",
+            "payment_partial_cancelled",
+            "payment_failed",
+            "payment_ignored",
+            -> eventType.lowercase()
+            else -> "other"
+        }
+
+    private fun normalizeAuditResult(result: String): String =
+        when (result.lowercase()) {
+            "success", "failure", "ignored", "event", "audit_record_failure" -> result.lowercase()
             else -> "other"
         }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentSyntheticMetricsProperties.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentSyntheticMetricsProperties.kt
@@ -1,0 +1,20 @@
+package com.moongchijang.domain.payment.application
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "monitoring.payment.synthetic")
+data class PaymentSyntheticMetricsProperties(
+    val orderSuccessCount: Int = 2,
+    val orderFailureCount: Int = 1,
+    val approvalSuccessCount: Int = 2,
+    val approvalFailureCount: Int = 1,
+    val webhookSuccessCount: Int = 1,
+    val webhookFailureCount: Int = 1,
+    val refundSuccessCount: Int = 1,
+    val refundFailureCount: Int = 0,
+    val cancelSuccessCount: Int = 1,
+    val portoneSuccessCount: Int = 2,
+    val portoneFailureCount: Int = 1,
+    val portoneSuccessLatencyMs: Long = 180,
+    val portoneFailureLatencyMs: Long = 850,
+)

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentSyntheticMetricsScheduler.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentSyntheticMetricsScheduler.kt
@@ -1,0 +1,79 @@
+package com.moongchijang.domain.payment.application
+
+import java.util.concurrent.TimeUnit
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("dev", "local", "local-demo")
+@ConditionalOnProperty(prefix = "monitoring.payment.synthetic", name = ["enabled"], havingValue = "true")
+class PaymentSyntheticMetricsScheduler(
+    private val paymentMetricsRecorder: PaymentMetricsRecorder,
+    private val properties: PaymentSyntheticMetricsProperties,
+) {
+    @Scheduled(
+        fixedDelayString = "\${monitoring.payment.synthetic.fixed-delay-ms:60000}",
+        initialDelayString = "\${monitoring.payment.synthetic.initial-delay-ms:10000}",
+    )
+    fun recordSamples() {
+        repeatPositive(properties.orderSuccessCount) {
+            paymentMetricsRecorder.recordOrderCreated(result = "success")
+        }
+        repeatPositive(properties.orderFailureCount) {
+            paymentMetricsRecorder.recordOrderCreated(result = "failure", reason = "PAYMENT_INVALID_QUANTITY")
+        }
+        repeatPositive(properties.approvalSuccessCount) {
+            paymentMetricsRecorder.recordApproval(source = "complete_api", result = "success")
+        }
+        repeatPositive(properties.approvalFailureCount) {
+            paymentMetricsRecorder.recordApproval(
+                source = "complete_api",
+                result = "failure",
+                reason = "PAYMENT_ORDER_NOT_FOUND",
+            )
+        }
+        repeatPositive(properties.webhookSuccessCount) {
+            paymentMetricsRecorder.recordWebhook(eventType = "Transaction.Paid", result = "success")
+        }
+        repeatPositive(properties.webhookFailureCount) {
+            paymentMetricsRecorder.recordWebhook(
+                eventType = "Transaction.Failed",
+                result = "failure",
+                reason = "FAILED",
+            )
+        }
+        repeatPositive(properties.refundSuccessCount) {
+            paymentMetricsRecorder.recordRefund(result = "success")
+        }
+        repeatPositive(properties.refundFailureCount) {
+            paymentMetricsRecorder.recordRefund(result = "failure", reason = "PAYMENT_CANCEL_FAILED")
+        }
+        repeatPositive(properties.cancelSuccessCount) {
+            paymentMetricsRecorder.recordCancel(source = "user", result = "success", partial = false)
+        }
+        repeatPositive(properties.portoneSuccessCount) {
+            paymentMetricsRecorder.recordPortOneRequest(
+                operation = "get_payment",
+                result = "success",
+                status = "PAID",
+                elapsedNanos = TimeUnit.MILLISECONDS.toNanos(properties.portoneSuccessLatencyMs.coerceAtLeast(0)),
+            )
+        }
+        repeatPositive(properties.portoneFailureCount) {
+            paymentMetricsRecorder.recordPortOneRequest(
+                operation = "get_payment",
+                result = "failure",
+                status = "PORTONE_UNEXPECTED_STATUS",
+                elapsedNanos = TimeUnit.MILLISECONDS.toNanos(properties.portoneFailureLatencyMs.coerceAtLeast(0)),
+            )
+        }
+    }
+
+    private fun repeatPositive(times: Int, action: () -> Unit) {
+        repeat(times.coerceAtLeast(0)) {
+            action()
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -143,3 +143,10 @@ business-registration:
     base-url: ${BUSINESS_REGISTRATION_API_BASE_URL:https://api.odcloud.kr}
     status-path: ${BUSINESS_REGISTRATION_API_STATUS_PATH:/api/nts-businessman/v1/status}
     service-key: ${BUSINESS_REGISTRATION_API_SERVICE_KEY:}
+
+monitoring:
+  payment:
+    synthetic:
+      enabled: ${PAYMENT_SYNTHETIC_METRICS_ENABLED:false}
+      fixed-delay-ms: ${PAYMENT_SYNTHETIC_METRICS_FIXED_DELAY_MS:60000}
+      initial-delay-ms: ${PAYMENT_SYNTHETIC_METRICS_INITIAL_DELAY_MS:10000}

--- a/src/main/resources/application-local-demo.yml
+++ b/src/main/resources/application-local-demo.yml
@@ -130,3 +130,10 @@ discord:
     payment: ${DISCORD_WEBHOOK_PAYMENT:}
     groupbuy: ${DISCORD_WEBHOOK_GROUPBUY:}
     onboarding: ${DISCORD_WEBHOOK_ONBOARDING:}
+
+monitoring:
+  payment:
+    synthetic:
+      enabled: ${PAYMENT_SYNTHETIC_METRICS_ENABLED:false}
+      fixed-delay-ms: ${PAYMENT_SYNTHETIC_METRICS_FIXED_DELAY_MS:60000}
+      initial-delay-ms: ${PAYMENT_SYNTHETIC_METRICS_INITIAL_DELAY_MS:10000}

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogServiceTest.kt
@@ -5,6 +5,8 @@ import com.moongchijang.domain.notification.infrastructure.discord.DiscordProper
 import com.moongchijang.domain.payment.domain.entity.PaymentAuditEventType
 import com.moongchijang.domain.payment.domain.entity.PaymentAuditSource
 import com.moongchijang.domain.payment.domain.repository.PaymentAuditLogRepository
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
@@ -22,10 +24,12 @@ class PaymentAuditLogServiceTest {
         val repository = mock(PaymentAuditLogRepository::class.java)
         val alertService = mock(AdminDiscordAlertService::class.java)
         val transactionManager = stubTransactionManager()
+        val meterRegistry = SimpleMeterRegistry()
         val service = PaymentAuditLogService(
             paymentAuditLogRepository = repository,
             adminDiscordAlertService = alertService,
             discordProperties = DiscordProperties(paymentSuccessAlertEnabled = true),
+            paymentMetricsRecorder = PaymentMetricsRecorder(meterRegistry),
             transactionManager = transactionManager,
         )
 
@@ -38,6 +42,15 @@ class PaymentAuditLogServiceTest {
             amount = 12000,
             method = "CARD",
         )
+        assertCounter(
+            meterRegistry,
+            "mcj_payment_audit_events_total",
+            1.0,
+            "source", "complete_api",
+            "event_type", "payment_approved",
+            "result", "success",
+            "reason", "paid",
+        )
     }
 
     @Test
@@ -45,10 +58,12 @@ class PaymentAuditLogServiceTest {
         val repository = mock(PaymentAuditLogRepository::class.java)
         val alertService = mock(AdminDiscordAlertService::class.java)
         val transactionManager = stubTransactionManager()
+        val meterRegistry = SimpleMeterRegistry()
         val service = PaymentAuditLogService(
             paymentAuditLogRepository = repository,
             adminDiscordAlertService = alertService,
             discordProperties = DiscordProperties(paymentSuccessAlertEnabled = false),
+            paymentMetricsRecorder = PaymentMetricsRecorder(meterRegistry),
             transactionManager = transactionManager,
         )
 
@@ -74,6 +89,17 @@ class PaymentAuditLogServiceTest {
             method = "CARD",
             notifySuccess = true,
         )
+
+    private fun assertCounter(
+        meterRegistry: SimpleMeterRegistry,
+        name: String,
+        expected: Double,
+        vararg tags: String,
+    ) {
+        val counter = meterRegistry.find(name).tags(*tags).counter()
+
+        assertEquals(expected, counter?.count())
+    }
 
     private fun stubTransactionManager(): PlatformTransactionManager {
         val transactionManager = mock(PlatformTransactionManager::class.java)

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogServiceTest.kt
@@ -78,6 +78,34 @@ class PaymentAuditLogServiceTest {
         )
     }
 
+    @Test
+    fun `감사 이력 저장 실패 metric은 pgStatus를 reason fallback으로 기록한다`() {
+        val repository = mock(PaymentAuditLogRepository::class.java)
+        val alertService = mock(AdminDiscordAlertService::class.java)
+        val transactionManager = stubTransactionManager()
+        val meterRegistry = SimpleMeterRegistry()
+        val service = PaymentAuditLogService(
+            paymentAuditLogRepository = repository,
+            adminDiscordAlertService = alertService,
+            discordProperties = DiscordProperties(paymentSuccessAlertEnabled = false),
+            paymentMetricsRecorder = PaymentMetricsRecorder(meterRegistry),
+            transactionManager = transactionManager,
+        )
+        `when`(repository.save(any())).thenThrow(IllegalStateException("db unavailable"))
+
+        service.record(successRecord())
+
+        assertCounter(
+            meterRegistry,
+            "mcj_payment_audit_events_total",
+            1.0,
+            "source", "complete_api",
+            "event_type", "payment_approved",
+            "result", "audit_record_failure",
+            "reason", "paid",
+        )
+    }
+
     private fun successRecord(): PaymentAuditRecord =
         PaymentAuditRecord(
             source = PaymentAuditSource.COMPLETE_API,

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentSyntheticMetricsSchedulerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentSyntheticMetricsSchedulerTest.kt
@@ -1,0 +1,109 @@
+package com.moongchijang.domain.payment.application
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class PaymentSyntheticMetricsSchedulerTest {
+
+    private val meterRegistry = SimpleMeterRegistry()
+    private val paymentMetricsRecorder = PaymentMetricsRecorder(meterRegistry)
+
+    @Test
+    fun `synthetic metric은 결제 도메인 counter와 PortOne timer만 기록한다`() {
+        val scheduler = PaymentSyntheticMetricsScheduler(
+            paymentMetricsRecorder = paymentMetricsRecorder,
+            properties = PaymentSyntheticMetricsProperties(
+                orderSuccessCount = 2,
+                orderFailureCount = 1,
+                approvalSuccessCount = 2,
+                approvalFailureCount = 1,
+                webhookSuccessCount = 1,
+                webhookFailureCount = 1,
+                refundSuccessCount = 1,
+                refundFailureCount = 1,
+                cancelSuccessCount = 1,
+                portoneSuccessCount = 2,
+                portoneFailureCount = 1,
+                portoneSuccessLatencyMs = 200,
+                portoneFailureLatencyMs = 900,
+            ),
+        )
+
+        scheduler.recordSamples()
+
+        assertCounter("mcj_payment_order_created_total", 2.0, "result", "success", "reason", "none")
+        assertCounter("mcj_payment_order_created_total", 1.0, "result", "failure", "reason", "payment_invalid_quantity")
+        assertCounter(
+            "mcj_payment_approval_total",
+            2.0,
+            "source", "complete_api",
+            "result", "success",
+            "reason", "none",
+        )
+        assertCounter(
+            "mcj_payment_approval_total",
+            1.0,
+            "source", "complete_api",
+            "result", "failure",
+            "reason", "payment_order_not_found",
+        )
+        assertCounter(
+            "mcj_payment_webhook_processed_total",
+            1.0,
+            "event_type", "transaction_paid",
+            "result", "success",
+            "reason", "none",
+        )
+        assertCounter(
+            "mcj_payment_webhook_processed_total",
+            1.0,
+            "event_type", "transaction_failed",
+            "result", "failure",
+            "reason", "failed",
+        )
+        assertCounter("mcj_payment_refund_processed_total", 1.0, "result", "success", "reason", "none")
+        assertCounter(
+            "mcj_payment_refund_processed_total",
+            1.0,
+            "result", "failure",
+            "reason", "payment_cancel_failed",
+        )
+        assertCounter(
+            "mcj_payment_cancel_total",
+            1.0,
+            "source", "user",
+            "result", "success",
+            "reason", "none",
+            "partial", "false",
+        )
+        assertCounter(
+            "mcj_portone_api_requests_total",
+            2.0,
+            "operation", "get_payment",
+            "result", "success",
+            "status", "paid",
+        )
+        assertCounter(
+            "mcj_portone_api_requests_total",
+            1.0,
+            "operation", "get_payment",
+            "result", "failure",
+            "status", "portone_unexpected_status",
+        )
+
+        val timer = meterRegistry.find("mcj_portone_api_latency_seconds")
+            .tags("operation", "get_payment", "result", "success", "status", "paid")
+            .timer()
+
+        assertEquals(2, timer?.count())
+        assertEquals(400.0, timer?.totalTime(TimeUnit.MILLISECONDS))
+    }
+
+    private fun assertCounter(name: String, expected: Double, vararg tags: String) {
+        val counter = meterRegistry.find(name).tags(*tags).counter()
+
+        assertEquals(expected, counter?.count())
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 결제 audit 저장 시 `mcj_payment_audit_events_total` metric과 `[payment_audit]` 로그를 남기도록 보강했습니다.
- dev/prod 결제 대시보드에 audit 이벤트 추적 패널과 Loki audit 로그 패널을 추가했습니다.
- `MCJ Dev Payment Monitoring`의 잘못된 `prod` 태그를 `dev`로 수정했습니다.
- synthetic metric은 실제 dev 결제 테스트 지표를 흐리지 않도록 기본 OFF, 명시 opt-in으로 제한했습니다.
- 결제 오류 발생 시 Grafana에서 확인할 순서를 운영 가이드에 정리했습니다.


## 🔍 참고 사항
- 실제 결제 오류 확인 시 `MCJ Dev Payment Monitoring`의 `결제 audit 이벤트 추적 (10m)`와 `결제 audit 로그` 패널을 함께 확인하면 됩니다.
- synthetic metric은 실결제 전 대시보드 표시 검증이 필요할 때만 `PAYMENT_SYNTHETIC_METRICS_ENABLED=true`로 켭니다.


## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #354

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
