### PR TITLE
[MCJ-1629] FIX: main 배포 전 결제 모니터링 오류 수정

### DIFF
--- a/load-tests/scenarios/payment-monitoring.js
+++ b/load-tests/scenarios/payment-monitoring.js
@@ -11,8 +11,6 @@ const ALLOW_STATE_CHANGE = parseBoolean(optionalEnv('ALLOW_STATE_CHANGE', 'false
 const RUN_COMPLETE_FAILURE = parseBoolean(optionalEnv('RUN_COMPLETE_FAILURE', 'true'));
 const RUN_WEBHOOK_INVALID = parseBoolean(optionalEnv('RUN_WEBHOOK_INVALID', 'false'));
 
-http.setResponseCallback(http.expectedStatuses({ min: 200, max: 499 }));
-
 export const options = createDefaultOptions({
   scenarios: {
     payment_monitoring_smoke: {

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentMetricsRecorder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentMetricsRecorder.kt
@@ -152,6 +152,7 @@ class PaymentMetricsRecorder(
             "PARTICIPATION_CANCEL_REASON_DETAIL_REQUIRED",
             "PORTONE_UNEXPECTED_STATUS",
             "PENDING_REFUND_TARGET_NOT_FOUND",
+            "PENDING_REFUND_COMPLETION_FAILED",
             "USER_NOT_FOUND",
             "GROUPBUY_NOT_FOUND",
             "FORBIDDEN",

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -942,10 +942,10 @@ class PaymentService(
             if (it) {
                 paymentMetricsRecorder.recordRefund(RESULT_SUCCESS)
             } else {
-                paymentMetricsRecorder.recordRefund(RESULT_FAILURE, "PENDING_REFUND_TARGET_NOT_FOUND")
+                paymentMetricsRecorder.recordRefund(RESULT_FAILURE, "PENDING_REFUND_COMPLETION_FAILED")
             }
         } ?: run {
-            paymentMetricsRecorder.recordRefund(RESULT_FAILURE, "PENDING_REFUND_TARGET_NOT_FOUND")
+            paymentMetricsRecorder.recordRefund(RESULT_FAILURE, "PENDING_REFUND_COMPLETION_FAILED")
             false
         }
     }

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -932,22 +932,20 @@ class PaymentService(
             return false
         }
 
-        return transactionTemplate().execute {
+        val completed = transactionTemplate().execute {
             applyPendingRefundCompletion(
                 target = target,
                 refundedAt = paymentResult.cancelledAt ?: clock.utcNow()
             )
             true
-        }?.also {
-            if (it) {
-                paymentMetricsRecorder.recordRefund(RESULT_SUCCESS)
-            } else {
-                paymentMetricsRecorder.recordRefund(RESULT_FAILURE, "PENDING_REFUND_COMPLETION_FAILED")
-            }
         } ?: run {
             paymentMetricsRecorder.recordRefund(RESULT_FAILURE, "PENDING_REFUND_COMPLETION_FAILED")
             false
         }
+        if (completed) {
+            paymentMetricsRecorder.recordRefund(RESULT_SUCCESS)
+        }
+        return completed
     }
 
     private fun findPendingRefundTarget(participationId: Long): PendingRefundTarget? {


### PR DESCRIPTION
## 📌 작업한 내용
- k6 결제 모니터링 시나리오에서 존재하지 않는 `http.setResponseCallback` 호출을 제거했습니다.
- 환불대기 대상을 이미 찾은 뒤 completion transaction이 실패한 경우 metric reason을 `PENDING_REFUND_COMPLETION_FAILED`로 기록하도록 보정했습니다.

## 🔍 참고 사항


## 🖼️ 스크린샷

## 🔗 관련 이슈
- Closes #365

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인