### PR TITLE
[MCJ-1626] CHORE: prod 결제 실패 원인 추적 관측성 강화

### DIFF
--- a/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
@@ -748,11 +748,11 @@
       },
       "targets": [
         {
-          "expr": "{service=\"moongchijang-be\",env=\"dev\"} |= \"[payment_audit]\"",
+          "expr": "{service=\"moongchijang-be\",env=\"dev\"} |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
           "refId": "A"
         }
       ],
-      "title": "결제 audit 로그",
+      "title": "결제 audit/invalid webhook 로그",
       "type": "logs"
     }
   ],

--- a/docker/monitoring/grafana/dashboards/payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/payment-monitoring.json
@@ -748,11 +748,11 @@
       },
       "targets": [
         {
-          "expr": "{service=\"moongchijang-be\",env=\"prod\"} |= \"[payment_audit]\"",
+          "expr": "{service=\"moongchijang-be\",env=\"prod\"} |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
           "refId": "A"
         }
       ],
-      "title": "결제 audit 로그",
+      "title": "결제 audit/invalid webhook 로그",
       "type": "logs"
     }
   ],

--- a/docs/monitoring-operations-guide.md
+++ b/docs/monitoring-operations-guide.md
@@ -150,7 +150,9 @@ sum by (operation, result, status) (increase(mcj_portone_api_requests_total{job=
 1. `결제 완료 API 401/403 비율`, `결제 핵심 엔드포인트 5xx 비율`에서 HTTP 실패 여부를 확인한다.
 2. `결제 승인 도메인 metric`, `PortOne API 성공/실패 도메인 metric`에서 승인 조회 실패인지 내부 처리 실패인지 구분한다.
 3. `결제 audit 이벤트 추적 (10m)`에서 `source`, `event_type`, `result`, `reason` 조합을 확인한다.
-4. `결제 audit 로그`에서 같은 시간대의 `[payment_audit]` 로그를 열어 `traceId`, `orderId`, `pgPaymentId`, `pgStatus`, `reason`을 확인한다.
+4. `결제 audit/invalid webhook 로그`에서 같은 시간대의 `[payment_audit]` 또는 `[payment_webhook_invalid]` 로그를 확인한다.
+5. `[payment_audit]` 로그는 `traceId`, `orderId`, `pgPaymentId`, `pgStatus`, `reason`으로 결제 처리 흐름을 좁힌다.
+6. `[payment_webhook_invalid]` 로그는 `stage`, `hasWebhookId`, `hasWebhookTimestamp`, `hasWebhookSignature`로 signature/JSON 단계 실패를 좁힌다.
 
 ```promql
 sum by (source, event_type, result, reason) (increase(mcj_payment_audit_events_total{job="app-dev"}[10m]))
@@ -158,8 +160,8 @@ sum by (source, event_type, result, reason) (increase(mcj_payment_audit_events_t
 ```
 
 ```bash
-{service="moongchijang-be",env="dev"} |= "[payment_audit]"
-{service="moongchijang-be",env="prod"} |= "[payment_audit]"
+{service="moongchijang-be",env="dev"} |~ "\\[payment_audit\\]|\\[payment_webhook_invalid\\]"
+{service="moongchijang-be",env="prod"} |~ "\\[payment_audit\\]|\\[payment_webhook_invalid\\]"
 ```
 
 ### 6.7 dev 결제 synthetic metric

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -124,9 +124,9 @@ class PaymentController(
             stage,
             errorCode.name,
             rawPayload.length,
-            headers[WEBHOOK_ID_HEADER] != null,
-            headers[WEBHOOK_TIMESTAMP_HEADER] != null,
-            headers[WEBHOOK_SIGNATURE_HEADER] != null,
+            headers.getFirst(WEBHOOK_ID_HEADER) != null,
+            headers.getFirst(WEBHOOK_TIMESTAMP_HEADER) != null,
+            headers.getFirst(WEBHOOK_SIGNATURE_HEADER) != null,
         )
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.payment.presentation
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.moongchijang.domain.payment.application.PaymentMetricsRecorder
 import com.moongchijang.domain.payment.application.PaymentService
 import com.moongchijang.domain.payment.application.PortOneWebhookSignatureVerifier
 import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.slf4j.LoggerFactory
 
 @RestController
 @RequestMapping("/api/v1")
@@ -39,7 +41,9 @@ class PaymentController(
     private val paymentService: PaymentService,
     private val portOneWebhookSignatureVerifier: PortOneWebhookSignatureVerifier,
     private val objectMapper: ObjectMapper,
+    private val paymentMetricsRecorder: PaymentMetricsRecorder,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("/group-buys/{groupBuyId}/checkout")
     @RequireCurrentRole(UserRole.BUYER)
@@ -79,10 +83,16 @@ class PaymentController(
         @RequestBody rawPayload: String,
         @RequestHeader headers: HttpHeaders,
     ): ResponseEntity<ApiResponse<PortOneWebhookResponse>> {
-        portOneWebhookSignatureVerifier.verify(headers, rawPayload)
+        try {
+            portOneWebhookSignatureVerifier.verify(headers, rawPayload)
+        } catch (e: CustomException) {
+            recordInvalidWebhook(stage = "signature_verification", headers = headers, rawPayload = rawPayload, errorCode = e.errorCode)
+            throw e
+        }
         val request = try {
             objectMapper.readValue(rawPayload, PortOneWebhookRequest::class.java)
         } catch (e: JsonProcessingException) {
+            recordInvalidWebhook(stage = "json_parse", headers = headers, rawPayload = rawPayload, errorCode = ErrorCode.PAYMENT_WEBHOOK_INVALID)
             throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
         }
         paymentService.handlePortOneWebhook(request, rawPayload)
@@ -100,5 +110,29 @@ class PaymentController(
     ): ResponseEntity<ApiResponse<CancelParticipationResponse>> {
         val response = ResponseEntity.ok(ApiResponse.success(paymentService.cancelParticipation(participationId, principal.id, request)))
         return response
+    }
+
+    private fun recordInvalidWebhook(
+        stage: String,
+        headers: HttpHeaders,
+        rawPayload: String,
+        errorCode: ErrorCode,
+    ) {
+        paymentMetricsRecorder.recordWebhook(eventType = null, result = "failure", reason = errorCode.name)
+        log.warn(
+            "[payment_webhook_invalid] stage={} errorCode={} payloadLength={} hasWebhookId={} hasWebhookTimestamp={} hasWebhookSignature={}",
+            stage,
+            errorCode.name,
+            rawPayload.length,
+            headers[WEBHOOK_ID_HEADER] != null,
+            headers[WEBHOOK_TIMESTAMP_HEADER] != null,
+            headers[WEBHOOK_SIGNATURE_HEADER] != null,
+        )
+    }
+
+    companion object {
+        private const val WEBHOOK_ID_HEADER = "webhook-id"
+        private const val WEBHOOK_TIMESTAMP_HEADER = "webhook-timestamp"
+        private const val WEBHOOK_SIGNATURE_HEADER = "webhook-signature"
     }
 }

--- a/src/test/kotlin/com/moongchijang/domain/payment/presentation/PaymentControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/presentation/PaymentControllerTest.kt
@@ -1,0 +1,90 @@
+package com.moongchijang.domain.payment.presentation
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.moongchijang.domain.payment.application.PaymentMetricsRecorder
+import com.moongchijang.domain.payment.application.PaymentService
+import com.moongchijang.domain.payment.application.PortOneWebhookSignatureVerifier
+import com.moongchijang.global.config.PortOneProperties
+import com.moongchijang.global.exception.CustomException
+import com.moongchijang.global.exception.ErrorCode
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.springframework.http.HttpHeaders
+
+class PaymentControllerTest {
+
+    private val meterRegistry = SimpleMeterRegistry()
+    private val paymentMetricsRecorder = PaymentMetricsRecorder(meterRegistry)
+
+    @Test
+    fun `웹훅 signature 검증 실패는 invalid webhook metric을 기록한다`() {
+        val controller = controller(
+            portOneWebhookSignatureVerifier = verifier(signatureVerificationEnabled = true),
+        )
+
+        val exception = assertThrows<CustomException> {
+            controller.handlePortOneWebhook(rawPayload = """{"paymentId":"MCJ-10-test"}""", headers = HttpHeaders())
+        }
+
+        assertEquals(ErrorCode.PAYMENT_WEBHOOK_INVALID, exception.errorCode)
+        assertCounter(
+            "mcj_payment_webhook_processed_total",
+            1.0,
+            "event_type", "unknown",
+            "result", "failure",
+            "reason", "payment_webhook_invalid",
+        )
+    }
+
+    @Test
+    fun `웹훅 JSON 파싱 실패는 invalid webhook metric을 기록한다`() {
+        val controller = controller(
+            portOneWebhookSignatureVerifier = verifier(signatureVerificationEnabled = false),
+        )
+
+        val exception = assertThrows<CustomException> {
+            controller.handlePortOneWebhook(rawPayload = "{not-json", headers = HttpHeaders())
+        }
+
+        assertEquals(ErrorCode.PAYMENT_WEBHOOK_INVALID, exception.errorCode)
+        assertCounter(
+            "mcj_payment_webhook_processed_total",
+            1.0,
+            "event_type", "unknown",
+            "result", "failure",
+            "reason", "payment_webhook_invalid",
+        )
+    }
+
+    private fun controller(portOneWebhookSignatureVerifier: PortOneWebhookSignatureVerifier): PaymentController =
+        PaymentController(
+            paymentService = mock(PaymentService::class.java),
+            portOneWebhookSignatureVerifier = portOneWebhookSignatureVerifier,
+            objectMapper = ObjectMapper(),
+            paymentMetricsRecorder = paymentMetricsRecorder,
+        )
+
+    private fun verifier(signatureVerificationEnabled: Boolean): PortOneWebhookSignatureVerifier =
+        PortOneWebhookSignatureVerifier(
+            portOneProperties = PortOneProperties(
+                storeId = "store-test",
+                channelKey = "channel-test",
+                apiSecret = "api-secret-test",
+                webhookSignatureVerificationEnabled = signatureVerificationEnabled,
+                webhookSecret = "webhook-secret-test",
+            ),
+            clock = Clock.fixed(Instant.parse("2026-06-19T00:00:00Z"), ZoneOffset.UTC),
+        )
+
+    private fun assertCounter(name: String, expected: Double, vararg tags: String) {
+        val counter = meterRegistry.find(name).tags(*tags).counter()
+
+        assertEquals(expected, counter?.count())
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- 웹훅이 서비스 진입 전 signature 검증 또는 JSON 파싱 단계에서 실패해도 `mcj_payment_webhook_processed_total` metric과 `[payment_webhook_invalid]` 로그를 남기도록 보강했습니다.
- dev/prod 결제 대시보드 로그 패널에서 `[payment_audit]`와 `[payment_webhook_invalid]` 로그를 함께 확인하도록 수정했습니다.
- prod 웹훅 400 원인 추적 시 signature header 존재 여부와 실패 stage를 확인하는 운영 절차를 문서화했습니다.


## 🔍 참고 사항
- 최근 prod에서 `/api/v1/payments/portone/webhook` 400이 다수 발생했지만 `payment_audit_logs`는 0건이어서, 서비스 진입 전 실패(signature/JSON)가 유력한 상태라고 판단했습니다.


## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #360

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
