### PR TITLE
[MCJ-1637] FEAT: 관리자 발주 상세 알림 이력과 환불 안내 제공

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOrderService.kt
@@ -8,6 +8,8 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.notification.domain.repository.NotificationDispatchHistoryRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.store.domain.repository.StoreStaffRepository
@@ -28,6 +30,7 @@ class AdminOrderService(
     private val participationRepository: ParticipationRepository,
     private val storeStaffRepository: StoreStaffRepository,
     private val notificationEventPublisher: NotificationEventPublisher,
+    private val notificationDispatchHistoryRepository: NotificationDispatchHistoryRepository,
     private val clock: Clock,
 ) {
     private val log = LoggerFactory.getLogger(AdminOrderService::class.java)
@@ -68,11 +71,7 @@ class AdminOrderService(
         val groupBuy = groupBuyRepository.findAdminOrderDetailById(orderId)
             .orElseThrow { CustomException(ErrorCode.GROUPBUY_NOT_FOUND) }
 
-        val response = AdminOrderDetailResponse.from(
-            groupBuy = groupBuy,
-            pendingRefundCount = countPendingRefunds(groupBuy.id),
-            now = now
-        )
+        val response = toDetailResponse(groupBuy, now)
         log.info("[AdminOrderService] 주문 상세 조회 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
         return response
     }
@@ -85,7 +84,7 @@ class AdminOrderService(
         validatePendingOrder(groupBuy)
         groupBuy.markOrderOwnerContacted(now)
 
-        val response = AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        val response = toDetailResponse(groupBuy, now)
         log.info("[AdminOrderService] 주문 사장님연락 상태 변경 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
         return response
     }
@@ -98,7 +97,7 @@ class AdminOrderService(
         validatePendingOrder(groupBuy)
         groupBuy.confirmOrder(now)
 
-        val response = AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        val response = toDetailResponse(groupBuy, now)
         log.info("[AdminOrderService] 주문 확정 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
         return response
     }
@@ -112,7 +111,7 @@ class AdminOrderService(
         groupBuy.cancelOrder(now)
         publishOwnerOrderCancelled(groupBuy, now)
 
-        val response = AdminOrderDetailResponse.from(groupBuy, countPendingRefunds(groupBuy.id), now)
+        val response = toDetailResponse(groupBuy, now)
         log.info("[AdminOrderService] 주문 취소 완료: orderId={}, orderStatus={}", orderId, response.orderStatus)
         return response
     }
@@ -142,6 +141,17 @@ class AdminOrderService(
             statuses = listOf(ParticipationStatus.REFUND_PENDING)
         )
 
+    private fun toDetailResponse(groupBuy: GroupBuy, now: LocalDateTime): AdminOrderDetailResponse =
+        AdminOrderDetailResponse.from(
+            groupBuy = groupBuy,
+            pendingRefundCount = countPendingRefunds(groupBuy.id),
+            now = now,
+            notificationHistories = notificationDispatchHistoryRepository.findAdminOrderHistories(
+                targetId = groupBuy.id,
+                triggerTypes = ADMIN_ORDER_NOTIFICATION_TRIGGER_TYPES
+            )
+        )
+
     private fun publishOwnerOrderCancelled(groupBuy: GroupBuy, occurredAt: LocalDateTime) {
         val ownerUserIds = storeStaffRepository.findUserIdsByStoreId(groupBuy.store.id).distinct()
         if (ownerUserIds.isEmpty()) return
@@ -168,4 +178,11 @@ class AdminOrderService(
             AdminOrderStatusFilter.CONFIRMED,
             AdminOrderStatusFilter.ALL -> null
         }
+
+    companion object {
+        private val ADMIN_ORDER_NOTIFICATION_TRIGGER_TYPES = listOf(
+            NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE,
+            NotificationTriggerType.OWNER_ORDER_CANCELLED_IMMEDIATE
+        )
+    }
 }

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOrderResponse.kt
@@ -3,6 +3,9 @@ package com.moongchijang.domain.admin.application.dto
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuy
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
 import org.springframework.data.domain.Page
 import java.time.Duration
 import java.time.LocalDate
@@ -99,6 +102,7 @@ data class AdminOrderDetailResponse(
     val finalQuantity: Int,
     val targetQuantity: Int,
     val pendingRefundCount: Long,
+    val pendingRefundNoticeRequired: Boolean,
     val pickupDate: LocalDate,
     val pickupTimeStart: String,
     val pickupTimeEnd: String,
@@ -111,12 +115,14 @@ data class AdminOrderDetailResponse(
     val orderConfirmedAt: LocalDateTime?,
     val orderCancelledAt: LocalDateTime?,
     val actionable: Boolean,
+    val notificationHistories: List<AdminOrderNotificationHistoryResponse>,
 ) {
     companion object {
         fun from(
             groupBuy: GroupBuy,
             pendingRefundCount: Long,
             now: LocalDateTime,
+            notificationHistories: List<NotificationDispatchHistory>,
         ): AdminOrderDetailResponse {
             val achievedAt = groupBuy.orderAchievedAt()
             return AdminOrderDetailResponse(
@@ -131,6 +137,7 @@ data class AdminOrderDetailResponse(
                 finalQuantity = groupBuy.currentQuantity,
                 targetQuantity = groupBuy.targetQuantity,
                 pendingRefundCount = pendingRefundCount,
+                pendingRefundNoticeRequired = pendingRefundCount > 0,
                 pickupDate = groupBuy.pickupDate,
                 pickupTimeStart = groupBuy.pickupTimeStart.toString(),
                 pickupTimeEnd = groupBuy.pickupTimeEnd.toString(),
@@ -142,9 +149,33 @@ data class AdminOrderDetailResponse(
                 ownerContactedAt = groupBuy.orderOwnerContactedAt,
                 orderConfirmedAt = groupBuy.orderConfirmedAt,
                 orderCancelledAt = groupBuy.orderCancelledAt,
-                actionable = groupBuy.isAdminOrderActionable()
+                actionable = groupBuy.isAdminOrderActionable(),
+                notificationHistories = notificationHistories.map(AdminOrderNotificationHistoryResponse::from)
             )
         }
+    }
+}
+
+data class AdminOrderNotificationHistoryResponse(
+    val historyId: Long,
+    val triggerType: NotificationTriggerType,
+    val scheduleKey: String,
+    val status: NotificationDispatchStatus,
+    val retryCount: Int,
+    val processedAt: LocalDateTime?,
+    val lastError: String?,
+) {
+    companion object {
+        fun from(history: NotificationDispatchHistory): AdminOrderNotificationHistoryResponse =
+            AdminOrderNotificationHistoryResponse(
+                historyId = history.id,
+                triggerType = history.triggerType,
+                scheduleKey = history.scheduleKey,
+                status = history.status,
+                retryCount = history.retryCount,
+                processedAt = history.processedAt,
+                lastError = history.lastError
+            )
     }
 }
 

--- a/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationDispatchHistoryRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/notification/domain/repository/NotificationDispatchHistoryRepository.kt
@@ -26,4 +26,18 @@ interface NotificationDispatchHistoryRepository : JpaRepository<NotificationDisp
         statuses: Collection<NotificationDispatchStatus>,
         nextRetryAt: LocalDateTime
     ): List<NotificationDispatchHistory>
+
+    @Query(
+        """
+        SELECT h
+        FROM NotificationDispatchHistory h
+        WHERE h.targetId = :targetId
+          AND h.triggerType IN :triggerTypes
+        ORDER BY COALESCE(h.processedAt, h.createdAt) DESC, h.id DESC
+        """
+    )
+    fun findAdminOrderHistories(
+        @Param("targetId") targetId: Long,
+        @Param("triggerTypes") triggerTypes: Collection<NotificationTriggerType>
+    ): List<NotificationDispatchHistory>
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -5967,7 +5967,7 @@ components:
 
     AdminOrderDetail:
       type: object
-      required: [orderId, groupBuyId, productName, productDescription, storeName, storeAddress, finalQuantity, targetQuantity, pendingRefundCount, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, elapsedHours, progressRate, orderStatus, actionable]
+      required: [orderId, groupBuyId, productName, productDescription, storeName, storeAddress, finalQuantity, targetQuantity, pendingRefundCount, pendingRefundNoticeRequired, pickupDate, pickupTimeStart, pickupTimeEnd, pickupLocation, elapsedHours, progressRate, orderStatus, actionable, notificationHistories]
       properties:
         orderId:
           type: integer
@@ -5996,6 +5996,9 @@ components:
           type: integer
           format: int64
           description: 해당 공구의 환불 대기 건수
+        pendingRefundNoticeRequired:
+          type: boolean
+          description: 환불 처리 중인 건이 있어 운영자 안내문구 노출이 필요한지 여부
         pickupDate: { type: string, format: date }
         pickupTimeStart: { type: string, format: time }
         pickupTimeEnd: { type: string, format: time }
@@ -6028,6 +6031,32 @@ components:
         actionable:
           type: boolean
           description: 발주 확정/연락 등 운영 작업 가능 여부
+        notificationHistories:
+          type: array
+          description: 발주 확정 요청 및 발주 취소 사장님 알림 발송 이력
+          items:
+            $ref: '#/components/schemas/AdminOrderNotificationHistory'
+
+    AdminOrderNotificationHistory:
+      type: object
+      required: [historyId, triggerType, scheduleKey, status, retryCount]
+      properties:
+        historyId: { type: integer, format: int64 }
+        triggerType:
+          type: string
+          enum: [OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE, OWNER_ORDER_CANCELLED_IMMEDIATE]
+        scheduleKey: { type: string }
+        status:
+          type: string
+          enum: [PENDING, SUCCESS, FAILED]
+        retryCount: { type: integer }
+        processedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastError:
+          type: string
+          nullable: true
 
     ApiResponseAdminCsTicketPage:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOrderServiceTest.kt
@@ -5,6 +5,10 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyOrderStatus
 import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyStatus
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchHistory
+import com.moongchijang.domain.notification.domain.entity.NotificationDispatchStatus
+import com.moongchijang.domain.notification.domain.entity.NotificationTriggerType
+import com.moongchijang.domain.notification.domain.repository.NotificationDispatchHistoryRepository
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.GroupBuyPendingRefundCount
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
@@ -33,12 +37,15 @@ class AdminOrderServiceTest {
     private val participationRepository: ParticipationRepository = mock(ParticipationRepository::class.java)
     private val storeStaffRepository: StoreStaffRepository = mock(StoreStaffRepository::class.java)
     private val notificationEventPublisher: NotificationEventPublisher = mock(NotificationEventPublisher::class.java)
+    private val notificationDispatchHistoryRepository: NotificationDispatchHistoryRepository =
+        mock(NotificationDispatchHistoryRepository::class.java)
     private val clock: Clock = Clock.fixed(Instant.parse("2026-05-27T04:00:00Z"), ZoneOffset.UTC)
     private val service = AdminOrderService(
         groupBuyRepository = groupBuyRepository,
         participationRepository = participationRepository,
         storeStaffRepository = storeStaffRepository,
         notificationEventPublisher = notificationEventPublisher,
+        notificationDispatchHistoryRepository = notificationDispatchHistoryRepository,
         clock = clock
     )
 
@@ -120,15 +127,32 @@ class AdminOrderServiceTest {
                 listOf(ParticipationStatus.REFUND_PENDING)
             )
         ).thenReturn(1L)
+        val history = NotificationDispatchHistory(
+            userId = 101L,
+            triggerType = NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE,
+            targetId = 31L,
+            scheduleKey = "owner-order-confirm-required:31",
+            status = NotificationDispatchStatus.SUCCESS,
+            retryCount = 1,
+            processedAt = now.minusHours(2),
+            id = 301L
+        )
+        stubNotificationHistories(31L, listOf(history))
 
         val result = service.getOrderDetail(31L)
 
         assertEquals(31L, result.orderId)
         assertEquals("뭉치장 베이커리", result.storeName)
         assertEquals(1L, result.pendingRefundCount)
+        assertTrue(result.pendingRefundNoticeRequired)
         assertEquals(3L, result.elapsedHours)
         assertEquals(80, result.progressRate)
         assertTrue(result.actionable)
+        assertEquals(1, result.notificationHistories.size)
+        assertEquals(301L, result.notificationHistories[0].historyId)
+        assertEquals(NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE, result.notificationHistories[0].triggerType)
+        assertEquals(NotificationDispatchStatus.SUCCESS, result.notificationHistories[0].status)
+        assertEquals("owner-order-confirm-required:31", result.notificationHistories[0].scheduleKey)
     }
 
     @Test
@@ -148,11 +172,13 @@ class AdminOrderServiceTest {
                 listOf(ParticipationStatus.REFUND_PENDING)
             )
         ).thenReturn(0L)
+        stubNotificationHistories(35L)
 
         val result = service.getOrderDetail(35L)
 
         assertEquals(35L, result.orderId)
         assertFalse(result.actionable)
+        assertFalse(result.pendingRefundNoticeRequired)
     }
 
     @Test
@@ -172,6 +198,7 @@ class AdminOrderServiceTest {
                 listOf(ParticipationStatus.REFUND_PENDING)
             )
         ).thenReturn(0L)
+        stubNotificationHistories(32L)
 
         val result = service.markOwnerContacted(32L)
 
@@ -197,6 +224,7 @@ class AdminOrderServiceTest {
                 listOf(ParticipationStatus.REFUND_PENDING)
             )
         ).thenReturn(0L)
+        stubNotificationHistories(33L)
 
         val result = service.confirmOrder(33L)
 
@@ -238,6 +266,7 @@ class AdminOrderServiceTest {
             )
         ).thenReturn(0L)
         `when`(storeStaffRepository.findUserIdsByStoreId(groupBuy.store.id)).thenReturn(listOf(201L, 202L))
