### PR TITLE
[MCJ-1633] FIX: PortOne V2 웹훅 payload 파싱 호환성 보강

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/payment/presentation/PaymentController.kt
@@ -1,6 +1,7 @@
 package com.moongchijang.domain.payment.presentation
 
 import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.moongchijang.domain.payment.application.PaymentMetricsRecorder
 import com.moongchijang.domain.payment.application.PaymentService
@@ -90,7 +91,7 @@ class PaymentController(
             throw e
         }
         val request = try {
-            objectMapper.readValue(rawPayload, PortOneWebhookRequest::class.java)
+            parsePortOneWebhookRequest(rawPayload)
         } catch (e: JsonProcessingException) {
             recordInvalidWebhook(stage = "json_parse", headers = headers, rawPayload = rawPayload, errorCode = ErrorCode.PAYMENT_WEBHOOK_INVALID)
             throw CustomException(ErrorCode.PAYMENT_WEBHOOK_INVALID)
@@ -129,6 +130,23 @@ class PaymentController(
             headers.getFirst(WEBHOOK_SIGNATURE_HEADER) != null,
         )
     }
+
+    private fun parsePortOneWebhookRequest(rawPayload: String): PortOneWebhookRequest {
+        val root = objectMapper.readTree(rawPayload)
+        val data = root.path("data")
+
+        return PortOneWebhookRequest(
+            type = root.textOrNull("type"),
+            storeId = root.textOrNull("storeId") ?: data.textOrNull("storeId"),
+            paymentId = root.textOrNull("paymentId") ?: data.textOrNull("paymentId"),
+        )
+    }
+
+    private fun JsonNode.textOrNull(fieldName: String): String? =
+        get(fieldName)
+            ?.takeIf { it.isTextual }
+            ?.asText()
+            ?.takeIf { it.isNotBlank() }
 
     companion object {
         private const val WEBHOOK_ID_HEADER = "webhook-id"

--- a/src/test/kotlin/com/moongchijang/domain/payment/presentation/PaymentControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/presentation/PaymentControllerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.moongchijang.domain.payment.application.PaymentMetricsRecorder
 import com.moongchijang.domain.payment.application.PaymentService
 import com.moongchijang.domain.payment.application.PortOneWebhookSignatureVerifier
+import com.moongchijang.domain.payment.application.dto.PortOneWebhookRequest
 import com.moongchijang.global.config.PortOneProperties
 import com.moongchijang.global.exception.CustomException
 import com.moongchijang.global.exception.ErrorCode
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.springframework.http.HttpHeaders
 
 class PaymentControllerTest {
@@ -62,9 +64,39 @@ class PaymentControllerTest {
         )
     }
 
-    private fun controller(portOneWebhookSignatureVerifier: PortOneWebhookSignatureVerifier): PaymentController =
+    @Test
+    fun `PortOne V2 웹훅 payload는 data 필드에서 결제 식별자를 파싱한다`() {
+        val paymentService = mock(PaymentService::class.java)
+        val controller = controller(
+            paymentService = paymentService,
+            portOneWebhookSignatureVerifier = verifier(signatureVerificationEnabled = false),
+        )
+        val rawPayload = """
+            {
+              "type": "Transaction.Paid",
+              "timestamp": "2026-06-26T00:00:00.000Z",
+              "data": {
+                "storeId": "store-test",
+                "paymentId": "MCJ-10-test",
+                "transactionId": "tx-test"
+              }
+            }
+        """.trimIndent()
+
+        controller.handlePortOneWebhook(rawPayload = rawPayload, headers = HttpHeaders())
+
+        verify(paymentService).handlePortOneWebhook(
+            PortOneWebhookRequest(type = "Transaction.Paid", storeId = "store-test", paymentId = "MCJ-10-test"),
+            rawPayload,
+        )
+    }
+
+    private fun controller(
+        portOneWebhookSignatureVerifier: PortOneWebhookSignatureVerifier,
+        paymentService: PaymentService = mock(PaymentService::class.java),
+    ): PaymentController =
         PaymentController(
-            paymentService = mock(PaymentService::class.java),
+            paymentService = paymentService,
             portOneWebhookSignatureVerifier = portOneWebhookSignatureVerifier,
             objectMapper = ObjectMapper(),
             paymentMetricsRecorder = paymentMetricsRecorder,


### PR DESCRIPTION
## 📌 작업한 내용
- PortOne V2 웹훅 payload의 `data.paymentId`, `data.storeId` 구조를 파싱하도록 보강
- 웹훅 payload에 `timestamp`, `transactionId` 등 추가 필드가 포함되어도 json_parse 단계에서 400으로 실패하지 않도록 수정
- PortOne V2 웹훅 payload 파싱 회귀 테스트 추가


## 🔍 참고 사항
- 운영에서 웹훅 400이 누적됐던 원인 후보 중 하나인 payload 스키마 불일치를 보정합니다.
- 실제 운영 결제 성공 여부는 Toss/PortOne 운영 심사 및 채널 설정 상태와 별도로 확인합니다.


## 🖼️ 스크린샷

## 🔗 관련 이슈

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인
