### PR TITLE
[MCJ-1636] FEAT: 관리자 정산 플랫폼 수수료 집계 구현

### DIFF
--- a/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/AdminSettlementService.kt
@@ -58,7 +58,7 @@ class AdminSettlementService(
             scheduledSettlementAmount = aggregations
                 .filter { it.scheduledSettlementDate().toSettlementStatus(today) == AdminSettlementStatus.SCHEDULED }
                 .sumOf { it.settlementAmount() },
-            platformFeeAmount = 0L,
+            platformFeeAmount = aggregations.sumOf { it.platformFeeAmount },
             totalTransactionAmount = aggregations.sumOf { it.totalPaymentAmount }
         )
         log.info("[AdminSettlementService] 정산 대시보드 조회 완료: year={}, month={}", year, month)

--- a/src/main/kotlin/com/moongchijang/domain/admin/application/dto/settlement/AdminSettlementResponse.kt
+++ b/src/main/kotlin/com/moongchijang/domain/admin/application/dto/settlement/AdminSettlementResponse.kt
@@ -77,7 +77,7 @@ data class AdminSettlementListItemResponse(
                 participantCount = aggregation.participantCount,
                 totalPaymentAmount = aggregation.totalPaymentAmount,
                 refundDeductionAmount = aggregation.refundDeductionAmount,
-                platformFeeAmount = 0L,
+                platformFeeAmount = aggregation.platformFeeAmount,
                 settlementAmount = aggregation.settlementAmount(),
                 scheduledSettlementDate = scheduledSettlementDate,
                 status = status,
@@ -90,7 +90,7 @@ data class AdminSettlementListItemResponse(
 typealias AdminSettlementDetailResponse = AdminSettlementListItemResponse
 
 fun AdminSettlementAggregation.settlementAmount(): Long =
-    (totalPaymentAmount - refundDeductionAmount).coerceAtLeast(0L)
+    (totalPaymentAmount - refundDeductionAmount - platformFeeAmount).coerceAtLeast(0L)
 
 fun AdminSettlementAggregation.scheduledSettlementDate(): LocalDate =
     pickupCompletedDate.plusDays(ADMIN_SETTLEMENT_DELAY_DAYS)

--- a/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
+++ b/src/main/kotlin/com/moongchijang/domain/participation/domain/repository/ParticipationRepository.kt
@@ -404,7 +404,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
                coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
                coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
-               0 as platformFeeAmount
+               coalesce(sum(case when p.status in :revenueStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
         where gb.status in :groupBuyStatuses
@@ -440,7 +440,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
                coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
                coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
-               0 as platformFeeAmount
+               coalesce(sum(case when p.status in :revenueStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
         where gb.status in :groupBuyStatuses
@@ -467,7 +467,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
                coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
                coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
-               0 as platformFeeAmount
+               coalesce(sum(case when p.status in :revenueStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
         where gb.store.id in :storeIds
@@ -497,7 +497,7 @@ interface ParticipationRepository : JpaRepository<Participation, Long> {
                coalesce(sum(case when p.status in :revenueStatuses then 1 else 0 end), 0) as participantCount,
                coalesce(sum(case when p.status in :transactionStatuses then p.totalAmount else 0 end), 0) as totalPaymentAmount,
                coalesce(sum(case when p.status in :refundStatuses then p.totalAmount else 0 end), 0) as refundDeductionAmount,
-               0 as platformFeeAmount
+               coalesce(sum(case when p.status in :revenueStatuses then p.feeAmount else 0 end), 0) as platformFeeAmount
         from GroupBuy gb
         left join Participation p on p.groupBuy = gb
         where gb.id = :groupBuyId

--- a/src/test/kotlin/com/moongchijang/domain/admin/application/AdminSettlementServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/application/AdminSettlementServiceTest.kt
@@ -35,14 +35,14 @@ class AdminSettlementServiceTest {
             pickupCompletedDate = LocalDate.of(2026, 5, 20),
             totalPaymentAmount = 120_000L,
             refundDeductionAmount = 20_000L,
-            platformFeeAmount = 0L
+            platformFeeAmount = 5_000L
         )
         val scheduled = aggregation(
             groupBuyId = 11L,
             pickupCompletedDate = LocalDate.of(2026, 5, 27),
             totalPaymentAmount = 80_000L,
             refundDeductionAmount = 0L,
-            platformFeeAmount = 0L
+            platformFeeAmount = 3_000L
         )
         `when`(
             participationRepository.findAdminSettlementAggregations(
@@ -59,9 +59,9 @@ class AdminSettlementServiceTest {
 
         assertEquals(2026, result.year)
         assertEquals(5, result.month)
-        assertEquals(100_000L, result.completedSettlementAmount)
-        assertEquals(80_000L, result.scheduledSettlementAmount)
-        assertEquals(0L, result.platformFeeAmount)
+        assertEquals(95_000L, result.completedSettlementAmount)
+        assertEquals(77_000L, result.scheduledSettlementAmount)
+        assertEquals(8_000L, result.platformFeeAmount)
         assertEquals(200_000L, result.totalTransactionAmount)
     }
 
@@ -73,7 +73,7 @@ class AdminSettlementServiceTest {
             pickupCompletedDate = LocalDate.of(2026, 5, 27),
             totalPaymentAmount = 50_000L,
             refundDeductionAmount = 10_000L,
-            platformFeeAmount = 0L
+            platformFeeAmount = 2_000L
         )
         `when`(
             participationRepository.findAdminSettlementPage(
@@ -93,7 +93,8 @@ class AdminSettlementServiceTest {
         assertEquals(12L, result.content[0].settlementId)
         assertEquals(LocalDate.of(2026, 5, 30), result.content[0].scheduledSettlementDate)
         assertEquals(AdminSettlementStatus.SCHEDULED, result.content[0].status)
-        assertEquals(40_000L, result.content[0].settlementAmount)
+        assertEquals(2_000L, result.content[0].platformFeeAmount)
+        assertEquals(38_000L, result.content[0].settlementAmount)
         assertTrue(result.content[0].actionable)
     }
 
@@ -104,7 +105,7 @@ class AdminSettlementServiceTest {
             pickupCompletedDate = LocalDate.of(2026, 5, 23),
             totalPaymentAmount = 100_000L,
             refundDeductionAmount = 20_000L,
-            platformFeeAmount = 0L
+            platformFeeAmount = 4_000L
         )
         `when`(
             participationRepository.findAdminSettlementDetail(
@@ -121,7 +122,8 @@ class AdminSettlementServiceTest {
         assertEquals(13L, result.settlementId)
         assertEquals("뭉치장 베이커리", result.storeName)
         assertEquals(AdminSettlementStatus.COMPLETED, result.status)
-        assertEquals(80_000L, result.settlementAmount)
+        assertEquals(4_000L, result.platformFeeAmount)
+        assertEquals(76_000L, result.settlementAmount)
         assertFalse(result.status == AdminSettlementStatus.SCHEDULED)
     }
 

--- a/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementControllerTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/admin/presentation/AdminSettlementControllerTest.kt
@@ -26,7 +26,7 @@ class AdminSettlementControllerTest {
             month = 5,
             completedSettlementAmount = 100_000,
             scheduledSettlementAmount = 50_000,
-            platformFeeAmount = 0,
+            platformFeeAmount = 8_000,
             totalTransactionAmount = 180_000
         )
         `when`(adminSettlementService.getDashboard(2026, 5)).thenReturn(response)
@@ -73,8 +73,8 @@ class AdminSettlementControllerTest {
             participantCount = 10,
             totalPaymentAmount = 100_000,
             refundDeductionAmount = 20_000,
-            platformFeeAmount = 0,
-            settlementAmount = 80_000,
+            platformFeeAmount = 4_000,
+            settlementAmount = 76_000,
             scheduledSettlementDate = LocalDate.of(2026, 5, 23),
             status = AdminSettlementStatus.COMPLETED,
             actionable = false


### PR DESCRIPTION
## 📌 작업한 내용
- 관리자 정산 집계에서 플랫폼 수수료를 실제 참여 수수료 합계로 계산하도록 수정
- 정산 예정/완료 금액에서 환불 차감과 플랫폼 수수료를 함께 차감
- 정산 서비스/컨트롤러 테스트 보강

## 🔍 참고 사항
- 검증: `./gradlew test --tests com.moongchijang.domain.admin.application.AdminSettlementServiceTest --tests com.moongchijang.domain.admin.presentation.AdminSettlementControllerTest`

## 🖼️ 스크린샷
- API 변경으로 스크린샷 없음

## 🔗 관련 이슈
- Closes #371

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인