### PR TITLE
[MCJ-1639] FEAT: 핵심 도메인 정합성 검증 강화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     kotlin("plugin.spring") version "2.2.21"
     id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
+    jacoco
     kotlin("plugin.jpa") version "2.2.21"
     kotlin("kapt") version "2.2.21"
 }
@@ -81,6 +82,38 @@ allOpen {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(false)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.test)
+
+    violationRules {
+        rule {
+            enabled = true
+            element = "BUNDLE"
+
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.60".toBigDecimal()
+            }
+        }
+    }
 }
 
 tasks.bootJar {

--- a/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/payment/application/PaymentServiceTest.kt
@@ -10,6 +10,7 @@ import com.moongchijang.domain.notification.application.discord.AdminDiscordAler
 import com.moongchijang.domain.notification.application.NotificationEventPublisher
 import com.moongchijang.domain.participation.domain.entity.Participation
 import com.moongchijang.domain.participation.domain.entity.ParticipationCancelReason
+import com.moongchijang.domain.participation.domain.entity.OwnerRefundReviewStatus
 import com.moongchijang.domain.participation.domain.entity.ParticipationStatus
 import com.moongchijang.domain.participation.domain.repository.ParticipationRepository
 import com.moongchijang.domain.payment.application.dto.CancelParticipationRequest
@@ -51,6 +52,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.lenient
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.data.domain.PageRequest
@@ -836,6 +838,72 @@ class PaymentServiceTest {
         assertEquals(PaymentStatus.CANCELLED, payment.status)
         assertEquals(ParticipationStatus.REFUNDED, participation.status)
         assertEquals(refundedAt, participation.refundedAt)
+        verify(refundRequestSyncService).markCompleted(participation, refundedAt)
+    }
+
+    @Test
+    fun `사용자 요청 환불은 사장님 승인 후 부분 환불로 완료 처리한다`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.FAILED)
+        val order = createPaymentOrder(user = user, groupBuy = groupBuy, quantity = 2).apply {
+            approve(LocalDateTime.now().minusMinutes(5))
+        }
+        val payment = Payment(
+            paymentOrder = order,
+            pgPaymentId = "portone-payment-id",
+            orderId = order.orderId,
+            amount = order.totalAmount,
+            method = "CARD",
+            approvedAt = order.approvedAt!!,
+        )
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 2,
+            productAmount = 12_000,
+            feeAmount = 0,
+            totalAmount = 12_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelReason = ParticipationCancelReason.TIME_UNAVAILABLE,
+            cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0),
+            approvedRefundAmount = 9_000,
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.APPROVED,
+        ).apply { id = 92L }
+        val refundedAt = LocalDateTime.of(2026, 5, 18, 11, 30)
+        val pageable = pendingRefundPageable()
+        stubTransaction()
+        `when`(
+            participationRepository.findByStatusOrderByCancelledAtAscCreatedAtAsc(
+                ParticipationStatus.REFUND_PENDING,
+                pageable
+            )
+        ).thenReturn(listOf(participation))
+        `when`(participationRepository.findByIdForUpdate(92L)).thenReturn(Optional.of(participation))
+        `when`(paymentOrderRepository.findByUserIdAndGroupBuyIdAndStatusForUpdate(1L, 10L, PaymentOrderStatus.APPROVED)).thenReturn(order)
+        `when`(paymentOrderRepository.findByOrderIdForUpdate(order.orderId)).thenReturn(order)
+        `when`(paymentRepository.findByPaymentOrderOrderId(order.orderId)).thenReturn(payment)
+        `when`(portOnePaymentPort.cancelPayment("portone-payment-id", "MINIMUM_QUANTITY_NOT_MET", 9_000))
+            .thenReturn(
+                PortOnePaymentResult(
+                    paymentId = "portone-payment-id",
+                    status = "PARTIAL_CANCELLED",
+                    totalAmount = 9_000,
+                    method = "CARD",
+                    paidAt = order.approvedAt,
+                    cancelledAt = refundedAt,
+                )
+            )
+
+        val result = service.processPendingRefunds()
+
+        assertEquals(1, result.targetCount)
+        assertEquals(1, result.successCount)
+        assertEquals(0, result.failedCount)
+        assertEquals(PaymentOrderStatus.PARTIAL_CANCELLED, order.status)
+        assertEquals(PaymentStatus.PARTIAL_CANCELLED, payment.status)
+        assertEquals(ParticipationStatus.REFUNDED, participation.status)
+        assertEquals(refundedAt, participation.refundedAt)
+        verify(refundRequestSyncService).markCompleted(participation, refundedAt)
     }
 
     @Test
