### PR TITLE
[MCJ-1638] FEAT: 관리자 공구 개설 요청 승인대기 계약 보강

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestService.kt
@@ -7,6 +7,8 @@ import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepositor
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestApprovalSummaryResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestApproveRequest
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestPageResponse
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
@@ -81,11 +83,16 @@ class AdminOwnerGroupBuyRequestService(
         return response
     }
 
-    fun approve(requestId: Long): AdminOwnerGroupBuyRequestActionResponse {
+    fun approve(
+        requestId: Long,
+        approveRequest: AdminOwnerGroupBuyRequestApproveRequest
+    ): AdminOwnerGroupBuyRequestActionResponse {
         log.info("[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 승인 시작: requestId={}", requestId)
         val request = findRequestForAction(requestId)
         validatePending(request)
         validateApprovalSource(request)
+        val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
+        validateApprovalConfirmation(request, approveRequest, images.size)
 
         val now = clock.kstNow()
         val groupBuy = groupBuyRepository.save(
@@ -112,7 +119,6 @@ class AdminOwnerGroupBuyRequestService(
             )
         )
 
-        val images = ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)
         groupBuyImageRepository.saveAll(
             images.map {
                 GroupBuyImage(
@@ -136,7 +142,14 @@ class AdminOwnerGroupBuyRequestService(
         val response = AdminOwnerGroupBuyRequestActionResponse(
             requestId = request.id,
             status = request.status,
-            groupBuyId = groupBuy.id
+            groupBuyId = groupBuy.id,
+            approvalSummary = AdminOwnerGroupBuyRequestApprovalSummaryResponse(
+                productName = groupBuy.productName,
+                price = groupBuy.price,
+                targetQuantity = groupBuy.targetQuantity,
+                pickupDate = groupBuy.pickupDate,
+                imageCount = images.size
+            )
         )
         log.info(
             "[AdminOwnerGroupBuyRequestService] 사장님 공구 요청 승인 완료: requestId={}, groupBuyId={}",
@@ -202,6 +215,22 @@ class AdminOwnerGroupBuyRequestService(
             !isPickupAfterDeadline(request.deadline, request.pickupDate, request.pickupTimeStart)
         ) {
             throw CustomException(ErrorCode.GROUPBUY_REQUEST_APPROVAL_INVALID_PICKUP)
+        }
+    }
+
+    private fun validateApprovalConfirmation(
+        request: OwnerGroupBuyRequest,
+        approveRequest: AdminOwnerGroupBuyRequestApproveRequest,
+        imageCount: Int
+    ) {
+        if (imageCount !in 1..5 ||
+            approveRequest.productName.trim() != request.productName.trim() ||
+            approveRequest.price != request.price ||
+            approveRequest.targetQuantity != request.targetQuantity ||
+            approveRequest.pickupDate != request.pickupDate ||
+            approveRequest.imageCount != imageCount
+        ) {
+            throw CustomException(ErrorCode.INVALID_INPUT, "승인 확인 정보가 요청 정보와 일치하지 않습니다.")
         }
     }
 

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyRequestDtos.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/AdminOwnerGroupBuyRequestDtos.kt
@@ -3,7 +3,10 @@ package com.moongchijang.domain.admin.application.dto
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import org.springframework.data.domain.Page
 import java.time.Duration
@@ -182,6 +185,28 @@ data class AdminOwnerGroupBuyRequestImageResponse(
     val sortOrder: Int
 )
 
+data class AdminOwnerGroupBuyRequestApproveRequest(
+    @field:NotBlank(message = "공구 제목은 필수입니다")
+    @field:Size(max = 100, message = "공구 제목은 100자 이하이어야 합니다")
+    val productName: String,
+
+    @field:NotNull(message = "공구가는 필수입니다")
+    @field:Min(value = 1, message = "공구가는 1원 이상이어야 합니다")
+    val price: Int,
+
+    @field:NotNull(message = "목표 수량은 필수입니다")
+    @field:Min(value = 1, message = "목표 수량은 1개 이상이어야 합니다")
+    val targetQuantity: Int,
+
+    @field:NotNull(message = "픽업일은 필수입니다")
+    val pickupDate: LocalDate,
+
+    @field:NotNull(message = "이미지 장수는 필수입니다")
+    @field:Min(value = 1, message = "이미지는 최소 1장 이상 필요합니다")
+    @field:Max(value = 5, message = "이미지는 최대 5장까지 등록할 수 있습니다")
+    val imageCount: Int
+)
+
 data class AdminOwnerGroupBuyRequestRejectRequest(
     @field:NotBlank(message = "반려 사유는 필수입니다")
     @field:Size(max = 200, message = "반려 사유는 200자 이하이어야 합니다")
@@ -191,7 +216,16 @@ data class AdminOwnerGroupBuyRequestRejectRequest(
 data class AdminOwnerGroupBuyRequestActionResponse(
     val requestId: Long,
     val status: OwnerGroupBuyRequestStatus,
-    val groupBuyId: Long? = null
+    val groupBuyId: Long? = null,
+    val approvalSummary: AdminOwnerGroupBuyRequestApprovalSummaryResponse? = null
+)
+
+data class AdminOwnerGroupBuyRequestApprovalSummaryResponse(
+    val productName: String,
+    val price: Int,
+    val targetQuantity: Int,
+    val pickupDate: LocalDate,
+    val imageCount: Int
 )
 
 private const val REQUEST_TYPE = "OWNER"

--- a/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestController.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestController.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminOwnerGroupBuyRequestService
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestApproveRequest
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestDetailResponse
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestPageResponse
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
@@ -56,11 +57,12 @@ class AdminOwnerGroupBuyRequestController(
     @PostMapping("/{requestId}/approve")
     @Operation(summary = "사장님 공구 개설 요청 승인 및 공구 생성")
     fun approve(
-        @PathVariable requestId: Long
+        @PathVariable requestId: Long,
+        @Valid @RequestBody request: AdminOwnerGroupBuyRequestApproveRequest
     ): ResponseEntity<ApiResponse<AdminOwnerGroupBuyRequestActionResponse>> {
         val response = ResponseEntity
             .status(HttpStatus.CREATED)
-            .body(ApiResponse.success(adminOwnerGroupBuyRequestService.approve(requestId)))
+            .body(ApiResponse.success(adminOwnerGroupBuyRequestService.approve(requestId, request)))
         return response
     }
 

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1142,6 +1142,12 @@ paths:
         - bearerAuth: []
       parameters:
         - $ref: '#/components/parameters/RequestId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminOwnerGroupBuyRequestApprove'
       responses:
         '200':
           description: 요청 상세
@@ -6596,6 +6602,32 @@ components:
           type: string
           maxLength: 200
 
+    AdminOwnerGroupBuyRequestApprove:
+      type: object
+      required: [productName, price, targetQuantity, pickupDate, imageCount]
+      properties:
+        productName:
+          type: string
+          maxLength: 100
+          description: 승인 확인 팝업에 표시된 공구 제목
+        price:
+          type: integer
+          minimum: 1
+          description: 승인 확인 팝업에 표시된 공구가
+        targetQuantity:
+          type: integer
+          minimum: 1
+          description: 승인 확인 팝업에 표시된 목표 수량
+        pickupDate:
+          type: string
+          format: date
+          description: 승인 확인 팝업에 표시된 픽업일
+        imageCount:
+          type: integer
+          minimum: 1
+          maximum: 5
+          description: 승인 확인 팝업에 표시된 이미지 장수
+
     ApiResponseAdminOwnerGroupBuyRequestAction:
       type: object
       required: [success, data, error]
@@ -6613,7 +6645,21 @@ components:
               type: integer
               format: int64
               nullable: true
+            approvalSummary:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/AdminOwnerGroupBuyRequestApprovalSummary'
         error: { nullable: true, example: null }
+
+    AdminOwnerGroupBuyRequestApprovalSummary:
+      type: object
+      required: [productName, price, targetQuantity, pickupDate, imageCount]
+      properties:
+        productName: { type: string }
+        price: { type: integer }
+        targetQuantity: { type: integer }
+        pickupDate: { type: string, format: date }
+        imageCount: { type: integer }
 
     ApiResponseAdminRefundPage:
       type: object

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminOwnerGroupBuyRequestServiceTest.kt
@@ -5,6 +5,7 @@ import com.moongchijang.domain.groupbuy.domain.entity.GroupBuyImage
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyImageRepository
 import com.moongchijang.domain.groupbuy.domain.repository.GroupBuyRepository
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestApproveRequest
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestImage
@@ -111,11 +112,16 @@ class AdminOwnerGroupBuyRequestServiceTest {
             (it.arguments[0] as GroupBuy).apply { id = 30L }
         }
 
-        val result = service.approve(requestId)
+        val result = service.approve(requestId, approveRequest(imageCount = 2))
 
         assertEquals(requestId, result.requestId)
         assertEquals(OwnerGroupBuyRequestStatus.APPROVED, result.status)
         assertEquals(30L, result.groupBuyId)
+        assertEquals("두쫀쿠 세트", result.approvalSummary?.productName)
+        assertEquals(9900, result.approvalSummary?.price)
+        assertEquals(20, result.approvalSummary?.targetQuantity)
+        assertEquals(LocalDate.of(2026, 6, 12), result.approvalSummary?.pickupDate)
+        assertEquals(2, result.approvalSummary?.imageCount)
         assertEquals(OwnerGroupBuyRequestStatus.APPROVED, request.status)
         assertEquals(LocalDateTime.of(2026, 6, 1, 12, 0), request.reviewedAt)
         assertEquals(30L, request.approvedGroupBuy?.id)
@@ -148,13 +154,20 @@ class AdminOwnerGroupBuyRequestServiceTest {
             pickupTimeStart = LocalTime.of(13, 0),
             pickupTimeEnd = LocalTime.of(18, 0),
         ).apply { id = requestId }
+        val images = listOf(OwnerGroupBuyRequestImage(request, "owner/1.jpg", 0))
         `when`(ownerGroupBuyRequestRepository.findWithLockById(requestId)).thenReturn(Optional.of(request))
-        `when`(ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)).thenReturn(emptyList())
+        `when`(ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)).thenReturn(images)
         `when`(groupBuyRepository.save(any(GroupBuy::class.java))).thenAnswer {
             (it.arguments[0] as GroupBuy).apply { id = 33L }
         }
 
-        val result = service.approve(requestId)
+        val result = service.approve(
+            requestId,
+            approveRequest(
+                pickupDate = deadline.toLocalDate(),
+                imageCount = 1
+            )
+        )
 
         assertEquals(OwnerGroupBuyRequestStatus.APPROVED, result.status)
         assertEquals(33L, result.groupBuyId)
@@ -167,10 +180,26 @@ class AdminOwnerGroupBuyRequestServiceTest {
         `when`(ownerGroupBuyRequestRepository.findWithLockById(requestId)).thenReturn(Optional.of(request))
 
         val ex = assertThrows<CustomException> {
-            service.approve(requestId)
+            service.approve(requestId, approveRequest())
         }
 
         assertEquals(ErrorCode.GROUPBUY_REQUEST_INVALID_STATUS_TRANSITION, ex.errorCode)
+        verify(groupBuyRepository, never()).save(any(GroupBuy::class.java))
+    }
+
+    @Test
+    fun `승인 확인 정보가 요청 정보와 다르면 승인할 수 없다`() {
+        val requestId = 14L
+        val request = ownerRequest(status = OwnerGroupBuyRequestStatus.PENDING).apply { id = requestId }
+        val images = listOf(OwnerGroupBuyRequestImage(request, "owner/1.jpg", 0))
+        `when`(ownerGroupBuyRequestRepository.findWithLockById(requestId)).thenReturn(Optional.of(request))
+        `when`(ownerGroupBuyRequestImageRepository.findAllByRequestIdOrderBySortOrderAsc(requestId)).thenReturn(images)
+
+        val ex = assertThrows<CustomException> {
+            service.approve(requestId, approveRequest(price = 10_900, imageCount = 1))
+        }
+
+        assertEquals(ErrorCode.INVALID_INPUT, ex.errorCode)
         verify(groupBuyRepository, never()).save(any(GroupBuy::class.java))
     }
 
@@ -232,4 +261,19 @@ class AdminOwnerGroupBuyRequestServiceTest {
         ).apply { id = 20L }
 
     private inline fun <reified T> argumentCaptor() = org.mockito.ArgumentCaptor.forClass(T::class.java)
+
+    private fun approveRequest(
+        productName: String = "두쫀쿠 세트",
+        price: Int = 9900,
+        targetQuantity: Int = 20,
+        pickupDate: LocalDate = LocalDate.of(2026, 6, 12),
+        imageCount: Int = 2,
+    ): AdminOwnerGroupBuyRequestApproveRequest =
+        AdminOwnerGroupBuyRequestApproveRequest(
+            productName = productName,
+            price = price,
+            targetQuantity = targetQuantity,
+            pickupDate = pickupDate,
+            imageCount = imageCount
+        )
 }

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminOwnerGroupBuyRequestControllerTest.kt
@@ -2,6 +2,7 @@ package com.moongchijang.domain.admin.presentation
 
 import com.moongchijang.domain.admin.application.AdminOwnerGroupBuyRequestService
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestActionResponse
+import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestApproveRequest
 import com.moongchijang.domain.admin.application.dto.AdminOwnerGroupBuyRequestRejectRequest
 import com.moongchijang.domain.owner.domain.entity.OwnerGroupBuyRequestStatus
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -10,6 +11,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.springframework.http.HttpStatus
+import java.time.LocalDate
 
 class AdminOwnerGroupBuyRequestControllerTest {
 
@@ -23,13 +25,14 @@ class AdminOwnerGroupBuyRequestControllerTest {
             status = OwnerGroupBuyRequestStatus.APPROVED,
             groupBuyId = 30L
         )
-        `when`(service.approve(10L)).thenReturn(response)
+        val request = approveRequest()
+        `when`(service.approve(10L, request)).thenReturn(response)
 
-        val result = controller.approve(10L)
+        val result = controller.approve(10L, request)
 
         assertEquals(HttpStatus.CREATED, result.statusCode)
         assertEquals(response, result.body?.data)
-        verify(service).approve(10L)
+        verify(service).approve(10L, request)
     }
 
     @Test
@@ -48,4 +51,13 @@ class AdminOwnerGroupBuyRequestControllerTest {
         assertEquals(response, result.body?.data)
         verify(service).reject(11L, request)
     }
+
+    private fun approveRequest(): AdminOwnerGroupBuyRequestApproveRequest =
+        AdminOwnerGroupBuyRequestApproveRequest(
+            productName = "두쫀쿠 세트",
+            price = 9900,
+            targetQuantity = 20,
+            pickupDate = LocalDate.of(2026, 6, 12),
+            imageCount = 2
+        )
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 사장님 공구 개설 요청 승인 API에 승인 확인 request body 추가
- 확인값 불일치 및 이미지 수 조건 검증 추가
- 생성된 공구 승인 요약 응답과 OpenAPI/테스트 보강

## 🔍 참고 사항
- 검증: `./gradlew test --tests com.moongchijang.domain.admin.application.AdminOwnerGroupBuyRequestServiceTest --tests com.moongchijang.domain.admin.presentation.AdminOwnerGroupBuyRequestControllerTest`

## 🖼️ 스크린샷
- API 변경으로 스크린샷 없음

## 🔗 관련 이슈
- Closes #373

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인