### PR TITLE
[MCJ-1627] fix: 결제 모니터링 수집 설정 반영 누락 보정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -97,6 +97,7 @@ jobs:
             aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin "$ECR_REGISTRY"
             docker compose --profile dev pull app-dev
             docker compose --profile dev up -d nginx app-dev
+            docker compose --profile monitoring up -d --force-recreate --no-deps prometheus grafana fluent-bit
 
             # 태그 없는 미사용 이미지를 정리해 디스크 사용량 누적을 완화합니다.
             docker image prune -f

--- a/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
@@ -748,7 +748,7 @@
       },
       "targets": [
         {
-          "expr": "{service=\"moongchijang-be\",env=\"dev\"} |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
+          "expr": "{service=\"moongchijang-be\"} |= \"\\\"env\\\":\\\"dev\\\"\" |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
           "refId": "A"
         }
       ],

--- a/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/dev-payment-monitoring.json
@@ -748,7 +748,7 @@
       },
       "targets": [
         {
-          "expr": "{service=\"moongchijang-be\"} |= \"\\\"env\\\":\\\"dev\\\"\" |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
+          "expr": "{service=\"moongchijang-be\"} | json | line_format \"{{.log}}\" | json app_env=\"env\", app_message=\"message\" | app_env=\"dev\" |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
           "refId": "A"
         }
       ],

--- a/docker/monitoring/grafana/dashboards/payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/payment-monitoring.json
@@ -748,7 +748,7 @@
       },
       "targets": [
         {
-          "expr": "{service=\"moongchijang-be\"} |= \"\\\"env\\\":\\\"prod\\\"\" |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
+          "expr": "{service=\"moongchijang-be\"} | json | line_format \"{{.log}}\" | json app_env=\"env\", app_message=\"message\" | app_env=\"prod\" |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
           "refId": "A"
         }
       ],

--- a/docker/monitoring/grafana/dashboards/payment-monitoring.json
+++ b/docker/monitoring/grafana/dashboards/payment-monitoring.json
@@ -748,7 +748,7 @@
       },
       "targets": [
         {
-          "expr": "{service=\"moongchijang-be\",env=\"prod\"} |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
+          "expr": "{service=\"moongchijang-be\"} |= \"\\\"env\\\":\\\"prod\\\"\" |~ \"\\\\[payment_audit\\\\]|\\\\[payment_webhook_invalid\\\\]\"",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## 📌 작업한 내용
- 결제 audit/invalid webhook 로그 패널이 Loki stream label의 `env` 대신 애플리케이션 JSON 로그 본문의 `env` 값으로 dev/prod를 구분하도록 수정했습니다.
- dev 배포 시 Prometheus/Grafana/Fluent Bit 컨테이너를 볼륨 삭제 없이 재생성해 monitoring 설정과 dashboard mount가 최신 파일을 다시 물도록 보정했습니다.

## 🔍 참고 사항
- dev 서버에서 invalid webhook 테스트 요청은 `400 PAYMENT_WEBHOOK_INVALID`로 정상 응답했습니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closes #362

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료: Grafana JSON 검증, Loki/Prometheus 쿼리 검증
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인