@@ -900,6 +968,43 @@ class PaymentServiceTest {
         assertEquals(PaymentStatus.APPROVED, payment.status)
         assertEquals(ParticipationStatus.REFUND_PENDING, participation.status)
         assertEquals(null, participation.refundedAt)
+    }
+
+    @Test
+    fun `사용자 요청 환불은 사장님 승인 전이면 처리 대상에서 제외한다`() {
+        val user = UserFixture.createKakaoUser(id = 1L)
+        val groupBuy = createGroupBuy(status = GroupBuyStatus.FAILED)
+        val participation = Participation(
+            user = user,
+            groupBuy = groupBuy,
+            quantity = 1,
+            productAmount = 6_000,
+            feeAmount = 0,
+            totalAmount = 6_000,
+            status = ParticipationStatus.REFUND_PENDING,
+            cancelReason = ParticipationCancelReason.TIME_UNAVAILABLE,
+            cancelledAt = LocalDateTime.of(2026, 5, 18, 10, 0),
+            ownerRefundReviewStatus = OwnerRefundReviewStatus.PENDING,
+        ).apply { id = 93L }
+        val pageable = pendingRefundPageable()
+        stubTransaction()
+        `when`(
+            participationRepository.findByStatusOrderByCancelledAtAscCreatedAtAsc(
+                ParticipationStatus.REFUND_PENDING,
+                pageable
+            )
+        ).thenReturn(listOf(participation))
+        `when`(participationRepository.findByIdForUpdate(93L)).thenReturn(Optional.of(participation))
+
+        val result = service.processPendingRefunds()
+
+        assertEquals(1, result.targetCount)
+        assertEquals(0, result.successCount)
+        assertEquals(1, result.failedCount)
+        assertEquals(ParticipationStatus.REFUND_PENDING, participation.status)
+        assertEquals(null, participation.refundedAt)
+        verifyNoInteractions(portOnePaymentPort)
+        verifyNoInteractions(refundRequestSyncService)
     }
 
     @Test

--- a/src/test/kotlin/com/moongchijang/domain/refund/application/RefundRequestSyncServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/refund/application/RefundRequestSyncServiceTest.kt
@@ -1,0 +1,96 @@
+package com.moongchijang.domain.refund.application
+
+import com.moongchijang.domain.refund.domain.entity.RefundRequest
+import com.moongchijang.domain.refund.domain.entity.RefundRequestStatus
+import com.moongchijang.domain.refund.domain.repository.RefundRequestRepository
+import com.moongchijang.support.ParticipationFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class RefundRequestSyncServiceTest {
+
+    private val refundRequestRepository: RefundRequestRepository = mock(RefundRequestRepository::class.java)
+
+    private val service = RefundRequestSyncService(refundRequestRepository)
+
+    @Test
+    fun `환불 승인 동기화 시 요청이 없으면 생성 후 승인 상태로 저장한다`() {
+        val participation = createParticipation().apply {
+            cancelledAt = LocalDateTime.of(2026, 5, 24, 9, 0)
+        }
+        val approvedAt = LocalDateTime.of(2026, 5, 24, 10, 30)
+        val captor = ArgumentCaptor.forClass(RefundRequest::class.java)
+
+        `when`(refundRequestRepository.findByParticipationId(101L)).thenReturn(null)
+        `when`(refundRequestRepository.save(captor.capture())).thenAnswer { it.arguments[0] }
+
+        service.markApproved(participation = participation, approvedAmount = 8_000, at = approvedAt)
+
+        val saved = captor.value
+        assertEquals(participation, saved.participation)
+        assertEquals(RefundRequestStatus.APPROVED, saved.status)
+        assertEquals(participation.totalAmount, saved.requestedAmount)
+        assertEquals(participation.cancelledAt, saved.requestedAt)
+        assertEquals(8_000, saved.approvedRefundAmount)
+        assertEquals(approvedAt, saved.approvedAt)
+        assertNull(saved.rejectedReason)
+        assertNull(saved.rejectedAt)
+    }
+
+    @Test
+    fun `환불 거절 동기화 시 기존 요청에 거절 사유와 시각을 반영한다`() {
+        val participation = createParticipation()
+        val refundRequest = RefundRequest(
+            participation = participation,
+            requestedAmount = participation.totalAmount,
+            requestedAt = LocalDateTime.of(2026, 5, 23, 12, 0),
+        )
+        val rejectedAt = LocalDateTime.of(2026, 5, 24, 15, 0)
+
+        `when`(refundRequestRepository.findByParticipationId(101L)).thenReturn(refundRequest)
+
+        service.markRejected(participation = participation, reason = "픽업 미진행", at = rejectedAt)
+
+        assertEquals(RefundRequestStatus.REJECTED, refundRequest.status)
+        assertEquals("픽업 미진행", refundRequest.rejectedReason)
+        assertEquals(rejectedAt, refundRequest.rejectedAt)
+        assertEquals(participation.totalAmount, refundRequest.requestedAmount)
+    }
+
+    @Test
+    fun `환불 완료 동기화 시 createdAt 기준으로 요청을 생성하고 완료 상태로 저장한다`() {
+        val participation = createParticipation()
+        val completedAt = LocalDateTime.of(2026, 5, 25, 11, 0)
+        val captor = ArgumentCaptor.forClass(RefundRequest::class.java)
+
+        `when`(refundRequestRepository.findByParticipationId(101L)).thenReturn(null)
+        `when`(refundRequestRepository.save(captor.capture())).thenAnswer { it.arguments[0] }
+
+        service.markCompleted(participation = participation, at = completedAt)
+
+        val saved = captor.value
+        assertEquals(RefundRequestStatus.COMPLETED, saved.status)
+        assertEquals(LocalDateTime.of(2026, 5, 22, 9, 0), saved.requestedAt)
+        assertEquals(completedAt, saved.refundedAt)
+    }
+
+    private fun createParticipation() = ParticipationFixture.createParticipation(
+        participationId = 101L,
+        groupBuyId = 201L,
+        quantity = 1,
+        totalAmount = 12_000,
+        currentQuantity = 10,
+        targetQuantity = 20,
+        deadline = LocalDateTime.of(2026, 5, 30, 12, 0),
+        pickupDate = LocalDate.of(2026, 5, 31),
+        pickupTimeStart = LocalTime.of(10, 0),
+        createdAt = LocalDateTime.of(2026, 5, 22, 9, 0),
+    )
+}