+        stubNotificationHistories(36L)
 
         val result = service.cancelOrder(36L)
 
@@ -255,4 +284,19 @@ class AdminOrderServiceTest {
             override val groupBuyId: Long = groupBuyId
             override val pendingRefundCount: Long = count
         }
+
+    private fun stubNotificationHistories(
+        groupBuyId: Long,
+        histories: List<NotificationDispatchHistory> = emptyList()
+    ) {
+        `when`(
+            notificationDispatchHistoryRepository.findAdminOrderHistories(
+                groupBuyId,
+                listOf(
+                    NotificationTriggerType.OWNER_ORDER_CONFIRM_REQUIRED_IMMEDIATE,
+                    NotificationTriggerType.OWNER_ORDER_CANCELLED_IMMEDIATE
+                )
+            )
+        ).thenReturn(histories)
+    }
 }

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOrderControllerTest.kt
@@ -75,6 +75,7 @@ class AdminOrderControllerTest {
             finalQuantity = 20,
             targetQuantity = 20,
             pendingRefundCount = 0,
+            pendingRefundNoticeRequired = false,
             pickupDate = LocalDate.of(2026, 6, 1),
             pickupTimeStart = "14:00",
             pickupTimeEnd = "18:00",
@@ -86,6 +87,7 @@ class AdminOrderControllerTest {
             ownerContactedAt = null,
             orderConfirmedAt = null,
             orderCancelledAt = null,
-            actionable = orderStatus == GroupBuyOrderStatus.PENDING
+            actionable = orderStatus == GroupBuyOrderStatus.PENDING,
+            notificationHistories = emptyList()
         )
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 관리자 발주 상세 응답에 환불 안내 필요 여부와 발주 관련 알림 발송 이력 추가
- 알림 발송 이력 repository 조회 쿼리 추가
- OpenAPI 및 발주 서비스/컨트롤러 테스트 보강

## 🔍 참고 사항
- 검증: `./gradlew test --tests com.moongchijang.domain.admin.application.AdminOrderServiceTest --tests com.moongchijang.domain.admin.presentation.AdminOrderControllerTest`

## 🖼️ 스크린샷
- API 변경으로 스크린샷 없음

## 🔗 관련 이슈
- Closes #372

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인