### PR TITLE
[MCJ-1630] FIX: 결제 주문 생성 실패 감사 이력 기록

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogService.kt
@@ -142,6 +142,7 @@ class PaymentAuditLogService(
             PaymentAuditEventType.PAYMENT_CANCELLED,
             PaymentAuditEventType.PAYMENT_PARTIAL_CANCELLED,
             -> "success"
+            PaymentAuditEventType.ORDER_CREATE_FAILED,
             PaymentAuditEventType.PAYMENT_FAILED -> "failure"
             PaymentAuditEventType.PAYMENT_IGNORED -> "ignored"
             PaymentAuditEventType.COMPLETE_REQUEST_RECEIVED,

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentMetricsRecorder.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentMetricsRecorder.kt
@@ -84,7 +84,7 @@ class PaymentMetricsRecorder(
 
     private fun normalizeSource(source: String): String =
         when (source.lowercase()) {
-            "complete_api", "webhook", "scheduler", "admin", "user", "cancel_api", "pending_refund" -> source.lowercase()
+            "order_create", "complete_api", "webhook", "scheduler", "admin", "user", "cancel_api", "pending_refund" -> source.lowercase()
             else -> "other"
         }
 
@@ -105,6 +105,7 @@ class PaymentMetricsRecorder(
 
     private fun normalizeAuditEventType(eventType: String): String =
         when (eventType.lowercase()) {
+            "order_create_failed",
             "complete_request_received",
             "webhook_received",
             "portone_status_fetched",

--- a/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/application/PaymentService.kt
@@ -146,6 +146,19 @@ class PaymentService(
             )
         } catch (e: CustomException) {
             paymentMetricsRecorder.recordOrderCreated(RESULT_FAILURE, e.errorCode.name)
+            recordPaymentAudit(
+                source = PaymentAuditSource.ORDER_CREATE,
+                eventType = PaymentAuditEventType.ORDER_CREATE_FAILED,
+                reason = e.errorCode.name,
+                rawPayload = buildOrderCreateFailureContext(groupBuyId, userId, request.quantity),
+            )
+            log.warn(
+                "[payment_order_create_failed] groupBuyId={} userId={} quantity={} errorCode={}",
+                groupBuyId,
+                userId,
+                request.quantity,
+                e.errorCode.name,
+            )
             throw e
         }
     }
@@ -1194,6 +1207,9 @@ class PaymentService(
             notifyFailure = true,
         )
     }
+
+    private fun buildOrderCreateFailureContext(groupBuyId: Long, userId: Long, quantity: Int): String =
+        "groupBuyId=$groupBuyId,userId=$userId,quantity=$quantity"
 
     private fun Throwable.toPaymentMetricReason(): String =
         if (this is CustomException) errorCode.name else "other"

--- a/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentAuditLog.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/domain/entity/PaymentAuditLog.kt
@@ -70,6 +70,7 @@ class PaymentAuditLog(
 ) : BaseEntity()
 
 enum class PaymentAuditEventType {
+    ORDER_CREATE_FAILED,
     COMPLETE_REQUEST_RECEIVED,
     WEBHOOK_RECEIVED,
     PORTONE_STATUS_FETCHED,
@@ -81,6 +82,7 @@ enum class PaymentAuditEventType {
 }
 
 enum class PaymentAuditSource {
+    ORDER_CREATE,
     COMPLETE_API,
     WEBHOOK,
     CANCEL_API,

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentAuditLogServiceTest.kt
@@ -106,6 +106,41 @@ class PaymentAuditLogServiceTest {
         )
     }
 
+    @Test
+    fun `주문 생성 실패 감사 이력은 order create failure metric으로 기록한다`() {
+        val repository = mock(PaymentAuditLogRepository::class.java)
+        val alertService = mock(AdminDiscordAlertService::class.java)
+        val transactionManager = stubTransactionManager()
+        val meterRegistry = SimpleMeterRegistry()
+        val service = PaymentAuditLogService(
+            paymentAuditLogRepository = repository,
+            adminDiscordAlertService = alertService,
+            discordProperties = DiscordProperties(paymentSuccessAlertEnabled = false),
+            paymentMetricsRecorder = PaymentMetricsRecorder(meterRegistry),
+            transactionManager = transactionManager,
+        )
+
+        service.record(
+            PaymentAuditRecord(
+                source = PaymentAuditSource.ORDER_CREATE,
+                eventType = PaymentAuditEventType.ORDER_CREATE_FAILED,
+                reason = "PAYMENT_DUPLICATE_PARTICIPATION",
+                rawPayload = "groupBuyId=10,userId=1,quantity=1",
+            )
+        )
+
+        verify(repository).save(any())
+        assertCounter(
+            meterRegistry,
+            "mcj_payment_audit_events_total",
+            1.0,
+            "source", "order_create",
+            "event_type", "order_create_failed",
+            "result", "failure",
+            "reason", "payment_duplicate_participation",
+        )
+    }
+
     private fun successRecord(): PaymentAuditRecord =
         PaymentAuditRecord(
             source = PaymentAuditSource.COMPLETE_API,

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -19,6 +19,8 @@ import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
 import com.moongchijang.domain.payment.application.port.PortOnePaymentPort
 import com.moongchijang.domain.payment.application.port.PortOnePaymentResult
 import com.moongchijang.domain.payment.domain.entity.Payment
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditEventType
+import com.moongchijang.domain.payment.domain.entity.PaymentAuditSource
 import com.moongchijang.domain.payment.domain.entity.PaymentOrder
 import com.moongchijang.domain.payment.domain.entity.PaymentOrderStatus
 import com.moongchijang.domain.payment.domain.entity.PaymentStatus
@@ -245,6 +247,35 @@ class PaymentServiceTest {
         }
 
         assertEquals(ErrorCode.PAYMENT_PER_USER_LIMIT_EXCEEDED, ex.errorCode)
+    }
+
+    @Test
+    fun `이미 참여한 공구 결제 주문 생성 실패는 감사 이력으로 기록한다`() {
+        val user = UserFixture.createKakaoUser(id = 1L, nickname = "은서")
+        val groupBuy = createGroupBuy()
+        `when`(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(user)
+        `when`(groupBuyRepository.findWithLockById(10L)).thenReturn(Optional.of(groupBuy))
+        `when`(participationRepository.existsByUserIdAndGroupBuyId(1L, 10L)).thenReturn(true)
+
+        val ex = assertThrows<CustomException> {
+            service.createPaymentOrder(10L, 1L, createOrderRequest(quantity = 1))
+        }
+
+        assertEquals(ErrorCode.PAYMENT_DUPLICATE_PARTICIPATION, ex.errorCode)
+        assertCounter(
+            "mcj_payment_order_created_total",
+            1.0,
+            "result", "failure",
+            "reason", "payment_duplicate_participation",
+        )
+        verify(paymentAuditLogService).record(
+            PaymentAuditRecord(
+                source = PaymentAuditSource.ORDER_CREATE,
+                eventType = PaymentAuditEventType.ORDER_CREATE_FAILED,
+                reason = ErrorCode.PAYMENT_DUPLICATE_PARTICIPATION.name,
+                rawPayload = "groupBuyId=10,userId=1,quantity=1",
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
## 📌 작업한 내용
- 결제 주문 생성 실패 시 `payment_audit_logs`에 `ORDER_CREATE_FAILED` 감사 이력을 기록하도록 보강
- 주문 생성 실패 감사 이력/metric 기록 테스트 추가


## 🔍 참고 사항
- prod 결제 실패 확인 중 `payment-orders`는 200이지만 `complete` 호출이 없고, webhook은 `json_parse` 또는 signature 검증 단계에서 400이 발생하는 상태를 확인했습니다.
- 이번 PR은 주문 생성 실패 원인을 Grafana/Loki에서 확인 가능하게 하는 관측성 보강 범위입니다.


## 🖼️ 스크린샷

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