--- a/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawnAccountCommandServiceTest.kt
+++ b/src/test/kotlin/com/moongchijang/domain/user/application/WithdrawnAccountCommandServiceTest.kt
@@ -1,0 +1,132 @@
+package com.moongchijang.domain.user.application
+
+import com.moongchijang.domain.user.domain.entity.WithdrawnAccount
+import com.moongchijang.domain.user.domain.repository.WithdrawnAccountRepository
+import com.moongchijang.security.crypto.PersonalInfoManager
+import com.moongchijang.support.UserFixture
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class WithdrawnAccountCommandServiceTest {
+
+    @Mock
+    private lateinit var withdrawnAccountRepository: WithdrawnAccountRepository
+
+    @Mock
+    private lateinit var withdrawalIdentifierHasher: WithdrawalIdentifierHasher
+
+    @Mock
+    private lateinit var personalInfoManager: PersonalInfoManager
+
+    private val service by lazy {
+        WithdrawnAccountCommandService(
+            withdrawnAccountRepository = withdrawnAccountRepository,
+            withdrawalIdentifierHasher = withdrawalIdentifierHasher,
+            personalInfoManager = personalInfoManager,
+        )
+    }
+
+    @Test
+    fun `providerId 기반 해시가 있으면 신규 탈퇴 계정을 생성한다`() {
+        val user = UserFixture.createKakaoUser(id = 10L, providerId = "kakao-10", email = "enc-email")
+        val withdrawnAt = LocalDateTime.of(2026, 7, 28, 14, 0)
+        val captor = ArgumentCaptor.forClass(WithdrawnAccount::class.java)
+
+        `when`(personalInfoManager.decryptIfNeeded("enc-email")).thenReturn("user@example.com")
+        `when`(
+            withdrawalIdentifierHasher.hashForWithdrawal(
+                provider = user.provider,
+                providerId = "kakao-10",
+                email = "user@example.com",
+            )
+        ).thenReturn("provider-hash")
+        `when`(withdrawnAccountRepository.findByProviderAndIdentifierHash(user.provider, "provider-hash")).thenReturn(null)
+        `when`(withdrawnAccountRepository.save(captor.capture())).thenAnswer { it.arguments[0] }
+
+        service.recordWithdrawal(user = user, withdrawnAt = withdrawnAt)
+
+        val saved = captor.value
+        assertEquals(user.provider, saved.provider)
+        assertEquals("provider-hash", saved.identifierHash)
+        assertEquals(10L, saved.withdrawnUserId)
+        assertEquals(withdrawnAt, saved.withdrawnAt)
+        assertEquals(withdrawnAt.plusDays(30), saved.rejoinAvailableAt)
+        verify(withdrawnAccountRepository, never()).findByWithdrawnUserId(10L)
+    }
+
+    @Test
+    fun `기존 탈퇴 계정이 있으면 재사용하며 탈퇴 시각과 재가입 가능 시각을 갱신한다`() {
+        val user = UserFixture.createKakaoUser(id = 11L, providerId = "kakao-11", email = "enc-email")
+        val existing = WithdrawnAccount(
+            provider = user.provider,
+            identifierHash = "old-hash",
+            withdrawnUserId = 3L,
+            withdrawnAt = LocalDateTime.of(2026, 6, 1, 9, 0),
+            rejoinAvailableAt = LocalDateTime.of(2026, 7, 1, 9, 0),
+            id = 77L,
+        )
+        val withdrawnAt = LocalDateTime.of(2026, 7, 28, 15, 0)
+        val captor = ArgumentCaptor.forClass(WithdrawnAccount::class.java)
+
+        `when`(personalInfoManager.decryptIfNeeded("enc-email")).thenReturn("user@example.com")
+        `when`(
+            withdrawalIdentifierHasher.hashForWithdrawal(
+                provider = user.provider,
+                providerId = "kakao-11",
+                email = "user@example.com",
+            )
+        ).thenReturn("new-hash")
+        `when`(withdrawnAccountRepository.findByProviderAndIdentifierHash(user.provider, "new-hash")).thenReturn(existing)
+        `when`(withdrawnAccountRepository.save(captor.capture())).thenAnswer { it.arguments[0] }
+
+        service.recordWithdrawal(user = user, withdrawnAt = withdrawnAt)
+
+        assertSame(existing, captor.value)
+        assertEquals("new-hash", existing.identifierHash)
+        assertEquals(11L, existing.withdrawnUserId)
+        assertEquals(withdrawnAt, existing.withdrawnAt)
+        assertEquals(withdrawnAt.plusDays(30), existing.rejoinAvailableAt)
+    }
+
+    @Test
+    fun `providerId가 없으면 이메일 기반 해시로 기존 계정을 조회해 저장한다`() {
+        val user = UserFixture.createEmailUser(id = 12L, email = "encrypted-email@example.com")
+        val withdrawnAt = LocalDateTime.of(2026, 7, 28, 16, 0)
+        val existing = WithdrawnAccount(
+            provider = user.provider,
+            identifierHash = "email-hash",
+            withdrawnUserId = 12L,
+            withdrawnAt = withdrawnAt.minusDays(10),
+            rejoinAvailableAt = withdrawnAt.plusDays(20),
+            id = 91L,
+        )
+
+        `when`(personalInfoManager.decryptIfNeeded("encrypted-email@example.com")).thenReturn("email@example.com")
+        `when`(
+            withdrawalIdentifierHasher.hashForWithdrawal(
+                provider = user.provider,
+                providerId = null,
+                email = "email@example.com",
+            )
+        ).thenReturn("email-hash")
+        `when`(withdrawnAccountRepository.findByProviderAndIdentifierHash(user.provider, "email-hash")).thenReturn(existing)
+        `when`(withdrawnAccountRepository.save(existing)).thenReturn(existing)
+
+        service.recordWithdrawal(user = user, withdrawnAt = withdrawnAt)
+
+        verify(withdrawnAccountRepository).findByProviderAndIdentifierHash(user.provider, "email-hash")
+        verify(withdrawnAccountRepository, never()).findByWithdrawnUserId(12L)
+        assertEquals(withdrawnAt, existing.withdrawnAt)
+        assertEquals(withdrawnAt.plusDays(30), existing.rejoinAvailableAt)
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- JaCoCo 기반 커버리지 측정 및 검증 환경을 추가했습니다.
- 환불 요청 동기화 로직에 대한 직접 테스트를 추가했습니다.
- 탈퇴 계정 기록 로직에 대한 직접 테스트를 추가했습니다.
- 환불 대기 처리 흐름에서 상위 정합성 시나리오를 보강했습니다.
- 사용자 요청 환불의 승인 전/후 처리 조건과 부분 환불 상태 전이를 검증하도록 테스트를 추가했습니다.

## 🔍 참고 사항
- 정합성 검증 강화를 목표로, 보조 서비스 단위 테스트와 상위 서비스 흐름 테스트를 함께 보강했습니다.
- `./gradlew test jacocoTestReport jacocoTestCoverageVerification` 기준 전체 테스트 및 커버리지 검증을 완료했습니다.
- JaCoCo 라인 커버리지는 76.5%입니다.

## 🖼️ 스크린샷
- 없음

## 🔗 관련 이슈
- Closed #377

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인